### PR TITLE
Revert "Make Azure resource group name more recognizable"

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -342,7 +342,7 @@ func checkParams() error {
 		return fmt.Errorf("no credentials file path specified")
 	}
 	if *aksResourceName == "" {
-		*aksResourceName = fmt.Sprintf("%s-%s", os.Getenv("JOB_NAME"), os.Getenv("BUILD_ID"))
+		*aksResourceName = "kubetest-" + uuid.NewV1().String()
 	}
 	if *aksResourceGroupName == "" {
 		*aksResourceGroupName = *aksResourceName


### PR DESCRIPTION
Reverts kubernetes/test-infra#14998
Will use resource group tags to correlate resource groups to jobs instead.
/assign @feiskyer 