### PR TITLE
Revert "Enable boskos in k8s.io/perf-test presubmits"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -308,7 +308,7 @@ presubmits:
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project-type=scalability-presubmit-project
+        - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -369,7 +369,7 @@ presubmits:
             - --gcp-master-size=n1-standard-2
             - --gcp-node-size=n1-standard-4
             - --gcp-nodes=4
-            - --gcp-project-type=scalability-presubmit-project
+            - --gcp-project=k8s-presubmit-scale
             - --gcp-zone=us-east1-b
             - --kubemark
             - --kubemark-nodes=100


### PR DESCRIPTION
This reverts commit 84ae9e57a7ffa4e23f608721327e61cdf5cdf6a7.

Unfortunately, it still doesn't work. I think https://github.com/kubernetes/test-infra/pull/14727 should fix the issues. Reverting till it gets merged.

Ref. kubernetes/perf-tests#650