### PR TITLE
prow/plugins/bugzilla: When dependent params are given, require a dependent bug

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -508,6 +508,23 @@ func validateBug(bug bugzilla.Bug, dependents []bugzilla.Bug, options plugins.Bu
 		}
 	}
 
+	if len(dependents) == 0 {
+		switch {
+		case options.DependentBugStates != nil && options.DependentBugTargetRelease != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting the %q release and in one of the following states: %s, but no dependents were found", bug.ID, endpoint, bug.ID, *options.DependentBugTargetRelease, expected))
+		case options.DependentBugStates != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug in one of the following states: %s, but no dependents were found", bug.ID, endpoint, bug.ID, expected))
+		case options.DependentBugTargetRelease != nil:
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting the %q release, but no dependents were found", bug.ID, endpoint, bug.ID, *options.DependentBugTargetRelease))
+		default:
+		}
+	}
+
 	return valid, errors
 }
 

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1173,7 +1173,8 @@ func TestValidateBug(t *testing.T) {
 			name:    "dependent status requirement with no dependent bugs means a valid bug",
 			bug:     bugzilla.Bug{DependsOn: []int{}},
 			options: plugins.BugzillaBranchOptions{DependentBugStates: &verified},
-			valid:   true,
+			valid:   false,
+			why:     []string{"expected [Bugzilla bug 0](bugzilla.com/show_bug.cgi?id=0) to depend on a bug in one of the following states: VERIFIED, but no dependents were found"},
 		},
 		{
 			name:       "not matching dependent bug status requirement means an invalid bug",


### PR DESCRIPTION
The OpenShift policy (reflected in the config [here][1]) currently requires release-4.2 pull requests to reference a bug targeting 4.2.z (already works).  It also requires those bugs to depend on a VERIFIED+ 4.3.0 bug to ensure that we don't regress by fixing something in 4.2.z that is unfixed in 4.3.  Before this commit, the Bugzilla bot would happily accept 4.2.z bugs with no dependencies.  With this commit, those bugs will generate errors like:

> expected Bugzilla bug 123 to depend on a bug targeting the 4.3.0 release and in one of the following states: VERIFIED, RELEASE_PENDING, CLOSED (ERRATA), but no dependents were found

[1]: https://github.com/openshift/release/blob/348c6a786f1d8b5bdc1f752580724a1c6309a066/core-services/prow/02_config/_plugins.yaml#L1836-L1879