### PR TITLE
[1.18] releng: Update milestoneappliers for 1.18

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -291,7 +291,7 @@ slack:
 
 milestone_applier:
   kubernetes/enhancements:
-    master: v1.17
+    master: v1.18
   kubernetes/kubernetes:
     master: v1.18
     release-1.17: v1.17
@@ -303,7 +303,7 @@ milestone_applier:
   kubernetes/sig-release:
     master: v1.18
   kubernetes/test-infra:
-    master: v1.17
+    master: v1.18
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/pull/15017#issuecomment-547540056

Pending 1.17 Code Thaw (Do not release hold until then).
/hold
/sig release
/area release-eng

cc: @kubernetes/release-engineering @kubernetes/sig-release-admins