### PR TITLE
Bump krte image to version for ipv6 job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -341,7 +341,7 @@ presubmits:
       nodeSelector:
         dedicated: "ubuntu"
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20191017-d96ae13-master
+      - image: gcr.io/k8s-testimages/krte:v20191018-d0e6c58-master
         command:
         - wrapper.sh
         - bash


### PR DESCRIPTION
current version is missing modprobe so we can't load the ipv6 modules