### PR TITLE
peribolos: Add capability to update existing repos

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -968,6 +968,11 @@ func configureRepos(client repoClient, orgName string, orgConfig org.Config) err
 			logrus.WithField("repo", wantName).Info("repo exists, considering an update")
 			delta := newRepoUpdateRequest(current, wantName, wantRepo)
 			if delta != nil {
+				if delta.Archived != nil && !*delta.Archived {
+					logrus.WithField("repo", wantName).Error("asked to unarchive an archived repo, unsupported by GH API")
+					allErrors = append(allErrors, fmt.Errorf("asked to unarchive an archived repo, unsupported by GH API"))
+					continue
+				}
 				logrus.WithField("repo", wantName).Info("repo exists and differs from desired state, updating")
 				if _, err := client.UpdateRepo(orgName, current.Name, *delta); err != nil {
 					allErrors = append(allErrors, err)

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -66,6 +66,9 @@ type Repo struct {
 	AllowMergeCommit *bool   `json:"allow_merge_commit,omitempty"`
 	AllowRebaseMerge *bool   `json:"allow_rebase_merge,omitempty"`
 
+	DefaultBranch *string `json:"default_branch,omitempty"`
+	Archived      *bool   `json:"archived,omitempty"`
+
 	OnCreate *RepoCreateOptions `json:"on_create,omitempty"`
 }
 

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -154,6 +154,7 @@ type RepositoryClient interface {
 	CreateFork(owner, repo string) error
 	ListRepoTeams(org, repo string) ([]Team, error)
 	CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (*Repo, error)
+	UpdateRepo(owner, name string, repo RepoUpdateRequest) (*Repo, error)
 }
 
 // TeamClient interface for team related API actions
@@ -1694,6 +1695,28 @@ func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (
 		path:        path,
 		requestBody: &repo,
 		exitCodes:   []int{201},
+	}, &retRepo)
+	return &retRepo, err
+}
+
+// UpdateRepo edits an existing repository
+// See https://developer.github.com/v3/repos/#edit
+func (c *client) UpdateRepo(owner, name string, repo RepoUpdateRequest) (*Repo, error) {
+	c.log("UpdateRepo", owner, name, repo)
+
+	if c.fake {
+		return nil, nil
+	} else if c.dry {
+		return repo.ToRepo(), nil
+	}
+
+	path := fmt.Sprintf("/repos/%s/%s", owner, name)
+	var retRepo Repo
+	_, err := c.request(&request{
+		method:      http.MethodPatch,
+		path:        path,
+		requestBody: &repo,
+		exitCodes:   []int{200},
 	}, &retRepo)
 	return &retRepo, err
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -379,6 +379,13 @@ func (r RepoRequest) ToRepo() *Repo {
 	return &repo
 }
 
+// Defined returns true if at least one of the pointer fields are not nil
+func (r RepoRequest) Defined() bool {
+	return r.Name != nil || r.Description != nil || r.Homepage != nil || r.Private != nil ||
+		r.HasIssues != nil || r.HasProjects != nil || r.HasWiki != nil || r.AllowSquashMerge != nil ||
+		r.AllowMergeCommit != nil || r.AllowRebaseMerge != nil
+}
+
 // RepoUpdateRequest contains metadata used for updating a repository
 // See also: https://developer.github.com/v3/repos/#edit
 type RepoUpdateRequest struct {
@@ -398,6 +405,10 @@ func (r RepoUpdateRequest) ToRepo() *Repo {
 	}
 
 	return repo
+}
+
+func (r RepoUpdateRequest) Defined() bool {
+	return r.RepoRequest.Defined() || r.DefaultBranch != nil || r.Archived != nil
 }
 
 // RepoPermissions describes which permission level an entity has in a

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -352,7 +352,7 @@ type RepoCreateRequest struct {
 	LicenseTemplate   *string `json:"license_template,omitempty"`
 }
 
-func (r RepoCreateRequest) ToRepo() *Repo {
+func (r RepoRequest) ToRepo() *Repo {
 	setString := func(dest, src *string) {
 		if src != nil {
 			*dest = *src
@@ -377,6 +377,27 @@ func (r RepoCreateRequest) ToRepo() *Repo {
 	setBool(&repo.AllowRebaseMerge, r.AllowRebaseMerge)
 
 	return &repo
+}
+
+// RepoUpdateRequest contains metadata used for updating a repository
+// See also: https://developer.github.com/v3/repos/#edit
+type RepoUpdateRequest struct {
+	RepoRequest `json:",omitempty"`
+
+	DefaultBranch *string `json:"default_branch,omitempty"`
+	Archived      *bool   `json:"archived,omitempty"`
+}
+
+func (r RepoUpdateRequest) ToRepo() *Repo {
+	repo := r.RepoRequest.ToRepo()
+	if r.DefaultBranch != nil {
+		repo.DefaultBranch = *r.DefaultBranch
+	}
+	if r.Archived != nil {
+		repo.Archived = *r.Archived
+	}
+
+	return repo
 }
 
 // RepoPermissions describes which permission level an entity has in a


### PR DESCRIPTION
A continuation of https://github.com/kubernetes/test-infra/pull/14732. Adds a capability to update the fields already supported when creating, plus two fields that can only be set on update (not on creation): `archived` and `default_branch`. A special case of GH API not supporting un-archival of repos is handled locally.

The feature notably does not support repo renaming yet (or more precisely, the GH client change does, but peribolos change does not).

/cc @stevekuznetsov @fejta 