### PR TITLE
bump bootstrap to gcr.io/k8s-testimages/bootstrap:v20191015-70267a4

### DIFF
--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -57,7 +57,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=github.com/google/cadvisor
       - --root=/go/src

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -37,7 +37,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
@@ -71,7 +71,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.13.yaml
@@ -82,7 +82,7 @@ periodics:
       - --extra-publish-file=k8s-stable3
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:
@@ -109,7 +109,7 @@ periodics:
       - --branch=release-1.13
       - --force
       - --script=./hack/jenkins/verify-dockerized.sh
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:
@@ -201,7 +201,7 @@ periodics:
       - --branch=release-1.13
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -114,7 +114,7 @@ periodics:
       - --extra-publish-file=k8s-stable2
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:
@@ -245,7 +245,7 @@ periodics:
       - --branch=release-1.14
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -147,7 +147,7 @@ periodics:
       - --extra-publish-file=k8s-stable1
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:
@@ -295,7 +295,7 @@ periodics:
       - --branch=release-1.15
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -148,7 +148,7 @@ periodics:
       - --extra-publish-file=k8s-beta
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:
@@ -300,7 +300,7 @@ periodics:
       - --branch=release-1.16
       - --force
       - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       name: ""
       resources:
         requests:

--- a/config/jobs/kubernetes/sig-release/shadow-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/shadow-builds.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
@@ -41,7 +41,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -80,7 +80,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+    - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
       args:
       - --repo=k8s.io/kubernetes
       - --timeout=100

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -154,7 +154,7 @@ presubmits:
     - release-1.11
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20191001-e584f29
+      - image: gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -15,7 +15,7 @@
 # This file creates a build environment for building and running kubernetes
 # unit and integration tests
 
-FROM gcr.io/k8s-testimages/bootstrap:v20190611-228ec26
+FROM gcr.io/k8s-testimages/bootstrap:v20191015-70267a4
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
version from https://storage.googleapis.com/kubernetes-jenkins/logs/post-test-infra-push-bootstrap/1184210031193624576/artifacts/build.log (most recent post-test-infra-push-bootstrap)

ref: https://github.com/kubernetes/test-infra/pull/14784