### PR TITLE
Omit kubeflow from tide pool error alerts.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -33,7 +33,7 @@
           {
             alert: 'TidePoolErrorRateIndividual',
             expr: |||
-              (max(sum(increase(tidepoolerrors[10m])) by (org, repo, branch)) or vector(0)) >= 3
+              (max(sum(increase(tidepoolerrors{org!="kubeflow"}[10m])) by (org, repo, branch)) or vector(0)) >= 3
             |||,
             'for': '5m',
             labels: {


### PR DESCRIPTION
Slack context: https://kubernetes.slack.com/archives/C7J9RP96G/p1571928405113600
GH context: https://github.com/kubeflow/pipelines/issues/930
I confirmed that this query works and would avoid the recent alerts.

/assign @Katharine 