### PR TITLE
Add new test suite for serial alpha kubelet features

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -250,6 +250,35 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-serial
+- name: ci-kubernetes-node-kubelet-serial-alpha
+  interval: 3h30m
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191017-ac4b4b5-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --timeout=200
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --gcp-project=k8s-jkns-ci-node-e2e
+      - --gcp-zone=us-west1-b
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
+      - --node-test-args=--feature-gates=StartupProbe=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+      - --node-tests=true
+      - --provider=gce
+      - --test_args=--nodes=1 --focus="\[Serial\].*\[NodeAlphaFeature:.+\]"
+      - --timeout=180m
+      env:
+      - name: GOPATH
+        value: /go
+  annotations:
+    testgrid-dashboards: sig-node-kubelet
+    testgrid-tab-name: node-kubelet-serial-alpha
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h
   labels:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -90,3 +90,12 @@ dashboards:
       description: k8s1.14.x node conformance test results for ee-19.03 on ubuntu16.04
 
 - name: sig-node-node-problem-detector
+
+test_groups:
+- name: ci-kubernetes-node-kubelet-serial-alpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-alpha
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'


### PR DESCRIPTION
Today we only run tests for stable features that has to be tested
serially, and this will add a new suite for tests maked as
[Serial] and [NodeAlphaFeature:XYZ].

Discussion about it can be found here: https://github.com/kubernetes/kubernetes/pull/83570#issuecomment-543962765