### PR TITLE
promoter jobs: reduce scope

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -17,7 +17,7 @@ presubmits:
         # Pod Utilities already sets pwd to
         # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
         # suffice, but it's nice to be explicit.
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
         # Without account keys (-key-files), we should not be trying to activate
         # any service accounts.
         - -no-service-account

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -821,7 +821,7 @@ postsubmits:
         command:
         - cip
         args:
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
         - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
         - -dry-run=false
         volumeMounts:
@@ -1216,7 +1216,7 @@ periodics:
       command:
       - cip
       args:
-      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
       - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
       - -dry-run=false
       volumeMounts:


### PR DESCRIPTION
Make the promoter only read thin manifests from the "manifests"
subdirectory.

/cc @thockin 