### PR TITLE
add KIND RunTime Environment image

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -106,6 +106,7 @@ filegroup(
         "//hack:all-srcs",
         "//images/bootstrap/barnacle:all-srcs",
         "//images/builder:all-srcs",
+        "//images/krte:all-srcs",
         "//images/kubekins-e2e:all-srcs",
         "//jenkins:all-srcs",
         "//jobs:all-srcs",

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -540,6 +540,37 @@ postsubmits:
       - name: creds
         secret:
           secretName: deployer-service-account
+  - name: post-test-infra-push-krte
+    cluster: test-infra-trusted
+    run_if_changed: '^images/krte/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "krte"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: builds and pushes the krte image
+    decorate: true
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20191004-v0.1-140-g5a84471
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/krte/
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+        volumeMounts:
+        - name: creds
+          mountPath: /creds
+      volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
   - name: post-test-infra-push-kubekins-test
     cluster: test-infra-trusted
     run_if_changed: '^images/kubekins-test/'

--- a/images/krte/BUILD.bazel
+++ b/images/krte/BUILD.bazel
@@ -1,0 +1,13 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -1,0 +1,97 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes tools used for sigs.k8s.io/kind CI
+# NOTE: we attempt to avoid unnecessary tools and image layers while
+# supporting kubernetes builds, kind installation, etc.
+
+FROM debian:buster
+
+# arg that specifies the image name (for debugging)
+ARG IMAGE_ARG
+# arg that specifies the bazel version to install
+ARG BAZEL_VERSION_ARG=0.23.1
+
+# add envs:
+# - so we can debug with the image name:tag
+# - with the bazel version
+# - adding gsutil etc. to path (where we will install them)
+# - disabling prompts when installing gsutil etc.
+# - hinting that we are in a docker container
+ENV IMAGE=${IMAGE_ARG} \
+    BAZEL_VERSION=${BAZEL_VERSION_ARG} \
+    PATH=/google-cloud-sdk/bin:${PATH} \
+    CLOUDSDK_CORE_DISABLE_PROMPTS=1 \
+    CONTAINER=docker
+
+# copy in image utility scripts
+COPY ["wrapper.sh", "create_bazel_cache_rcs.sh", "install-bazel.sh", \
+        "/usr/local/bin/"]
+
+# Install tools needed to:
+# - install docker
+# - build kind (dockerized)
+# - build kubernetes (dockerized, or with bazel)
+#
+# TODO: the `sed` is a bit of a hack, look into alternatives.
+# Why this exists: `docker service start` on debian runs a `cgroupfs_mount` method,
+# We're already inside docker though so we can be sure these are already mounted.
+# Trying to remount these makes for a very noisy error block in the beginning of
+# the pod logs, so we just comment out the call to it... :shrug:
+RUN echo "Installing Packages ..." \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        apt-transport-https \
+        build-essential \
+        ca-certificates \
+        curl \
+        file \
+        git \
+        gnupg2 \
+        lsb-release \
+        mercurial \
+        pkg-config \
+        procps \
+        python \
+        python-dev \
+        python-pip \
+        software-properties-common \
+        unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "Installing Bazel ..." \
+    && install-bazel.sh \
+    && echo "Installing gcloud SDK, kubectl ..." \
+    && curl https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz --output google-cloud-sdk.tar.gz \
+    && tar xzf google-cloud-sdk.tar.gz -C / \
+    && rm google-cloud-sdk.tar.gz \
+    && /google-cloud-sdk/install.sh \
+        --disable-installation-options \
+        --bash-completion=false \
+        --path-update=false \
+        --usage-reporting=false \
+    && gcloud components install kubectl \
+    && echo "Installing docker ..." \
+    && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
+    && add-apt-repository \
+        "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
+         $(lsb_release -cs) stable" \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce \
+    && rm -rf /var/lib/apt/lists/* \
+    && sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker
+
+# entrypoint is our wrapper script, in Prow you will need to explicitly re-specify this
+ENTRYPOINT ["wrapper.sh"]
+# volume for docker in docker, use an emptyDir in Prow
+VOLUME ["/var/lib/docker"]

--- a/images/krte/Makefile
+++ b/images/krte/Makefile
@@ -1,0 +1,35 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+K8S ?= everything
+EXTRA_ARG =
+
+ifneq ($(K8S), everything)
+  EXTRA_ARG = --variant $(K8S)
+endif
+
+push-prod:
+	bazel run //images/builder -- $(EXTRA_ARG) --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/krte
+
+push:
+	bazel run //images/builder -- $(EXTRA_ARG) --allow-dirty images/krte
+
+.PHONY: push push-prod help
+
+help:
+	@echo "By default, build all the images"
+	@echo "But you can also specify one of a supported k8s version, \"experimental\", or \"master\", e.g."
+	@echo
+	@echo "    make build K8S=1.14"
+	@echo

--- a/images/krte/README.md
+++ b/images/krte/README.md
@@ -1,0 +1,3 @@
+krte - [KIND](https://sigs.k8s.io/kind) RunTime Environment
+
+This image contains things we need to run kind in Kubernetes CI

--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -1,0 +1,32 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
+    - --build-arg=GO_VERSION=$_GO_VERSION
+    - --build-arg=K8S_RELEASE=$_K8S_RELEASE
+    - --build-arg=BAZEL_VERSION_ARG=$_BAZEL_VERSION
+    - --build-arg=CFSSL_VERSION=$_CFSSL_VERSION
+    - --build-arg=UPGRADE_DOCKER_ARG=$_UPGRADE_DOCKER
+    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
+    - .
+    dir: images/krte
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - tag
+    - gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG
+    - gcr.io/$PROJECT_ID/krte:latest-$_CONFIG
+    dir: images/krte
+substitutions:
+  _GIT_TAG: '12345'
+  _CONFIG: master
+  _GO_VERSION: 1.12.1
+  _K8S_RELEASE: stable
+  _BAZEL_VERSION: 0.23.2
+  _UPGRADE_DOCKER: 'false'
+  _CFSSL_VERSION: R1.2
+options:
+  substitution_option: ALLOW_LOOSE
+images:
+  - 'gcr.io/$PROJECT_ID/krte:$_GIT_TAG-$_CONFIG'
+  - 'gcr.io/$PROJECT_ID/krte:latest-$_CONFIG'

--- a/images/krte/create_bazel_cache_rcs.sh
+++ b/images/krte/create_bazel_cache_rcs.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CACHE_HOST="bazel-cache.default.svc.cluster.local."
+CACHE_PORT="8080"
+
+# get the installed version of a debian package
+package_to_version () {
+    dpkg-query --showformat='${Version}' --show "$1"
+}
+
+# look up a binary with `command -v $1` and return the debian package it belongs to
+command_to_package () {
+    # NOTE: we resolve symlinks first because debian packages can provide alternatives
+    # by `update-alternatives` in postinit scripts, which updates a common
+    # symlink for a provided file to the backing entry.
+    # https://wiki.debian.org/DebianAlternatives
+    local binary_path
+    binary_path=$(readlink -f "$(command -v "$1")")
+    # `dpkg-query --search $file-pattern` outputs lines with the format: "$package: $file-path"
+    # where $file-path belongs to $package
+    # https://manpages.debian.org/jessie/dpkg/dpkg-query.1.en.html
+    dpkg-query --search "${binary_path}" | cut -d':' -f1
+}
+
+# get the installed package version relating to a binary
+command_to_version () {
+    local package
+    package=$(command_to_package "$1")
+    package_to_version "${package}"
+}
+
+hash_toolchains () {
+    # if $CC is set bazel will use this to detect c/c++ toolchains, otherwise gcc
+    # https://blog.bazel.build/2016/03/31/autoconfiguration.html
+    local cc="${CC:-gcc}"
+    local cc_version
+    cc_version=$(command_to_version "$cc")
+    # NOTE: IIRC some rules call python internally, this can't hurt
+    local python_version
+    python_version=$(command_to_version python)
+    # the rpm packaging rules use rpmbuild
+    local rpmbuild_version
+    rpmbuild_version=$(command_to_version rpmbuild)
+    # combine all tool versions into a hash
+    # NOTE: if we change the set of tools considered we should
+    # consider prepending the hash with a """schema version""" for completeness
+    local tool_versions
+    tool_versions="CC:${cc_version},PY:${python_version},RPM:${rpmbuild_version}"
+    echo "${tool_versions}" | md5sum | cut -d" " -f1
+}
+
+get_workspace () {
+    # get org/repo from prow, otherwise use $PWD
+    if [[ -n "${REPO_NAME}" ]] && [[ -n "${REPO_OWNER}" ]]; then
+        echo "${REPO_OWNER}/${REPO_NAME}"
+    else
+        echo "$(basename "$(dirname "$PWD")")/$(basename "$PWD")"
+    fi
+}
+
+make_bazel_rc () {
+    # this is the default for recent releases but we set it explicitly
+    # since this is the only hash our cache supports
+    echo "startup --host_jvm_args=-Dbazel.DigestFunction=sha256"
+    # use remote caching for all the things
+    # Only set this flag for older bazel versions, it is now enabled by 
+    # default and the flag was removed.
+    #
+    # NOTE: This is an exceptional case (version comparison)
+    # shellcheck disable=SC2072
+    # https://github.com/koalaman/shellcheck/wiki/SC2072#exceptions
+    if [[ "${BAZEL_VERSION:-}" < '0.25' ]]; then
+       echo "build --experimental_remote_spawn_cache"
+    fi
+    # don't fail if the cache is unavailable
+    echo "build --remote_local_fallback"
+    # point bazel at our http cache ...
+    # NOTE our caches are versioned by all path segments up until the last two
+    # IE PUT /foo/bar/baz/cas/asdf -> is in cache "/foo/bar/baz"
+    local cache_id
+    cache_id="$(get_workspace),$(hash_toolchains)"
+    local cache_url
+    cache_url="http://${CACHE_HOST}:${CACHE_PORT}/${cache_id}"
+    echo "build --remote_http_cache=${cache_url}"
+    # specifically for bazel 0.15.0 we want to set this flag
+    # our docker image now sets BAZEL_VERSION with the bazel version as installed
+    # https://github.com/bazelbuild/bazel/issues/5047#issuecomment-401295174
+    if [[ "${BAZEL_VERSION:-}" = "0.15.0" ]]; then
+        echo "build --remote_max_connections=200"
+    fi
+}
+
+# https://docs.bazel.build/versions/master/user-manual.html#bazelrc
+# bazel will look for two RC files, taking the first option in each set of paths
+# firstly:
+# - The path specified by the --bazelrc=file startup option. If specified, this option must appear before the command name (e.g. build)
+# - A file named .bazelrc in your base workspace directory
+# - A file named .bazelrc in your home directory
+bazel_rc_contents=$(make_bazel_rc)
+echo "create_bazel_cache_rcs.sh: Configuring '${HOME}/.bazelrc' and '/etc/bazel.bazelrc' with"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}"
+echo "# ------------------------------------------------------------------------------"
+echo "${bazel_rc_contents}" >> "${HOME}/.bazelrc"
+# Aside from the optional configuration file described above, Bazel also looks for a master rc file next to the binary, in the workspace at tools/bazel.rc or system-wide at /etc/bazel.bazelrc.
+# These files are here to support installation-wide options or options shared between users. Reading of this file can be disabled using the --nomaster_bazelrc option.
+echo "${bazel_rc_contents}" >> "/etc/bazel.bazelrc"
+# hopefully no repos create *both* of these ...

--- a/images/krte/install-bazel.sh
+++ b/images/krte/install-bazel.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# this script fetches and runs the upstream installer based on BAZEL_VERSION
+# like 0.14.0 or 0.14.0rc1 etc.
+set -o errexit
+set -o nounset
+
+# match BAZEL_VERSION to installer URL
+INSTALLER="bazel-${BAZEL_VERSION}-installer-linux-x86_64.sh"
+if [[ "${BAZEL_VERSION}" =~ ([0-9\.]+)(rc[0-9]+) ]]; then
+    DOWNLOAD_URL="https://storage.googleapis.com/bazel/${BASH_REMATCH[1]}/${BASH_REMATCH[2]}/${INSTALLER}"
+else
+    DOWNLOAD_URL="https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/${INSTALLER}"
+fi
+echo "$DOWNLOAD_URL"
+# get the installer
+curl -L --output "${INSTALLER}" "${DOWNLOAD_URL}" && chmod +x "${INSTALLER}"
+# install to user dir
+"./${INSTALLER}"
+# remove the installer, we no longer need it
+rm "${INSTALLER}"

--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,0 +1,34 @@
+# follow ./../kubekins-e2e
+# NOTE: we don't actually use GO_VERSION currently but /shrug
+variants:
+  experimental:
+    CONFIG: experimental
+    GO_VERSION: 1.12.10
+    K8S_RELEASE: stable
+    BAZEL_VERSION: 0.28.1
+    UPGRADE_DOCKER: 'true'
+  master:
+    CONFIG: master
+    GO_VERSION: 1.12.10
+    K8S_RELEASE: stable
+    BAZEL_VERSION: 0.23.2
+  '1.16':
+    CONFIG: '1.16'
+    GO_VERSION: 1.12.10
+    K8S_RELEASE: stable-1.16
+    BAZEL_VERSION: 0.23.2
+  '1.15':
+    CONFIG: '1.15'
+    GO_VERSION: 1.12.10
+    K8S_RELEASE: stable-1.15
+    BAZEL_VERSION: 0.23.2
+  '1.14':
+    CONFIG: '1.14'
+    GO_VERSION: 1.12.10
+    K8S_RELEASE: stable-1.14
+    BAZEL_VERSION: 0.21.0
+  '1.13':
+    CONFIG: '1.13'
+    GO_VERSION: 1.11.13
+    K8S_RELEASE: stable-1.13
+    BAZEL_VERSION: 0.18.1

--- a/images/krte/wrapper.sh
+++ b/images/krte/wrapper.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# generic wrapper script, handles DIND, bazelrc for caching, etc.
+
+# Check if the job has opted-in to bazel remote caching and if so generate 
+# .bazelrc entries pointing to the remote cache
+export BAZEL_REMOTE_CACHE_ENABLED=${BAZEL_REMOTE_CACHE_ENABLED:-false}
+if [[ "${BAZEL_REMOTE_CACHE_ENABLED}" == "true" ]]; then
+    echo "Bazel remote cache is enabled, generating .bazelrcs ..."
+    /usr/local/bin/create_bazel_cache_rcs.sh
+fi
+
+
+# terminate any remaining containers
+cleanup_dind() {
+    docker ps -aq | xargs docker rm -f
+}
+
+# optionally enable ipv6 docker
+export DOCKER_IN_DOCKER_IPV6_ENABLED=${DOCKER_IN_DOCKER_IPV6_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_IPV6_ENABLED}" == "true" ]]; then
+    echo "Enabling IPV6 for Docker."
+    # configure the daemon with ipv6
+    mkdir -p /etc/docker/
+    cat <<EOF >/etc/docker/daemon.json
+{
+  "ipv6": true,
+  "fixed-cidr-v6": "fc00:db8:1::/64"
+}
+EOF
+    # enable ipv6
+    sysctl net.ipv6.conf.all.disable_ipv6=0
+    sysctl net.ipv6.conf.all.forwarding=1
+    # enable ipv6 iptables
+    modprobe -v ip6table_nat
+fi
+
+# Check if the job has opted-in to docker-in-docker availability.
+export DOCKER_IN_DOCKER_ENABLED=${DOCKER_IN_DOCKER_ENABLED:-false}
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Docker in Docker enabled, initializing..."
+    printf '=%.0s' {1..80}; echo
+    # If we have opted in to docker in docker, start the docker daemon,
+    service docker start
+    # the service can be started but the docker socket not ready, wait for ready
+    WAIT_N=0
+    MAX_WAIT=5
+    while true; do
+        # docker ps -q should only work if the daemon is ready
+        docker ps -q > /dev/null 2>&1 && break
+        if [[ ${WAIT_N} -lt ${MAX_WAIT} ]]; then
+            WAIT_N=$((WAIT_N+1))
+            echo "Waiting for docker to be ready, sleeping for ${WAIT_N} seconds."
+            sleep ${WAIT_N}
+        else
+            echo "Reached maximum attempts, not waiting any longer..."
+            break
+        fi
+    done
+    cleanup_dind
+    printf '=%.0s' {1..80}; echo
+    echo "Done setting up docker in docker."
+fi
+
+# disable error exit so we can run post-command cleanup
+set +o errexit
+
+# add $GOPATH/bin to $PATH
+export GOPATH="${GOPATH:-${HOME}/go}"
+export PATH="${GOPATH}/bin:${PATH}"
+mkdir -p "${GOPATH}/bin"
+# Authenticate gcloud, allow failures
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+fi
+
+# Use a reproducible build date based on the most recent git commit timestamp.
+SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct || true)
+export SOURCE_DATE_EPOCH
+
+# actually start the user supplied command
+set -o xtrace
+"$@"
+EXIT_VALUE=$?
+set +o xtrace
+
+# cleanup after job
+if [[ "${DOCKER_IN_DOCKER_ENABLED}" == "true" ]]; then
+    echo "Cleaning up after docker in docker."
+    printf '=%.0s' {1..80}; echo
+    cleanup_dind
+    printf '=%.0s' {1..80}; echo
+    echo "Done cleaning up after docker in docker."
+fi
+
+# preserve exit value from user supplied command
+exit ${EXIT_VALUE}


### PR DESCRIPTION
My goal is to create an image for use with pod-utils jobs that test kubernetes with [kind](https://sigs.k8s.io/kind).

This is similar to kubekins-e2e but:
- no support for legacy bootstrap.py behavior and other legacy oddities
- trimmed out some unnecessary dependencies for this use case (I'm sure there's lots of room to iterate and fine tune this)
- generally trying to simplify
- way less layers / tighter coupling (pushing / pulling kubekins-e2e is comical due to these ...)

This PR is an MVP to get the infra up. I'll follow-up with work to get a kind canary job on this image and refine / further reduce cruft.

I would refine kubekins-e2e but .. it's used by tons of legacy bootstrap jobs using all sorts of quirks, instead I intend to explore cutting it down in a new image...