### PR TITLE
Add a prow-canary.k8s.io with gke-managed certs.

### DIFF
--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -46,6 +46,7 @@ release(
     ),
     component("hook", "service", "deployment"),
     component("horologium", "deployment"),
+    component("ing", "ingress"),
     component(
         "mem-limit-range",
         "limitrange",
@@ -54,6 +55,7 @@ release(
     component("needs-rebase", "deployment"),
     component("pipeline", "deployment"),
     component("plank", "service", "deployment"),
+    component("prow-canary-k8s-io", "managedcertificate"),
     component("prowjob", "customresourcedefinition"),
     component("pushgateway", "deployment"),
     component("sinker", "service", "deployment"),

--- a/prow/cluster/ing_ingress.yaml
+++ b/prow/cluster/ing_ingress.yaml
@@ -1,0 +1,26 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  namespace: default
+  name: ing
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: prow-managed-certs
+    kubernetes.io/ingress.class: "gce"
+    networking.gke.io/managed-certificates: prow-canary-k8s-io
+spec:
+  rules:
+  - host: prow-canary.k8s.io
+    http:
+      paths:
+      - path: /*
+        backend:
+          serviceName: deck
+          servicePort: 80
+      - path: /hook
+        backend:
+          serviceName: hook
+          servicePort: 8888
+      - path: /metrics
+        backend:
+          serviceName: pushgateway-external
+          servicePort: 80

--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -19,6 +19,8 @@ release(
     component("alertmanager_rbac", MULTI_KIND),
     component("alertmanager_expose", MULTI_KIND),
     component("prow", "alertmanager"),
+    component("ing", "ingress"),
+    component("monitoring-prow-canary-k8s-io", "managedcertificate"),
 )
 
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")

--- a/prow/cluster/monitoring/ing_ingress.yaml
+++ b/prow/cluster/monitoring/ing_ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: prow-monitoring-managed-certs
+    kubernetes.io/ingress.class: "gce"
+    networking.gke.io/managed-certificates: monitoring-prow-canary-k8s-io
+  name: grafana
+  namespace: prow-monitoring
+spec:
+  rules:
+  - host: monitoring.prow.k8s.io
+    http:
+      paths:
+      - backend:
+          serviceName: grafana
+          servicePort: 80

--- a/prow/cluster/monitoring/monitoring-prow-canary-k8s-io_managedcertificate.yaml
+++ b/prow/cluster/monitoring/monitoring-prow-canary-k8s-io_managedcertificate.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: monitoring-prow-canary-k8s-io
+  namespace: prow-monitoring
+spec:
+  domains:
+  - monitoring.prow-canary.k8s.io

--- a/prow/cluster/prow-canary-k8s-io_managedcertificate.yaml
+++ b/prow/cluster/prow-canary-k8s-io_managedcertificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: prow-canary-k8s-io
+spec:
+  domains:
+  - prow-canary.k8s.io


### PR DESCRIPTION
This adds new ingresses for prow-canary.k8s.io and monitoring.prow-canary.k8s.io, pointing at the same services but with gke-managed certs.

This is the first stage. The second is to swap the other domains over to this ingress (probably over the weekend), and the third is to shut down and remove all the then-unused cert-managed cruft.

/cc @fejta @BenTheElder 