### PR TITLE
Install kmod in krte images

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -59,6 +59,7 @@ RUN echo "Installing Packages ..." \
         file \
         git \
         gnupg2 \
+        kmod \
         lsb-release \
         mercurial \
         pkg-config \


### PR DESCRIPTION
We need modprobe in order to install the ipv6 modules

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/46662/pull-kubernetes-e2e-kind-ipv6/1185305447767216128

> net.ipv6.conf.all.forwarding = 1
Z /usr/local/bin/wrapper.sh: line 65: modprobe: command not found