### PR TITLE
[1.17] releng: Update milestoneappliers for 1.17

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -257,10 +257,10 @@ milestone_applier:
     master: v1.17
   kubernetes/kubernetes:
     master: v1.17
+    release-1.17: v1.17
     release-1.16: v1.16
     release-1.15: v1.15
     release-1.14: v1.14
-    release-1.13: v1.13
   kubernetes/release:
     master: v1.17
   kubernetes/sig-release:


### PR DESCRIPTION
Release cut issue: kubernetes/sig-release#842

Pending branch cut:
/hold
/sig release
/area release-eng

cc: @kubernetes/release-engineering @kubernetes/sig-release-admins