### PR TITLE
Set KUBE_GCE_PRIVATE_CLUSTER_PORTS_PER_VM in kubemark tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -62,6 +62,9 @@ presets:
   # Use private clusters for scalability tests - https://github.com/kubernetes/kubernetes/issues/76374
   - name: KUBE_GCE_PRIVATE_CLUSTER
     value: "true"
+  # We create approx. 70 hollow nodes per VM. Allow ~4 connections from each of them.
+  - name: KUBE_GCE_PRIVATE_CLUSTER_PORTS_PER_VM
+    value: 300
   - name: PROMETHEUS_SCRAPE_ETCD
     value: "true"
 ### kubemark-gce-scale


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/81073 migrates to --nat-primary-subnet-ip-ranges instead of --nat-all-subnet-ip-ranges which is a right thing to do (we need to nat only primary ranges), but as a side effect reduces a number of ports available for a single hollow node.

This PR increases the number of ports available for a single hollow-nodes to ~4 connections which should be sufficient.
This is no-op until https://github.com/kubernetes/kubernetes/pull/81073 is submitted.


/assign @wojtek-t 