### PR TITLE
Revert "Make autobumper ignore existing PRs that have `lgtm` and `app…

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -76,7 +76,7 @@ func UpdatePR(gc github.Client, org, repo string, images map[string]string, extr
 // with "title" and "body" of PR matching "matchTitle" from "source" to "branch"
 func UpdatePullRequest(gc github.Client, org, repo, title, body, matchTitle, source, branch string) error {
 	logrus.Info("Creating or updating PR...")
-	n, err := updater.EnsurePR(org, repo, title, body, source, branch, matchTitle, "-label:lgtm -label:approved", gc)
+	n, err := updater.EnsurePR(org, repo, title, body, source, branch, matchTitle, gc)
 	if err != nil {
 		return fmt.Errorf("failed to ensure PR exists: %v", err)
 	}

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -98,7 +98,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to create github client")
 	}
 
-	n, err := updater.EnsurePR(o.org, o.repo, o.title, o.body, o.source, o.branch, o.matchTitle, "", gc)
+	n, err := updater.EnsurePR(o.org, o.repo, o.title, o.body, o.source, o.branch, o.matchTitle, gc)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to ensure PR exists.")
 	}

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -35,7 +35,7 @@ type ensureClient interface {
 	CreatePullRequest(org, repo, title, body, head, base string, canModify bool) (int, error)
 }
 
-func UpdatePR(org, repo, title, body, matchTitle, extraQuery string, gc updateClient) (*int, error) {
+func UpdatePR(org, repo, title, body, matchTitle string, gc updateClient) (*int, error) {
 	if matchTitle == "" {
 		return nil, nil
 	}
@@ -46,8 +46,7 @@ func UpdatePR(org, repo, title, body, matchTitle, extraQuery string, gc updateCl
 		return nil, fmt.Errorf("bot name: %v", err)
 	}
 
-	query := fmt.Sprintf("is:open is:pr archived:false author:%s in:title %s %s", me, matchTitle, extraQuery)
-	issues, err := gc.FindIssues(query, "updated", false)
+	issues, err := gc.FindIssues("is:open is:pr archived:false in:title author:"+me+" "+matchTitle, "updated", false)
 	if err != nil {
 		return nil, fmt.Errorf("find issues: %v", err)
 	} else if len(issues) == 0 {
@@ -66,8 +65,8 @@ func UpdatePR(org, repo, title, body, matchTitle, extraQuery string, gc updateCl
 	return &n, nil
 }
 
-func EnsurePR(org, repo, title, body, source, branch, matchTitle, extraQuery string, gc ensureClient) (*int, error) {
-	n, err := UpdatePR(org, repo, title, body, matchTitle, extraQuery, gc)
+func EnsurePR(org, repo, title, body, source, branch, matchTitle string, gc ensureClient) (*int, error) {
+	n, err := UpdatePR(org, repo, title, body, matchTitle, gc)
 	if err != nil {
 		return nil, fmt.Errorf("update error: %v", err)
 	}


### PR DESCRIPTION
…roved` labels."

This reverts commit 291f2cc9a9eaf26f4fdd592237d5409877c2e914.

Reverts https://github.com/kubernetes/test-infra/pull/14472
fixes https://github.com/kubernetes/test-infra/issues/14801
/assign @fejta 