### PR TITLE
Deprecate config.yaml in testgrid

### DIFF
--- a/config/testgrids/README.md
+++ b/config/testgrids/README.md
@@ -1,7 +1,7 @@
 # Testgrid Configurations
 
 This readme covers information specific to testgrid.k8s.io and this repository.
-See Testgrid's [config.md](../../testgrid/config.md) for more information Testgrid config files.
+See Testgrid's [config.md](/testgrid/config.md) for more information Testgrid config files.
 
 ## Adding a Prow Job to Testgrid
 
@@ -12,10 +12,28 @@ no changes are necessary here unless you are adding a brand new dashboard.
 
 Any file put in this directory or a subdirectory will be picked up by [testgrid.k8s.io](https://testgrid.k8s.io).
 
+To add a new test, perform the following steps under any `.yaml` file in this
+directory (including a new one, if desired):
+
+1.   If writing a presubmit and not using [annotations](/testgrid/config.md#prow-job-configuration),
+     append a new testgroup under `test_groups`, and specify the name and where to get the log.
+1.   Append a new `dashboard_tab` under the dashboard you would like to add the testgroup to,
+     or create a new `dashboard` and assign the testgroup to the dashboard.
+     * The testgroup name from a dashboard tab should match the name from a testgroup
+     * Note that a testgroup can be within multiple dashboards.
+1.   Test your new config (`bazel test //config/tests/...`)
+
+
+NOTE: If you're adding a periodic or postsubmit and don't want to specially configure your test
+group, you don't need to: [Configurator](/testgrid/cmd/configurator) implicitly assume a testgroup
+exists for all periodics and postsubmits. You still need to add presubmits here, and all jobs still
+need to be added to a dashboard further down.
+
 ## Testing
 
-Run `bazel test //config/jobs/tests/...` to ensure these configurations are valid.
+Run `bazel test //config/tests/...` to ensure these configurations are valid.
 
 This finds common problems such as malformed yaml, a tab referring to a
 non-existent test group, a test group never appearing on any tab, etc. It also enforces some
-repository-specific conventions.
+repository-specific conventions. More details about specific tests can be found
+in that directory.

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -1,23 +1,10 @@
-#  -- Yaml representation for configuring testgrid.k8s.io
-#
-#  To add a new test:
-#   1. Append a new testgroup under test_groups, specify the name and where to get the log.
-#   2. Append a new dashboardtab under the dashboard you would like to add the testgroup to,
-#      or create a new dashboard and assign the testgroup to the dashboard.
-#      * The testgroup name from a dashboardtab should match the name from a testgroup
-#      ** Note that a testgroup can be within multiple dashboards.
-#   3. Run config_test.go to make sure the config is valid.
-#
+# DEPRECATED: Please do not add to this document.
+# If you have test groups or tabs in this document, please:
+# 1. Move them to a .yaml file in an appropriate subdirectory. Create one, if needed.
+# 2. If there isn't an OWNERS file, create one and add yourself and others who work with these test groups.
+# See the OWNERS docs at https://go.k8s.io/owners for more info
 
 # Start testgroups
-#
-# NOTE: If you're adding a periodic or postsubmit and don't want to specially configure your test
-# group, you don't need to add it here: we implicitly assume a testgroup exists for all periodics
-# and postsubmits. You still need to add presubmits here, and all jobs still need to be added to a
-# dashboard further down.
-#
-# If you want to do some special configuration on your test group (e.g. specifying name_elements,
-# days_of_results, num_columns_recent, etc.) you can still add it to this test_groups list manually.
 test_groups:
 - name: ci-kubernetes-node-kubelet-benchmark
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark


### PR DESCRIPTION
Improves readme documentation to contain info that was in `config.yaml`

Includes a deprecation notice in `config.yaml`

This is part of an effort to shard testgrid's config, and should close #13541

/cc @michelle192837 @Katharine @spiffxp 