### PR TITLE
Remove containerd 1.1 test.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -57,25 +57,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build
-- name: ci-containerd-build-1-1
-  interval: 30m
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-4802b07-master
-      args:
-      - --repo=github.com/containerd/containerd=release/1.1
-      - --repo=github.com/containerd/cri=release/1.0
-      - --root=/go/src
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=execute
-      - --
-      - --env=DEPLOY_DIR=containerd/release-1.1
-      - /go/src/github.com/containerd/cri/test/containerd/build.sh
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-build-1.1
 - name: ci-containerd-build-1-2
   interval: 30m
   labels:
@@ -144,37 +125,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci
-- interval: 1h
-  name: ci-containerd-e2e-gci-gce-1-1
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-e2e-containerd: "true"
-    preset-e2e-containerd-image-load-legacy: "true"
-  spec:
-    containers:
-    - args:
-      - --repo=github.com/containerd/cri=release/1.0
-      - --timeout=70
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBELET_TEST_ARGS=--redirect-container-streaming
-      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
-      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env
-      - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.13
-      - --gcp-node-image=gci
-      - --gcp-nodes=4
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=30
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-e2e-gci-1.1
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-2
   labels:
@@ -296,36 +246,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cri
     testgrid-tab-name: containerd-node-conformance
-- name: ci-containerd-node-e2e-1-1
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
-      args:
-      - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.13
-      - --repo=github.com/containerd/cri=release/1.0
-      - --timeout=90
-      - --scenario=kubernetes_e2e
-      - --
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
-      - --deployment=node
-      - --gcp-project=cri-containerd-node-e2e
-      - --gcp-zone=us-west1-b
-      - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --redirect-container-streaming" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Serial\]" --flakeAttempts=2
-      - --timeout=65m
-      env:
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-node-e2e-1.1
 - name: ci-containerd-node-e2e-1-2
   interval: 1h
   labels:
@@ -416,36 +336,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cri
     testgrid-tab-name: containerd-node-features
-- name: ci-containerd-node-e2e-features-1-1
-  interval: 1h
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
-      args:
-      - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.13
-      - --repo=github.com/containerd/cri=release/1.0
-      - --timeout=90
-      - --scenario=kubernetes_e2e
-      - --
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
-      - --deployment=node
-      - --gcp-project=cri-containerd-node-e2e
-      - --gcp-zone=us-west1-b
-      - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service --redirect-container-streaming" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=8 --focus="\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Serial\]" --flakeAttempts=2
-      - --timeout=65m
-      env:
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-node-containerd
-    testgrid-tab-name: containerd-node-e2e-features-1.1
 - name: ci-containerd-node-e2e-features-1-2
   interval: 1h
   labels:

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -90,13 +90,6 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-containerd-node-e2e-1-1
-  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e-1-1
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
 - name: ci-containerd-node-e2e-1-2
   gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e-1-2
   test_name_config:
@@ -106,13 +99,6 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-containerd-node-e2e-features
   gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e-features
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-containerd-node-e2e-features-1-1
-  gcs_prefix: kubernetes-jenkins/logs/ci-containerd-node-e2e-features-1-1
   test_name_config:
     name_elements:
     - target_config: Tests name

--- a/jobs/e2e_node/containerd/containerd-release-1.1/env
+++ b/jobs/e2e_node/containerd/containerd-release-1.1/env
@@ -1,4 +1,0 @@
-CONTAINERD_TEST: 'true'
-CONTAINERD_LOG_LEVEL: 'debug'
-CONTAINERD_DEPLOY_PATH: 'cri-containerd-staging/containerd/release-1.1'
-CONTAINERD_PKG_PREFIX: 'containerd-cni'

--- a/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.1/image-config.yaml
@@ -1,9 +1,0 @@
-images:
-  ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
-    project: ubuntu-os-gke-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env"
-  cos-stable:
-    image_regex: cos-stable-60-9592-84-0
-    project: cos-cloud
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.1/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Containerd 1.1 is EOL. https://github.com/containerd/containerd/pull/3780

Remove the CI test.

Signed-off-by: Lantao Liu <lantaol@google.com>