### PR TITLE
Fix Tide k/k progress alert to ignore stale pool size metrics.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -12,7 +12,7 @@
                - (sum(merges_sum{org="kubernetes",repo="kubernetes",branch="master"} offset 5m ) or vector(0)),
               0) < 0.5
               and
-              max(min_over_time(pooledprs{org="kubernetes",repo="kubernetes",branch="master"}[4h])) > 0.5
+              (avg(pooledprs{branch="master",org="kubernetes",repo="kubernetes"} and ((time() - updatetime) < 240))  or vector(0)) > 0.5
             |||,
             'for': '4h',
             labels: {


### PR DESCRIPTION
I forgot to use the `updatetime` metric to filter out stale pool size metrics. We also don't need to use the `[4h]` range vector because the alert has a pending period of 4h (required for the first condition of the alert).

/assign @stevekuznetsov @hongkailiu @michelle192837 