### PR TITLE
add: kubebuilder e2e to prow

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -18,3 +18,25 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
+  - name: pull-kubebuilder-e2e
+    decorate: true
+    always_run: true
+    optional: true
+    path_alias: sigs.k8s.io/kubebuilder
+    branches:
+    - ^master$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191009-4f1de38-master
+        command:
+        - ./test_e2e.sh
+        resources:
+          requests:
+            cpu: 4000m
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: kubebuilder-e2e
+    labels:
+      preset-dind-enabled: "true"


### PR DESCRIPTION
follow up to https://github.com/kubernetes/test-infra/pull/14692

adds the e2e in addition to the base tests.

this could probably merge with #14692, but i'd like to chunk out the work separately to get each test working. i'll fix the commit history as necessary after the other one merges.

depends on https://github.com/kubernetes-sigs/kubebuilder/pull/1106