### PR TITLE
Fix pj-on-kind.sh prowjob output directory mounting.

### DIFF
--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -25,7 +25,7 @@ function main() {
 
   # Generate PJ and Pod.
   docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj "--config-path=${config}" "${job_config_flag}" "--job=${job}" > "${PWD}/pj.yaml"
-  docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}" > "${PWD}/pod.yaml"
+  docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
  
   # Add any k8s resources that the pod depends on to the kind cluster here. (secrets, configmaps, etc.)
 
@@ -42,7 +42,7 @@ function parseArgs() {
   job="${1:-}"
   config="${CONFIG_PATH:-}"
   job_config_path="${JOB_CONFIG_PATH:-}"
-  out_dir="${OUT_DIR:-/mnt/disks/prowjob-out/${job}}"
+  out_dir="${OUT_DIR:-/mnt/disks/prowjob-out}"
   kind_config="${KIND_CONFIG:-}"
   node_dir="${NODE_DIR:-/mnt/disks/kind-node}"  # Any pod hostPath mounts should be under this dir to reach the true host via the kind node.
 


### PR DESCRIPTION
The prowjob output volume was being mounted at the job directory level instead of one level higher up, meaning the `mkpod` cluster could only output prowjob output for the job that it ran the first time it was created. Any other prowjobs tested on the same kind cluster fail to properly pass output from the kind node container to the host FS.

Users will need to run `kind delete cluster --name mkpod` to delete the old `mkpod` kind cluster and allow a new one to be created with the correct mounts. (They probably already need to do this after they sleep or restart their machine).

/kind bug
/assign @clarketm 