### PR TITLE
Retire optional contexts removed from repos

### DIFF
--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -193,6 +193,15 @@ func (t *Tide) GetPRStatusBaseURL(repo OrgRepo) string {
 	return t.PRStatusBaseURLs["*"]
 }
 
+// SkipUnknownContexts returns the SkipUnknownContexts policy for a repo.
+func (t *Tide) SkipUnknownContexts(org, repo string) bool {
+	skip := parseTideContextPolicyOptions(org, repo, "", t.ContextOptions).SkipUnknownContexts
+	if skip != nil {
+		return *skip
+	}
+	return false
+}
+
 // TideQuery is turned into a GitHub search query. See the docs for details:
 // https://help.github.com/articles/searching-issues-and-pull-requests/
 type TideQuery struct {

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -229,6 +229,56 @@ func TestMergeTemplate(t *testing.T) {
 	}
 }
 
+func TestSkipUnknownContexts(t *testing.T) {
+	yes := true
+	testCases := []struct {
+		name           string
+		contextOptions TideContextPolicyOptions
+		expected       bool
+	}{
+		{
+			name: "global SkipUnknownContexts set",
+			contextOptions: TideContextPolicyOptions{
+				TideContextPolicy: TideContextPolicy{SkipUnknownContexts: &yes},
+			},
+			expected: true,
+		},
+		{
+			name: "org SkipUnknownContexts overrides global policy",
+			contextOptions: TideContextPolicyOptions{
+				Orgs: map[string]TideOrgContextPolicy{
+					"org": {
+						TideContextPolicy: TideContextPolicy{SkipUnknownContexts: &yes},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "repo SkipUnknownContexts overrides org policy",
+			contextOptions: TideContextPolicyOptions{
+				Orgs: map[string]TideOrgContextPolicy{
+					"org": {
+						Repos: map[string]TideRepoContextPolicy{
+							"repo": {
+								TideContextPolicy: TideContextPolicy{SkipUnknownContexts: &yes},
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		config := Tide{ContextOptions: tc.contextOptions}
+		if got := config.SkipUnknownContexts("org", "repo"); got != tc.expected {
+			t.Errorf("%s - expected: %v got: %v for skip_unknown_contexts", tc.name, tc.expected, got)
+		}
+	}
+}
+
 func TestParseTideContextPolicyOptions(t *testing.T) {
 	yes := true
 	no := false


### PR DESCRIPTION
`status-reconciler` now retires any optional contexts that are removed
from repos, as these will otherwise block merges due to `tide`'s
`skip-unknown-contexts` being false by default.

Fixes #14705
