### PR TITLE
Fix pj-on-kind.sh to work without JOB_CONFIG.

### DIFF
--- a/prow/pj-on-kind.sh
+++ b/prow/pj-on-kind.sh
@@ -24,7 +24,7 @@ function main() {
   ensureInstall
 
   # Generate PJ and Pod.
-  docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj "--config-path=${config}" "${job_config_flag}" "--job=${job}" > "${PWD}/pj.yaml"
+  docker run -i --rm -v "${PWD}:${PWD}" -v "${config}:${config}" ${job_config_mnt} -w "${PWD}" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job=${job}" ${job_config_flag} > "${PWD}/pj.yaml"
   docker run -i --rm -v "${PWD}:${PWD}" -w "${PWD}" gcr.io/k8s-prow/mkpod --build-id=snowflake "--prow-job=${PWD}/pj.yaml" --local "--out-dir=${out_dir}/${job}" > "${PWD}/pod.yaml"
  
   # Add any k8s resources that the pod depends on to the kind cluster here. (secrets, configmaps, etc.)


### PR DESCRIPTION
An empty string position argument makes `mkpj` unhappy.

/assign @fejta @clarketm 