### PR TITLE
Add a new optional CAPA CI job for running e2e conformance tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -75,3 +75,53 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: verify
+    # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
+  - name: pull-cluster-api-provider-aws-conformance
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+    always_run: false
+    optional: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191024-4a89182-master
+          args:
+            - "--job=$(JOB_NAME)"
+            - "--root=/go/src"
+            - "--repo=k8s.io/kubernetes=master"
+            - "--repo=sigs.k8s.io/cluster-api=master"
+            - "--repo=sigs.k8s.io/image-builder=master"
+            - "--repo=sigs.k8s.io/cluster-api-provider-aws=$(PULL_REFS)"
+            - "--repo=sigs.k8s.io/kind=master"
+            - "--service-account=/etc/service-account/service-account.json"
+            - "--upload=gs://kubernetes-jenkins/pr-logs"
+            - "--scenario=execute"
+            - "--"
+            - "bash"
+            - "--"
+            - "-c"
+            - "cd ./../../sigs.k8s.io/cluster-api-provider-aws && scripts/ci-conformance.sh"
+          # we need privileged mode in order to do docker in docker
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-conformance
+      testgrid-num-columns-recent: '20'


### PR DESCRIPTION
Similar to the CAPG CI presubmit job.

Needs https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/1254 to merge for this to work