### PR TITLE
Use legacy_resolver for prometheus_operator

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,10 @@ run --workspace_status_command=./hack/print-workspace-status.sh
 build --incompatible_disable_deprecated_attr_params=false
 query --incompatible_disable_deprecated_attr_params=false
 
+# https://github.com/kubernetes/test-infra/issues/13239
+# https://github.com/bazelbuild/rules_k8s/issues/433
+build --host_force_python=PY2
+
 # enable data race detection
 test --features=race --test_output=errors
 

--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -7,7 +7,11 @@ release(
     "production",
     component("prow_monitoring", "namespace"),
     component("prometheus_operator_rbac", MULTI_KIND),
-    component("prometheus_operator", "deployment"),
+    component(
+        "prometheus_operator",
+        "deployment",
+        use_legacy_resolver = True,  # https://github.com/kubernetes/test-infra/issues/14678
+    ),
     component("prow_servicemonitors", MULTI_KIND),
     component("prometheus_rbac", MULTI_KIND),
     component("prow", "prometheus"),


### PR DESCRIPTION
/assign @hongkailiu @stevekuznetsov @chases2 
/cc @smukherj1 

Otherwise we get:
```
nable to get image quay.io/coreos/prometheus-operator:v0.29.0 from registry: unsupported MediaType: "application/vnd.docker.distribution.manifest.v1+prettyjws", see https://github.com/google/go-containerregistry/issues/377
```

ref https://github.com/kubernetes/test-infra/issues/14678 https://github.com/kubernetes/test-infra/issues/14763 https://github.com/bazelbuild/rules_k8s/issues/433 https://github.com/google/go-containerregistry/issues/377