### PR TITLE
prow: only add label comment when invalid /label is used

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -160,7 +160,6 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 		}
 
 		if !RepoLabelsExisting.Has(labelToAdd) {
-			nonexistent = append(nonexistent, labelToAdd)
 			continue
 		}
 
@@ -177,7 +176,6 @@ func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *gi
 		}
 
 		if !RepoLabelsExisting.Has(labelToRemove) {
-			nonexistent = append(nonexistent, labelToRemove)
 			continue
 		}
 

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -149,7 +149,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Non Org Member Can't Add",
@@ -177,7 +176,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Add Multiple Area Labels",
@@ -214,7 +212,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Label Prefix Must Match Command (Priority-Area Mismatch)",
@@ -224,7 +221,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels(),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Add Multiple Area Labels (Some Valid)",
@@ -234,7 +230,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels("area/infra"),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Add Multiple Committee Labels (Some Valid)",
@@ -244,7 +239,6 @@ func TestLabel(t *testing.T) {
 			expectedNewLabels:     formatLabels("committee/steering"),
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
-			expectedBotComment:    true,
 		},
 		{
 			name:                  "Add Multiple Types of Labels Different Lines",
@@ -415,6 +409,7 @@ func TestLabel(t *testing.T) {
 			expectedRemovedLabels: []string{},
 			commenter:             orgMember,
 			expectedBotComment:    true,
+			expectedCommentText:   "The label(s) `/label orchestrator/foo` cannot be applied. These labels are supported: `orchestrator/jar, orchestrator/bar`",
 		},
 		{
 			name:                  "Remove custom label",


### PR DESCRIPTION
Removes part of comment on invalid labels that includes all configured additional labels. These labels have been configured for specific projects / repos and it is confusing when comment says they are supported when an invalid label has been added to other repos.

Fixes https://github.com/kubernetes/test-infra/issues/14420

/cc @liztio @BenTheElder 