### PR TITLE
releng: Add shadow kubernetes build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/shadow-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/shadow-builds.yaml
@@ -1,0 +1,66 @@
+periodics:
+- interval: 1h
+  name: ci-kubernetes-shadow-build
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=180
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-staging-release-test
+      - --allow-dup
+      - --extra-publish-file=k8s-master
+      - --hyperkube
+      - --registry=gcr.io/k8s-staging-release-test
+        # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-release-shadow-master-blocking
+    testgrid-tab-name: build-master
+    testgrid-alert-email: release-managers@kubernetes.io
+
+- interval: 5m
+  name: ci-kubernetes-shadow-build-fast
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=30
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-staging-release-test
+      - --allow-dup
+      - --fast
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 4
+          memory: "8Gi"
+  annotations:
+    testgrid-dashboards: sig-release-shadow-master-blocking
+    testgrid-tab-name: build-master-fast
+    testgrid-alert-email: release-managers@kubernetes.io
+    description: 'Ends up running: make quick-release'

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -21,6 +21,7 @@ dashboard_groups:
   - sig-release-misc
   - sig-release-publishing-bot
   - sig-release-release-notes-presubmits
+  - sig-release-shadow-master-blocking
 
 # Dashboards
 
@@ -69,3 +70,4 @@ dashboards:
   - name: test
     test_group_name: pull-release-notes-test
     base_options: width=10
+- name: sig-release-shadow-master-blocking


### PR DESCRIPTION
Here we add a set of "shadow jobs" (`ci-kubernetes-shadow-build` and
`ci-kubernetes-shadow-build-fast`), which mirror the configs of
`ci-kubernetes-build` and `ci-kubernetes-build-fast`, save a few
configuration details.

The intent here is to begin getting signal by pushing builds to the
community-hosted GCP project (`k8s-staging-release-test`) instead of the
Google-hosted one.

Having artifacts in the community-hosted GCP project will also enable us
to begin testing flows like building, signing, and publishing debs/rpms.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles 
cc: @kubernetes/release-engineering 
/sig release
/area release-eng