### PR TITLE
Fix failures when no update of image is made (2)

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -118,6 +118,19 @@ func getNewProwVersion(images map[string]string) string {
 	return ""
 }
 
+// HasChanges checks if the current git repo contains any changes
+func HasChanges() (bool, error) {
+	cmd := "git"
+	args := []string{"status", "--porcelain"}
+	logrus.WithField("cmd", cmd).WithField("args", args).Info("running command ...")
+	combinedOutput, err := exec.Command(cmd, args...).CombinedOutput()
+	if err != nil {
+		logrus.WithField("cmd", cmd).Debugf("output is '%s'", string(combinedOutput))
+		return false, err
+	}
+	return len(strings.TrimSuffix(string(combinedOutput), "\n")) > 0, nil
+}
+
 func makeCommitSummary(images map[string]string) string {
 	return fmt.Sprintf("Update prow to %s, and other images as necessary.", getNewProwVersion(images))
 }

--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -159,7 +159,12 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to update references.")
 	}
 
-	if len(images) == 0 {
+	changed, err := bumper.HasChanges()
+	if err != nil {
+		logrus.WithError(err).Fatal("error occurred when checking changes")
+	}
+
+	if !changed {
 		logrus.Info("no images updated, exiting ...")
 		return
 	}


### PR DESCRIPTION
The reason is that the images map returned from bumper pkg does not
reflect the files that have been modifed.

We implement this by a git-status call.

[1]. https://github.com/kubernetes/test-infra/pull/14649

/cc @stevekuznetsov 