### PR TITLE
update aks-engine version for dual-stack job

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191012-482f444-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=master
@@ -63,7 +63,7 @@ periodics:
       - --acsengine-location=eastus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/dualstack/kubernetes.json
-      - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.0/aks-engine-v0.39.0-linux-amd64.tar.gz
+      - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.42.0/aks-engine-v0.42.0-linux-amd64.tar.gz
       - --timeout=450m
       # can enable [sig-network] tests too once we validate the job is successfully working
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\] --ginkgo.skip=\[Feature:IPv6DualStackAlphaFeature:Phase2\]


### PR DESCRIPTION
- Update to aks-engine `v0.42.0` that has support for dual-stack phase2.

Dependent on:
- This PR getting merged - https://github.com/kubernetes/test-infra/pull/14722
- New release of `kubekins-e2e` after the #14722 is merged.

Todo before merging this PR -

- [x] #14722 merged
- [x] New `kubekins-e2e` release
- [x] Update this PR with new `kubekins-e2e` release

/cc @ritazh 