### PR TITLE
kops: pass the --host to the test suite

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -562,6 +562,13 @@ func (k kops) TestSetup() error {
 
 // BuildTester returns a standard ginkgo-script tester, except for GCE where we build an e2e.Tester
 func (k kops) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
+	kubecfg, err := parseKubeconfig(k.kubecfg)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing kubeconfig %q: %v", k.kubecfg, err)
+	}
+
+	log.Printf("running ginkgo tests directly")
+
 	t := e2e.NewGinkgoTester(o)
 	t.KubeRoot = "."
 
@@ -569,6 +576,10 @@ func (k kops) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
 	t.Provider = k.provider
 
 	t.ClusterID = k.cluster
+
+	if len(kubecfg.Clusters) > 0 {
+		t.KubeMasterURL = kubecfg.Clusters[0].Cluster.Server
+	}
 
 	if k.provider == "gce" {
 		t.GCEProject = k.gcpProject
@@ -729,5 +740,31 @@ func getAWSEC2Session(region string) (*ec2.EC2, error) {
 	}
 
 	return ec2.New(s, config), nil
+}
 
+// kubeconfig is a simplified version of the kubernetes Config type
+type kubeconfig struct {
+	Clusters []struct {
+		Cluster struct {
+			Server string `json:"server"`
+		} `json:"cluster"`
+	} `json:"clusters"`
+}
+
+// parseKubeconfig uses kubectl to extract the current kubeconfig configuration
+func parseKubeconfig(kubeconfigPath string) (*kubeconfig, error) {
+	cmd := "kubectl"
+
+	o, err := control.Output(exec.Command(cmd, "config", "view", "--minify", "-ojson", "--kubeconfig", kubeconfigPath))
+	if err != nil {
+		log.Printf("kubectl config view failed: %s\n%s", wrapError(err).Error(), string(o))
+		return nil, err
+	}
+
+	cfg := &kubeconfig{}
+	if err := json.Unmarshal(o, cfg); err != nil {
+		return nil, fmt.Errorf("error parsing kubectl config view output: %v", err)
+	}
+
+	return cfg, nil
 }


### PR DESCRIPTION
There are a few tests that require this to be directly passed.