### PR TITLE
Use "kubetest" instead of JOB_NAME env var as Azure resource group prefix

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -342,7 +342,7 @@ func checkParams() error {
 		return fmt.Errorf("no credentials file path specified")
 	}
 	if *aksResourceName == "" {
-		*aksResourceName = fmt.Sprintf("%s-%s", os.Getenv("JOB_NAME"), os.Getenv("BUILD_ID"))
+		*aksResourceName = "kubetest-" + os.Getenv("BUILD_ID")
 	}
 	if *aksResourceGroupName == "" {
 		*aksResourceGroupName = *aksResourceName


### PR DESCRIPTION
Using `JOB_NAME` env var as the prefix of the resource group can cause an aks-engine error when deploying a cluster:
```
Error: loading API model in generateCmd: error parsing the api model: DNSPrefix 'ci-cloud-provider-azure-multiple-zones-1189263845219110913' is invalid. The DNSPrefix must contain between 3 and 45 characters and can contain only letters, numbers, and hyphens.  It must start with a letter and must end with a letter or a number. (length was 58)
```

Sorry for not testing PR https://github.com/kubernetes/test-infra/pull/14998 thoroughly. 
/assign @feiskyer 