### PR TITLE
Addition of config-lint to forbid yml extension

### DIFF
--- a/config/BUILD.bazel
+++ b/config/BUILD.bazel
@@ -21,7 +21,7 @@ alias(
 filegroup(
     name = "prowjobs",
     srcs = glob([
-        "jobs/**",
+        "jobs/**/*.yaml",
     ]),
 )
 
@@ -29,7 +29,6 @@ filegroup(
     name = "testgrids",
     srcs = glob([
         "testgrids/**/*.yaml",
-        "testgrids/**/*.yml",
     ]),
 )
 
@@ -51,6 +50,7 @@ filegroup(
         ":package-srcs",
         "//config/prow:all-srcs",
         "//config/tests/jobs:all-srcs",
+        "//config/tests/lint:all-srcs",
         "//config/tests/testgrids:all-srcs",
     ],
     tags = ["automanaged"],

--- a/config/tests/lint/BUILD.bazel
+++ b/config/tests/lint/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["config_lint_test.go"],
+    data = [
+        "//config:all-srcs",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/config/tests/lint/config_lint_test.go
+++ b/config/tests/lint/config_lint_test.go
@@ -1,0 +1,22 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+var configPath = "../../../config/"
+
+func Test_ForbidYmlExtension(t *testing.T) {
+	err := filepath.Walk(configPath, func(path string, info os.FileInfo, err error) error {
+		if filepath.Ext(path) == ".yml" {
+			t.Errorf("*.yml extension not allowed in this repository's configuration; use *.yaml instead (at %s)", path)
+		}
+		return nil
+	})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Config lint is a test that checks the config source files themselves.

Forbids *.yml files for both Prow and TestGrid configs, so that Bazel can
pick up only *.yaml files and be correct.

Improvement on #14900
Originating issue #14888 

/assign @cblecker @Katharine @michelle192837 