### PR TITLE
images/builder: Optionally force logging to stdout with `LOG_TO_STDOUT`

### DIFF
--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -48,3 +48,15 @@ bazel run //images/builder -- [options] path/to/build-directory/
 - `--build-dir`: If provided, this directory will be uploaded as the source for the Google Cloud Build run.
 - `--gcb-config`: If provided, this will be used as the name of the Google Cloud Build config file.
 - `--no-source`: If true, no source will be uploaded with this build.
+
+### A note about logging in Prow
+
+Prow job logs can be viewed at a URI constructed as follows: `https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/<job-name>/<job-number>` e.g., https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187171788975509509
+
+When `--log-dir` is specified (which is the default case when running in Prow), the GCB build logs will be written to a set of log files, based on the variant(s).
+
+For example:
+- No variant --> `build.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/post-release-push-image-k8s-cloud-builder/1186437931728900096/artifacts/build.log)
+- Variant: `build-ci` --> `build-ci.log` (https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-prototype-build/1187156434249322500/artifacts/build-ci.log)
+
+For single-variant jobs where the preference is to log directly to stdout (so that the log is instead visible in `https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/<job-name>/<job-number>`), `LOG_TO_STDOUT="y"` can be specified.

--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -119,6 +119,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 	s = append(s, "_GIT_TAG="+version)
 	args := []string{
 		"builds", "submit",
+		"--verbosity", "info",
 		"--config", o.cloudbuildFile,
 		"--substitutions", strings.Join(s, ","),
 	}

--- a/images/builder/run.sh
+++ b/images/builder/run.sh
@@ -22,7 +22,7 @@ echo "Activating service account..."
 gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 
 echo "Running..."
-if [[ ! -z "${ARTIFACTS}" ]]; then
+if [ -n "${ARTIFACTS}" ] && [ -z "${LOG_TO_STDOUT}" ]; then
   echo "\$ARTIFACTS is set, sending logs to ${ARTIFACTS}"
   /builder --log-dir="${ARTIFACTS}" "$@"
 else


### PR DESCRIPTION
- Set the verbosity of `gcloud builds submit` to "info"
- Optionally force logging to stdout with `LOG_TO_STDOUT`
  
  Here we add a check for an env var called `LOG_TO_STDOUT`.
  If it is set to `y|Y`, we will force logs to stdout instead of a
  specified log directory.

  This is useful for CI instances where a single variant is run.
  The current behavior writes to a build log which you need to dig for a
  little, as opposed to being able to view via prow.k8s.io/view.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @Katharine @BenTheElder 