### PR TITLE
podutils: add a timestamp wrapper for build log

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -84,6 +84,16 @@ const (
 	DefaultClusterAlias = "default"
 )
 
+// DateTimeLayout specifies a datetime format string.
+type DateTimeLayout string
+
+func (d *DateTimeLayout) Get() string {
+	if d == nil {
+		return ""
+	}
+	return string(*d)
+}
+
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -287,7 +297,9 @@ type DecorationConfig struct {
 	// after sending SIGINT to send SIGKILL when aborting
 	// a job. Only applicable if decorating the PodSpec.
 	GracePeriod *Duration `json:"grace_period,omitempty"`
-
+	// DateTimeFormat is the datetime format to prefix log lines with.
+	// If omitted or empty, no datetime prefix will be added.
+	DateTimeFormat *DateTimeLayout `json:"datetime_format,omitempty"`
 	// UtilityImages holds pull specs for utility container
 	// images used to decorate a PodSpec.
 	UtilityImages *UtilityImages `json:"utility_images,omitempty"`
@@ -335,6 +347,9 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 	}
 	if merged.GracePeriod == nil {
 		merged.GracePeriod = def.GracePeriod
+	}
+	if merged.DateTimeFormat == nil {
+		merged.DateTimeFormat = def.DateTimeFormat
 	}
 	if merged.GCSCredentialsSecret == "" {
 		merged.GCSCredentialsSecret = def.GCSCredentialsSecret

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -25,6 +25,8 @@ import (
 func TestDecorationDefaulting(t *testing.T) {
 	truth := true
 	lies := false
+	datetimeDefault := DateTimeLayout("2006-01-02T15:04:05Z07:00")
+	datetimeOverride := DateTimeLayout("3:04PM")
 
 	var testCases = []struct {
 		name     string
@@ -56,6 +58,16 @@ func TestDecorationDefaulting(t *testing.T) {
 			},
 			expected: func(orig, def *DecorationConfig) *DecorationConfig {
 				def.GracePeriod = orig.GracePeriod
+				return def
+			},
+		},
+		{
+			name: "datetime provided",
+			provided: &DecorationConfig{
+				DateTimeFormat: &datetimeOverride,
+			},
+			expected: func(orig, def *DecorationConfig) *DecorationConfig {
+				def.DateTimeFormat = orig.DateTimeFormat
 				return def
 			},
 		},
@@ -181,6 +193,7 @@ func TestDecorationDefaulting(t *testing.T) {
 				GCSCredentialsSecret: "secretName",
 				SSHKeySecrets:        []string{"first", "second"},
 				SSHHostFingerprints:  []string{"primero", "segundo"},
+				DateTimeFormat:       &datetimeDefault,
 				SkipCloning:          &truth,
 			}
 			t.Parallel()

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -40,6 +40,11 @@ func (in *DecorationConfig) DeepCopyInto(out *DecorationConfig) {
 		*out = new(Duration)
 		**out = **in
 	}
+	if in.DateTimeFormat != nil {
+		in, out := &in.DateTimeFormat, &out.DateTimeFormat
+		*out = new(DateTimeLayout)
+		**out = **in
+	}
 	if in.UtilityImages != nil {
 		in, out := &in.UtilityImages, &out.UtilityImages
 		*out = new(UtilityImages)

--- a/prow/cmd/build/controller.go
+++ b/prow/cmd/build/controller.go
@@ -682,7 +682,7 @@ func decorateSteps(steps []coreapi.Container, dc prowjobv1.DecorationConfig, too
 			previousMarker = entries[i-1].MarkerFile
 		}
 		// TODO(fejta): consider refactoring entrypoint to accept --expire=time.Now.Add(dc.Timeout) so we timeout each step correctly (assuming a good clock)
-		opt, err := decorate.InjectEntrypoint(&steps[i], dc.Timeout.Get(), dc.GracePeriod.Get(), steps[i].Name, previousMarker, alwaysPass, logMount, toolsMount)
+		opt, err := decorate.InjectEntrypoint(&steps[i], dc.Timeout.Get(), dc.GracePeriod.Get(), dc.DateTimeFormat.Get(), steps[i].Name, previousMarker, alwaysPass, logMount, toolsMount)
 		if err != nil {
 			return nil, fmt.Errorf("inject entrypoint into %s: %v", steps[i].Name, err)
 		}

--- a/prow/cmd/build/controller_test.go
+++ b/prow/cmd/build/controller_test.go
@@ -1563,8 +1563,10 @@ func TestMakeBuild(t *testing.T) {
 
 func TestDecorateSteps(t *testing.T) {
 	var dc prowjobv1.DecorationConfig
+	dt := prowjobv1.DateTimeLayout("Mon Jan _2 15:04:05 2006")
 	dc.Timeout = &prowjobv1.Duration{Duration: 10 * time.Minute}
 	dc.GracePeriod = &prowjobv1.Duration{Duration: 5 * time.Minute}
+	dc.DateTimeFormat = &dt
 	_, tm := tools()
 	tm.Name += "not-static"
 	tm.MountPath += "fancy"
@@ -1591,15 +1593,15 @@ func TestDecorateSteps(t *testing.T) {
 		},
 	}
 	expected[1].Name = "step-1"
-	o1, err := decorate.InjectEntrypoint(&expected[0], dc.Timeout.Get(), dc.GracePeriod.Get(), expected[0].Name, "", true, logMount, tm)
+	o1, err := decorate.InjectEntrypoint(&expected[0], dc.Timeout.Get(), dc.GracePeriod.Get(), dc.DateTimeFormat.Get(), expected[0].Name, "", true, logMount, tm)
 	if err != nil {
 		t.Fatalf("inject expected 0: %v", err)
 	}
-	o2, err := decorate.InjectEntrypoint(&expected[1], dc.Timeout.Get(), dc.GracePeriod.Get(), expected[1].Name, o1.MarkerFile, true, logMount, tm)
+	o2, err := decorate.InjectEntrypoint(&expected[1], dc.Timeout.Get(), dc.GracePeriod.Get(), dc.DateTimeFormat.Get(), expected[1].Name, o1.MarkerFile, true, logMount, tm)
 	if err != nil {
 		t.Fatalf("inject expected 1: %v", err)
 	}
-	o3, err := decorate.InjectEntrypoint(&expected[2], dc.Timeout.Get(), dc.GracePeriod.Get(), expected[2].Name, o2.MarkerFile, true, logMount, tm)
+	o3, err := decorate.InjectEntrypoint(&expected[2], dc.Timeout.Get(), dc.GracePeriod.Get(), dc.DateTimeFormat.Get(), expected[2].Name, o2.MarkerFile, true, logMount, tm)
 	if err != nil {
 		t.Fatalf("inject expected 2: %v", err)
 	}

--- a/prow/entrypoint/BUILD.bazel
+++ b/prow/entrypoint/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//prow/pod-utils/wrapper:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
     ],
 )
 
@@ -39,5 +40,6 @@ go_test(
     deps = [
         "//prow/pod-utils/wrapper:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )

--- a/prow/entrypoint/options.go
+++ b/prow/entrypoint/options.go
@@ -23,11 +23,13 @@ import (
 	"time"
 
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
+	"k8s.io/utils/clock"
 )
 
 // NewOptions returns an empty Options with no nil fields
 func NewOptions() *Options {
 	return &Options{
+		clock:   clock.RealClock{},
 		Options: &wrapper.Options{},
 	}
 }
@@ -43,6 +45,9 @@ type Options struct {
 	// sending SIGINT before the entrypoint sends
 	// SIGKILL.
 	GracePeriod time.Duration `json:"grace_period"`
+	// DateTimeFormat is the datetime format to prefix log lines with.
+	// If omitted or empty, no datetime prefix will be added.
+	DateTimeFormat string `json:"datetime_format,omitempty"`
 	// ArtifactDir is a directory where test processes can dump artifacts
 	// for upload to persistent storage (courtesy of sidecar).
 	// If specified, it is created by entrypoint before starting the test process.
@@ -59,6 +64,8 @@ type Options struct {
 	// AlwaysZero will cause entrypoint to exit zero, regardless of the marker it writes.
 	// Primarily useful in case a subsequent entrypoint will read this entrypoint's marker
 	AlwaysZero bool `json:"always_zero,omitempty"`
+
+	clock clock.Clock
 
 	*wrapper.Options
 }

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -414,7 +414,7 @@ func entrypointLocation(tools coreapi.VolumeMount) string {
 }
 
 // InjectEntrypoint will make the entrypoint binary in the tools volume the container's entrypoint, which will output to the log volume.
-func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, prefix, previousMarker string, exitZero bool, log, tools coreapi.VolumeMount) (*wrapper.Options, error) {
+func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, dateTimeFormat string, prefix, previousMarker string, exitZero bool, log, tools coreapi.VolumeMount) (*wrapper.Options, error) {
 	wrapperOptions := &wrapper.Options{
 		Args:         append(c.Command, c.Args...),
 		ProcessLog:   processLog(log, prefix),
@@ -427,6 +427,7 @@ func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, 
 		GracePeriod:    gracePeriod,
 		Options:        wrapperOptions,
 		Timeout:        timeout,
+		DateTimeFormat: dateTimeFormat,
 		AlwaysZero:     exitZero,
 		PreviousMarker: previousMarker,
 	})
@@ -602,7 +603,7 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 		previous = ""
 		exitZero = false
 	)
-	wrapperOptions, err := InjectEntrypoint(&spec.Containers[0], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), prefix, previous, exitZero, logMount, toolsMount)
+	wrapperOptions, err := InjectEntrypoint(&spec.Containers[0], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), pj.Spec.DecorationConfig.DateTimeFormat.Get(), prefix, previous, exitZero, logMount, toolsMount)
 	if err != nil {
 		return fmt.Errorf("wrap container: %v", err)
 	}

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -378,6 +378,7 @@ func TestCloneRefs(t *testing.T) {
 func TestProwJobToPod(t *testing.T) {
 	truth := true
 	falseth := false
+	datetime := prowapi.DateTimeLayout("2006-01-02T15:04:05Z07:00")
 	var sshKeyMode int32 = 0400
 	tests := []struct {
 		podName  string
@@ -1637,6 +1638,7 @@ func TestProwJobToPod(t *testing.T) {
 					GCSCredentialsSecret: "secret-name",
 					SSHKeySecrets:        []string{"ssh-1", "ssh-2"},
 					SkipCloning:          &truth,
+					DateTimeFormat:       &datetime,
 				},
 				Agent: prowapi.KubernetesAgent,
 				Refs: &prowapi.Refs{
@@ -1747,7 +1749,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"datetime_format":"2006-01-02T15:04:05Z07:00","artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							VolumeMounts: []coreapi.VolumeMount{
 								{


### PR DESCRIPTION
Add a timestamp wrapper for build log.
> Note: the **datetime** format is a standard **layout** string - [func (t Time) Format(layout string) string](https://golang.org/pkg/time/#Time.Format)

For backwards compatibility this is *optional* and **disabled** by default, thus this functionality is opt-in.

fixes #10100

---

Specify a *default* in `plank` config.
```yaml
plank:
  default_decoration_config:
    datetime_format: "2006-01-02T15:04:05Z07:00"
```
```text
2019-10-22T06:06:17Z some log line
```
---
Override via `decoration_config` in job.
```yaml
    decoration_config:
      datetime_format: "3:15PM"
```
```text
10:30AM some log line
```
---
Set to empty string to omit datetime from log line.
```yaml
    decoration_config:
      datetime_format: ""
```
```text
some log line
```
