### PR TITLE
Move cluster location from eastus2 to westus2

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -91,7 +91,7 @@ presubmits:
         - "--acsengine-agentvmsize=Standard_D4s_v3"
         - "--acsengine-ccm=True"
         - "--acsengine-hyperkube=True"
-        - "--acsengine-location=eastus2"
+        - "--acsengine-location=westus2"
         - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json"
         - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz"
@@ -144,7 +144,7 @@ presubmits:
         - "--acsengine-agentvmsize=Standard_D4s_v3"
         - "--acsengine-ccm=True"
         - "--acsengine-hyperkube=True"
-        - "--acsengine-location=eastus2"
+        - "--acsengine-location=westus2"
         - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json"
         - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz"
@@ -223,7 +223,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -282,7 +282,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-autoscaler.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -342,7 +342,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -401,7 +401,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/e2e-slow.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -459,7 +459,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-serial.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -524,7 +524,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -582,7 +582,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -641,7 +641,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz
@@ -700,7 +700,7 @@ periodics:
       - --acsengine-agentvmsize=Standard_D4s_v3
       - --acsengine-ccm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=eastus2
+      - --acsengine-location=westus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.39.1/aks-engine-v0.39.1-linux-amd64.tar.gz


### PR DESCRIPTION
Moving the cluster deployment location from eastus2 to westus2 due to the following error:
```
The operation couldn't be completed as it results in exceeding quota limit of standardDSv3Family Cores. Maximum allowed: 200, Current in use: 198, Additional requested: 8.
```

/assign @ritazh 