### PR TITLE
Add initial config for Kyma TestGrid display

### DIFF
--- a/config/testgrids/kyma/kyma.yaml
+++ b/config/testgrids/kyma/kyma.yaml
@@ -1,0 +1,473 @@
+dashboard_groups:
+- name: kyma
+  dashboard_names:
+  - kyma-all
+  - kyma-release
+  - kyma-cleaners
+  - kyma-presubmit
+  - kyma-postsubmit
+  - kyma-nightly
+  - kyma-weekly
+  - kyma-incubator
+
+dashboards:
+  # Kyma ALL dashboard
+- name: kyma-all
+  dashboard_tab:
+  #release
+  - name: Kyma release 1.6
+    description: Release jobs for 1.6
+    test_group_name: kyma-release-1.6
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma release 1.5
+    description: Release jobs for 1.5
+    test_group_name: kyma-release-1.5
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma release 1.4
+    description: Release jobs for 1.4
+    test_group_name: kyma-release-1.4
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  #cleaners
+  - name: Orphaned Cluster Cleaner
+    description: Tracks orphaned cluster cleaners
+    test_group_name: orphaned-cluster-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned VMs Cleaner
+    description: Tracks orphaned vms cleaners
+    test_group_name: orphaned-vms-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Firewall Cleaner
+    description: Tracks firewall cleaners
+    test_group_name: firewall-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Disk Cleaner
+    description: Tracks orphaned disk cleaners
+    test_group_name: orphaned-disk-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Utilities Kyma Integration Cleaner
+    description: Tracks utilities Kyma integration cleaners
+    test_group_name: utilities-kyma-integration-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned DNS Cleaner
+    description: Tracks orphaned dns cleaners
+    test_group_name: orphaned-dns-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Loadbalancer Cleaner
+    description: Tracks orphaned loadbalancer cleaners
+    test_group_name: orphaned-loadbalancer-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned AZ Storage Accounts Cleaner
+    description: Tracks orphaned Azure storage account cleaners
+    test_group_name: orphaned-az-storage-accounts-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Assetstore GCP Bucket Cleaner
+    description: Tracks orphaned Assetstore GCP bucket cleaners
+    test_group_name: orphaned-assetstore-gcp-bucket-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+
+  #presubmit
+  - name: pre-master-kyma-gke-upgrade
+    description: Tracks presubmit master gke upgrade jobs
+    test_group_name: pre-master-kyma-gke-upgrade
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  #postsubmit
+  - name: post-master-kyma-gke-upgrade
+    description: Tracks posubmit master gke upgrade jobs
+    test_group_name: post-master-kyma-gke-upgrade
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  #nightly
+  - name: Kyma GKE nightly
+    description: Tracks runtime of nightly GKE deployment
+    test_group_name: kyma-gke-nightly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma AKS nightly
+    description: Tracks runtime of nightly AKS deployment
+    test_group_name: kyma-aks-nightly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  #weekly
+  - name: Kyma GKE weekly
+    description: Tracks runtime of weekly GKE deployment
+    test_group_name: kyma-gke-weekly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  #incubator
+  - name: Hydroform presubmit
+    description: Tracks hydroform presubmit jobs
+    test_group_name: hydroform-presubmit
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-incubator/hydroform/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-incubator/hydroform/issues/
+  - name: Hydroform postsubmit
+    description: Tracks hydroform postsubmit jobs
+    test_group_name: hydroform-postsubmit
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-incubator/hydroform/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-incubator/hydroform/issues/
+
+  # Kyma presubmit dashboard
+- name: kyma-release
+  dashboard_tab:
+  - name: Kyma release 1.6
+    description: Release jobs for 1.6
+    test_group_name: kyma-release-1.6
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma release 1.5
+    description: Release jobs for 1.5
+    test_group_name: kyma-release-1.5
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma release 1.4
+    description: Release jobs for 1.4
+    test_group_name: kyma-release-1.4
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+
+  # Kyma cleaners dashboard
+- name: kyma-cleaners
+  dashboard_tab:
+  - name: Orphaned Cluster Cleaner
+    description: Tracks orphaned cluster cleaners
+    test_group_name: orphaned-cluster-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned VMs Cleaner
+    description: Tracks orphaned vms cleaners
+    test_group_name: orphaned-vms-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Firewall Cleaner
+    description: Tracks firewall cleaners
+    test_group_name: firewall-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Disk Cleaner
+    description: Tracks orphaned disk cleaners
+    test_group_name: orphaned-disk-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Utilities Kyma Integration Cleaner
+    description: Tracks utilities Kyma integration cleaners
+    test_group_name: utilities-kyma-integration-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned DNS Cleaner
+    description: Tracks orphaned dns cleaners
+    test_group_name: orphaned-dns-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Loadbalancer Cleaner
+    description: Tracks orphaned loadbalancer cleaners
+    test_group_name: orphaned-loadbalancer-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned AZ Storage Accounts Cleaner
+    description: Tracks orphaned Azure storage account cleaners
+    test_group_name: orphaned-az-storage-accounts-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+  - name: Orphaned Assetstore GCP Bucket Cleaner
+    description: Tracks orphaned Assetstore GCP bucket cleaners
+    test_group_name: orphaned-assetstore-gcp-bucket-cleaner
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/test-infra/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/test-infra/issues/
+
+  # Kyma presubmit dashboard
+- name: kyma-presubmit
+  dashboard_tab:
+  - name: pre-master-kyma-gke-upgrade
+    description: Tracks presubmit master gke upgrade jobs
+    test_group_name: pre-master-kyma-gke-upgrade
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  # Kyma postsubmit dashboard
+- name: kyma-postsubmit
+  dashboard_tab:
+  - name: post-master-kyma-gke-upgrade
+    description: Tracks posubmit master gke upgrade jobs
+    test_group_name: post-master-kyma-gke-upgrade
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  # Kyma nightly dashboard
+- name: kyma-nightly
+  dashboard_tab:
+  - name: Kyma GKE nightly
+    description: Tracks runtime of nightly GKE deployment
+    test_group_name: kyma-gke-nightly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+  - name: Kyma AKS nightly
+    description: Tracks runtime of nightly AKS deployment
+    test_group_name: kyma-aks-nightly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  # Kyma weekly dashboard
+- name: kyma-weekly
+  dashboard_tab:
+  - name: Kyma GKE weekly
+    description: Tracks runtime of weekly GKE deployment
+    test_group_name: kyma-gke-weekly
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-project/kyma/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-project/kyma/issues/
+
+  # Kyma incubator dashboard
+- name: kyma-incubator
+  dashboard_tab:
+  - name: Hydroform presubmit
+    description: Tracks hydroform presubmit jobs
+    test_group_name: hydroform-presubmit
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-incubator/hydroform/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-incubator/hydroform/issues/
+  - name: Hydroform postsubmit
+    description: Tracks hydroform postsubmit jobs
+    test_group_name: hydroform-postsubmit
+    # alert_options:
+    #   alert_mail_to_addresses: email-here@sap.com
+    code_search_url_template:
+      url: https://github.com/kyma-incubator/hydroform/compare/<start-custom-0>...<end-custom-0>
+    open_bug_template:
+      url: https://github.com/kyma-incubator/hydroform/issues/
+
+
+test_groups:
+#release
+- name: kyma-release-1.6
+  gcs_prefix: kyma-prow-logs/logs/post-rel16-kyma-release-candidate
+  num_failures_to_alert: 1
+- name: kyma-release-1.5
+  gcs_prefix: kyma-prow-logs/logs/post-rel15-kyma-release-candidate
+  num_failures_to_alert: 1
+- name: kyma-release-1.4
+  gcs_prefix: kyma-prow-logs/logs/post-rel14-kyma-release-candidate
+  num_failures_to_alert: 1
+
+#cleaners
+- name: orphaned-cluster-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-cluster-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-vms-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-vms-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-disk-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-disk-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-loadbalancer-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-loadbalancer-cleaner
+  num_failures_to_alert: 1
+- name: firewall-cleaner
+  gcs_prefix: kyma-prow-logs/logs/firewall-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-dns-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-dns-cleaner
+  num_failures_to_alert: 1
+- name: utilities-kyma-integration-cleaner
+  gcs_prefix: kyma-prow-logs/logs/utilities-kyma-integration-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-az-storage-accounts-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-az-storage-accounts-cleaner
+  num_failures_to_alert: 1
+- name: orphaned-assetstore-gcp-bucket-cleaner
+  gcs_prefix: kyma-prow-logs/logs/orphaned-assetstore-gcp-bucket-cleaner
+  num_failures_to_alert: 1
+
+#presubmit
+- name: pre-master-kyma-gke-upgrade
+  gcs_prefix: kyma-prow-logs/pr-logs/pull/kyma-project_kyma
+  num_failures_to_alert: 3
+
+#postsubmit
+- name: post-master-kyma-gke-upgrade
+  gcs_prefix: kyma-prow-logs/logs/post-master-kyma-gke-upgrade
+  num_failures_to_alert: 3
+
+#nightly
+- name: kyma-gke-nightly
+  gcs_prefix: kyma-prow-logs/logs/kyma-gke-nightly
+  num_failures_to_alert: 1
+- name: kyma-aks-nightly
+  gcs_prefix: kyma-prow-logs/logs/kyma-aks-nightly
+  num_failures_to_alert: 1
+
+#weekly
+- name: kyma-gke-weekly
+  gcs_prefix: kyma-prow-logs/logs/kyma-gke-weekly
+  num_failures_to_alert: 1
+
+#incubator
+- name: hydroform-presubmit
+  gcs_prefix: kyma-prow-logs/pr-logs/pull/kyma-incubator_hydroform
+  num_failures_to_alert: 3
+- name: hydroform-postsubmit
+  gcs_prefix: kyma-prow-logs/logs/post-master-hydroform
+  num_failures_to_alert: 3

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -50,6 +50,7 @@ var (
 		"vmware",
 		"gardener",
 		"jetstack",
+		"kyma",
 	}
 	orgs = []string{
 		"conformance",


### PR DESCRIPTION
For better insights into our pipelines we want to add Kyma (https://github.com/kyma-project/, https://kyma-project.io) to TestGrid. This PR is adding a `Kyma` dashboard and a couple sub dashboards. I have specified some initial jobs, that are to be displayed and we started on our side defining them in the prow config: https://github.com/kyma-project/test-infra/pull/1646. We'd like fill up our dashboards with more jobs as we go.

We'd be very happy if this would get merged to allow us to use TestGrid.