### PR TITLE
peribolos: Allow renaming repositories

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -883,14 +883,15 @@ func validateRepos(repos map[string]org.Repo) error {
 	var dups []string
 
 	for wantName, repo := range repos {
-		toCheck := []string{wantName}
-		toCheck = append(toCheck, repo.Previously...)
+		toCheck := append([]string{wantName}, repo.Previously...)
 		for _, name := range toCheck {
 			normName := strings.ToLower(name)
 			if seenName, have := seen[normName]; have {
 				dups = append(dups, fmt.Sprintf("%s/%s", seenName, name))
-				continue
 			}
+		}
+		for _, name := range toCheck {
+			normName := strings.ToLower(name)
 			seen[normName] = name
 		}
 

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2784,6 +2784,16 @@ func TestConfigureRepos(t *testing.T) {
 			expectedRepos: []github.Repo{{Name: newName, Description: "renamed repo"}},
 		},
 		{
+			description: "renaming a repo by just changing case is successful",
+			orgConfig: org.Config{
+				Repos: map[string]org.Repo{
+					"repo": {Previously: []string{"REPO"}},
+				},
+			},
+			repos:         []github.Repo{{Name: "REPO", Description: "renamed repo"}},
+			expectedRepos: []github.Repo{{Name: "repo", Description: "renamed repo"}},
+		},
+		{
 			description: "dup between a repo name and a previous name is detected",
 			orgConfig: org.Config{
 				Repos: map[string]org.Repo{
@@ -2878,6 +2888,12 @@ func TestValidateRepos(t *testing.T) {
 				"another-repo": {Previously: []string{"conflict"}},
 			},
 			expectError: true,
+		},
+		{
+			description: "allows case-duplicate name between former and current name",
+			config: map[string]org.Repo{
+				"repo": {Previously: []string{"REPO"}},
+			},
 		},
 	}
 

--- a/prow/config/org/org.go
+++ b/prow/config/org/org.go
@@ -69,6 +69,8 @@ type Repo struct {
 	DefaultBranch *string `json:"default_branch,omitempty"`
 	Archived      *bool   `json:"archived,omitempty"`
 
+	Previously []string `json:"previously,omitempty"`
+
 	OnCreate *RepoCreateOptions `json:"on_create,omitempty"`
 }
 


### PR DESCRIPTION
Builds on https://github.com/kubernetes/test-infra/pull/14885 which hopefully close to merge. Contains only one additional commit over https://github.com/kubernetes/test-infra/pull/14885.

Allows renaming repositories, using the `previously:` pattern used in other parts in peribolos and elsewhere.

/cc @fejta @stevekuznetsov 

