### PR TITLE
README: List another prow cluster in the wild

### DIFF
--- a/prow/README.md
+++ b/prow/README.md
@@ -81,6 +81,7 @@ Prow is used by the following organizations and projects:
 - [Knative](https://prow.knative.dev/)
 - [Jetstack](https://prow.build-infra.jetstack.net/)
 - [Kyma](https://status.build.kyma-project.io/)
+- [Metal³](https://prow.apps.ci.metal3.io/)
 - [Prometheus](http://prombench.prometheus.io/)
 - [Caicloud](https://github.com/caicloud)
 - [Kubeflow](https://github.com/kubeflow)


### PR DESCRIPTION
The metal3.io project is now using prow.  Add it to the list of sample clusters in the wild.