### PR TITLE
[wip] Add plank prowjob pod metrics

### DIFF
--- a/prow/metrics/prowjobs/collector.go
+++ b/prow/metrics/prowjobs/collector.go
@@ -17,12 +17,15 @@ limitations under the License.
 package prowjobs
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -68,7 +71,7 @@ func update(histogramVec *prometheus.HistogramVec, oldJob *prowapi.ProwJob, newJ
 // Data is collected by hooking itself into the prowjob informer.
 // The collector will never record the same state transition twice, even if reboots happen.
 func NewProwJobLifecycleHistogramVec(informer cache.SharedIndexInformer) *prometheus.HistogramVec {
-	histogramVec := newHistogramVec()
+	histogramVec := newGenericProwJobHistogramVec()
 	informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: func(oldJob, newJob interface{}) {
 			update(histogramVec, oldJob.(*prowapi.ProwJob), newJob.(*prowapi.ProwJob))
@@ -114,7 +117,7 @@ func (jl *jobLabel) values() []string {
 	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.last_state, jl.state, jl.org, jl.repo, jl.baseRef}
 }
 
-func newHistogramVec() *prometheus.HistogramVec {
+func newGenericProwJobHistogramVec() *prometheus.HistogramVec {
 	return prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name: "prow_job_runtime_seconds",
@@ -156,4 +159,195 @@ func newHistogramVec() *prometheus.HistogramVec {
 			"base_ref",
 		},
 	)
+}
+
+func newPlankProwJobHistogramVec() *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "plank_pod_runtime_seconds",
+			Buckets: []float64{
+				time.Minute.Seconds() / 2,
+				(1 * time.Minute).Seconds(),
+				(2 * time.Minute).Seconds(),
+				(5 * time.Minute).Seconds(),
+				(10 * time.Minute).Seconds(),
+				(1 * time.Hour).Seconds() / 2,
+				(1 * time.Hour).Seconds(),
+				(2 * time.Hour).Seconds(),
+				(3 * time.Hour).Seconds(),
+				(4 * time.Hour).Seconds(),
+				(5 * time.Hour).Seconds(),
+				(6 * time.Hour).Seconds(),
+				(7 * time.Hour).Seconds(),
+				(8 * time.Hour).Seconds(),
+				(9 * time.Hour).Seconds(),
+				(10 * time.Hour).Seconds(),
+			},
+		},
+		[]string{
+			// namespace of the job
+			"job_namespace",
+			// name of the job
+			"job_name",
+			// type of the prowjob: presubmit, postsubmit, periodic, batch
+			"type",
+			// state of the prowjob pod: scheduled, initialized, run, postprocessed, succeeded, failed, unknown
+			"state",
+			// the org of the prowjob's repo
+			"org",
+			// the prowjob's repo
+			"repo",
+			// the base_ref of the prowjob's repo
+			"base_ref",
+		},
+	)
+}
+
+func updatePlank(histogramVec *prometheus.HistogramVec, jobInformer cache.SharedIndexInformer, oldPod *v1.Pod, newPod *v1.Pod) {
+	uid := newPod.ObjectMeta.Labels["prow.k8s.io/id"]
+	if uid == "" {
+		return
+	}
+	jobs, err := jobInformer.GetIndexer().Index("uid", uid)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to fetch prowJob from informer")
+		return
+	}
+	if len(jobs) == 0 {
+		return
+	}
+
+	if len(jobs) > 1 {
+		logrus.Error("Found more than one prowjob for pod")
+		return
+	}
+	job := jobs[0].(*prowapi.ProwJob)
+
+	if job.Status.PodName != newPod.Name {
+		// we don't care about this pod anymore
+		return
+	}
+
+	if newPod.DeletionTimestamp != nil {
+		// TODO, we will have to check for this on the ProwJob
+		return
+	}
+
+	oldState, oldTime := determineState(oldPod)
+	newState, newTime := determineState(newPod)
+
+	if oldState == newState {
+		return
+	}
+
+	labels := getPlankJobLabel(job, newState)
+	histogram, err := histogramVec.GetMetricWithLabelValues(labels.values()...)
+	if err != nil {
+		logrus.WithError(err).Error("Failed to get a histogram for a prowjob")
+		return
+	}
+	histogram.Observe(newTime.Sub(oldTime.Time).Seconds())
+}
+
+func determineState(pod *v1.Pod) (state string, timestamp metav1.Time) {
+	state = "scheduling"
+	timestamp = pod.CreationTimestamp
+	if scheduledCondition := getCondition(pod, v1.PodScheduled); scheduledCondition != nil {
+		state = "initializing"
+		timestamp = scheduledCondition.LastTransitionTime
+		if initContainerStatus := getInitContainerTerminationStatus(pod, "initupload"); initContainerStatus != nil {
+			timestamp = initContainerStatus.FinishedAt
+			if initContainerStatus.ExitCode == 0 {
+				state = "running"
+			} else {
+				state = "init_failed"
+			}
+		}
+		if testContainerStatus := getContainerTerminationStatus(pod, "test"); testContainerStatus != nil {
+			timestamp = testContainerStatus.FinishedAt
+			if testContainerStatus.ExitCode == 0 {
+				state = "succeeded"
+			} else {
+				state = "failed"
+			}
+			if sidecarStatus := getContainerTerminationStatus(pod, "sidecar"); sidecarStatus != nil {
+				timestamp = sidecarStatus.FinishedAt
+				if sidecarStatus.ExitCode == 0 {
+					state = "postprocessing_succeeded"
+				} else {
+					state = "postprocessing_failed"
+				}
+			}
+		}
+	}
+	return
+}
+
+// NewPlankJobLifecycleHistogramVec creates histograms which can track the timespan between ProwJob state transitions when plank is the agent.
+// The histograms are based on the job name, the old job state and the new job state.
+// Data is collected by hooking itself into the prowjob informer and checking pending substates from pods, which belong to the job.
+// The collector will never record the same state transition twice, even if reboots happen.
+func NewPlankJobLifecycleHistogramVec(jobInformer cache.SharedIndexInformer, podInformer cache.SharedIndexInformer) *prometheus.HistogramVec {
+	jobInformer.AddIndexers(map[string]cache.IndexFunc{"uid": MetaUIDIndexFunc})
+	histogramVec := newPlankProwJobHistogramVec()
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldPod, newPod interface{}) {
+			updatePlank(histogramVec, jobInformer, oldPod.(*v1.Pod), newPod.(*v1.Pod))
+		},
+	})
+	return histogramVec
+}
+
+func MetaUIDIndexFunc(obj interface{}) ([]string, error) {
+	meta, err := meta.Accessor(obj)
+	if err != nil {
+		return []string{""}, fmt.Errorf("object has no meta: %v", err)
+	}
+	return []string{string(meta.GetUID())}, nil
+}
+
+func getCondition(pod *v1.Pod, conditionType v1.PodConditionType) *v1.PodCondition {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == conditionType {
+			return &condition
+		}
+	}
+	return nil
+}
+
+func getContainerTerminationStatus(pod *v1.Pod, containerName string) *v1.ContainerStateTerminated {
+	for _, containerStatus := range pod.Status.ContainerStatuses {
+		if containerStatus.Name == containerName {
+			return containerStatus.State.Terminated
+		}
+	}
+	return nil
+}
+func getInitContainerTerminationStatus(pod *v1.Pod, containerName string) *v1.ContainerStateTerminated {
+	for _, containerStatus := range pod.Status.InitContainerStatuses {
+		if containerStatus.Name == containerName {
+			return containerStatus.State.Terminated
+		}
+	}
+	return nil
+}
+
+func getPlankJobLabel(newJob *prowapi.ProwJob, state string) jobLabel {
+	jl := jobLabel{
+		jobNamespace: newJob.Namespace,
+		jobName:      newJob.Spec.Job,
+		jobType:      string(newJob.Spec.Type),
+		state:        state,
+	}
+
+	if newJob.Spec.Refs != nil {
+		jl.org = newJob.Spec.Refs.Org
+		jl.repo = newJob.Spec.Refs.Repo
+		jl.baseRef = newJob.Spec.Refs.BaseRef
+	} else if len(newJob.Spec.ExtraRefs) > 0 {
+		jl.org = newJob.Spec.ExtraRefs[0].Org
+		jl.repo = newJob.Spec.ExtraRefs[0].Repo
+		jl.baseRef = newJob.Spec.ExtraRefs[0].BaseRef
+	}
+	return jl
 }

--- a/prow/metrics/prowjobs/collector_test.go
+++ b/prow/metrics/prowjobs/collector_test.go
@@ -209,7 +209,7 @@ func TestProwJobLifecycleCollectorUpdate(t *testing.T) {
 	for _, tt := range tests {
 		for x := 0; x < len(tt.oldJobStates); x++ {
 			t.Run(fmt.Sprintf(tt.name, tt.oldJobStates[x], tt.newJobStates[x]), func(t *testing.T) {
-				histogramVec := newHistogramVec()
+				histogramVec := newGenericProwJobHistogramVec()
 				tt.args.oldJob.Status.State = tt.oldJobStates[x]
 				tt.args.newJob.Status.State = tt.newJobStates[x]
 				update(histogramVec, tt.args.oldJob, tt.args.newJob)


### PR DESCRIPTION
Implement plank specific prowjob metrics. The collector uses Pod and ProwJob informers. It closely watches transitions on the pod and derives substates (scheduling, initializing, running/init_failed, succeeded/failed, postprocessing_succeeded/postprocessing_failed).