### PR TITLE
Remove TideNoProgressKK prometheus alert.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -5,24 +5,6 @@
         name: 'Tide progress',
         rules: [
           {
-            alert: 'TideNoProgressKK',
-            expr: |||
-              clamp_min(
-              (sum(merges_sum{org="kubernetes",repo="kubernetes",branch="master"}) or vector(0))
-               - (sum(merges_sum{org="kubernetes",repo="kubernetes",branch="master"} offset 5m ) or vector(0)),
-              0) < 0.5
-              and
-              (avg(pooledprs{branch="master",org="kubernetes",repo="kubernetes"} and ((time() - updatetime) < 240))  or vector(0)) > 0.5
-            |||,
-            'for': '4h',
-            labels: {
-              severity: 'warning',
-            },
-            annotations: {
-              message: 'Tide has not merged any PRs in kubernetes/kubernetes:master in the past 4 hours despite PRs in the pool. See the <https://prow.k8s.io/tide-history?repo=kubernetes%2Fkubernetes&branch=master|tide-history> page for k/k:m.',
-            },
-          },
-          {
             alert: 'TideSyncLoopDuration',
             expr: |||
               avg_over_time(syncdur{job="tide"}[15m]) > 120


### PR DESCRIPTION
This alert usually isn't actionable for oncall. We have seen some pathological Tide behavior that this would catch, but most of the time Tide progress on K/K is impeded by flaky and slow presubmits, not misbehavior from Tide so this is more noisy than it is worth at the moment.

/assign @fejta @stevekuznetsov 