### PR TITLE
Add the aws-janitor-boskos image to automatic pushes

### DIFF
--- a/boskos/BUILD.bazel
+++ b/boskos/BUILD.bazel
@@ -19,6 +19,7 @@ prow_push(
     name = "push",
     images = tags(targets = {
         "{STABLE_PROW_REPO}/boskos/aws-janitor": "//maintenance/aws-janitor:image",
+        "{STABLE_PROW_REPO}/boskos/aws-janitor-boskos": "//maintenance/aws-janitor/cmd/aws-janitor-boskos:image",
         "{STABLE_PROW_REPO}/boskos/boskos": "//boskos:image",
         "{STABLE_PROW_REPO}/boskos/fake-mason": "//boskos/mason/fake-mason:image",
         "{STABLE_PROW_REPO}/boskos/cleaner": "//boskos/cleaner/cmd:image",

--- a/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
+++ b/maintenance/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
@@ -1,11 +1,16 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("//prow:def.bzl", "prow_image")
-
-prow_image(name = "aws-janitor-boskos-image")
 
 go_binary(
     name = "aws-janitor-boskos",
     embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+prow_image(
+    name = "image",
+    base = "@gcloud-go//image",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
We are currently using `gcr.io/k8s-testimages/janitor-aws:v20190326-5dd3da15c` which seems to have been built by someone by hand:
- https://github.com/kubernetes/test-infra/blob/master/prow/cluster/boskos-janitor.yaml#L95
- https://console.cloud.google.com/gcr/images/k8s-testimages/GLOBAL/janitor-aws?gcrImageListsize=30

We should build this image along with the rest of images and push it

