### PR TITLE
Add kyma owners for TestGrid dashboards

### DIFF
--- a/config/testgrids/kyma/OWNERS
+++ b/config/testgrids/kyma/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- tehcyx
+- mszostok
+- piotrmiskiewicz


### PR DESCRIPTION
As suggested (https://github.com/kubernetes/test-infra/pull/14896#issuecomment-544747883) I'm adding a Kyma OWNERS file to the folder, to maintain dashboards.