### PR TITLE
peribolos: Add support for creating repositories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -82,6 +82,7 @@ require (
 	k8s.io/code-generator v0.0.0-20190831074504-732c9ca86353
 	k8s.io/klog v0.4.0
 	k8s.io/repo-infra v0.0.0-20190921032325-1fedfadec8ce
+	k8s.io/utils v0.0.0-20190506122338-8fab8cb257d5
 	mvdan.cc/xurls/v2 v2.0.0
 	sigs.k8s.io/controller-runtime v0.2.1
 	sigs.k8s.io/yaml v1.1.0

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -44,12 +44,26 @@ type Metadata struct {
 	MembersCanCreateRepositories *bool                       `json:"members_can_create_repositories,omitempty"`
 }
 
+// Repo declares metadata about the GitHub repository
+//
+// See https://developer.github.com/v3/repos/#edit
+type Repo struct {
+	Name        *string `json:"name,omitempty"`
+	Description *string `json:"description,omitempty"`
+	HomePage    *string `json:"homepage,omitempty"`
+	Private     *bool   `json:"private,omitempty"`
+	HasIssues   *bool   `json:"has_issues,omitempty"`
+	HasProjects *bool   `json:"has_projects,omitempty"`
+	HasWiki     *bool   `json:"has_wiki,omitempty"`
+}
+
 // Config declares org metadata as well as its people and teams.
 type Config struct {
 	Metadata
 	Teams   map[string]Team `json:"teams,omitempty"`
 	Members []string        `json:"members,omitempty"`
 	Admins  []string        `json:"admins,omitempty"`
+	Repos   map[string]Repo `json:"repos,omitempty"`
 }
 
 // TeamMetadata declares metadata about the github team.

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -44,17 +44,29 @@ type Metadata struct {
 	MembersCanCreateRepositories *bool                       `json:"members_can_create_repositories,omitempty"`
 }
 
+// RepoCreateOptions declares options for creating new repos
+// See https://developer.github.com/v3/repos/#create
+type RepoCreateOptions struct {
+	AutoInit          *bool   `json:"auto_init,omitempty"`
+	GitignoreTemplate *string `json:"gitignore_template,omitempty"`
+	LicenseTemplate   *string `json:"license_template,omitempty"`
+}
+
 // Repo declares metadata about the GitHub repository
 //
 // See https://developer.github.com/v3/repos/#edit
 type Repo struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
-	HomePage    *string `json:"homepage,omitempty"`
-	Private     *bool   `json:"private,omitempty"`
-	HasIssues   *bool   `json:"has_issues,omitempty"`
-	HasProjects *bool   `json:"has_projects,omitempty"`
-	HasWiki     *bool   `json:"has_wiki,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	HomePage         *string `json:"homepage,omitempty"`
+	Private          *bool   `json:"private,omitempty"`
+	HasIssues        *bool   `json:"has_issues,omitempty"`
+	HasProjects      *bool   `json:"has_projects,omitempty"`
+	HasWiki          *bool   `json:"has_wiki,omitempty"`
+	AllowSquashMerge *bool   `json:"allow_squash_merge,omitempty"`
+	AllowMergeCommit *bool   `json:"allow_merge_commit,omitempty"`
+	AllowRebaseMerge *bool   `json:"allow_rebase_merge,omitempty"`
+
+	OnCreate *RepoCreateOptions `json:"on_create,omitempty"`
 }
 
 // Config declares org metadata as well as its people and teams.

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     deps = [
         "//ghproxy/ghcache:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_utils//diff:go_default_library",
     ],
 )
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -364,7 +364,7 @@ func (r RepoCreateRequest) ToRepo() *Repo {
 		}
 	}
 
-	repo := Repo{}
+	var repo Repo
 	setString(&repo.Name, r.Name)
 	setString(&repo.Description, r.Description)
 	setString(&repo.Homepage, r.Homepage)

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -300,27 +300,83 @@ type PullRequestChange struct {
 // Repo contains general repository information.
 // See also https://developer.github.com/v3/repos/#get
 type Repo struct {
-	Owner             User   `json:"owner"`
-	Name              string `json:"name"`
-	FullName          string `json:"full_name"`
-	HTMLURL           string `json:"html_url"`
-	Fork              bool   `json:"fork"`
-	DefaultBranch     string `json:"default_branch"`
-	Archived          bool   `json:"archived"`
-	Private           bool   `json:"private"`
-	Description       string `json:"description"`
-	Homepage          string `json:"homepage"`
-	HasIssues         bool   `json:"has_issues"`
-	HasProjects       bool   `json:"has_projects"`
-	HasWiki           bool   `json:"has_wiki"`
-	AllowSquashMerge  bool   `json:"allow_squash_merge"`
-	AllowMergeCommit  bool   `json:"allow_merge_commit"`
-	AllowRebaseCommit bool   `json:"allow_rebase_commit"`
+	Owner            User   `json:"owner"`
+	Name             string `json:"name"`
+	FullName         string `json:"full_name"`
+	HTMLURL          string `json:"html_url"`
+	Fork             bool   `json:"fork"`
+	DefaultBranch    string `json:"default_branch"`
+	Archived         bool   `json:"archived"`
+	Private          bool   `json:"private"`
+	Description      string `json:"description"`
+	Homepage         string `json:"homepage"`
+	HasIssues        bool   `json:"has_issues"`
+	HasProjects      bool   `json:"has_projects"`
+	HasWiki          bool   `json:"has_wiki"`
+	AllowSquashMerge bool   `json:"allow_squash_merge"`
+	AllowMergeCommit bool   `json:"allow_merge_commit"`
+	AllowRebaseMerge bool   `json:"allow_rebase_merge"`
 	// Permissions reflect the permission level for the requester, so
 	// on a repository GET call this will be for the user whose token
 	// is being used, if listing a team's repos this will be for the
 	// team's privilege level in the repo
 	Permissions RepoPermissions `json:"permissions"`
+}
+
+// RepoRequest contains metadata used in requests to create or update a Repo.
+// Compared to `Repo`, its members are pointers to allow the "not set/use default
+// semantics.
+// See also:
+// - https://developer.github.com/v3/repos/#create
+// - https://developer.github.com/v3/repos/#edit
+type RepoRequest struct {
+	Name             *string `json:"name,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	Homepage         *string `json:"homepage,omitempty"`
+	Private          *bool   `json:"private,omitempty"`
+	HasIssues        *bool   `json:"has_issues,omitempty"`
+	HasProjects      *bool   `json:"has_projects,omitempty"`
+	HasWiki          *bool   `json:"has_wiki,omitempty"`
+	AllowSquashMerge *bool   `json:"allow_squash_merge,omitempty"`
+	AllowMergeCommit *bool   `json:"allow_merge_commit,omitempty"`
+	AllowRebaseMerge *bool   `json:"allow_rebase_merge,omitempty"`
+}
+
+// RepoCreateRequest contains metadata used in requests to create a repo.
+// See also: https://developer.github.com/v3/repos/#create
+type RepoCreateRequest struct {
+	RepoRequest `json:",omitempty"`
+
+	AutoInit          *bool   `json:"auto_init,omitempty"`
+	GitignoreTemplate *string `json:"gitignore_template,omitempty"`
+	LicenseTemplate   *string `json:"license_template,omitempty"`
+}
+
+func (r RepoCreateRequest) ToRepo() *Repo {
+	setString := func(dest, src *string) {
+		if src != nil {
+			*dest = *src
+		}
+	}
+	setBool := func(dest, src *bool) {
+		if src != nil {
+			*dest = *src
+		}
+	}
+
+	repo := Repo{}
+	setString(&repo.Name, r.Name)
+	setString(&repo.Description, r.Description)
+	setString(&repo.Homepage, r.Homepage)
+	setBool(&repo.Private, r.Private)
+	setBool(&repo.HasIssues, r.HasIssues)
+	setBool(&repo.HasProjects, r.HasProjects)
+	setBool(&repo.HasWiki, r.HasWiki)
+	setBool(&repo.AllowSquashMerge, r.AllowSquashMerge)
+	setBool(&repo.AllowMergeCommit, r.AllowMergeCommit)
+	setBool(&repo.AllowRebaseMerge, r.AllowRebaseMerge)
+
+	return &repo
 }
 
 // RepoPermissions describes which permission level an entity has in a

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -300,14 +300,22 @@ type PullRequestChange struct {
 // Repo contains general repository information.
 // See also https://developer.github.com/v3/repos/#get
 type Repo struct {
-	Owner         User   `json:"owner"`
-	Name          string `json:"name"`
-	FullName      string `json:"full_name"`
-	HTMLURL       string `json:"html_url"`
-	Fork          bool   `json:"fork"`
-	DefaultBranch string `json:"default_branch"`
-	Archived      bool   `json:"archived"`
-
+	Owner             User   `json:"owner"`
+	Name              string `json:"name"`
+	FullName          string `json:"full_name"`
+	HTMLURL           string `json:"html_url"`
+	Fork              bool   `json:"fork"`
+	DefaultBranch     string `json:"default_branch"`
+	Archived          bool   `json:"archived"`
+	Private           bool   `json:"private"`
+	Description       string `json:"description"`
+	Homepage          string `json:"homepage"`
+	HasIssues         bool   `json:"has_issues"`
+	HasProjects       bool   `json:"has_projects"`
+	HasWiki           bool   `json:"has_wiki"`
+	AllowSquashMerge  bool   `json:"allow_squash_merge"`
+	AllowMergeCommit  bool   `json:"allow_merge_commit"`
+	AllowRebaseCommit bool   `json:"allow_rebase_commit"`
 	// Permissions reflect the permission level for the requester, so
 	// on a repository GET call this will be for the user whose token
 	// is being used, if listing a team's repos this will be for the


### PR DESCRIPTION
Very basic support for creating GH repository entities (not git repo content) if they do not exist. No further actions (updates, deletes) are currently implemented (with repos, these operations have some additional complexity, so it's best to implement them incrementally). For the same reason, the set of current fields allowed to be set is just a subset of the Repositories API (https://developer.github.com/v3/repos/#create)

/cc @stevekuznetsov 