### PR TITLE
add backup job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1229,3 +1229,28 @@ periodics:
         secretName: k8s-artifacts-prod-service-account
   annotations:
     testgrid-dashboards: sig-release-misc
+  # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
+- interval: 1h
+  cluster: test-infra-trusted
+  max_concurrency: 1
+  name: ci-k8sio-backup
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191021-b891e54-master
+      command:
+      - "./infra/gcp/backup_tools/backup.sh /etc/k8s-artifacts-prod-bak-service-account"
+      volumeMounts:
+      - name: k8s-artifacts-prod-bak-service-account-creds
+        mountPath: /etc/k8s-artifacts-prod-bak-service-account
+        readOnly: true
+    volumes:
+    - name: k8s-artifacts-prod-bak-service-account-creds
+      secret:
+        secretName: k8s-artifacts-prod-bak-service-account
+  annotations:
+    testgrid-dashboards: sig-release-misc


### PR DESCRIPTION
This adds an hourly backup job to backup all images in k8s-artifacts-prod.

This is blocked by https://github.com/kubernetes/k8s.io/pull/377

/hold

/cc @thockin @justinsb