### PR TITLE
prow: do not welcome org members

### DIFF
--- a/prow/plugins/welcome/BUILD.bazel
+++ b/prow/plugins/welcome/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/trigger:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],


### PR DESCRIPTION
Makes prow welcome plugin skip welcome comment if the contributor is
either an org member or collaborator.

Fixes #14979