### PR TITLE
Override plugin: Use GetPresubmits

### DIFF
--- a/prow/plugins/override/BUILD.bazel
+++ b/prow/plugins/override/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",


### PR DESCRIPTION
This changes the override plugin to use the `GetPresubmits` func to make it compatible with `inrepoconfig`, I missed it before.

I also refactored it a little to only do the `GetPresubmits` call once.

/assign @stevekuznetsov 