### PR TITLE
phaino: Default mount path to mount/<name>

### DIFF
--- a/prow/cmd/phaino/local.go
+++ b/prow/cmd/phaino/local.go
@@ -55,10 +55,15 @@ func scanln(ctx context.Context) (string, error) {
 }
 
 func readMount(ctx context.Context, mount coreapi.VolumeMount) (string, error) {
-	fmt.Fprintf(os.Stderr, "local %s path (%q mount): ", mount.MountPath, mount.Name)
+	defaultMount := "mounts/" + mount.Name
+
+	fmt.Fprintf(os.Stderr, "local %s path (%q mount, default %q): ", mount.MountPath, mount.Name, defaultMount)
 	out, err := scanln(ctx)
 	if err != nil {
 		return "", fmt.Errorf("scan: %v", err)
+	}
+	if out == "" {
+		out = defaultMount
 	}
 	return realPath(out)
 }


### PR DESCRIPTION
This should save people from having to type it in every time.

One thing I'm not sure about: do people instead just run from the same
directory normally?  (i.e. flatten all their secrets / config?)