### PR TITLE
Handle embedded inline structs in genyaml

### DIFF
--- a/pkg/genyaml/BUILD.bazel
+++ b/pkg/genyaml/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "@com_github_clarketm_json//:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 
@@ -21,6 +22,7 @@ go_test(
         "//pkg/genyaml/testdata/alias_simple_types:go_default_library",
         "//pkg/genyaml/testdata/alias_types:go_default_library",
         "//pkg/genyaml/testdata/embedded_structs:go_default_library",
+        "//pkg/genyaml/testdata/inline_structs:go_default_library",
         "//pkg/genyaml/testdata/interface_types:go_default_library",
         "//pkg/genyaml/testdata/multiline_comments:go_default_library",
         "//pkg/genyaml/testdata/nested_structs:go_default_library",
@@ -40,6 +42,7 @@ filegroup(
         "//pkg/genyaml/testdata/alias_types:test-data",
         "//pkg/genyaml/testdata/embedded_structs:test-data",
         "//pkg/genyaml/testdata/inject_comments:test-data",
+        "//pkg/genyaml/testdata/inline_structs:test-data",
         "//pkg/genyaml/testdata/interface_types:test-data",
         "//pkg/genyaml/testdata/multiline_comments:test-data",
         "//pkg/genyaml/testdata/multiple_paths:test-data",
@@ -69,6 +72,7 @@ filegroup(
         "//pkg/genyaml/testdata/alias_types:all-srcs",
         "//pkg/genyaml/testdata/embedded_structs:all-srcs",
         "//pkg/genyaml/testdata/inject_comments:all-srcs",
+        "//pkg/genyaml/testdata/inline_structs:all-srcs",
         "//pkg/genyaml/testdata/interface_types:all-srcs",
         "//pkg/genyaml/testdata/multiline_comments:all-srcs",
         "//pkg/genyaml/testdata/multiple_paths:all-srcs",

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -74,6 +74,7 @@ import (
 
 	"github.com/clarketm/json"
 	yaml3 "gopkg.in/yaml.v3"
+	"k8s.io/apimachinery/pkg/util/sets"
 )
 
 const (
@@ -190,18 +191,19 @@ func fmtRawDoc(rawDoc string) string {
 	return postDoc
 }
 
+// fieldTag extracts the given tag or returns an empty string if the tag is not defined.
+func fieldTag(field *ast.Field, tag string) string {
+	if field.Tag == nil {
+		return ""
+	}
+
+	return reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get(tag)
+}
+
 // fieldName extracts the name of the field as it should appear in YAML format and returns the resultant string.
 // "-" indicates that this field is not part of the YAML representation and is thus excluded.
 func fieldName(field *ast.Field, tag string) string {
-	tagVal := ""
-	if field.Tag != nil {
-		tagVal = reflect.StructTag(field.Tag.Value[1 : len(field.Tag.Value)-1]).Get(tag) // Delete first and last quotation.
-		if strings.Contains(tagVal, "inline") {
-			return "-"
-		}
-	}
-
-	tagVal = strings.Split(tagVal, ",")[0] // This can return "-".
+	tagVal := strings.Split(fieldTag(field, tag), ",")[0] // This can return "-".
 	if tagVal == "" {
 		// Set field name to the defined name in struct if defined.
 		if field.Names != nil {
@@ -212,6 +214,13 @@ func fieldName(field *ast.Field, tag string) string {
 		return name
 	}
 	return tagVal
+}
+
+// fieldIsInlined returns true if the field is tagged with ",inline"
+func fieldIsInlined(field *ast.Field, tag string) bool {
+	values := sets.NewString(strings.Split(fieldTag(field, tag), ",")...)
+
+	return values.Has("inline")
 }
 
 // fieldType extracts the type of the field and returns the resultant string type and a bool indicating if it is an object type.
@@ -256,6 +265,8 @@ func (cm *CommentMap) genDocMap(path string) error {
 		return errors.New("unable to generate AST documentation map")
 	}
 
+	inlineFields := map[string][]string{}
+
 	for _, t := range pkg.Types {
 		if typeSpec, ok := t.Decl.Specs[0].(*ast.TypeSpec); ok {
 
@@ -287,7 +298,26 @@ func (cm *CommentMap) genDocMap(path string) error {
 					typeName, isObj := fieldType(field, true)
 					docString := fmtRawDoc(field.Doc.Text())
 					cm.comments[typeSpecName][tagName] = Comment{typeName, isObj, docString}
+
+					if fieldIsInlined(field, jsonTag) {
+						existing, ok := inlineFields[typeSpecName]
+						if !ok {
+							existing = []string{}
+						}
+						inlineFields[typeSpecName] = append(existing, tagName)
+					}
 				}
+			}
+		}
+	}
+
+	// copy comments for inline fields from their original parent structures; this is needed
+	// because when walking the generated YAML, the step to switch to the "correct" parent
+	// struct is missing
+	for typeSpecName, inlined := range inlineFields {
+		for _, inlinedType := range inlined {
+			for tagName, comment := range cm.comments[inlinedType] {
+				cm.comments[typeSpecName][tagName] = comment
 			}
 		}
 	}

--- a/pkg/genyaml/genyaml_test.go
+++ b/pkg/genyaml/genyaml_test.go
@@ -28,6 +28,7 @@ import (
 	simplealiases "k8s.io/test-infra/pkg/genyaml/testdata/alias_simple_types"
 	aliases "k8s.io/test-infra/pkg/genyaml/testdata/alias_types"
 	embedded "k8s.io/test-infra/pkg/genyaml/testdata/embedded_structs"
+	inlines "k8s.io/test-infra/pkg/genyaml/testdata/inline_structs"
 	interfaces "k8s.io/test-infra/pkg/genyaml/testdata/interface_types"
 	multiline "k8s.io/test-infra/pkg/genyaml/testdata/multiline_comments"
 	nested "k8s.io/test-infra/pkg/genyaml/testdata/nested_structs"
@@ -359,6 +360,15 @@ func TestGenYAML(t *testing.T) {
 					{Name: "Jenny", Age: 5},
 				},
 				Name: "Mildred",
+			},
+			expected: true,
+		},
+		{
+			name: "inline structs",
+			structObj: &inlines.Resource{
+				Metadata: inlines.Metadata{
+					Name: "test",
+				},
 			},
 			expected: true,
 		},

--- a/pkg/genyaml/testdata/inline_structs/BUILD.bazel
+++ b/pkg/genyaml/testdata/inline_structs/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["example_config.go"],
+    importpath = "k8s.io/test-infra/pkg/genyaml/testdata/inline_structs",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test-data",
+    srcs = glob(["*"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/genyaml/testdata/inline_structs/example_config.go
+++ b/pkg/genyaml/testdata/inline_structs/example_config.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inline_structs
+
+type Metadata struct {
+	// Name is the name of a resource.
+	Name string `json:"name"`
+}
+
+type Resource struct {
+	// This comment string disappears due to the inlining.
+	Metadata `json:",inline"`
+}

--- a/pkg/genyaml/testdata/inline_structs/inline_structs.yaml
+++ b/pkg/genyaml/testdata/inline_structs/inline_structs.yaml
@@ -1,0 +1,2 @@
+# Name is the name of a resource.
+name: test


### PR DESCRIPTION
When inlining an embedded struct, the owning struct's name is not available for searching the comments.

This PR copies comments from the actual owning struct to every struct that inlines the owner. This makes comments for fields of embedded inline structs available to the top level structure.

I don't know why inline fields were explicitly ignored so far. I would either remove this restriction or make it configurable.