### PR TITLE
[Gerrit] Modify lastUpdate to be per project instead of global.

### DIFF
--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -149,7 +149,7 @@ func TestSyncTime(t *testing.T) {
 	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	cur := (*st.Current())["foo"]["bar"]
+	cur := st.Current()["foo"]["bar"]
 	if now.After(cur) {
 		t.Fatalf("%v should be >= time before init was called: %v", cur, now)
 	}
@@ -157,17 +157,17 @@ func TestSyncTime(t *testing.T) {
 	earlier := now.Add(-time.Hour)
 	later := now.Add(time.Hour)
 
-	if err := st.Update(&client.LastSyncState{"foo": {"bar": earlier}}); err != nil {
+	if err := st.Update(client.LastSyncState{"foo": {"bar": earlier}}); err != nil {
 		t.Fatalf("Failed update: %v", err)
 	}
-	if actual := (*st.Current())["foo"]["bar"]; !actual.Equal(cur) {
+	if actual := st.Current()["foo"]["bar"]; !actual.Equal(cur) {
 		t.Errorf("Update(%v) should not have reduced value from %v, got %v", earlier, cur, actual)
 	}
 
-	if err := st.Update(&client.LastSyncState{"foo": {"bar": later}}); err != nil {
+	if err := st.Update(client.LastSyncState{"foo": {"bar": later}}); err != nil {
 		t.Fatalf("Failed update: %v", err)
 	}
-	if actual := (*st.Current())["foo"]["bar"]; !actual.After(cur) {
+	if actual := st.Current()["foo"]["bar"]; !actual.After(cur) {
 		t.Errorf("Update(%v) did not move current value to after %v, got %v", later, cur, actual)
 	}
 
@@ -180,7 +180,7 @@ func TestSyncTime(t *testing.T) {
 	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	if actual := (*st.Current())["foo"]["bar"]; !actual.Equal(expected) {
+	if actual := st.Current()["foo"]["bar"]; !actual.Equal(expected) {
 		t.Errorf("init() failed to reload %v, got %v", expected, actual)
 	}
 
@@ -192,7 +192,7 @@ func TestSyncTime(t *testing.T) {
 	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	if actual := (*st.Current())["foo"]["bar"]; now.After(actual) || actual.After(later) {
+	if actual := st.Current()["foo"]["bar"]; now.After(actual) || actual.After(later) {
 		t.Fatalf("should initialize to start %v <= actual <= later %v, but got %v", now, later, actual)
 	}
 }

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -144,11 +144,12 @@ func TestSyncTime(t *testing.T) {
 		opener: open,
 		ctx:    ctx,
 	}
+	testProjectsFlag := client.ProjectsFlag{"foo": []string{"bar"}}
 	now := time.Now()
-	if err := st.init(); err != nil {
+	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	cur := st.Current()
+	cur := (*st.Current())["foo"]["bar"]
 	if now.After(cur) {
 		t.Fatalf("%v should be >= time before init was called: %v", cur, now)
 	}
@@ -156,30 +157,30 @@ func TestSyncTime(t *testing.T) {
 	earlier := now.Add(-time.Hour)
 	later := now.Add(time.Hour)
 
-	if err := st.Update(earlier); err != nil {
+	if err := st.Update(&client.LastSyncState{"foo": {"bar": earlier}}); err != nil {
 		t.Fatalf("Failed update: %v", err)
 	}
-	if actual := st.Current(); !actual.Equal(cur) {
+	if actual := (*st.Current())["foo"]["bar"]; !actual.Equal(cur) {
 		t.Errorf("Update(%v) should not have reduced value from %v, got %v", earlier, cur, actual)
 	}
 
-	if err := st.Update(later); err != nil {
+	if err := st.Update(&client.LastSyncState{"foo": {"bar": later}}); err != nil {
 		t.Fatalf("Failed update: %v", err)
 	}
-	if actual := st.Current(); !actual.After(cur) {
+	if actual := (*st.Current())["foo"]["bar"]; !actual.After(cur) {
 		t.Errorf("Update(%v) did not move current value to after %v, got %v", later, cur, actual)
 	}
 
-	expected := later.Truncate(time.Second)
+	expected := later
 	st = syncTime{
 		path:   path,
 		opener: open,
 		ctx:    ctx,
 	}
-	if err := st.init(); err != nil {
+	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	if actual := st.Current(); !actual.Equal(expected) {
+	if actual := (*st.Current())["foo"]["bar"]; !actual.Equal(expected) {
 		t.Errorf("init() failed to reload %v, got %v", expected, actual)
 	}
 
@@ -188,10 +189,10 @@ func TestSyncTime(t *testing.T) {
 		opener: fakeOpener{}, // return storage.ErrObjectNotExist on open
 		ctx:    ctx,
 	}
-	if err := st.init(); err != nil {
+	if err := st.init(testProjectsFlag); err != nil {
 		t.Fatalf("Failed init: %v", err)
 	}
-	if actual := st.Current(); now.After(actual) || actual.After(later) {
+	if actual := (*st.Current())["foo"]["bar"]; now.After(actual) || actual.After(later) {
 		t.Fatalf("should initialize to start %v <= actual <= later %v, but got %v", now, later, actual)
 	}
 }

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -40,7 +40,7 @@ type prowJobClient interface {
 }
 
 type gerritClient interface {
-	QueryChanges(lastUpdate time.Time, rateLimit int) map[string][]client.ChangeInfo
+	QueryChanges(lastState *client.LastSyncState, rateLimit int) map[string][]client.ChangeInfo
 	GetBranchRevision(instance, project, branch string) (string, error)
 	SetReview(instance, id, revision, message string, labels map[string]string) error
 	Account(instance string) *gerrit.AccountInfo
@@ -59,8 +59,8 @@ type Controller struct {
 }
 
 type LastSyncTracker interface {
-	Current() time.Time
-	Update(time.Time) error
+	Current() *client.LastSyncState
+	Update(*client.LastSyncState) error
 }
 
 // NewController returns a new gerrit controller client
@@ -87,22 +87,24 @@ func NewController(lastSyncTracker LastSyncTracker, cookiefilePath string, proje
 // and creates prowjobs according to specs
 func (c *Controller) Sync() error {
 	syncTime := c.tracker.Current()
-	latest := syncTime
+	latest := syncTime.DeepCopy()
 
 	for instance, changes := range c.gc.QueryChanges(syncTime, c.config().Gerrit.RateLimit) {
 		for _, change := range changes {
 			if err := c.ProcessChange(instance, change); err != nil {
 				logrus.WithError(err).Errorf("Failed process change %v", change.CurrentRevision)
 			}
-			if latest.Before(change.Updated.Time) {
-				latest = change.Updated.Time
+			lastTime, ok := latest[instance][change.Project]
+			if !ok || lastTime.Before(change.Updated.Time) {
+				lastTime = change.Updated.Time
+				latest[instance][change.Project] = lastTime
 			}
 		}
 
 		logrus.Infof("Processed %d changes for instance %s", len(changes), instance)
 	}
 
-	return c.tracker.Update(latest)
+	return c.tracker.Update(&latest)
 }
 
 func makeCloneURI(instance, project string) (*url.URL, error) {
@@ -241,7 +243,13 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		if latestReport != nil {
 			logger.Infof("Found latest report: %s", latestReport)
 		}
-		lastUpdate := c.tracker.Current()
+
+		lastUpdate, ok := (*c.tracker.Current())[instance][change.Project]
+		if !ok {
+			logrus.Warnf("could not find lastTime for project %q, probably something went wrong with initTracker?", change.Project)
+			lastUpdate = time.Now()
+		}
+
 		filter, err := messageFilter(lastUpdate, change, presubmits, latestReport, logger)
 		if err != nil {
 			logger.WithError(err).Warn("failed to create filter on messages for presubmits")

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -40,7 +40,7 @@ type prowJobClient interface {
 }
 
 type gerritClient interface {
-	QueryChanges(lastState *client.LastSyncState, rateLimit int) map[string][]client.ChangeInfo
+	QueryChanges(lastState client.LastSyncState, rateLimit int) map[string][]client.ChangeInfo
 	GetBranchRevision(instance, project, branch string) (string, error)
 	SetReview(instance, id, revision, message string, labels map[string]string) error
 	Account(instance string) *gerrit.AccountInfo
@@ -59,8 +59,8 @@ type Controller struct {
 }
 
 type LastSyncTracker interface {
-	Current() *client.LastSyncState
-	Update(*client.LastSyncState) error
+	Current() client.LastSyncState
+	Update(client.LastSyncState) error
 }
 
 // NewController returns a new gerrit controller client
@@ -104,7 +104,7 @@ func (c *Controller) Sync() error {
 		logrus.Infof("Processed %d changes for instance %s", len(changes), instance)
 	}
 
-	return c.tracker.Update(&latest)
+	return c.tracker.Update(latest)
 }
 
 func makeCloneURI(instance, project string) (*url.URL, error) {
@@ -244,7 +244,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 			logger.Infof("Found latest report: %s", latestReport)
 		}
 
-		lastUpdate, ok := (*c.tracker.Current())[instance][change.Project]
+		lastUpdate, ok := c.tracker.Current()[instance][change.Project]
 		if !ok {
 			logrus.Warnf("could not find lastTime for project %q, probably something went wrong with initTracker?", change.Project)
 			lastUpdate = time.Now()

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -55,7 +55,7 @@ func (f *fca) Config() *config.Config {
 
 type fgc struct{}
 
-func (f *fgc) QueryChanges(lastUpdate *client.LastSyncState, rateLimit int) map[string][]client.ChangeInfo {
+func (f *fgc) QueryChanges(lastUpdate client.LastSyncState, rateLimit int) map[string][]client.ChangeInfo {
 	return nil
 }
 
@@ -123,17 +123,17 @@ func TestMakeCloneURI(t *testing.T) {
 }
 
 type fakeSync struct {
-	val  *client.LastSyncState
+	val  client.LastSyncState
 	lock sync.Mutex
 }
 
-func (s *fakeSync) Current() *client.LastSyncState {
+func (s *fakeSync) Current() client.LastSyncState {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.val
 }
 
-func (s *fakeSync) Update(t *client.LastSyncState) error {
+func (s *fakeSync) Update(t client.LastSyncState) error {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.val = t
@@ -716,7 +716,7 @@ func TestProcessChange(t *testing.T) {
 			config:        fca.Config,
 			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
 			gc:            &fgc{},
-			tracker:       &fakeSync{val: &fakeLastSync},
+			tracker:       &fakeSync{val: fakeLastSync},
 		}
 
 		err := c.ProcessChange(testInstance, tc.change)

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -122,6 +122,20 @@ type RevisionInfo = gerrit.RevisionInfo
 // FileInfo is a gerrit.FileInfo
 type FileInfo = gerrit.FileInfo
 
+// Map from instance name to repos to lastsync time for that repo
+type LastSyncState map[string]map[string]time.Time
+
+func (l *LastSyncState) DeepCopy() LastSyncState {
+	result := LastSyncState{}
+	for host, lastSyncs := range *l {
+		result[host] = map[string]time.Time{}
+		for projects, lastSync := range lastSyncs {
+			result[host][projects] = lastSync
+		}
+	}
+	return result
+}
+
 // NewClient returns a new gerrit client
 func NewClient(instances map[string][]string) (*Client, error) {
 	c := &Client{
@@ -193,10 +207,11 @@ func (c *Client) Start(cookiefilePath string) {
 
 // QueryChanges queries for all changes from all projects after lastUpdate time
 // returns an instance:changes map
-func (c *Client) QueryChanges(lastUpdate time.Time, rateLimit int) map[string][]ChangeInfo {
+func (c *Client) QueryChanges(lastState *LastSyncState, rateLimit int) map[string][]ChangeInfo {
 	result := map[string][]ChangeInfo{}
 	for _, h := range c.handlers {
-		changes := h.queryAllChanges(lastUpdate, rateLimit)
+		lastStateForInstance := (*lastState)[h.instance]
+		changes := h.queryAllChanges(&lastStateForInstance, rateLimit)
 		if len(changes) > 0 {
 			result[h.instance] = []ChangeInfo{}
 			for _, change := range changes {
@@ -246,9 +261,15 @@ func (c *Client) Account(instance string) *gerrit.AccountInfo {
 
 // private handler implementation details
 
-func (h *gerritInstanceHandler) queryAllChanges(lastUpdate time.Time, rateLimit int) []gerrit.ChangeInfo {
+func (h *gerritInstanceHandler) queryAllChanges(lastState *map[string]time.Time, rateLimit int) []gerrit.ChangeInfo {
 	result := []gerrit.ChangeInfo{}
+	timeNow := time.Now()
 	for _, project := range h.projects {
+		lastUpdate, ok := (*lastState)[project]
+		if !ok {
+			logrus.WithField("project", project).Warnf("could not find lastTime for project %q, probably something went wrong with initTracker?", project)
+			lastUpdate = timeNow
+		}
 		changes, err := h.queryChangesForProject(project, lastUpdate, rateLimit)
 		if err != nil {
 			// don't halt on error from one project, log & continue

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -77,18 +77,22 @@ func TestQueryChange(t *testing.T) {
 
 	var testcases = []struct {
 		name       string
-		lastUpdate time.Time
+		lastUpdate map[string]time.Time
 		changes    map[string][]gerrit.ChangeInfo
 		revisions  map[string][]string
 	}{
 		{
-			name:       "no changes",
-			lastUpdate: now,
-			revisions:  map[string][]string{},
+			name: "no changes",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
+			revisions: map[string][]string{},
 		},
 		{
-			name:       "one outdated change",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one outdated change",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -108,8 +112,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "one outdated change, but there's a new message",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one outdated change, but there's a new message",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -137,8 +143,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{"foo": {"1-1"}},
 		},
 		{
-			name:       "one up-to-date change",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date change",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -160,8 +168,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "one up-to-date change, same timestamp",
-			lastUpdate: now.Truncate(time.Second),
+			name: "one up-to-date change, same timestamp",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -183,8 +193,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "one up-to-date change but stale commit",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date change but stale commit",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -204,8 +216,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "one up-to-date change, wrong instance",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date change, wrong instance",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"evil": {
 					{
@@ -225,8 +239,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "one up-to-date change, wrong project",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date change, wrong project",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -246,8 +262,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "two up-to-date changes, two projects",
-			lastUpdate: now.Add(-time.Minute),
+			name: "two up-to-date changes, two projects",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -281,8 +299,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "one good one bad",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one good one bad",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -316,8 +336,11 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "multiple up-to-date changes",
-			lastUpdate: now.Add(-time.Minute),
+			name: "multiple up-to-date changes",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+				"boo": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -381,8 +404,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "one up-to-date merged change",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date merged change",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -400,8 +425,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "one up-to-date abandoned change",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one up-to-date abandoned change",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -417,8 +444,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "merged change recently updated but submitted before last update",
-			lastUpdate: now.Add(-time.Minute),
+			name: "merged change recently updated but submitted before last update",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -434,8 +463,10 @@ func TestQueryChange(t *testing.T) {
 			revisions: map[string][]string{},
 		},
 		{
-			name:       "one abandoned, one merged",
-			lastUpdate: now.Add(-time.Minute),
+			name: "one abandoned, one merged",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -460,8 +491,10 @@ func TestQueryChange(t *testing.T) {
 			},
 		},
 		{
-			name:       "merged change with new message, should ignore",
-			lastUpdate: now.Add(-time.Minute),
+			name: "merged change with new message, should ignore",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
 			changes: map[string][]gerrit.ChangeInfo{
 				"foo": {
 					{
@@ -507,7 +540,8 @@ func TestQueryChange(t *testing.T) {
 			},
 		}
 
-		changes := client.QueryChanges(tc.lastUpdate, 5)
+		testLastSync := &LastSyncState{"foo": tc.lastUpdate, "baz": tc.lastUpdate}
+		changes := client.QueryChanges(testLastSync, 5)
 
 		revisions := map[string][]string{}
 		for instance, changes := range changes {

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -540,7 +540,7 @@ func TestQueryChange(t *testing.T) {
 			},
 		}
 
-		testLastSync := &LastSyncState{"foo": tc.lastUpdate, "baz": tc.lastUpdate}
+		testLastSync := LastSyncState{"foo": tc.lastUpdate, "baz": tc.lastUpdate}
 		changes := client.QueryChanges(testLastSync, 5)
 
 		revisions := map[string][]string{}


### PR DESCRIPTION
Having a global lastUpdateTime runs into this problem:
chronologically:
(complete querying project A) -> (new change "foo" in project A) -> (new change "bar" in project B) ->(query project B) -> (update global last sync time based on "bar")
resultis in missing "foo" in the next sync loop

/cc @fejta @Katharine @krzyzacy 