### PR TITLE
add dashboard for all azure jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -20,7 +20,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-verify
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure Disk CSI driver."
@@ -45,7 +45,7 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure Disk CSI driver."
@@ -73,7 +73,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-sanity
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure Disk CSI driver."
@@ -101,7 +101,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-integration
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure Disk CSI driver."
@@ -150,7 +150,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests for Azure Disk CSI driver."

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -20,7 +20,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-verify
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure Disk CSI driver."
@@ -45,7 +45,7 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure Disk CSI driver."
@@ -73,7 +73,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-sanity
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure Disk CSI driver."
@@ -101,7 +101,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-integration
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure Disk CSI driver."
@@ -150,7 +150,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azuredisk-csi-driver-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests for Azure Disk CSI driver."

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -20,7 +20,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-verify
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure File CSI driver."
@@ -45,7 +45,7 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure File CSI driver."
@@ -73,7 +73,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-sanity
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure File CSI driver."
@@ -101,7 +101,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-integration
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure File CSI driver."
@@ -150,7 +150,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests for Azure File CSI driver."

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -20,7 +20,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-verify
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure File CSI driver."
@@ -45,7 +45,7 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure File CSI driver."
@@ -73,7 +73,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-sanity
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure File CSI driver."
@@ -101,7 +101,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-integration
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure File CSI driver."
@@ -150,7 +150,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-azurefile-csi-driver-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests for Azure File CSI driver."

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -82,7 +82,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-windows
+      testgrid-dashboards: sig-windows, sig-azure-on-call
       testgrid-tab-name: aks-engine-azure-windows-presubmit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -127,7 +127,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows
+    testgrid-dashboards: sig-windows, sig-azure-on-call
     testgrid-tab-name: aks-engine-azure-windows-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -171,7 +171,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.14-all, sig-windows
+    testgrid-dashboards: sig-release-1.14-all, sig-windows, sig-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-14-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -215,7 +215,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.15-all, sig-windows
+    testgrid-dashboards: sig-release-1.15-all, sig-windows, sig-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-15-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -259,7 +259,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing
+    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing, sig-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-16-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -303,7 +303,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows
+    testgrid-dashboards: sig-windows, sig-azure-on-call
     testgrid-tab-name: aks-engine-azure-windows-master-staging
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -303,7 +303,6 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-on-call
+    testgrid-dashboards: sig-windows
     testgrid-tab-name: aks-engine-azure-windows-master-staging
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -82,7 +82,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-windows, sig-azure-on-call
+      testgrid-dashboards: sig-windows, provider-azure-on-call
       testgrid-tab-name: aks-engine-azure-windows-presubmit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -127,7 +127,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-on-call
     testgrid-tab-name: aks-engine-azure-windows-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -171,7 +171,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.14-all, sig-windows, sig-azure-on-call
+    testgrid-dashboards: sig-release-1.14-all, sig-windows, provider-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-14-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -215,7 +215,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-1.15-all, sig-windows, sig-azure-on-call
+    testgrid-dashboards: sig-release-1.15-all, sig-windows, provider-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-15-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -259,7 +259,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing, sig-azure-on-call
+    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing, provider-azure-on-call
     testgrid-tab-name: aks-engine-azure-1-16-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -303,7 +303,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-on-call
     testgrid-tab-name: aks-engine-azure-windows-master-staging
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -47,7 +47,7 @@ presubmits:
 
   # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-cloud-provider-check
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run lint check tests for cloud-provider-azure."
@@ -100,7 +100,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-cloud-provider-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run Kubernetes e2e tests for cloud-provider-azure."
@@ -152,7 +152,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-cloud-provider-e2e-ccm
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -175,7 +175,7 @@ presubmits:
         - make
         - test-unit
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-cloud-provider-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for cloud-provider-azure."
@@ -236,7 +236,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -297,7 +297,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-autoscaling
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -356,7 +356,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -415,7 +415,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -478,7 +478,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-serial
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes serial tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -537,7 +537,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-master-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -596,7 +596,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-conformance-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -655,7 +655,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: cloud-provider-azure-slow-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -719,7 +719,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master
+    testgrid-dashboards: sig-azure-master, sig-azure-on-call
     testgrid-tab-name: ci-cloud-provider-azure-multiple-zones
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes multiple availability zones tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."

--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -47,7 +47,7 @@ presubmits:
 
   # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-cloud-provider-check
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run lint check tests for cloud-provider-azure."
@@ -100,7 +100,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-cloud-provider-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run Kubernetes e2e tests for cloud-provider-azure."
@@ -152,7 +152,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-cloud-provider-e2e-ccm
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -175,7 +175,7 @@ presubmits:
         - make
         - test-unit
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-cloud-provider-unit
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for cloud-provider-azure."
@@ -236,7 +236,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -297,7 +297,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-autoscaling
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -356,7 +356,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -415,7 +415,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -478,7 +478,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-serial
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes serial tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure)."
@@ -537,7 +537,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-master-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -596,7 +596,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-conformance-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -655,7 +655,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: cloud-provider-azure-slow-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."
@@ -719,7 +719,7 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: sig-azure-master, sig-azure-on-call
+    testgrid-dashboards: provider-azure-master, provider-azure-on-call
     testgrid-tab-name: ci-cloud-provider-azure-multiple-zones
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes multiple availability zones tests with cloud-provider-azure (https://github.com/kubernetes/cloud-provider-azure) on VMSS."

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -74,7 +74,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master
+      testgrid-dashboards: sig-azure-master, sig-azure-on-call
       testgrid-tab-name: pr-k8s-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: Run e2e tests

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -74,7 +74,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-azure-master, sig-azure-on-call
+      testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-k8s-e2e
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: Run e2e tests

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -70,7 +70,7 @@ periodics:
       securityContext:
          privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, sig-azure-on-call
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-on-call
     testgrid-tab-name: dualstack-azure-e2e
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -70,7 +70,7 @@ periodics:
       securityContext:
          privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, sig-azure-on-call
     testgrid-tab-name: dualstack-azure-e2e
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -1,5 +1,5 @@
 dashboard_groups:
-- name: sig-azure
+- name: provider-azure
   dashboard_names:
     - provider-azure-master
     - provider-azure-on-call

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -2,6 +2,8 @@ dashboard_groups:
 - name: sig-azure
   dashboard_names:
     - sig-azure-master
+    - sig-azure-on-call
 
 dashboards:
 - name: sig-azure-master
+- name: sig-azure-on-call

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -1,9 +1,9 @@
 dashboard_groups:
 - name: sig-azure
   dashboard_names:
-    - sig-azure-master
-    - sig-azure-on-call
+    - provider-azure-master
+    - provider-azure-on-call
 
 dashboards:
-- name: sig-azure-master
-- name: sig-azure-on-call
+- name: provider-azure-master
+- name: provider-azure-on-call


### PR DESCRIPTION
- Add new `sig-azure-on-call` dashboard in `sig-azure` testgrid to see all azure related jobs + jobs running on aks-engine clusters.

/cc @ritazh @PatrickLang 