### PR TITLE
CAPG CI job against k/k master

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -121,3 +121,47 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
     testgrid-tab-name: e2e-tests-stable
+- name: ci-cluster-api-provider-gcp-make-conformance-stable-k8s-ci-artifacts
+  interval: 3h
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191012-482f444-master
+        env:
+          - name: "CAPI_BRANCH"
+            value: "stable"
+          - name: "CABPK_BRANCH"
+            value: "stable"
+        args:
+          - "--repo=k8s.io/kubernetes=master"
+          - "--repo=sigs.k8s.io/cluster-api-provider-gcp=master"
+          - "--repo=sigs.k8s.io/cluster-api=master"
+          - "--repo=sigs.k8s.io/image-builder=master"
+          - "--repo=sigs.k8s.io/kind=master"
+          - "--root=/go/src"
+          - "--service-account=/etc/service-account/service-account.json"
+          - "--upload=gs://kubernetes-jenkins/logs"
+          - "--scenario=execute"
+          - "--"
+          - "bash"
+          - "--"
+          - "-c"
+          - "cd ./../../sigs.k8s.io/cluster-api-provider-gcp && scripts/ci-e2e.sh --use-ci-artifacts"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+    testgrid-tab-name: e2e-tests-stable-k8s-ci-artifacts


### PR DESCRIPTION
uses latest green CI builds from k/k with the "stable" version of CAPG and dependencies.