### PR TITLE
Fix prometheus service port number in monitoring README.

### DIFF
--- a/prow/cluster/monitoring/README.md
+++ b/prow/cluster/monitoring/README.md
@@ -96,10 +96,10 @@ Cluster admins can use [k8s port-forward](https://kubernetes.io/docs/tasks/acces
 access the web.
 
     ```
-    $ kubectl -n prow-monitoring port-forward $( kubectl -n prow-monitoring get pods --selector app=prometheus -o jsonpath={.items[0].metadata.name} ) 9000
+    $ kubectl -n prow-monitoring port-forward $( kubectl -n prow-monitoring get pods --selector app=prometheus -o jsonpath={.items[0].metadata.name} ) 9090
     $ kubectl -n prow-monitoring port-forward $( kubectl -n prow-monitoring get pods --selector app=alertmanager -o jsonpath={.items[0].metadata.name} ) 9093
     ```
 
-    Then, visit [127.0.0.1:9000](http://127.0.0.1:9000) for the `prometheus` pod and [127.0.0.1:9093](http://127.0.0.1:9093) for the `alertmanager` pod.
+    Then, visit [127.0.0.1:9090](http://127.0.0.1:9090) for the `prometheus` pod and [127.0.0.1:9093](http://127.0.0.1:9093) for the `alertmanager` pod.
 
     As a result of no public domain for those two components, some of the links on the UI do not work, eg, the links on the slack alerts.


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/blob/131c7b1aecf0a1cf77ad7d94ed68db5d81fcf8ad/prow/cluster/monitoring/prometheus_expose.yaml#L10-L14

/kind bug
/assign @hongkailiu @stevekuznetsov 