### PR TITLE
Rename config.Presubmits to PresubmitsStatic

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -267,7 +267,7 @@ func checkContext(t *testing.T, repo string, p cfg.Presubmit) {
 }
 
 func TestContextMatches(t *testing.T) {
-	for repo, presubmits := range c.Presubmits {
+	for repo, presubmits := range c.PresubmitsStatic {
 		for _, p := range presubmits {
 			checkContext(t, repo, p)
 		}
@@ -284,7 +284,7 @@ func checkRetest(t *testing.T, repo string, presubmits []cfg.Presubmit) {
 }
 
 func TestRetestMatchJobsName(t *testing.T) {
-	for repo, presubmits := range c.Presubmits {
+	for repo, presubmits := range c.PresubmitsStatic {
 		checkRetest(t, repo, presubmits)
 	}
 }
@@ -316,7 +316,7 @@ func TestTrustedJobs(t *testing.T) {
 	trustedDir := path.Join(*jobConfigPath, "image-pushing") + "/"
 
 	// Presubmits may not use trusted clusters.
-	for _, pre := range c.AllPresubmits(nil) {
+	for _, pre := range c.AllStaticPresubmits(nil) {
 		if pre.Cluster == trusted {
 			t.Errorf("%s: presubmits cannot use trusted clusters", pre.Name)
 		}
@@ -397,7 +397,7 @@ func TestTrustedJobSecretsRestricted(t *testing.T) {
 	}
 
 	// All presubmit jobs should not use any restricted secrets.
-	for _, job := range c.AllPresubmits(nil) {
+	for _, job := range c.AllStaticPresubmits(nil) {
 		if job.Cluster != prowapi.DefaultClusterAlias {
 			// check against default public cluster only
 			continue
@@ -455,7 +455,7 @@ func TestTrustedJobSecretsRestricted(t *testing.T) {
 // Unit test jobs outside kubernetes-security do not use the security cluster
 // and that jobs inside kubernetes-security DO
 func TestConfigSecurityClusterRestricted(t *testing.T) {
-	for repo, jobs := range c.Presubmits {
+	for repo, jobs := range c.PresubmitsStatic {
 		if strings.HasPrefix(repo, "kubernetes-security/") {
 			for _, job := range jobs {
 				if job.Agent != "jenkins" && job.Cluster != "security" {
@@ -506,7 +506,7 @@ func checkDockerSocketVolumes(volumes []coreapi.Volume) error {
 
 // Make sure jobs are not using the docker socket as a host path
 func TestJobDoesNotHaveDockerSocket(t *testing.T) {
-	for _, presubmit := range c.AllPresubmits(nil) {
+	for _, presubmit := range c.AllStaticPresubmits(nil) {
 		if presubmit.Spec != nil {
 			if err := checkDockerSocketVolumes(presubmit.Spec.Volumes); err != nil {
 				t.Errorf("Error in presubmit: %v", err)
@@ -556,7 +556,7 @@ func checkLatestUsesImagePullPolicy(spec *coreapi.PodSpec) error {
 
 // Make sure jobs that use `latest-*` tags specify `imagePullPolicy: Always`
 func TestLatestUsesImagePullPolicy(t *testing.T) {
-	for _, presubmit := range c.AllPresubmits(nil) {
+	for _, presubmit := range c.AllStaticPresubmits(nil) {
 		if presubmit.Spec != nil {
 			if err := checkLatestUsesImagePullPolicy(presubmit.Spec); err != nil {
 				t.Errorf("Error in presubmit %q: %v", presubmit.Name, err)
@@ -654,7 +654,7 @@ func TestValidPresets(t *testing.T) {
 		return
 	}
 
-	for _, presubmit := range c.AllPresubmits(nil) {
+	for _, presubmit := range c.AllStaticPresubmits(nil) {
 		if presubmit.Spec != nil && !presubmit.Decorate {
 			if err := checkKubekinsPresets(presubmit.Name, presubmit.Spec, presubmit.Labels, validLabels); err != nil {
 				t.Errorf("Error in presubmit %q: %v", presubmit.Name, err)
@@ -881,7 +881,7 @@ func checkScenarioArgs(jobName, imageName string, args []string) error {
 
 // TestValidScenarioArgs makes sure all scenario args in job configs are valid
 func TestValidScenarioArgs(t *testing.T) {
-	for _, job := range c.AllPresubmits(nil) {
+	for _, job := range c.AllStaticPresubmits(nil) {
 		if job.Spec != nil && !job.Decorate {
 			if err := checkScenarioArgs(job.Name, job.Spec.Containers[0].Image, job.Spec.Containers[0].Args); err != nil {
 				t.Errorf("Invalid Scenario Args : %s", err)

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -378,7 +378,7 @@ func TestKubernetesProwInstanceJobsMustHaveMatchingTestgridEntries(t *testing.T)
 		t.Fatalf("Could not load prow configs: %v\n", err)
 	}
 
-	for repo, presubmits := range prowConfig.Presubmits {
+	for repo, presubmits := range prowConfig.PresubmitsStatic {
 		if hasAnyPrefix(repo, noPresubmitsInTestgridPrefixes) {
 			continue
 		}

--- a/experiment/ci-janitor/main.go
+++ b/experiment/ci-janitor/main.go
@@ -152,7 +152,7 @@ func main() {
 
 	var jobs []config.JobBase
 
-	for _, v := range conf.AllPresubmits(nil) {
+	for _, v := range conf.AllStaticPresubmits(nil) {
 		jobs = append(jobs, v.JobBase)
 	}
 	for _, v := range conf.AllPostsubmits(nil) {

--- a/experiment/config-forker/main.go
+++ b/experiment/config-forker/main.go
@@ -76,7 +76,7 @@ func generatePostsubmits(c config.JobConfig, version string) (map[string][]confi
 
 func generatePresubmits(c config.JobConfig, version string) (map[string][]config.Presubmit, error) {
 	newPresubmits := map[string][]config.Presubmit{}
-	for repo, presubmits := range c.PresubmitsStatic() {
+	for repo, presubmits := range c.PresubmitsStatic {
 		for _, presubmit := range presubmits {
 			if presubmit.Annotations[forkAnnotation] != "true" {
 				continue

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -499,7 +499,7 @@ func TestGeneratePresubmits(t *testing.T) {
 		},
 	}
 
-	result, err := generatePresubmits(config.JobConfig{Presubmits: presubmits}, "1.15")
+	result, err := generatePresubmits(config.JobConfig{PresubmitsStatic: presubmits}, "1.15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/experiment/config-rotator/main.go
+++ b/experiment/config-rotator/main.go
@@ -85,7 +85,7 @@ func updateJobBase(j *config.JobBase, old, new string) {
 }
 
 func updateEverything(c *config.JobConfig, old, new string) {
-	for _, presubmits := range c.PresubmitsStatic() {
+	for _, presubmits := range c.PresubmitsStatic {
 		for i := range presubmits {
 			updateJobBase(&presubmits[i].JobBase, old, new)
 		}
@@ -137,7 +137,7 @@ func main() {
 	updateEverything(&c, o.oldVersion, o.newVersion)
 
 	output, err := yaml.Marshal(map[string]interface{}{
-		"presubmits":  c.PresubmitsStatic(),
+		"presubmits":  c.PresubmitsStatic,
 		"postsubmits": c.Postsubmits,
 		"periodics":   c.Periodics,
 	})

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -193,7 +193,7 @@ func (p *protector) protect() {
 	// Using PresubmitsStatic here is safe because this is only about getting to
 	// know which repos exist. Repos that use in-repo config will appear here,
 	// because we generate a verification job for them
-	for repo := range p.cfg.PresubmitsStatic() {
+	for repo := range p.cfg.PresubmitsStatic {
 		if p.completedRepos[repo] == true {
 			continue
 		}
@@ -360,7 +360,7 @@ func validateRestrictions(org, repo string, bp *github.BranchProtectionRequest, 
 
 // UpdateBranch updates the branch with the specified configuration
 func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch config.Branch, protected bool, authorizedCollaborators, authorizedTeams []string) error {
-	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic()[orgName+"/"+repo])
+	bp, err := p.cfg.GetPolicy(orgName, repo, branchName, branch, p.cfg.PresubmitsStatic[orgName+"/"+repo])
 	if err != nil {
 		return fmt.Errorf("get policy: %v", err)
 	}

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -476,7 +476,7 @@ func getJSONTagName(field reflect.StructField) string {
 
 func validateJobRequirements(c config.JobConfig) error {
 	var validationErrs []error
-	for repo, jobs := range c.PresubmitsStatic() {
+	for repo, jobs := range c.PresubmitsStatic {
 		for _, job := range jobs {
 			validationErrs = append(validationErrs, validatePresubmitJob(repo, job))
 		}
@@ -795,7 +795,7 @@ func ensureValidConfiguration(plugin, label, verb string, tideSubSet, tideSuperS
 
 func validateDecoratedJobs(cfg *config.Config) error {
 	var nonDecoratedJobs []string
-	for _, presubmit := range cfg.AllPresubmits([]string{}) {
+	for _, presubmit := range cfg.AllStaticPresubmits([]string{}) {
 		if presubmit.Agent == string(v1.KubernetesAgent) && !presubmit.Decorate {
 			nonDecoratedJobs = append(nonDecoratedJobs, presubmit.Name)
 		}
@@ -925,7 +925,7 @@ func verifyOwnersPlugin(cfg *plugins.Configuration) error {
 
 func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 	configuredRepos := sets.NewString()
-	for orgRepo := range cfg.JobConfig.PresubmitsStatic() {
+	for orgRepo := range cfg.JobConfig.PresubmitsStatic {
 		configuredRepos.Insert(orgRepo)
 	}
 	for orgRepo := range cfg.JobConfig.Postsubmits {

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -984,7 +984,7 @@ func TestHandleConfig(t *testing.T) {
 	trueVal := true
 	c := config.Config{
 		JobConfig: config.JobConfig{
-			Presubmits: map[string][]config.Presubmit{
+			PresubmitsStatic: map[string][]config.Presubmit{
 				"org/repo": {
 					{
 						Reporter: config.Reporter{

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -377,7 +377,7 @@ func TestGetGCSDirsForPR(t *testing.T) {
 					},
 				},
 				JobConfig: config.JobConfig{
-					Presubmits: map[string][]config.Presubmit{
+					PresubmitsStatic: map[string][]config.Presubmit{
 						"kubernetes/prow": {
 							{
 								JobBase: config.JobBase{

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -55,7 +55,7 @@ type options struct {
 }
 
 func (o *options) genJobSpec(conf *config.Config, name string) (config.JobBase, prowapi.ProwJobSpec) {
-	for fullRepoName, ps := range conf.PresubmitsStatic() {
+	for fullRepoName, ps := range conf.PresubmitsStatic {
 		org, repo, err := splitRepoName(fullRepoName)
 		if err != nil {
 			logrus.WithError(err).Warnf("Invalid repo name %s.", fullRepoName)

--- a/prow/cmd/tot/fallbackcheck/main.go
+++ b/prow/cmd/tot/fallbackcheck/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 
 	var notFound bool
-	for _, pre := range cfg.AllPresubmits(nil) {
+	for _, pre := range cfg.AllStaticPresubmits(nil) {
 		spec := pjutil.PresubmitToJobSpec(pre)
 		nf, err := getJobFallbackNumber(o.bucket, spec)
 		if err != nil {

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -234,7 +234,7 @@ func (f fallbackHandler) getURL(jobName string) string {
 	var spec *downwardapi.JobSpec
 	cfg := f.configAgent.Config()
 
-	for _, pre := range cfg.AllPresubmits(nil) {
+	for _, pre := range cfg.AllStaticPresubmits(nil) {
 		if jobName == pre.Name {
 			spec = pjutil.PresubmitToJobSpec(pre)
 			break

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -619,7 +619,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -653,7 +653,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -689,7 +689,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -718,7 +718,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -751,7 +751,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -790,7 +790,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							{
 								JobBase: JobBase{
@@ -811,7 +811,7 @@ func TestConfig_GetBranchProtection(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := tc.config.GetBranchProtection("org", "repo", "branch", tc.config.Presubmits["org/repo"])
+			actual, err := tc.config.GetBranchProtection("org", "repo", "branch", tc.config.PresubmitsStatic["org/repo"])
 			switch {
 			case err != nil:
 				if !tc.err {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -426,7 +426,7 @@ periodics:
 		if tc.expectError && err == nil {
 			t.Errorf("tc %s: Expect error, but got nil", tc.name)
 		} else if !tc.expectError && err != nil {
-			t.Errorf("tc %s: Expect no error, but got error %v", tc.name, err)
+			t.Fatalf("tc %s: Expect no error, but got error %v", tc.name, err)
 		}
 
 		if tc.expected != nil {
@@ -1781,7 +1781,7 @@ postsubmits:
 			}
 
 			if len(tc.expectEnv) > 0 {
-				for _, j := range cfg.AllPresubmits(nil) {
+				for _, j := range cfg.AllStaticPresubmits(nil) {
 					if envs, ok := tc.expectEnv[j.Name]; ok {
 						if !reflect.DeepEqual(envs, j.Spec.Containers[0].Env) {
 							t.Errorf("tc %s: expect env %v for job %s, got %+v", tc.name, envs, j.Name, j.Spec.Containers[0].Env)

--- a/prow/config/jobtests/job_config_test.go
+++ b/prow/config/jobtests/job_config_test.go
@@ -95,7 +95,7 @@ func missingMountsForSpec(spec *v1.PodSpec) sets.String {
 
 // verify that all volume mounts reference volumes that exist
 func TestMountsHaveVolumes(t *testing.T) {
-	for _, job := range c.AllPresubmits(nil) {
+	for _, job := range c.AllStaticPresubmits(nil) {
 		if job.Spec != nil {
 			validateVolumesAndMounts(job.Name, job.Spec, t)
 		}
@@ -130,7 +130,7 @@ func checkContext(t *testing.T, repo string, p cfg.Presubmit) {
 }
 
 func TestContextMatches(t *testing.T) {
-	for repo, presubmits := range c.Presubmits {
+	for repo, presubmits := range c.PresubmitsStatic {
 		for _, p := range presubmits {
 			checkContext(t, repo, p)
 		}
@@ -147,7 +147,7 @@ func checkRetest(t *testing.T, repo string, presubmits []cfg.Presubmit) {
 }
 
 func TestRetestMatchJobsName(t *testing.T) {
-	for repo, presubmits := range c.Presubmits {
+	for repo, presubmits := range c.PresubmitsStatic {
 		checkRetest(t, repo, presubmits)
 	}
 }
@@ -181,7 +181,7 @@ func allJobs() ([]cfg.Presubmit, []cfg.Postsubmit, []cfg.Periodic, error) {
 	{ // Find all presubmit jobs
 		q := []cfg.Presubmit{}
 
-		for _, p := range c.Presubmits {
+		for _, p := range c.PresubmitsStatic {
 			for _, p2 := range p {
 				q = append(q, p2)
 			}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -383,7 +383,7 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 					},
 				},
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							Presubmit{
 								Reporter: Reporter{
@@ -527,7 +527,7 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 			name: "both static and inrepoconfig jobs are consired",
 			config: Config{
 				JobConfig: JobConfig{
-					Presubmits: map[string][]Presubmit{
+					PresubmitsStatic: map[string][]Presubmit{
 						"org/repo": {
 							Presubmit{
 								Reporter: Reporter{

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -212,8 +212,8 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		}
 	case client.New:
 		// TODO: Do we want to add support for dynamic presubmits?
-		presubmits := c.config().PresubmitsStatic()[cloneURI.String()]
-		presubmits = append(presubmits, c.config().PresubmitsStatic()[cloneURI.Host+"/"+cloneURI.Path]...)
+		presubmits := c.config().PresubmitsStatic[cloneURI.String()]
+		presubmits = append(presubmits, c.config().PresubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 
 		var filters []pjutil.Filter
 		var latestReport *reporter.JobReport

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -680,7 +680,7 @@ func TestProcessChange(t *testing.T) {
 		fca := &fca{
 			c: &config.Config{
 				JobConfig: config.JobConfig{
-					Presubmits: map[string][]config.Presubmit{
+					PresubmitsStatic: map[string][]config.Presubmit{
 						"gerrit/test-infra": testInfraPresubmits,
 						"https://gerrit/other-repo": {
 							{

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -86,7 +86,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int, operators []config.Jen
 				StatusErrorLink: "https://github.com/kubernetes/test-infra/issues",
 			},
 			JobConfig: config.JobConfig{
-				Presubmits: presubmitMap,
+				PresubmitsStatic: presubmitMap,
 			},
 		},
 	}

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -97,7 +97,7 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 				},
 			},
 			JobConfig: config.JobConfig{
-				Presubmits: presubmitMap,
+				PresubmitsStatic: presubmitMap,
 			},
 		},
 	}

--- a/prow/plugins/skip/skip_test.go
+++ b/prow/plugins/skip/skip_test.go
@@ -319,8 +319,11 @@ func TestSkipStatus(t *testing.T) {
 		}
 		l := logrus.WithField("plugin", pluginName)
 
-		c := &config.Config{}
-		c.SetTestPresubmits("org/repo", test.presubmits)
+		c := &config.Config{
+			JobConfig: config.JobConfig{
+				PresubmitsStatic: map[string][]config.Presubmit{"org/repo": test.presubmits},
+			},
+		}
 
 		if err := handle(fghc, l, test.event, c, &git.Client{}, true); err != nil {
 			t.Errorf("%s: unexpected error: %v", test.name, err)

--- a/prow/statusreconciler/controller.go
+++ b/prow/statusreconciler/controller.go
@@ -163,21 +163,21 @@ func (c *Controller) Run(ctx context.Context, changes <-chan config.Delta) {
 
 func (c *Controller) reconcile(delta config.Delta) error {
 	var errors []error
-	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
+	if err := c.triggerNewPresubmits(addedBlockingPresubmits(delta.Before.PresubmitsStatic, delta.After.PresubmitsStatic)); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
+	if err := c.retireRemovedContexts(removedBlockingPresubmits(delta.Before.PresubmitsStatic, delta.After.PresubmitsStatic)); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)
 		}
 	}
 
-	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.PresubmitsStatic(), delta.After.PresubmitsStatic())); err != nil {
+	if err := c.updateMigratedContexts(migratedBlockingPresubmits(delta.Before.PresubmitsStatic, delta.After.PresubmitsStatic)); err != nil {
 		errors = append(errors, err)
 		if !c.continueOnError {
 			return errorutil.NewAggregate(errors...)

--- a/prow/statusreconciler/controller_test.go
+++ b/prow/statusreconciler/controller_test.go
@@ -779,7 +779,7 @@ func TestControllerReconcile(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(oldConfigData), &oldConfig); err != nil {
 		t.Fatalf("could not unmarshal old config: %v", err)
 	}
-	for _, presubmits := range oldConfig.Presubmits {
+	for _, presubmits := range oldConfig.PresubmitsStatic {
 		if err := config.SetPresubmitRegexes(presubmits); err != nil {
 			t.Fatalf("could not set presubmit regexes for old config: %v", err)
 		}
@@ -787,7 +787,7 @@ func TestControllerReconcile(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(newConfigData), &newConfig); err != nil {
 		t.Fatalf("could not unmarshal new config: %v", err)
 	}
-	for _, presubmits := range newConfig.Presubmits {
+	for _, presubmits := range newConfig.PresubmitsStatic {
 		if err := config.SetPresubmitRegexes(presubmits); err != nil {
 			t.Fatalf("could not set presubmit regexes for new config: %v", err)
 		}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -263,7 +263,7 @@ func TestAccumulateBatch(t *testing.T) {
 				config: func() *config.Config {
 					return &config.Config{
 						JobConfig: config.JobConfig{
-							Presubmits: map[string][]config.Presubmit{
+							PresubmitsStatic: map[string][]config.Presubmit{
 								"org/repo": test.presubmits,
 							},
 							FakeInRepoConfig: test.fakeInRepoConfig,
@@ -846,7 +846,7 @@ func TestPickBatch(t *testing.T) {
 			},
 		},
 		JobConfig: config.JobConfig{
-			Presubmits: map[string][]config.Presubmit{
+			PresubmitsStatic: map[string][]config.Presubmit{
 				"o/r": {{
 					AlwaysRun: true,
 					JobBase: config.JobBase{
@@ -876,8 +876,8 @@ func TestPickBatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error from pickBatch: %v", err)
 	}
-	if !equality.Semantic.DeepEqual(presubmits, ca.Config().PresubmitsStatic()["o/r"]) {
-		t.Errorf("resolving presubmits failed, diff:\n%v\n", diff.ObjectReflectDiff(presubmits, ca.Config().PresubmitsStatic()["o/r"]))
+	if !equality.Semantic.DeepEqual(presubmits, ca.Config().PresubmitsStatic["o/r"]) {
+		t.Errorf("resolving presubmits failed, diff:\n%v\n", diff.ObjectReflectDiff(presubmits, ca.Config().PresubmitsStatic["o/r"]))
 	}
 	for _, testpr := range testprs {
 		var found bool
@@ -2976,7 +2976,7 @@ func TestPresubmitsForBatch(t *testing.T) {
 				config: func() *config.Config {
 					return &config.Config{
 						JobConfig: config.JobConfig{
-							Presubmits: map[string][]config.Presubmit{
+							PresubmitsStatic: map[string][]config.Presubmit{
 								"org/repo": tc.jobs,
 							},
 							FakeInRepoConfig: tc.inrepoconfig,

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -191,7 +191,7 @@ func applyProwjobAnnotations(c *Config, prowConfigAgent *prowConfig.Agent) error
 		}
 	}
 
-	for repo, js := range jobs.PresubmitsStatic() {
+	for repo, js := range jobs.PresubmitsStatic {
 		for _, j := range js {
 			if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PresubmitJob, repo); err != nil {
 				return err


### PR DESCRIPTION
In preparation for #13370, this PR renames the `config.Presubmits` field to `PresubmitsStatic` to make it obvious that this config field no longer necessarily holds all Presubmits. The json tag is kept the same to not break any configs.

Likewise, the `config.AllPresubmits` function got renamed to `config.AllStaticPresubmits`.

Initially I tried to instead unexport the `presubmits` field, but after spending some time yak shaving (unexporting breaks marshaller -> custom marshaller needed -> custom marshaller gets promoted due to embedding of `JobConfig` into `Config` -> checkConfigs field validation breaks and cant be fixed easely) I stopped pursuing that angle.