### PR TITLE
testgrid: Add a disruptive e2e suite to the testgrid

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -106,6 +106,25 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
     name: release-openshift-ocp-installer-e2e-aws-upi-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -392,6 +411,8 @@ test_groups:
   name: release-openshift-ocp-installer-e2e-aws-mirrors-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.2
   name: release-openshift-ocp-installer-e2e-aws-proxy-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
+  name: release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.2
   name: release-openshift-ocp-installer-e2e-aws-upi-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.2

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.3-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.3-informing.yaml
@@ -30,6 +30,25 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-origin-installer-e2e-aws-disruptive-4.3
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-aws-disruptive-4.3
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
     name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -194,6 +213,8 @@ dashboards:
 test_groups:
 - gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.3
+  name: release-openshift-origin-installer-e2e-aws-disruptive-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-4.3


### PR DESCRIPTION
This is generated from the latest openshift/release

/assign @stevekuznetsov