### PR TITLE
Add prometheus alerts for Tide progress.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/prometheus/BUILD.bazel
@@ -8,6 +8,8 @@ jsonnet_library(
         "hook_alert.libsonnet",
         "prometheus.libsonnet",
         "prow_monitoring_absent_alerts.libsonnet",
+        "sinker_alerts.libsonnet",
+        "tide_alerts.libsonnet",
     ],
 )
 

--- a/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -1,4 +1,6 @@
 (import 'ci_absent_alerts.libsonnet') +
 (import 'prow_monitoring_absent_alerts.libsonnet') +
 (import 'configmap_alerts.libsonnet') +
-(import 'hook_alert.libsonnet')
+(import 'hook_alert.libsonnet') +
+(import 'sinker_alerts.libsonnet') +
+(import 'tide_alerts.libsonnet')

--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -1,0 +1,55 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'Tide progress',
+        rules: [
+          {
+            alert: 'TideNoProgressKK',
+            expr: |||
+              clamp_min(
+              (sum(merges_sum{org="kubernetes",repo="kubernetes",branch="master"}) or vector(0))
+               - (sum(merges_sum{org="kubernetes",repo="kubernetes",branch="master"} offset 5m ) or vector(0)),
+              0) < 0.5
+              and
+              max(min_over_time(pooledprs{org="kubernetes",repo="kubernetes",branch="master"}[4h])) > 0.5
+            |||,
+            'for': '4h',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'Tide has not merged any PRs in kubernetes/kubernetes:master in the past 4 hours despite PRs in the pool.',
+            },
+          },
+          {
+            alert: 'TideSyncLoopDuration',
+            expr: |||
+              avg_over_time(syncdur{job="tide"}[15m]) > 120
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'The Tide sync controllers loop period has averaged more than 2 minutes for the last 15 mins.',
+            },
+          },
+          {
+            alert: 'TideStatusUpdateLoopDuration',
+            expr: |||
+              avg_over_time(statusupdatedur{job="tide"}[15m]) > 120
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'The Tide status update controllers loop period has averaged more than 2 minutes for the last 15 mins.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}


### PR DESCRIPTION
I'm not sure how to test these besides by running the queries against prometheus and trying to determine when the alert would have fired. Let me know if there is a better way. I'm also happy to start with more strict or forgiving alert thresholds if that is preferred.

I noticed `severity: 'slack',` used for some alerts. Is that required to route alerts to slack?
/assign @stevekuznetsov @hongkailiu 

I intend to add a metric to track pool sync error rates next.