### PR TITLE
Add a blackbox prober to the new monitoring stack.

### DIFF
--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -21,6 +21,8 @@ release(
     component("prow", "alertmanager"),
     component("ing", "ingress"),
     component("monitoring-prow-canary-k8s-io", "managedcertificate"),
+    component("additional-scrape-configs", "secret"),
+    component("blackbox_prober", MULTI_KIND),
 )
 
 load("@io_bazel_rules_k8s//k8s:object.bzl", "k8s_object")

--- a/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: additional-scrape-configs
+  namespace: prow-monitoring
+stringData:
+  prometheus-additional.yaml: |
+    - job_name: 'blackbox'
+      metrics_path: /probe
+      params:
+        module: [http_2xx]
+      static_configs:
+        - targets:
+          - https://prow.k8s.io
+          - https://prow.k8s.io/hook
+          - https://monitoring.prow.k8s.io
+          - https://testgrid.k8s.io
+          - https://gubernator.k8s.io
+          - https://gubernator.k8s.io/pr/fejta # Deep health check of someone's PR dashboard.
+          - https://go.k8s.io/triage
+          - https://go.k8s.io/oncall
+      relabel_configs:
+        - source_labels: [__address__]
+          target_label: __param_target
+        - source_labels: [__param_target]
+          target_label: instance
+        - target_label: __address__
+          replacement: blackbox-prober
+type: Opaque

--- a/prow/cluster/monitoring/blackbox_prober.yaml
+++ b/prow/cluster/monitoring/blackbox_prober.yaml
@@ -1,0 +1,63 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: blackbox-prober
+  namespace: prow-monitoring
+  labels:
+    app: blackbox-prober
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: blackbox-prober
+    spec:
+      containers:
+      - name: blackbox-prober
+        args:
+        - --config.file=/etc/config/prober.yaml
+        image: prom/blackbox-exporter:v0.15.1
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config/
+      volumes:
+      - name: config
+        configMap:
+          name: blackbox-prober-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: blackbox-prober-config
+  namespace: prow-monitoring
+  labels:
+    app: blackbox-prober
+data:
+  prober.yaml: |-
+    modules:
+      http_2xx:
+        prober: http
+        timeout: 5s
+        http:
+          # valid_status_codes defaults to 2xx
+          method: GET
+          no_follow_redirects: false
+          fail_if_ssl: false
+          fail_if_not_ssl: true
+          preferred_ip_protocol: "ip4" # Defaults to ip6
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: blackbox-prober
+  namespace: prow-monitoring
+  labels:
+    app: blackbox-prober
+spec:
+  type: ClusterIP
+  ports:
+  - name: blackbox-prober
+    port: 80
+    targetPort: 9115
+  selector:
+    app: blackbox-prober

--- a/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/prow/cluster/monitoring/prow_prometheus.yaml
@@ -41,3 +41,6 @@ spec:
     fsGroup: 2000
     runAsNonRoot: true
     runAsUser: 1000
+  additionalScrapeConfigs:
+    name: additional-scrape-configs
+    key: prometheus-additional.yaml


### PR DESCRIPTION
Based on Velodrome's blackbox prober (which may have never worked since the service name was wrong).  This uses the prometheus-operators `additionalScrapeConfig` option documented [here](https://github.com/coreos/prometheus-operator/blob/master/Documentation/additional-scrape-config.md).
I'd like to monitor when we deploy this since an invalid scrape config could break things.
/hold
/assign @hongkailiu @stevekuznetsov 