### PR TITLE
Make Azure resource group name more recognizable

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -342,7 +342,7 @@ func checkParams() error {
 		return fmt.Errorf("no credentials file path specified")
 	}
 	if *aksResourceName == "" {
-		*aksResourceName = "kubetest-" + uuid.NewV1().String()
+		*aksResourceName = fmt.Sprintf("%s-%s", os.Getenv("JOB_NAME"), os.Getenv("BUILD_ID"))
 	}
 	if *aksResourceGroupName == "" {
 		*aksResourceGroupName = *aksResourceName


### PR DESCRIPTION
Currently, there are a lot of stale resource groups in the upstream Azure subscription and it is difficult to figure out which jobs created them because they all have a `kubetest` prefix, followed by a unique identifier that doesn't mean anything.

This PR renames the resource group according to the job name and build ID so we can easily figure out which jobs create stale resource groups if they are still a problem in the future.

/assign @feiskyer 
/cc @ritazh 