### PR TITLE
Add users to checkconfig OWNERS file

### DIFF
--- a/prow/cmd/checkconfig/OWNERS
+++ b/prow/cmd/checkconfig/OWNERS
@@ -2,3 +2,6 @@
 
 approvers:
 - stevekuznetsov
+- cjwagner
+reviewers:
+- chases2


### PR DESCRIPTION
I'd like to begin doing reviews of Prow's config checker, to complement reviewing the configs themselves.

/assign @stevekuznetsov 
/cc @cjwagner 