### PR TITLE
Download kind binary instead of go get

### DIFF
--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -48,12 +48,11 @@ cleanup() {
 install_kind() {
     # install `kind` to tempdir
     TMP_DIR=$(mktemp -d)
-    # ensure bin dir
-    mkdir -p "${TMP_DIR}/bin"
     pushd "${TMP_DIR}"
-    env "GOPATH=${TMP_DIR}" GO111MODULE="on" go get -u "sigs.k8s.io/kind@${STABLE_KIND_VERSION}"
+    curl -L https://github.com/kubernetes-sigs/kind/releases/download/${STABLE_KIND_VERSION}/kind-linux-amd64 --output kind
+    chmod +x ./kind
     popd
-    PATH="${TMP_DIR}/bin:${PATH}"
+    PATH="${TMP_DIR}:${PATH}"
     export PATH
 }
 


### PR DESCRIPTION
Go get is apt to breaking and as of recently will not build
kind as expected due to module issues. If we want to pin a
version we should just download it directly.