### PR TITLE
Entrypoint: Write command start error to log

### DIFF
--- a/prow/entrypoint/BUILD.bazel
+++ b/prow/entrypoint/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//prow/pod-utils/wrapper:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
     ],
 )
 

--- a/prow/entrypoint/run_test.go
+++ b/prow/entrypoint/run_test.go
@@ -135,6 +135,13 @@ func TestOptions_Run(t *testing.T) {
 			expectedMarker: "4",
 			expectedCode:   4,
 		},
+		{
+			name:           "start error is written to log",
+			args:           []string{"./this-command-does-not-exist"},
+			expectedLog:    "could not start the process: fork/exec ./this-command-does-not-exist: no such file or directory",
+			expectedMarker: "127",
+			expectedCode:   InternalErrorCode,
+		},
 	}
 
 	// we write logs to the process log if wrapping fails


### PR DESCRIPTION
This PR makes entrypoint write errors encountered when trying to start the command to the log. Currently they are only visible in the pod logs, which results in failed jobs with empty log once the pod is gone.

Fixes #14868