### PR TITLE
Disable kubernetes-dashboard in kubemark tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -67,6 +67,10 @@ presets:
     value: 300
   - name: PROMETHEUS_SCRAPE_ETCD
     value: "true"
+  # Disable kubernetes-dashboard
+  - name: KUBE_ENABLE_CLUSTER_UI
+    value: "false"
+
 ### kubemark-gce-scale
 - labels:
     preset-e2e-kubemark-gce-scale: "true"


### PR DESCRIPTION
It keeps restarting constantly, there is little value in debugging it.
In addition, I've applied minor formatting fix - adding a space before
next preset so that it is better separated visually.