### PR TITLE
Enable boskos in k8s.io/perf-test presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -305,7 +305,7 @@ presubmits:
         - --cluster=
         - --extract=ci/latest
         - --gcp-nodes=100
-        - --gcp-project=k8s-presubmit-scale
+        - --gcp-project-type=scalability-presubmit-project
         - --gcp-zone=us-east1-b
         - --provider=gce
         - --tear-down-previous
@@ -364,7 +364,7 @@ presubmits:
             - --gcp-master-size=n1-standard-2
             - --gcp-node-size=n1-standard-4
             - --gcp-nodes=4
-            - --gcp-project=k8s-presubmit-scale
+            - --gcp-project-type=scalability-presubmit-project
             - --gcp-zone=us-east1-b
             - --kubemark
             - --kubemark-nodes=100


### PR DESCRIPTION
This time it should work. The `scalability-presubmit-project` has been
added to boskos in https://github.com/kubernetes/test-infra/pull/14727.

Velodrome reports all projects in the pool as `free`: http://velodrome.k8s.io/dashboard/db/boskos-dashboard?orgId=1

![Te3GdTLt0Za](https://user-images.githubusercontent.com/2604887/67379970-f4ece000-f589-11e9-9186-5d6b1fef4d72.png)


Ref. kubernetes/perf-tests#650