### PR TITLE
prow checkconfig: ignore gerrit jobs when validating trigger plugin enabled

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -935,8 +935,18 @@ func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 	configured := newOrgRepoConfig(map[string]sets.String{}, configuredRepos)
 	enabled := enabledOrgReposForPlugin(pcfg, trigger.PluginName, false)
 
-	if missing := configured.difference(enabled).items(); len(missing) > 0 {
-		return fmt.Errorf("the following repos have jobs configured but do not have the %s plugin enabled: %s", trigger.PluginName, strings.Join(missing, ", "))
+	missing := configured.difference(enabled).items()
+	var missNotGerrit []string
+	if len(missing) > 0 {
+		for _, repo := range missing {
+			if !strings.Contains(repo, "googlesource.com") {
+				missNotGerrit = append(missNotGerrit, repo)
+			}
+		}
+	}
+
+	if len(missNotGerrit) > 0 {
+		return fmt.Errorf("the following repos have jobs configured but do not have the %s plugin enabled: %s", trigger.PluginName, strings.Join(missNotGerrit, ", "))
 	}
 	return nil
 }

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -42,7 +42,7 @@ const (
 type Configuration struct {
 	// Plugins is a map of repositories (eg "k/k") to lists of
 	// plugin names.
-	// You can find a comprehensive list of the default avaulable plugins here
+	// You can find a comprehensive list of the default available plugins here
 	// https://github.com/kubernetes/test-infra/tree/master/prow/plugins
 	// note that you're also able to add external plugins.
 	Plugins map[string][]string `json:"plugins,omitempty"`


### PR DESCRIPTION
Modifies [checkconfig](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/checkconfig) to ignore gerrit repos when validating that the trigger plugin is enabled on repos that specified a job.

Fixes #14743 

/cc @cjwagner 