### PR TITLE
Fix config's BUILD dependencies

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -21,7 +21,7 @@ alias(
 filegroup(
     name = "prowjobs",
     srcs = glob([
-        "jobs/**/*.yaml",
+        "jobs/**",
     ]),
 )
 
@@ -29,6 +29,7 @@ filegroup(
     name = "testgrids",
     srcs = glob([
         "testgrids/**/*.yaml",
+        "testgrids/**/*.yml",
     ]),
 )
 


### PR DESCRIPTION
Prow currently picks up everything that parses as YAML in its
subdirectory
TestGrid currently picks up everything that ends in ".yaml" or ".yml"

xref #14888 