### PR TITLE
Ensure CAPA managed resources are cleaned up in aws-janitor-boskos

### DIFF
--- a/maintenance/aws-janitor/resources/iam_roles.go
+++ b/maintenance/aws-janitor/resources/iam_roles.go
@@ -43,6 +43,11 @@ func roleIsManaged(role *iam.Role) bool {
 		return false
 	}
 
+	// CAPA roles have names end with `cluster-api-provider-aws.sigs.k8s.io`
+	if strings.HasSuffix(name, "cluster-api-provider-aws.sigs.k8s.io") {
+		return true
+	}
+
 	// kops roles have names start with `masters.` or `nodes.`
 	if strings.HasPrefix(name, "masters.") || strings.HasPrefix(name, "nodes.") {
 		return true


### PR DESCRIPTION
Looks like during cleanup we are ignoring some new resources. We should try to clean them out

log snippet from https://gist.githubusercontent.com/Katharine/96cf8f27f2093f8b3c6bbf3816c281ee/raw/e07fbbdd9d4ee3d6d8f7bfbe35bb6d89c4423ee1/h6h2j.txt
```
I1029 22:03:55.864463       1 iam_roles.go:51] Unknown role name="control-plane.cluster-api-provider-aws.sigs.k8s.io", path="/"; assuming not managed
I1029 22:03:55.864567       1 iam_instance_profiles.go:54] ignoring unmanaged profile arn:aws:iam::306967352268:instance-profile/control-plane.cluster-api-provider-aws.sigs.k8s.io
```