### PR TITLE
testgrid: Update OpenShift dashboard naming to be consistent

### DIFF
--- a/config/testgrids/openshift/groups.yaml
+++ b/config/testgrids/openshift/groups.yaml
@@ -1,16 +1,17 @@
 dashboard_groups:
 - dashboard_names:
-  - redhat-openshift-ocp-release-4.1-blocking
-  - redhat-openshift-ocp-release-4.2-blocking
-  - redhat-openshift-ocp-release-4.2-informing
-  - redhat-openshift-ocp-release-4.3-blocking
-  - redhat-openshift-ocp-release-4.3-informing
-  - redhat-openshift-okd-release-4.1-blocking
-  - redhat-openshift-okd-release-4.1-informing
-  - redhat-openshift-okd-release-4.2-blocking
-  - redhat-openshift-okd-release-4.2-informing
-  - redhat-openshift-okd-release-4.3-blocking
-  - redhat-openshift-okd-release-4.3-informing
+  - redhat-openshift-informing
+  - redhat-openshift-release-4.1-blocking-ci
+  - redhat-openshift-release-4.1-blocking-ocp
+  - redhat-openshift-release-4.1-informing-ci
+  - redhat-openshift-release-4.2-blocking-ci
+  - redhat-openshift-release-4.2-blocking-ocp
+  - redhat-openshift-release-4.2-informing-ci
+  - redhat-openshift-release-4.2-informing-ocp
+  - redhat-openshift-release-4.3-blocking-ci
+  - redhat-openshift-release-4.3-blocking-ocp
+  - redhat-openshift-release-4.3-informing-ci
+  - redhat-openshift-release-4.3-informing-ocp
   - redhat-osd-int
   - redhat-osd-prod
   - redhat-osd-stage

--- a/config/testgrids/openshift/redhat-openshift-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-informing.yaml
@@ -1,0 +1,25 @@
+dashboards:
+- dashboard_tab:
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-origin-installer-e2e-aws-upgrade
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade
+  name: redhat-openshift-informing
+test_groups:
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade
+  name: release-openshift-origin-installer-e2e-aws-upgrade

--- a/config/testgrids/openshift/redhat-openshift-release-4.1-blocking-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.1-blocking-ci.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-4.3
+    name: release-openshift-origin-installer-e2e-aws-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-4.3
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.1
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-serial-4.3
+    name: release-openshift-origin-installer-e2e-aws-serial-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.3
-  name: redhat-openshift-okd-release-4.3-blocking
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
+  name: redhat-openshift-release-4.1-blocking-ci
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3
-  name: release-openshift-origin-installer-e2e-aws-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.3
-  name: release-openshift-origin-installer-e2e-aws-serial-4.3
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
+  name: release-openshift-origin-installer-e2e-aws-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
+  name: release-openshift-origin-installer-e2e-aws-serial-4.1

--- a/config/testgrids/openshift/redhat-openshift-release-4.1-blocking-ocp.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.1-blocking-ocp.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-4.2
+    name: release-openshift-ocp-installer-e2e-aws-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
+    test_group_name: release-openshift-ocp-installer-e2e-aws-4.1
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+    name: release-openshift-ocp-installer-e2e-aws-serial-4.1
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-  name: redhat-openshift-ocp-release-4.2-blocking
+    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.1
+  name: redhat-openshift-release-4.1-blocking-ocp
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
-  name: release-openshift-ocp-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
-  name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.1
+  name: release-openshift-ocp-installer-e2e-aws-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.1
+  name: release-openshift-ocp-installer-e2e-aws-serial-4.1

--- a/config/testgrids/openshift/redhat-openshift-release-4.1-informing-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.1-informing-ci.yaml
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1
-  name: redhat-openshift-okd-release-4.1-informing
+  name: redhat-openshift-release-4.1-informing-ci
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.1

--- a/config/testgrids/openshift/redhat-openshift-release-4.2-blocking-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.2-blocking-ci.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-4.3
+    name: release-openshift-origin-installer-e2e-aws-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-4.3
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-serial-4.3
+    name: release-openshift-origin-installer-e2e-aws-serial-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.3
-  name: redhat-openshift-ocp-release-4.3-blocking
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
+  name: redhat-openshift-release-4.2-blocking-ci
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.3
-  name: release-openshift-ocp-installer-e2e-aws-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.3
-  name: release-openshift-ocp-installer-e2e-aws-serial-4.3
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
+  name: release-openshift-origin-installer-e2e-aws-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
+  name: release-openshift-origin-installer-e2e-aws-serial-4.2

--- a/config/testgrids/openshift/redhat-openshift-release-4.2-blocking-ocp.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.2-blocking-ocp.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-4.1
+    name: release-openshift-ocp-installer-e2e-aws-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-4.1
+    test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-serial-4.1
+    name: release-openshift-ocp-installer-e2e-aws-serial-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.1
-  name: redhat-openshift-okd-release-4.1-blocking
+    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
+  name: redhat-openshift-release-4.2-blocking-ocp
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.1
-  name: release-openshift-origin-installer-e2e-aws-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.1
-  name: release-openshift-origin-installer-e2e-aws-serial-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
+  name: release-openshift-ocp-installer-e2e-aws-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
+  name: release-openshift-ocp-installer-e2e-aws-serial-4.2

--- a/config/testgrids/openshift/redhat-openshift-release-4.2-informing-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.2-informing-ci.yaml
@@ -228,7 +228,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.2
-  name: redhat-openshift-okd-release-4.2-informing
+  name: redhat-openshift-release-4.2-informing-ci
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2

--- a/config/testgrids/openshift/redhat-openshift-release-4.2-informing-ocp.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.2-informing-ocp.yaml
@@ -399,7 +399,45 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
-  name: redhat-openshift-ocp-release-4.2-informing
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-promote-openshift-machine-os-content-e2e-aws-4.1
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-promote-openshift-machine-os-content-e2e-aws-4.1
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-promote-openshift-machine-os-content-e2e-aws-4.2
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-promote-openshift-machine-os-content-e2e-aws-4.2
+  name: redhat-openshift-release-4.2-informing-ocp
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.2
   name: release-openshift-ocp-installer-console-aws-4.2
@@ -443,3 +481,7 @@ test_groups:
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
+- gcs_prefix: origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.1
+  name: release-promote-openshift-machine-os-content-e2e-aws-4.1
+- gcs_prefix: origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.2
+  name: release-promote-openshift-machine-os-content-e2e-aws-4.2

--- a/config/testgrids/openshift/redhat-openshift-release-4.3-blocking-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.3-blocking-ci.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-4.2
+    name: release-openshift-origin-installer-e2e-aws-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-4.2
+    test_group_name: release-openshift-origin-installer-e2e-aws-4.3
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-serial-4.2
+    name: release-openshift-origin-installer-e2e-aws-serial-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.2
-  name: redhat-openshift-okd-release-4.2-blocking
+    test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.3
+  name: redhat-openshift-release-4.3-blocking-ci
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.2
-  name: release-openshift-origin-installer-e2e-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.2
-  name: release-openshift-origin-installer-e2e-aws-serial-4.2
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3
+  name: release-openshift-origin-installer-e2e-aws-4.3
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.3
+  name: release-openshift-origin-installer-e2e-aws-serial-4.3

--- a/config/testgrids/openshift/redhat-openshift-release-4.3-blocking-ocp.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.3-blocking-ocp.yaml
@@ -11,14 +11,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-4.1
+    name: release-openshift-ocp-installer-e2e-aws-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-4.1
+    test_group_name: release-openshift-ocp-installer-e2e-aws-4.3
   - base_options: width=10
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -30,17 +30,17 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-ocp-installer-e2e-aws-serial-4.1
+    name: release-openshift-ocp-installer-e2e-aws-serial-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.1
-  name: redhat-openshift-ocp-release-4.1-blocking
+    test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.3
+  name: redhat-openshift-release-4.3-blocking-ocp
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.1
-  name: release-openshift-ocp-installer-e2e-aws-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.1
-  name: release-openshift-ocp-installer-e2e-aws-serial-4.1
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.3
+  name: release-openshift-ocp-installer-e2e-aws-4.3
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.3
+  name: release-openshift-ocp-installer-e2e-aws-serial-4.3

--- a/config/testgrids/openshift/redhat-openshift-release-4.3-informing-ci.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.3-informing-ci.yaml
@@ -209,7 +209,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
-  name: redhat-openshift-okd-release-4.3-informing
+  name: redhat-openshift-release-4.3-informing-ci
 test_groups:
 - gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.3-cnv

--- a/config/testgrids/openshift/redhat-openshift-release-4.3-informing-ocp.yaml
+++ b/config/testgrids/openshift/redhat-openshift-release-4.3-informing-ocp.yaml
@@ -380,7 +380,45 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
-  name: redhat-openshift-ocp-release-4.3-informing
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-openshift-ansible-e2e-aws-scaleup-rhel7-4.3
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-openshift-ansible-e2e-aws-scaleup-rhel7-4.3
+  - base_options: width=10
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-promote-openshift-machine-os-content-e2e-aws-4.3
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-promote-openshift-machine-os-content-e2e-aws-4.3
+  name: redhat-openshift-release-4.3-informing-ocp
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.3
   name: release-openshift-ocp-installer-console-aws-4.3
@@ -422,3 +460,7 @@ test_groups:
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
+- gcs_prefix: origin-ci-test/logs/release-openshift-openshift-ansible-e2e-aws-scaleup-rhel7-4.3
+  name: release-openshift-openshift-ansible-e2e-aws-scaleup-rhel7-4.3
+- gcs_prefix: origin-ci-test/logs/release-promote-openshift-machine-os-content-e2e-aws-4.3
+  name: release-promote-openshift-machine-os-content-e2e-aws-4.3


### PR DESCRIPTION
CI builds do not represent OKD, they are the source for both of those.
Also changed the ordering of segments to keep them visually close.
Added the new redhat-openshift-informing dashboard for jobs that
cross multiple releases.

/assign @stevekuznetsov

Generated by https://github.com/openshift/ci-tools/pull/212