### PR TITLE
Implement inrepoconfig for Presubmits

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "branch_protection_test.go",
         "config_test.go",
+        "inrepoconfig_test.go",
         "jobs_test.go",
         "tide_test.go",
     ],
@@ -23,6 +24,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/git:go_default_library",
+        "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/kube:go_default_library",
@@ -43,6 +45,7 @@ go_library(
         "agent.go",
         "branch_protection.go",
         "config.go",
+        "inrepoconfig.go",
         "jobs.go",
         "tide.go",
     ],

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -1,0 +1,125 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/prow/git"
+	"k8s.io/test-infra/prow/github"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	inRepoConfigFileName = ".prow.yaml"
+)
+
+// ProwYAML represents the content of a .prow.yaml file
+// used to version Presubmits inside the tested repo.
+type ProwYAML struct {
+	Presubmits []Presubmit `json:"presubmits"`
+}
+
+// ProwYAMLGetter is used to retrieve a ProwYAML. Tests should provide
+// their own implementation and set that on the *Config.
+type ProwYAMLGetter func(*Config, *git.Client, string, string, ...string) (*ProwYAML, error)
+
+// Verify defaultProwYAMLGetter is a ProwYAMLGetter
+var _ ProwYAMLGetter = defaultProwYAMLGetter
+
+func defaultProwYAMLGetter(
+	c *Config,
+	gc *git.Client,
+	identifier string,
+	baseSHA string,
+	headSHAs ...string) (*ProwYAML, error) {
+
+	log := logrus.WithField("repo", identifier)
+	log.Debugf("Attempting to get %q.", inRepoConfigFileName)
+
+	if gc == nil {
+		log.Error("defaultProwYAMLGetter was called with a nil git client")
+		return nil, errors.New("gitClient is nil")
+	}
+
+	repo, err := gc.Clone(identifier)
+	if err != nil {
+		return nil, fmt.Errorf("failed to clone repo for %q: %v", identifier, err)
+	}
+	defer func() {
+		if err := repo.Clean(); err != nil {
+			log.WithError(err).Error("Failed to clean up repo.")
+		}
+	}()
+
+	if err := repo.Config("user.name", "prow"); err != nil {
+		return nil, err
+	}
+	if err := repo.Config("user.email", "prow@localhost"); err != nil {
+		return nil, err
+	}
+	if err := repo.Config("commit.gpgsign", "false"); err != nil {
+		return nil, err
+	}
+
+	var mergeMethod github.PullRequestMergeType
+	identifierSlashSplit := strings.Split(identifier, "/")
+	if len(identifierSlashSplit) == 2 {
+		mergeMethod = c.Tide.MergeMethod(identifierSlashSplit[0], identifierSlashSplit[1])
+		log.Debugf("Using merge strategy %q.", mergeMethod)
+	} else {
+		return nil, fmt.Errorf("didn't get two but %d results when splitting repo identifier %q", len(identifierSlashSplit), identifier)
+	}
+
+	if err := repo.MergeAndCheckout(baseSHA, mergeMethod, headSHAs...); err != nil {
+		return nil, fmt.Errorf("failed to merge: %v", err)
+	}
+
+	prowYAMLFilePath := path.Join(repo.Directory(), inRepoConfigFileName)
+	if _, err := os.Stat(prowYAMLFilePath); err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("File %q does not exist.", inRepoConfigFileName)
+			return &ProwYAML{}, nil
+		}
+		return nil, fmt.Errorf("failed to check if file %q exists: %v", inRepoConfigFileName, err)
+	}
+
+	bytes, err := ioutil.ReadFile(prowYAMLFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %q: %v", inRepoConfigFileName, err)
+	}
+
+	prowYAML := &ProwYAML{}
+	if err := yaml.Unmarshal(bytes, prowYAML); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal %q: %v", inRepoConfigFileName, err)
+	}
+
+	if err := defaultAndValidateProwYAML(c, prowYAML, identifier); err != nil {
+		return nil, err
+	}
+
+	log.Debugf("Successfully got %d presubmits from %q.", len(prowYAML.Presubmits), inRepoConfigFileName)
+	return prowYAML, nil
+}
+
+func defaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error {
+	if err := defaultPresubmits(p.Presubmits, c, identifier); err != nil {
+		return err
+	}
+	if err := validatePresubmits(append(p.Presubmits, c.Presubmits[identifier]...), c.PodNamespace); err != nil {
+		return err
+	}
+
+	for _, ps := range p.Presubmits {
+		if ps.Branches != nil || ps.SkipBranches != nil {
+			return fmt.Errorf("job %q contains branchconfig. This is not allowed for jobs in %q", ps.Name, inRepoConfigFileName)
+		}
+	}
+
+	return nil
+}

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -26,8 +26,8 @@ type ProwYAML struct {
 }
 
 // ProwYAMLGetter is used to retrieve a ProwYAML. Tests should provide
-// their own implementation and set that on the *Config.
-type ProwYAMLGetter func(*Config, *git.Client, string, string, ...string) (*ProwYAML, error)
+// their own implementation and set that on the Config.
+type ProwYAMLGetter func(c *Config, gc *git.Client, identifier, baseSHA string, headSHAs ...string) (*ProwYAML, error)
 
 // Verify defaultProwYAMLGetter is a ProwYAMLGetter
 var _ ProwYAMLGetter = defaultProwYAMLGetter
@@ -111,7 +111,7 @@ func defaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	if err := defaultPresubmits(p.Presubmits, c, identifier); err != nil {
 		return err
 	}
-	if err := validatePresubmits(append(p.Presubmits, c.Presubmits[identifier]...), c.PodNamespace); err != nil {
+	if err := validatePresubmits(append(p.Presubmits, c.PresubmitsStatic[identifier]...), c.PodNamespace); err != nil {
 		return err
 	}
 

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -118,7 +118,7 @@ func TestDefaultProwYAMLGetter(t *testing.T) {
 				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
 			},
 			config: &Config{JobConfig: JobConfig{
-				Presubmits: map[string][]Presubmit{
+				PresubmitsStatic: map[string][]Presubmit{
 					org + "/" + repo: {{JobBase: JobBase{Name: "hans"}}},
 				},
 			}},

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -1,0 +1,256 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"k8s.io/test-infra/prow/git/localgit"
+)
+
+func TestDefaultProwYAMLGetter(t *testing.T) {
+	org, repo := "org", "repo"
+	testCases := []struct {
+		name              string
+		baseContent       map[string][]byte
+		headContent       map[string][]byte
+		config            *Config
+		dontPassGitClient bool
+		validate          func(*ProwYAML, error) error
+	}{
+		{
+			name: "Basic happy path",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
+			},
+			validate: func(p *ProwYAML, err error) error {
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
+					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Yaml unmarshaling is not strict",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "undef_attr": true, "spec": {"containers": [{}]}}]`),
+			},
+			validate: func(p *ProwYAML, err error) error {
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
+					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Merging is executed",
+			headContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
+			},
+			validate: func(p *ProwYAML, err error) error {
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
+					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
+				}
+				return nil
+			},
+		},
+		{
+			name: "No prow.yaml, no error, no nullpointer",
+			validate: func(p *ProwYAML, err error) error {
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if p == nil {
+					return errors.New("prowYAML is nil")
+				}
+				if n := len(p.Presubmits); n != 0 {
+					return fmt.Errorf("expected to get zero presubmits, got %d", n)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Presubmit defaulting is executed",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
+			},
+			validate: func(p *ProwYAML, err error) error {
+				if err != nil {
+					return fmt.Errorf("unexpected error: %v", err)
+				}
+				if n := len(p.Presubmits); n != 1 || p.Presubmits[0].Name != "hans" {
+					return fmt.Errorf(`expected exactly one presubmit with name "hans", got %v`, p.Presubmits)
+				}
+				if p.Presubmits[0].Context != "hans" {
+					return fmt.Errorf(`expected defaulting to set context to "hans", was %q`, p.Presubmits[0].Context)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Presubmit validation is executed",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}},{"name": "hans", "spec": {"containers": [{}]}}]`),
+			},
+			validate: func(_ *ProwYAML, err error) error {
+				if err == nil {
+					return errors.New("error is nil")
+				}
+				expectedErrMsg := "duplicated presubmit job: hans"
+				if err.Error() != expectedErrMsg {
+					return fmt.Errorf("expected error message to be %q, was %q", expectedErrMsg, err.Error())
+				}
+				return nil
+			},
+		},
+		{
+			name: "Presubmit validation includes static presubmits",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
+			},
+			config: &Config{JobConfig: JobConfig{
+				Presubmits: map[string][]Presubmit{
+					org + "/" + repo: {{JobBase: JobBase{Name: "hans"}}},
+				},
+			}},
+			validate: func(_ *ProwYAML, err error) error {
+				if err == nil {
+					return errors.New("error is nil")
+				}
+				expectedErrMsg := "duplicated presubmit job: hans"
+				if err.Error() != expectedErrMsg {
+					return fmt.Errorf("expected error message to be %q, was %q", expectedErrMsg, err.Error())
+				}
+				return nil
+			},
+		},
+		{
+			name: "Branchconfig on presubmit is not allowed",
+			baseContent: map[string][]byte{
+				".prow.yaml": []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}, "branches":["master"]}]`),
+			},
+			validate: func(_ *ProwYAML, err error) error {
+				if err == nil {
+					return errors.New("error is nil")
+				}
+				expectedErrMsg := `job "hans" contains branchconfig. This is not allowed for jobs in ".prow.yaml"`
+				if err.Error() != expectedErrMsg {
+					return fmt.Errorf("expected error message to be %q, was %q", expectedErrMsg, err.Error())
+				}
+				return nil
+			},
+		},
+		{
+			name:              "No panic on nil gitClient",
+			dontPassGitClient: true,
+			validate: func(_ *ProwYAML, err error) error {
+				if err == nil || err.Error() != "gitClient is nil" {
+					return fmt.Errorf(`expected error to be "gitClient is nil", was %v`, err)
+				}
+				return nil
+			},
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			lg, gc, err := localgit.New()
+			if err != nil {
+				t.Fatalf("Making local git repo: %v", err)
+			}
+			defer func() {
+				if err := lg.Clean(); err != nil {
+					t.Errorf("Error cleaning LocalGit: %v", err)
+				}
+				if err := gc.Clean(); err != nil {
+					t.Errorf("Error cleaning Client: %v", err)
+				}
+			}()
+
+			if err := lg.MakeFakeRepo(org, repo); err != nil {
+				t.Fatalf("Making fake repo: %v", err)
+			}
+			if tc.baseContent != nil {
+				if err := lg.AddCommit(org, repo, tc.baseContent); err != nil {
+					t.Fatalf("failed to commit baseContent: %v", err)
+				}
+			}
+			if tc.headContent != nil {
+				if err := lg.CheckoutNewBranch(org, repo, "can-I-haz-pulled"); err != nil {
+					t.Fatalf("failed to create new branch: %v", err)
+				}
+				if err := lg.AddCommit(org, repo, tc.headContent); err != nil {
+					t.Fatalf("failed to add head commit: %v", err)
+				}
+			}
+
+			baseSHA, err := lg.RevParse(org, repo, "master")
+			if err != nil {
+				t.Fatalf("failed to get baseSHA: %v", err)
+			}
+			headSHA, err := lg.RevParse(org, repo, "HEAD")
+			if err != nil {
+				t.Fatalf("failed to head headSHA: %v", err)
+			}
+
+			if tc.config == nil {
+				tc.config = &Config{}
+			}
+			// Validation fails when no NS is provided
+			tc.config.PodNamespace = "my-ns"
+
+			testGC := gc
+			if tc.dontPassGitClient {
+				testGC = nil
+			}
+
+			var p *ProwYAML
+			if headSHA == baseSHA {
+				p, err = defaultProwYAMLGetter(tc.config, testGC, org+"/"+repo, baseSHA)
+			} else {
+				p, err = defaultProwYAMLGetter(tc.config, testGC, org+"/"+repo, baseSHA, headSHA)
+			}
+
+			if err := tc.validate(p, err); err != nil {
+				t.Fatal(err)
+			}
+
+		})
+	}
+}
+
+func TestDefaultProwYAMLGetter_RejectsNonGitHubRepo(t *testing.T) {
+	lg, gc, err := localgit.New()
+	if err != nil {
+		t.Fatalf("Making local git repo: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Error cleaning LocalGit: %v", err)
+		}
+		if err := gc.Clean(); err != nil {
+			t.Errorf("Error cleaning Client: %v", err)
+		}
+	}()
+
+	identifier := "my-repo"
+	if err := lg.MakeFakeRepo(identifier, ""); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	expectedErrMsg := `didn't get two but 1 results when splitting repo identifier "my-repo"`
+	if _, err := defaultProwYAMLGetter(&Config{}, gc, identifier, ""); err == nil || err.Error() != expectedErrMsg {
+		t.Errorf("Error %v does not have expected message %s", err, expectedErrMsg)
+	}
+}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -316,18 +316,19 @@ func (r *Repo) MergeWithStrategy(commitlike string, mergeStrategy prowgithub.Pul
 }
 
 // MergeAndCheckout merges the provided headSHAs in order onto baseSHA using the provided strategy.
+// If no headSHAs are provided, it will only checkout the baseSHA and return.
 // Only the `merge` and `squash` strategies are supported.
-func (r *Repo) MergeAndCheckout(baseSHA string, headSHAs []string, mergeStrategy prowgithub.PullRequestMergeType) error {
+func (r *Repo) MergeAndCheckout(baseSHA string, mergeStrategy prowgithub.PullRequestMergeType, headSHAs ...string) error {
 	if baseSHA == "" {
 		return errors.New("baseSHA must be set")
 	}
-	if len(headSHAs) == 0 {
-		return errors.New("at least one headSHA must be provided")
-	}
-	r.logger.Infof("Merging headSHAs %v onto base %s using strategy %s", headSHAs, baseSHA, mergeStrategy)
 	if err := r.Checkout(baseSHA); err != nil {
 		return err
 	}
+	if len(headSHAs) == 0 {
+		return nil
+	}
+	r.logger.Infof("Merging headSHAs %v onto base %s using strategy %s", headSHAs, baseSHA, mergeStrategy)
 	for _, headSHA := range headSHAs {
 		ok, err := r.MergeWithStrategy(headSHA, mergeStrategy)
 		if err != nil {

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -286,7 +286,6 @@ func TestMergeAndCheckout(t *testing.T) {
 		{
 			name:       "No pullRequestHead, error",
 			setBaseSHA: true,
-			err:        "at least one headSHA must be provided",
 		},
 		{
 			name:          "Merge succeeds with one head and merge strategy",
@@ -382,7 +381,7 @@ func TestMergeAndCheckout(t *testing.T) {
 				t.Fatalf("failed to disable gpg signing for test repo: %v", err)
 			}
 
-			err = clonedRepo.MergeAndCheckout(baseSHA, commitsToMerge, tc.mergeStrategy)
+			err = clonedRepo.MergeAndCheckout(baseSHA, tc.mergeStrategy, commitsToMerge...)
 			if err == nil && tc.err == "" {
 				return
 			}

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -74,5 +74,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
+	utilpointer "k8s.io/utils/pointer"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -89,11 +90,11 @@ func TestAccumulateBatch(t *testing.T) {
 		state prowapi.ProwJobState
 	}
 	tests := []struct {
-		name             string
-		presubmits       []config.Presubmit
-		pulls            []pull
-		prowJobs         []prowjob
-		fakeInRepoConfig map[string][]config.Presubmit
+		name           string
+		presubmits     []config.Presubmit
+		pulls          []pull
+		prowJobs       []prowjob
+		prowYAMLGetter config.ProwYAMLGetter
 
 		merges  []int
 		pending bool
@@ -187,13 +188,10 @@ func TestAccumulateBatch(t *testing.T) {
 				{job: "bar", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "baz", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 			},
-			// We need to use the concatenated headSHAs of all PRs here, as GetPresubmits is called
-			// for the whole batch and not for individual PRs, because inrepoconfig allows one Pr to
-			// change the required PRs for all batch members
-			fakeInRepoConfig: map[string][]config.Presubmit{"ab": {{
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"a", "b"}, []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "boo"},
-			}}},
+			}}),
 		},
 		{
 			name:       "successful run with PR that requires additional job",
@@ -205,10 +203,6 @@ func TestAccumulateBatch(t *testing.T) {
 				{job: "baz", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 				{job: "boo", state: prowapi.SuccessState, prs: []pull{{1, "a"}, {2, "b"}}},
 			},
-			fakeInRepoConfig: map[string][]config.Presubmit{"b": {{
-				AlwaysRun: true,
-				Reporter:  config.Reporter{Context: "boo"},
-			}}},
 			merges: []int{1, 2},
 		},
 		{
@@ -263,6 +257,11 @@ func TestAccumulateBatch(t *testing.T) {
 			for idx := range test.presubmits {
 				test.presubmits[idx].AlwaysRun = true
 			}
+
+			inrepoconfig := config.InRepoConfig{}
+			if test.prowYAMLGetter != nil {
+				inrepoconfig.Enabled = map[string]*bool{"*": utilpointer.BoolPtr(true)}
+			}
 			c := &Controller{
 				config: func() *config.Config {
 					return &config.Config{
@@ -270,7 +269,10 @@ func TestAccumulateBatch(t *testing.T) {
 							PresubmitsStatic: map[string][]config.Presubmit{
 								"org/repo": test.presubmits,
 							},
-							FakeInRepoConfig: test.fakeInRepoConfig,
+							ProwYAMLGetter: test.prowYAMLGetter,
+						},
+						ProwConfig: config.ProwConfig{
+							InRepoConfig: inrepoconfig,
 						},
 					}
 				},
@@ -2208,7 +2210,7 @@ func TestPresubmitsByPull(t *testing.T) {
 		initialChangeCache map[changeCacheKey][]string
 		presubmits         []config.Presubmit
 		prs                []PullRequest
-		fakeInRepoConfig   map[string][]config.Presubmit
+		prowYAMLGetter     config.ProwYAMLGetter
 
 		expectedPresubmits  map[int][]config.Presubmit
 		expectedChangeCache map[changeCacheKey][]string
@@ -2410,10 +2412,10 @@ func TestPresubmitsByPull(t *testing.T) {
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "always"},
 			}},
-			fakeInRepoConfig: map[string][]config.Presubmit{"1": {{
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"1"}, []config.Presubmit{{
 				AlwaysRun: true,
 				Reporter:  config.Reporter{Context: "inrepoconfig"},
-			}}},
+			}}),
 			prs: []PullRequest{
 				{Number: githubql.Int(1), HeadRefOID: githubql.String("1")},
 			},
@@ -2444,7 +2446,10 @@ func TestPresubmitsByPull(t *testing.T) {
 			"/":       tc.presubmits,
 			"foo/bar": {{Reporter: config.Reporter{Context: "wrong-repo"}, AlwaysRun: true}},
 		})
-		cfg.FakeInRepoConfig = tc.fakeInRepoConfig
+		if tc.prowYAMLGetter != nil {
+			cfg.InRepoConfig.Enabled = map[string]*bool{"*": utilpointer.BoolPtr(true)}
+			cfg.ProwYAMLGetter = tc.prowYAMLGetter
+		}
 		cfgAgent := &config.Agent{}
 		cfgAgent.Set(cfg)
 		sp := &subpool{
@@ -2844,12 +2849,12 @@ func TestAccumulateReturnsCorrectMissingTests(t *testing.T) {
 
 func TestPresubmitsForBatch(t *testing.T) {
 	testCases := []struct {
-		name         string
-		prs          []PullRequest
-		changedFiles *changedFilesAgent
-		jobs         []config.Presubmit
-		inrepoconfig map[string][]config.Presubmit
-		expected     []config.Presubmit
+		name           string
+		prs            []PullRequest
+		changedFiles   *changedFilesAgent
+		jobs           []config.Presubmit
+		prowYAMLGetter config.ProwYAMLGetter
+		expected       []config.Presubmit
 	}{
 		{
 			name: "All jobs get picked",
@@ -2936,12 +2941,10 @@ func TestPresubmitsForBatch(t *testing.T) {
 					Reporter:  config.Reporter{Context: "foo"},
 				},
 			},
-			inrepoconfig: map[string][]config.Presubmit{
-				"sha": {{
-					AlwaysRun: true,
-					Reporter:  config.Reporter{Context: "bar"},
-				}},
-			},
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"sha", ""}, []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "bar"},
+			}}),
 			expected: []config.Presubmit{
 				{
 					AlwaysRun: true,
@@ -2967,12 +2970,10 @@ func TestPresubmitsForBatch(t *testing.T) {
 					Reporter:  config.Reporter{Context: "foo"},
 				},
 			},
-			inrepoconfig: map[string][]config.Presubmit{
-				"other-sha": {{
-					AlwaysRun: true,
-					Reporter:  config.Reporter{Context: "bar"},
-				}},
-			},
+			prowYAMLGetter: prowYAMLGetterForHeadRefs([]string{"other-sha", ""}, []config.Presubmit{{
+				AlwaysRun: true,
+				Reporter:  config.Reporter{Context: "bar"},
+			}}),
 			expected: []config.Presubmit{
 				{
 					AlwaysRun: true,
@@ -3003,6 +3004,11 @@ func TestPresubmitsForBatch(t *testing.T) {
 			if err := config.SetPresubmitRegexes(tc.jobs); err != nil {
 				t.Fatalf("failed to set presubmit regexes: %v", err)
 			}
+
+			inrepoconfig := config.InRepoConfig{}
+			if tc.prowYAMLGetter != nil {
+				inrepoconfig.Enabled = map[string]*bool{"*": utilpointer.BoolPtr(true)}
+			}
 			c := &Controller{
 				changedFiles: tc.changedFiles,
 				config: func() *config.Config {
@@ -3011,7 +3017,10 @@ func TestPresubmitsForBatch(t *testing.T) {
 							PresubmitsStatic: map[string][]config.Presubmit{
 								"org/repo": tc.jobs,
 							},
-							FakeInRepoConfig: tc.inrepoconfig,
+							ProwYAMLGetter: tc.prowYAMLGetter,
+						},
+						ProwConfig: config.ProwConfig{
+							InRepoConfig: inrepoconfig,
 						},
 					}
 				},
@@ -3260,4 +3269,19 @@ func (c *indexingClient) List(ctx context.Context, list runtime.Object, opts ...
 
 	*pjList = result
 	return nil
+}
+
+func prowYAMLGetterForHeadRefs(headRefsToLookFor []string, ps []config.Presubmit) config.ProwYAMLGetter {
+	return func(_ *config.Config, _ *git.Client, _, _ string, headRefs ...string) (*config.ProwYAML, error) {
+		if len(headRefsToLookFor) != len(headRefs) {
+			return nil, fmt.Errorf("expcted %d headrefs, got %d", len(headRefsToLookFor), len(headRefs))
+		}
+		var presubmits []config.Presubmit
+		if sets.NewString(headRefsToLookFor...).Equal(sets.NewString(headRefs...)) {
+			presubmits = ps
+		}
+		return &config.ProwYAML{
+			Presubmits: presubmits,
+		}, nil
+	}
 }


### PR DESCRIPTION
Towards #13370, this PR implements inrepoconfig for presubmits. It also replaces the `FakeInRepoConfig` property of the `config.Config` struct and instead uses a `ProwYAMLGetter` that gets defaulted and can be set by tests.

/assign @stevekuznetsov 