### PR TITLE
Run kind ipv6 tests on presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -319,7 +319,8 @@ presubmits:
 
   - name: pull-kubernetes-e2e-kind-ipv6
     optional: true
-    always_run: false # manual for testing new configurations
+    always_run: true
+    skip_report: true
     decorate: true
     skip_branches:
     - release-\d+\.\d+ # per-release settings

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -732,13 +732,13 @@ dashboards:
     test_group_name: pull-kubernetes-e2e-kind
     base_options: width=10
     alert_options:
-      alert_mail_to_addresses: bentheelder+alerts@google.com
+      alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
   - name: pull-kubernetes-e2e-kind-canary
     test_group_name: pull-kubernetes-e2e-kind-canary
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: bentheelder+alerts@google.com
-  - name: pull-kubernetes-e2e-kind-ipv6-canary
+  - name: pull-kubernetes-e2e-kind-ipv6
     test_group_name: pull-kubernetes-e2e-kind-ipv6
     base_options: width=10
     alert_options:


### PR DESCRIPTION
It runs the same regex that the kind ipv4 job to have more signals on ipv6.

The tests are passing per
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-e2e-kind-ipv6/1185981012337758218