### PR TITLE
Upgrade bootstrap base and docker

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -14,7 +14,7 @@
 
 # Includes basic workspace setup, with gcloud and a bootstrap runner
 
-FROM debian:stretch
+FROM debian:buster
 
 WORKDIR /workspace
 RUN mkdir -p /workspace

--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -98,7 +98,7 @@ RUN curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID"
 # Trying to remount these makes for a very noisy error block in the beginning of
 # the pod logs, so we just comment out the call to it... :shrug:
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends docker-ce=5:18.09.* && \
+    apt-get install -y --no-install-recommends docker-ce=5:19.03.* && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
 


### PR DESCRIPTION
- debian buster has been the stable debian since ~july
- docker 18.06 was last patched in february, 19.03.X is the current stable docker and has seen very recent patches for security fixes (amongst other things)

there's a lot of fixes in docker in particular, however we should keep an eye on the upgrade for other deps (gcloud?)