### PR TITLE
Isolate censoring logger from Secret Agent

### DIFF
--- a/prow/config/secret/BUILD.bazel
+++ b/prow/config/secret/BUILD.bazel
@@ -10,7 +10,11 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/config/secret",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "//prow/logrusutil:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
 )
 
 filegroup(
@@ -31,5 +35,8 @@ go_test(
     name = "go_default_test",
     srcs = ["agent_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "//prow/logrusutil:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )

--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -1,11 +1,14 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
     srcs = ["logrusutil.go"],
     importpath = "k8s.io/test-infra/prow/logrusutil",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_sirupsen_logrus//:go_default_library"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
 )
 
 filegroup(
@@ -20,4 +23,14 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["logrusutil_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
 )


### PR DESCRIPTION
This allows for the logger with censoring to be imported without
the context of secret agent.

/cc @petr-muller @stevekuznetsov 