### PR TITLE
Handle simple type aliases in genyaml

### DIFF
--- a/pkg/genyaml/BUILD.bazel
+++ b/pkg/genyaml/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     data = [":test-data"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/genyaml/testdata/alias_simple_types:go_default_library",
         "//pkg/genyaml/testdata/alias_types:go_default_library",
         "//pkg/genyaml/testdata/embedded_structs:go_default_library",
         "//pkg/genyaml/testdata/interface_types:go_default_library",
@@ -35,6 +36,7 @@ go_test(
 filegroup(
     name = "test-data",
     srcs = [
+        "//pkg/genyaml/testdata/alias_simple_types:test-data",
         "//pkg/genyaml/testdata/alias_types:test-data",
         "//pkg/genyaml/testdata/embedded_structs:test-data",
         "//pkg/genyaml/testdata/inject_comments:test-data",
@@ -63,6 +65,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/genyaml/testdata/alias_simple_types:all-srcs",
         "//pkg/genyaml/testdata/alias_types:all-srcs",
         "//pkg/genyaml/testdata/embedded_structs:all-srcs",
         "//pkg/genyaml/testdata/inject_comments:all-srcs",

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -258,6 +258,7 @@ func (cm *CommentMap) genDocMap(path string) error {
 
 	for _, t := range pkg.Types {
 		if typeSpec, ok := t.Decl.Specs[0].(*ast.TypeSpec); ok {
+
 			var lst []*ast.Field
 
 			// Support struct type, interface type, and type alias.

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -258,7 +258,6 @@ func (cm *CommentMap) genDocMap(path string) error {
 
 	for _, t := range pkg.Types {
 		if typeSpec, ok := t.Decl.Specs[0].(*ast.TypeSpec); ok {
-
 			var lst []*ast.Field
 
 			// Support struct type, interface type, and type alias.
@@ -268,10 +267,13 @@ func (cm *CommentMap) genDocMap(path string) error {
 			case *ast.StructType:
 				lst = typ.Fields.List
 			case *ast.Ident:
-				if alias, ok := typ.Obj.Decl.(*ast.TypeSpec).Type.(*ast.InterfaceType); ok {
-					lst = alias.Methods.List
-				} else if alias, ok := typ.Obj.Decl.(*ast.TypeSpec).Type.(*ast.StructType); ok {
-					lst = alias.Fields.List
+				// ensure that aliases for non-struct/interface types continue to work
+				if typ.Obj != nil {
+					if alias, ok := typ.Obj.Decl.(*ast.TypeSpec).Type.(*ast.InterfaceType); ok {
+						lst = alias.Methods.List
+					} else if alias, ok := typ.Obj.Decl.(*ast.TypeSpec).Type.(*ast.StructType); ok {
+						lst = alias.Fields.List
+					}
 				}
 			}
 

--- a/pkg/genyaml/genyaml_test.go
+++ b/pkg/genyaml/genyaml_test.go
@@ -19,8 +19,13 @@ package genyaml
 import (
 	"bytes"
 	"encoding/json"
-	yaml3 "gopkg.in/yaml.v3"
 	"io/ioutil"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	yaml3 "gopkg.in/yaml.v3"
+	simplealiases "k8s.io/test-infra/pkg/genyaml/testdata/alias_simple_types"
 	aliases "k8s.io/test-infra/pkg/genyaml/testdata/alias_types"
 	embedded "k8s.io/test-infra/pkg/genyaml/testdata/embedded_structs"
 	interfaces "k8s.io/test-infra/pkg/genyaml/testdata/interface_types"
@@ -31,9 +36,6 @@ import (
 	pointers "k8s.io/test-infra/pkg/genyaml/testdata/pointer_types"
 	primitives "k8s.io/test-infra/pkg/genyaml/testdata/primitive_types"
 	private "k8s.io/test-infra/pkg/genyaml/testdata/private_members"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 const (
@@ -317,6 +319,13 @@ func TestGenYAML(t *testing.T) {
 			name: "alias types",
 			structObj: &aliases.Alias{
 				StringField: "string",
+			},
+			expected: true,
+		},
+		{
+			name: "alias simple types",
+			structObj: &simplealiases.SimpleAliases{
+				AliasField: simplealiases.Alias("string"),
 			},
 			expected: true,
 		},

--- a/pkg/genyaml/testdata/alias_simple_types/BUILD.bazel
+++ b/pkg/genyaml/testdata/alias_simple_types/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["example_config.go"],
+    importpath = "k8s.io/test-infra/pkg/genyaml/testdata/alias_simple_types",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test-data",
+    srcs = glob(["*"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/genyaml/testdata/alias_simple_types/alias_simple_types.yaml
+++ b/pkg/genyaml/testdata/alias_simple_types/alias_simple_types.yaml
@@ -1,0 +1,2 @@
+# AliasField is a specialized field
+string: string

--- a/pkg/genyaml/testdata/alias_simple_types/example_config.go
+++ b/pkg/genyaml/testdata/alias_simple_types/example_config.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package alias_simple_types
+
+type Alias string
+
+type SimpleAliases struct {
+	// AliasField is a specialized field
+	AliasField Alias `json:"string"`
+}


### PR DESCRIPTION
This fixes a panic that occurs when a type alias is defined for a non-struct/interface type. It's not terribly pretty, but gets the job done.