### PR TITLE
Reduce "JobAgent.update" to one sort operation

### DIFF
--- a/prow/deck/jobs/BUILD.bazel
+++ b/prow/deck/jobs/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/kube:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )
 

--- a/prow/deck/jobs/jobs.go
+++ b/prow/deck/jobs/jobs.go
@@ -191,12 +191,6 @@ func (ja *JobAgent) tryUpdate() {
 	}
 }
 
-type byStartTime []Job
-
-func (a byStartTime) Len() int           { return len(a) }
-func (a byStartTime) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a byStartTime) Less(i, j int) bool { return a[i].st.After(a[j].st) }
-
 type byPJStartTime []prowapi.ProwJob
 
 func (a byPJStartTime) Len() int      { return len(a) }
@@ -213,6 +207,9 @@ func (ja *JobAgent) update() error {
 	var njs []Job
 	njsMap := make(map[string]Job)
 	njsIDMap := make(map[string]map[string]prowapi.ProwJob)
+
+	sort.Sort(byPJStartTime(pjs))
+
 	for _, j := range pjs {
 		ft := time.Time{}
 		if j.Status.CompletionTime != nil {
@@ -255,9 +252,6 @@ func (ja *JobAgent) update() error {
 		}
 		njsIDMap[j.Spec.Job][buildID] = j
 	}
-
-	sort.Sort(byStartTime(njs))
-	sort.Sort(byPJStartTime(pjs))
 
 	ja.mut.Lock()
 	defer ja.mut.Unlock()


### PR DESCRIPTION
Micro-optimization in Deck `JobAgent.update()`

Only *one* sort is **required** here since `Jobs` are derived from `ProwJobs`. Originally I was going to resolve this as part of #14254. But since we want to continue to serve both `data.js` and `prowjobs.js` for some time we should go ahead and make this minor tweak. 

May help with #14910