### PR TITLE
Build client: Use api reader for checking on CRD existence

### DIFF
--- a/prow/cmd/build/main.go
+++ b/prow/cmd/build/main.go
@@ -117,7 +117,7 @@ func newBuildConfig(cfg rest.Config, stop <-chan struct{}) (*buildConfig, error)
 	// Ensure the knative-build CRD is deployed
 	// TODO(fejta): probably a better way to do this
 	buildList := &buildv1alpha1.BuildList{}
-	if err := mgr.GetClient().List(context.TODO(), buildList, listSingleItem{}); err != nil {
+	if err := mgr.GetAPIReader().List(context.TODO(), buildList, listSingleItem{}); err != nil {
 		return nil, err
 	}
 	cache := mgr.GetCache()


### PR DESCRIPTION
Fixes #14976 

We abuse a list call to determine if the build crd is deployed using the default client which is cache-backed. So far, listing from the client when the cache wasn't started just returned nothing which got fixed upstream in https://github.com/kubernetes-sigs/controller-runtime/pull/627 to instead return an error.

This PR changes the call to instead use the api reader.

/assign @fejta 