### PR TITLE
images/builder: Allow GCB builds from arbitrary build directories

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -47,6 +47,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/alpine-bash/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -75,6 +76,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/boskosctl-base/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -161,6 +163,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - velodrome/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -219,6 +222,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - kettle/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -250,6 +254,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - planter/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -281,6 +286,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - triage/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -312,6 +318,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/bazelbuild/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -343,6 +350,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/bazel-krte/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -374,6 +382,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/bigquery/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -405,6 +414,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/bootstrap/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -436,6 +446,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/cluster-api/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -467,6 +478,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/gcb-docker-gcloud/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -498,6 +510,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/gcloud/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -529,6 +542,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/kubekins-e2e/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -591,6 +605,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/kubekins-test/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -622,6 +637,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/kubemci/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -653,6 +669,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/pull-test-infra-gubernator/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
@@ -684,6 +701,7 @@ postsubmits:
         args:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
+        - --build-dir=.
         - images/builder/
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -1,6 +1,6 @@
-# Image Builder
+# GCB Builder
 
-This image builder is sugar on top of `gcloud builds submit`. It offers the following features:
+This builder is sugar on top of `gcloud builds submit`. It offers the following features:
 
 - Automatically injecting the standard commit-based tag (e.g. `20190403-dddd315ad-dirty`) as `_GIT_TAG`
 - Optionally blocking pushes of dirty builds
@@ -13,22 +13,22 @@ and `cloudbuild.yaml`. For example, a subset of the `kubekins-e2e` variants look
 
 ```yaml
 variants:
-  '1.14':
-    CONFIG: '1.14'
-    GO_VERSION: 1.12.1
-    K8S_RELEASE: latest
-    BAZEL_VERSION: 0.21.0
-  '1.13':
-    CONFIG: '1.13'
-    GO_VERSION: 1.11.5
-    K8S_RELEASE: stable-1.13
-    BAZEL_VERSION: 0.18.1
+  '1.16':
+    CONFIG: '1.16'
+    GO_VERSION: 1.12.12
+    K8S_RELEASE: stable-1.16
+    BAZEL_VERSION: 0.23.2
+  '1.15':
+    CONFIG: '1.15'
+    GO_VERSION: 1.12.12
+    K8S_RELEASE: stable-1.15
+    BAZEL_VERSION: 0.23.2
 ```
 
-By default, the image builder will build both the `1.13` and `1.14` groups simultaneously.
-If `--log-dir` is specified, it will write the build logs for each to `1.13.log` and `1.14.log`.
+By default, the image builder will build both the `1.15` and `1.16` groups simultaneously.
+If `--log-dir` is specified, it will write the build logs for each to `1.15.log` and `1.16.log`.
 
-Alternatively, you can use `--variant` to build only one variant, e.g. `--variant 1.13`.
+Alternatively, you can use `--variant` to build only one variant, e.g. `--variant 1.15`.
 
 If no `variants.yaml` is specified, `cloudbuild.yaml` will be run once with no extra substitutions
 beyond `_GIT_TAG`.
@@ -36,7 +36,7 @@ beyond `_GIT_TAG`.
 ## Usage
 
 ```shell
-bazel run //images/builder -- [options] path/to/image-directory/
+bazel run //images/builder -- [options] path/to/build-directory/
 ```
 
 - `--allow-dirty`: If true, allow pushing dirty builds.
@@ -44,5 +44,7 @@ bazel run //images/builder -- [options] path/to/image-directory/
 - `--project`: If specified, use a non-default GCP project.
 - `--scratch-bucket`: If provided, the complete GCS path for Cloud Build to store scratch files (sources, logs). Necessary for upload reuse. If omitted, `gcloud` will create or reuse a bucket of its choosing.
 - `--variant`: If specified, build only the given variant. An error if no variants are defined.
-- `--env-passthrough`: A comma-separated list of environment variables to pass through as substitutions.
-  The substitution names will automatically be prefixed with underscores, as required by GCB.
+- `--env-passthrough`: Comma-separated list of specified environment variables to be passed to GCB as substitutions with an underscore (`_`) prefix. If the variable doesn't exist, the substitution will exist but be empty.
+- `--build-dir`: If provided, this directory will be uploaded as the source for the Google Cloud Build run.
+- `--gcb-config`: If provided, this will be used as the name of the Google Cloud Build config file.
+- `--no-source`: If true, no source will be uploaded with this build.

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -1,5 +1,4 @@
-Image Builder
-=============
+# Image Builder
 
 This image builder is sugar on top of `gcloud builds submit`. It offers the following features:
 
@@ -36,14 +35,14 @@ beyond `_GIT_TAG`.
 
 ## Usage
 
-```
+```shell
 bazel run //images/builder -- [options] path/to/image-directory/
 ```
 
-* `--allow-dirty`: If true, allow pushing dirty builds.
-* `--log-dir`: If provided, build logs will be sent to files in this directory instead of to stdout/stderr.
-* `--project`: If specified, use a non-default GCP project.
-* `--scratch-bucket`: If provided, the complete GCS path for Cloud Build to store scratch files (sources, logs). Necessary for upload reuse. If omitted, `gcloud` will create or reuse a bucket of its choosing.
-* `--variant`: If specified, build only the given variant. An error if no variants are defined.
-* `--env-passthrough`: A comma-separated list of environment variables to pass through as substitutions.
+- `--allow-dirty`: If true, allow pushing dirty builds.
+- `--log-dir`: If provided, build logs will be sent to files in this directory instead of to stdout/stderr.
+- `--project`: If specified, use a non-default GCP project.
+- `--scratch-bucket`: If provided, the complete GCS path for Cloud Build to store scratch files (sources, logs). Necessary for upload reuse. If omitted, `gcloud` will create or reuse a bucket of its choosing.
+- `--variant`: If specified, build only the given variant. An error if no variants are defined.
+- `--env-passthrough`: A comma-separated list of environment variables to pass through as substitutions.
   The substitution names will automatically be prefixed with underscores, as required by GCB.

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -54,21 +54,26 @@ func getVersion() (string, error) {
 	return fmt.Sprintf("v%s-%s", t, strings.TrimSpace(string(output))), nil
 }
 
-func cdToRootDir() error {
-	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
-		if err := os.Chdir(bazelWorkspace); err != nil {
-			return fmt.Errorf("failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
-		}
+func (o *options) validateConfigDir() error {
+	configDir := o.configDir
+	dirInfo, err := os.Stat(o.configDir)
+	if os.IsNotExist(err) {
+		log.Fatalf("Config directory (%s) does not exist", configDir)
 	}
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	output, err := cmd.Output()
-	if err != nil {
-		return err
+
+	if !dirInfo.IsDir() {
+		log.Fatalf("Config directory (%s) is not actually a directory", configDir)
 	}
-	return os.Chdir(strings.TrimSpace(string(output)))
+
+	_, err = os.Stat(path.Join(configDir, o.cloudbuildFile))
+	if os.IsNotExist(err) {
+		log.Fatalf("%s does not exist", o.cloudbuildFile)
+	}
+
+	return nil
 }
 
-func uploadWorkingDir(targetBucket string) (string, error) {
+func (o *options) uploadBuildDir(targetBucket string) (string, error) {
 	f, err := ioutil.TempFile("", "")
 	if err != nil {
 		return "", fmt.Errorf("failed to create temp file: %v", err)
@@ -112,7 +117,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 	s = append(s, "_GIT_TAG="+version)
 	args := []string{
 		"builds", "submit",
-		"--config", path.Join(o.imageDirectory, "cloudbuild.yaml"),
+		"--config", o.cloudbuildFile,
 		"--substitutions", strings.Join(s, ","),
 	}
 	if o.project != "" {
@@ -153,7 +158,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 type variants map[string]map[string]string
 
 func getVariants(o options) (variants, error) {
-	content, err := ioutil.ReadFile(path.Join(o.imageDirectory, "variants.yaml"))
+	content, err := ioutil.ReadFile("variants.yaml")
 	if err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("failed to load variants.yaml: %v", err)
@@ -183,7 +188,7 @@ func runBuildJobs(o options) []error {
 	var uploaded string
 	if o.scratchBucket != "" {
 		var err error
-		uploaded, err = uploadWorkingDir(o.scratchBucket + gcsSourceDir)
+		uploaded, err = o.uploadBuildDir(o.scratchBucket + gcsSourceDir)
 		if err != nil {
 			return []error{fmt.Errorf("failed to upload source: %v", err)}
 		}
@@ -236,9 +241,11 @@ func runBuildJobs(o options) []error {
 }
 
 type options struct {
+	buildDir       string
+	configDir      string
+	cloudbuildFile string
 	logDir         string
 	scratchBucket  string
-	imageDirectory string
 	project        string
 	allowDirty     bool
 	variant        string
@@ -257,30 +264,58 @@ func mergeMaps(maps ...map[string]string) map[string]string {
 
 func parseFlags() options {
 	o := options{}
+	flag.StringVar(&o.buildDir, "build-dir", "", "If provided, this directory will be uploaded as the source for the Google Cloud Build run.")
+	flag.StringVar(&o.cloudbuildFile, "gcb-config", "cloudbuild.yaml", "If provided, this will be used as the name of the Google Cloud Build config file.")
 	flag.StringVar(&o.logDir, "log-dir", "", "If provided, build logs will be sent to files in this directory instead of to stdout/stderr.")
 	flag.StringVar(&o.scratchBucket, "scratch-bucket", "", "The complete GCS path for Cloud Build to store scratch files (sources, logs).")
 	flag.StringVar(&o.project, "project", "", "If specified, use a non-default GCP project.")
 	flag.BoolVar(&o.allowDirty, "allow-dirty", false, "If true, allow pushing dirty builds.")
 	flag.StringVar(&o.variant, "variant", "", "If specified, build only the given variant. An error if no variants are defined.")
-	flag.StringVar(&o.envPassthrough, "env-passthrough", "", "Comma-separated list of specified environment variables to be passed to GCB as subtitutions with an _ prefix. If the variable doesn't exist, the substitution will exist but be empty.")
+	flag.StringVar(&o.envPassthrough, "env-passthrough", "", "Comma-separated list of specified environment variables to be passed to GCB as substitutions with an _ prefix. If the variable doesn't exist, the substitution will exist but be empty.")
+
 	flag.Parse()
+
 	if flag.NArg() < 1 {
-		_, _ = fmt.Fprintln(os.Stderr, "expected an image directory to be provided")
+		_, _ = fmt.Fprintln(os.Stderr, "expected a config directory to be provided")
 		os.Exit(1)
 	}
-	o.imageDirectory = flag.Arg(0)
+
+	o.configDir = strings.TrimSuffix(flag.Arg(0), "/")
+
 	return o
 }
 
 func main() {
 	o := parseFlags()
-	if err := cdToRootDir(); err != nil {
-		log.Fatalf("Failed to cd to root: %v\n", err)
+
+	if bazelWorkspace := os.Getenv("BUILD_WORKSPACE_DIRECTORY"); bazelWorkspace != "" {
+		if err := os.Chdir(bazelWorkspace); err != nil {
+			log.Fatalf("Failed to chdir to bazel workspace (%s): %v", bazelWorkspace, err)
+		}
+	}
+
+	configDirErr := o.validateConfigDir()
+	if configDirErr != nil {
+		log.Fatalf("Could not validate config directory: %v", configDirErr)
+	}
+
+	if o.buildDir != "" {
+		o.cloudbuildFile = path.Join(o.configDir, o.cloudbuildFile)
+	} else {
+		o.buildDir = o.configDir
+	}
+
+	log.Printf("Build directory: %s\n", o.buildDir)
+	log.Printf("Config directory: %s\n", o.configDir)
+
+	log.Printf("cd-ing to build directory: %s\n", o.buildDir)
+	if err := os.Chdir(o.buildDir); err != nil {
+		log.Fatalf("Failed to chdir to build directory (%s): %v", o.buildDir, err)
 	}
 
 	errors := runBuildJobs(o)
 	if len(errors) != 0 {
-		log.Fatalf("Failed to push some images: %v", errors)
+		log.Fatalf("Failed to run some build jobs: %v", errors)
 	}
 	log.Println("Finished.")
 }


### PR DESCRIPTION
- Remove `cdToRootDir`
    This function was not actually cd-ing into directories
- Add `--build-dir` flag to support builds that require the entire
   repo/workspace to be uploaded to GCB
- Add a validation method to ensure config directory and `cloudbuild.yaml`
   exist before submitting build

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @Katharine @dims @tpepper 
cc: @alexeldeib @kubernetes/release-engineering 
/sig release
/area release-eng
/milestone v1.17
/priority important-soon

---

After wiring k/release up to do image building/pushing via post-submit (https://github.com/kubernetes/test-infra/pull/14711, https://github.com/kubernetes/test-infra/pull/14735, https://github.com/kubernetes/release/pull/895, https://github.com/kubernetes/release/pull/896), I noticed that we had a few build failures:

`https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1182793236758925320`:
```
Created [https://cloudbuild.googleapis.com/v1/projects/k8s-staging-release-test/builds/75d28263-9671-4359-854e-2535a29ad3b0].
Logs are available at [https://console.cloud.google.com/gcr/builds/75d28263-9671-4359-854e-2535a29ad3b0?project=634027639865].
----------------------------- REMOTE BUILD OUTPUT ------------------------------
ERROR: (gcloud.builds.submit) build 75d28263-9671-4359-854e-2535a29ad3b0 completed with status "FAILURE"
starting build "75d28263-9671-4359-854e-2535a29ad3b0"

FETCHSOURCE
Fetching storage object: gs://k8s-staging-release-test-gcb/source/1570834875.37-297cf4b31fb547218dc02ad9004339f8.tgz#1570834875611654
Copying gs://k8s-staging-release-test-gcb/source/1570834875.37-297cf4b31fb547218dc02ad9004339f8.tgz#1570834875611654...
/ [0 files][    0.0 B/166.4 KiB]                                                
/ [1 files][166.4 KiB/166.4 KiB]                                                
Operation completed over 1 objects/166.4 KiB.                                    
BUILD
Already have image (with digest): gcr.io/cloud-builders/docker
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /workspace/Dockerfile: no such file or directory
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1
--------------------------------------------------------------------------------
```

`https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-deb-builder/1182793236758925319`: 
```
Created [https://cloudbuild.googleapis.com/v1/projects/k8s-staging-release-test/builds/42fb12ed-fff8-4e50-8cc2-21037cbf38e1].
Logs are available at [https://console.cloud.google.com/gcr/builds/42fb12ed-fff8-4e50-8cc2-21037cbf38e1?project=634027639865].
----------------------------- REMOTE BUILD OUTPUT ------------------------------
starting build "42fb12ed-fff8-4e50-8cc2-21037cbf38e1"

FETCHSOURCE
Fetching storage object: gs://k8s-staging-release-test-gcb/source/1570834875.55-c6f9168b8c5c4e239177f86f7161df02.tgz#1570834875702092
Copying gs://k8s-staging-release-test-gcb/source/1570834875.55-c6f9168b8c5c4e239177f86f7161df02.tgz#1570834875702092...
/ [0 files][    0.0 B/166.4 KiB]                                                
/ [1 files][166.4 KiB/166.4 KiB]                                                
Operation completed over 1 objects/166.4 KiB.                                    
BUILD
Starting Step #0
Step #0: Pulling image: golang:1.13
Step #0: 1.13: Pulling from library/golang
Step #0: Digest: sha256:68f8870ee1723cafd45bed29414fbaa151e9bf2bba369c8b4436c08a18907012
Step #0: Status: Downloaded newer image for golang:1.13
Step #0: docker.io/library/golang:1.13
Step #0: build .: cannot find module for path .
Finished Step #0
ERROR
ERROR: build step 0 "golang:1.13" failed: exit status 1
--------------------------------------------------------------------------------

ERROR: (gcloud.builds.submit) build 42fb12ed-fff8-4e50-8cc2-21037cbf38e1 completed with status "FAILURE"
```

`https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-release-push-image-rpm-builder/1182793236758925321`: 
```
Created [https://cloudbuild.googleapis.com/v1/projects/k8s-staging-release-test/builds/133ed19d-2e9d-41ae-92f1-0a04766a25e3].
Logs are available at [https://console.cloud.google.com/gcr/builds/133ed19d-2e9d-41ae-92f1-0a04766a25e3?project=634027639865].
----------------------------- REMOTE BUILD OUTPUT ------------------------------
ERROR: (gcloud.builds.submit) build 133ed19d-2e9d-41ae-92f1-0a04766a25e3 completed with status "FAILURE"
starting build "133ed19d-2e9d-41ae-92f1-0a04766a25e3"

FETCHSOURCE
Fetching storage object: gs://k8s-staging-release-test-gcb/source/1570834874.08-db53a5ba6bd64a5d8bbfe614d8634184.tgz#1570834874408813
Copying gs://k8s-staging-release-test-gcb/source/1570834874.08-db53a5ba6bd64a5d8bbfe614d8634184.tgz#1570834874408813...
/ [0 files][    0.0 B/166.4 KiB]                                                
/ [1 files][166.4 KiB/166.4 KiB]                                                
Operation completed over 1 objects/166.4 KiB.                                    
BUILD
Already have image (with digest): gcr.io/cloud-builders/docker
unable to prepare context: unable to evaluate symlinks in Dockerfile path: lstat /workspace/Dockerfile: no such file or directory
ERROR
ERROR: build step 0 "gcr.io/cloud-builders/docker" failed: exit status 1
--------------------------------------------------------------------------------
```


Basically what's happening is the builder is looking for assets in `/workspace` and can't find them.
This was happening because the `os.Chdir` command was in a separate function scope, so it was ultimately not being respected. This was further obfuscated by the fact that the builder in its' current state specifies the `cloudbuild.yaml` while you're outside of the image directory.


I tried testing this locally with commands close to what would be running in CI and all seems to be working...

Build the image builder from the root of k/test-infra:
```shell
CGO_ENABLED=0 \
GOOS=linux \
GOARCH=amd64 \
GO111MODULE=on \
GOPROXY=https://proxy.golang.org \
GOSUMDB=sum.golang.org \
go build -o=./images/builder/builder ./images/builder
```

Submitting an image push from the root of k/release:
```shell
time /home/augustus/go/src/k8s.io/test-infra/images/builder/builder --project=kubernetes-release-test --scratch-bucket=gs://kubernetes-release-test-gcb --env-passthrough=PULL_BASE_REF build/debs/
2019/10/12 01:36:51 working directory: /home/augustus/go/src/k8s.io/release/build/debs
2019/10/12 01:36:51 Creating source tarball at /tmp/221087232...
2019/10/12 01:36:54 Uploading /tmp/221087232 to gs://kubernetes-release-test-gcb/source/9464065b-2e94-4ebd-84e7-591dff4d38ef.tgz...
Copying file:///tmp/221087232 [Content-Type=application/octet-stream]...
- [1 files][ 57.4 MiB/ 57.4 MiB]    1.2 MiB/s                                   
Operation completed over 1 objects/57.4 MiB.                                     
2019/10/12 01:37:37 Running build jobs...
2019/10/12 01:37:37 No variants.yaml, starting single build job...
Created [https://cloudbuild.googleapis.com/v1/projects/kubernetes-release-test/builds/47e371f8-d6d9-4370-8a56-567236fe103a].
Logs are available at [https://console.cloud.google.com/gcr/builds/47e371f8-d6d9-4370-8a56-567236fe103a?project=648026197307].
------------------------------------------------------------------------------------------------------ REMOTE BUILD OUTPUT -------------------------------------------------------------------------------------------------------
starting build "47e371f8-d6d9-4370-8a56-567236fe103a"

FETCHSOURCE
Fetching storage object: gs://kubernetes-release-test-gcb/source/1570858658.2-904011a4abf44c4eb7cfc1663efaa590.tgz#1570858658617748
Copying gs://kubernetes-release-test-gcb/source/1570858658.2-904011a4abf44c4eb7cfc1663efaa590.tgz#1570858658617748...
\ [1 files][ 57.4 MiB/ 57.4 MiB]                                                
Operation completed over 1 objects/57.4 MiB.                                     
BUILD

<snip>

DONE
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

ID                                    CREATE_TIME                DURATION  SOURCE                                                                                     IMAGES                                                                              STATUS
47e371f8-d6d9-4370-8a56-567236fe103a  2019-10-12T05:37:38+00:00  2M16S     gs://kubernetes-release-test-gcb/source/1570858658.2-904011a4abf44c4eb7cfc1663efaa590.tgz  gcr.io/kubernetes-release-test/deb-builder:v20191012-v0.1.3-124-ga49231d (+2 more)  SUCCESS
2019/10/12 01:39:56 Finished.

real	3m5.147s
user	0m6.419s
sys	0m1.151s
```