### PR TITLE
sig-cluster-lifecycle: Enable dind for pull-etcdadm-test-init

### DIFF
--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -14,12 +14,17 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-etcdadm
       testgrid-tab-name: pr-verify
   - name: pull-etcdadm-test-init
+    labels:
+      preset-dind-enabled: "true"
     path_alias: "sigs.k8s.io/etcdadm"
     always_run: true
     decorate: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191028-e674b0d-master
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
         command:
         - "runner.sh"
         - "./test/e2e/init.sh"


### PR DESCRIPTION
Etcdadm needs systemd, and docker-in-docker enables etcdadm to run in a
container with systemd. Later docker-in-docker will be used to test
etcdadm join.

/cc @neolit123 