### PR TITLE
Add prometheus alerts for Tide pool errors.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -19,7 +19,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'Tide has not merged any PRs in kubernetes/kubernetes:master in the past 4 hours despite PRs in the pool.',
+              message: 'Tide has not merged any PRs in kubernetes/kubernetes:master in the past 4 hours despite PRs in the pool. See the <https://prow.k8s.io/tide-history?repo=kubernetes%2Fkubernetes&branch=master|tide-history> page for k/k:m.',
             },
           },
           {
@@ -32,7 +32,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'The Tide sync controllers loop period has averaged more than 2 minutes for the last 15 mins.',
+              message: 'The Tide sync controllers loop period has averaged more than 2 minutes for the last 15 mins. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
             },
           },
           {
@@ -45,7 +45,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'The Tide status update controllers loop period has averaged more than 2 minutes for the last 15 mins.',
+              message: 'The Tide status update controllers loop period has averaged more than 2 minutes for the last 15 mins. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
             },
           },
           {
@@ -58,7 +58,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'At least one Tide pool encountered 3+ sync errors in a 10 minute window. If the TidePoolErrorRateMultiple alert has not fired this is likely an isolated configuration issue. See the <deck-url>/tide-history page.',
+              message: 'At least one Tide pool encountered 3+ sync errors in a 10 minute window. If the TidePoolErrorRateMultiple alert has not fired this is likely an isolated configuration issue. See the <https://prow.k8s.io/tide-history|/tide-history> page and the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now|sync error graph>.',
             },
           },
           {
@@ -71,7 +71,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <deck-url>/tide-history page.',
+              message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <https://prow.k8s.io/tide-history|tide-history> page and the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now|sync error graph>.',
             },
           },
         ],

--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -48,6 +48,32 @@
               message: 'The Tide status update controllers loop period has averaged more than 2 minutes for the last 15 mins.',
             },
           },
+          {
+            alert: 'TidePoolErrorRateIndividual',
+            expr: |||
+              (max(sum(increase(tidepoolerrors[10m])) by (org, repo, branch)) or vector(0)) >= 3
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'At least one Tide pool encountered 3+ sync errors in a 10 minute window. If the TidePoolErrorRateMultiple alert has not fired this is likely an isolated configuration issue. See the <deck-url>/tide-history page.',
+            },
+          },
+          {
+            alert: 'TidePoolErrorRateMultiple',
+            expr: |||
+              (count(sum(increase(tidepoolerrors[10m])) by (org, repo) >= 3) or vector(0)) >= 3
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <deck-url>/tide-history page.',
+            },
+          },
         ],
       },
     ],


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/14844
I went with 2 different alerts:
1. Alert if any individual Tide pool appears to be stuck. This is a `warning` level alert because this is usually an indication that a pool/repo has been misconfigured such that the GitHub settings don't match Tide's. While this is problematic and requires oncall to escalate to the repo owner to unblock merges to the repo, it doesn't usually indicate a problem with Tide itself and is not cause for a roll back.
1. Alert if 3 or more repos appear to be stuck. This is a `critical` level alert because it may indicate a more widespread problem with Tide. 
    - I checked for 3 or more __repos__ instead of 3 or more __pools__ because it is common for misconfigurations to affect all branches in a repo and I don't want this alert to fire on isolated misconfigurations
    - I considered just measuring the overall error rate across all pools, but I think measuring the number of repos that appear to be having problems will provide a better signal.


I included `or vector(0)` to prevent "no data points in range" when evaluating the alert. If no data does not trigger an alert that we can get rid of that.

/assign @stevekuznetsov @hongkailiu 