### PR TITLE
Merge duplicate lines when parsing coverage profiles

### DIFF
--- a/gopherage/cmd/html/static/browser_bundle.es2015.js
+++ b/gopherage/cmd/html/static/browser_bundle.es2015.js
@@ -72,16 +72,26 @@
         constructor(filename, fileNumber) {
             this.filename = filename;
             this.fileNumber = fileNumber;
-            this.blocks = [];
+            this.blocks = new Map();
         }
         addBlock(block) {
-            this.blocks.push(block);
+            const k = this.keyForBlock(block);
+            const oldBlock = this.blocks.get(k);
+            if (oldBlock) {
+                oldBlock.hits += block.hits;
+            }
+            else {
+                this.blocks.set(k, block);
+            }
         }
         get totalStatements() {
-            return this.blocks.reduce((acc, b) => acc + b.statements, 0);
+            return reduce(this.blocks.values(), (acc, b) => acc + b.statements, 0);
         }
         get coveredStatements() {
-            return this.blocks.reduce((acc, b) => acc + (b.hits > 0 ? b.statements : 0), 0);
+            return reduce(this.blocks.values(), (acc, b) => acc + (b.hits > 0 ? b.statements : 0), 0);
+        }
+        keyForBlock(block) {
+            return `${block.start.line}.${block.start.col},${block.end.line}.${block.end.col}`;
         }
     }
     class Coverage {

--- a/gopherage/cmd/html/static/parser.ts
+++ b/gopherage/cmd/html/static/parser.ts
@@ -29,21 +29,31 @@ export interface Block {
 }
 
 export class FileCoverage {
-  public blocks: Block[] = [];
+  private blocks: Map<string, Block> = new Map<string, Block>();
 
   constructor(readonly filename: string, readonly fileNumber: number) {}
 
   public addBlock(block: Block) {
-    this.blocks.push(block);
+    const k = this.keyForBlock(block);
+    const oldBlock = this.blocks.get(k);
+    if (oldBlock) {
+      oldBlock.hits += block.hits;
+    } else {
+      this.blocks.set(k, block);
+    }
   }
 
   get totalStatements(): number {
-    return this.blocks.reduce((acc, b) => acc + b.statements, 0);
+    return reduce(this.blocks.values(), (acc, b) => acc + b.statements, 0);
   }
 
   get coveredStatements(): number {
-    return this.blocks.reduce(
+    return reduce(this.blocks.values(),
         (acc, b) => acc + (b.hits > 0 ? b.statements : 0), 0);
+  }
+
+  private keyForBlock(block: Block): string {
+    return `${block.start.line}.${block.start.col},${block.end.line}.${block.end.col}`;
   }
 }
 


### PR DESCRIPTION
Sometimes go produces mangled coverage profiles which have multiple entries for each block. Handle this by summing up the entries instead of becoming very confused.

/cc @BenTheElder 

Fixes #14876 