### PR TITLE
Use latest aws-janitor-boskos

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -92,6 +92,6 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-aws
-        image: gcr.io/k8s-testimages/janitor-aws:v20190326-5dd3da15c
+        image: gcr.io/k8s-prow/boskos/aws-janitor-boskos:v20191029-3656cc1b6
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.


### PR DESCRIPTION
In ad4120f107b79c72c80816a5d943d5f490935a35, we enabled the image to be
built and pushed in a post-submit job. Now let's make use of the latest
image.

Also see the https://github.com/kubernetes/test-infra/pull/15005