### PR TITLE
releng: Fix ci-release-build-packages-debs command

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -102,10 +102,7 @@ periodics:
     - image: gcr.io/k8s-staging-release-test/deb-builder:latest
       imagePullPolicy: Always
       command:
-      - ./deb-builder
-      args:
-      - -distros
-      - bionic
+      - ./debs
       resources:
         requests:
           cpu: 4


### PR DESCRIPTION
The deb building tool was refactored in https://github.com/kubernetes/release/pull/884, so the tool name change and flag changes were causing the test job to fail. This should fix it.

Fixes: https://github.com/kubernetes/kubernetes/issues/83888 (@alenkacz)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @calebamiles
cc: @kubernetes/release-engineering
/sig release
/area release-eng