### PR TITLE
trivial change to krte to trigger the image push postsubmit

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -81,7 +81,7 @@ RUN echo "Installing Packages ..." \
         --path-update=false \
         --usage-reporting=false \
     && gcloud components install kubectl \
-    && echo "Installing docker ..." \
+    && echo "Installing Docker ..." \
     && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
     && add-apt-repository \
         "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \


### PR DESCRIPTION
obviously the postsubmit will not run when we first add it :man_shrugging: 
https://prow.k8s.io/?repo=kubernetes%2Ftest-infra&type=postsubmit
technically this is as slight (unnecessary) consistency fix anyhow :man_shrugging: 

/cc @amwat @Katharine 