### PR TITLE
typo fix

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -19,7 +19,7 @@ info, it was sourced from the following:
 
 There are three types of prow jobs:
 
-- **Presubumits** run against code in PRs
+- **Presubmits** run against code in PRs
 - **Postsubmits** run after merging code
 - **Periodics** run on a periodic basis
 


### PR DESCRIPTION
Doing a grep to understand how presubmit jobs are specified I stumbled
on this "presubumits" text which should be "presubmit".

Signed-off-by: Tim Pepper <tpepper@vmware.com>