### PR TITLE
Bump krte image to master for ipv6 job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -341,7 +341,7 @@ presubmits:
       nodeSelector:
         dedicated: "ubuntu"
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20191017-d96ae13-master
+      - image: gcr.io/k8s-testimages/krte:latest-master
         command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
use master so we don't have to keep the image bumping for this job that is only meant to be triggered manually