### PR TITLE
Update rules_k8s and provide a kubectl toolchain

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,10 +6,6 @@ run --workspace_status_command=./hack/print-workspace-status.sh
 build --incompatible_disable_deprecated_attr_params=false
 query --incompatible_disable_deprecated_attr_params=false
 
-# https://github.com/kubernetes/test-infra/issues/13239
-# https://github.com/bazelbuild/rules_k8s/issues/433
-build --host_force_python=PY2
-
 # enable data race detection
 test --features=race --test_output=errors
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -34,6 +34,9 @@ load("@io_bazel_rules_docker//go:image.bzl", _go_repositories = "repositories")
 _go_repositories()
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", _k8s_repos = "k8s_repositories")
+load("@io_bazel_rules_k8s//toolchains/kubectl:kubectl_configure.bzl", "kubectl_configure")
+
+kubectl_configure(name = "k8s_config")
 
 _k8s_repos()
 

--- a/load.bzl
+++ b/load.bzl
@@ -31,9 +31,10 @@ def repositories():
 
     git_repository(
         name = "io_bazel_rules_k8s",
-        commit = "9de8297b3bb96b010ddc69d025db058c72f7a609",
+        commit = "c7db606023bef31ca5c2ad49942f33c6137cb7f8",
         remote = "https://github.com/bazelbuild/rules_k8s.git",
-        shallow_since = "1570817943 -0400",
+        shallow_since = "1571437004 -0400",
+        # branch = master
     )
 
     # https://github.com/bazelbuild/rules_nodejs

--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -7,11 +7,7 @@ release(
     "production",
     component("prow_monitoring", "namespace"),
     component("prometheus_operator_rbac", MULTI_KIND),
-    component(
-        "prometheus_operator",
-        "deployment",
-        use_legacy_resolver = True,  # https://github.com/kubernetes/test-infra/issues/14678
-    ),
+    component("prometheus_operator", "deployment"),
     component("prow_servicemonitors", MULTI_KIND),
     component("prometheus_rbac", MULTI_KIND),
     component("prow", "prometheus"),


### PR DESCRIPTION
* Configure the [kubectl toolchain](https://github.com/bazelbuild/rules_k8s/tree/master/toolchains/kubectl#kubectl-toolchain)
  - Sadly avoid recompiling this all the time to save Steve's electricity bill.
* Fixes #13239 (no force py2)
* Use go resolver for `//prow/cluster/monitoring:prometheus_operator`
