### PR TITLE
Adding label for Vietnamese language

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -337,6 +337,7 @@ larger set of contributors to apply/remove them.
 | <a id="language/no" href="#language/no">`language/no`</a> | Issues or PRs related to Norwegian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/pt" href="#language/pt">`language/pt`</a> | Issues or PRs related to Portuguese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/ru" href="#language/ru">`language/ru`</a> | Issues or PRs related to Russian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/vi" href="#language/vi">`language/vi`</a> | Issues or PRs related to Vietnamese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1225,6 +1225,12 @@ repos:
         target: both
         prowPlugin: label
         addedBy: anyone
+      - color: e9b3f9
+        description: Issues or PRs related to Vietnamese language
+        name: language/vi
+        target: both
+        prowPlugin: label
+        addedBy: anyone
   kubernetes-sigs/cluster-api:
     labels:
       - color: 0052cc


### PR DESCRIPTION
Adding a label for the Vietnamese translation of our docs.

Ref: [kubernetes/website/#16965](https://github.com/kubernetes/website/pull/16965)

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>