### PR TITLE
releng: Move prototype Kubernetes builds to test-infra-trusted cluster

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-release-test.yaml
+++ b/config/jobs/image-pushing/k8s-staging-release-test.yaml
@@ -1,6 +1,7 @@
 periodics:
 - interval: 1h
   name: ci-kubernetes-prototype-build
+  cluster: test-infra-trusted
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -38,6 +39,7 @@ periodics:
 
 - interval: 1h
   name: ci-kubernetes-prototype-build-fast
+  cluster: test-infra-trusted
   decorate: true
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
We missed this in a previous PR, but these prototype build jobs should
run in the test-infra-trusted cluster so that they have credentials to
execute GCB runs on the `k8s-staging-release-test` GCP project.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: #14788 

/assign @Katharine @BenTheElder 