### PR TITLE
Fix regex for building aws-janitor-boskos image automatically

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -177,7 +177,7 @@ postsubmits:
           secretName: deployer-service-account
   - name: post-test-infra-push-boskos
     cluster: test-infra-trusted
-    run_if_changed: '^boskos/'
+    run_if_changed: '^(boskos\/|maintenance\/aws-janitor)'
     annotations:
       testgrid-dashboards: "sig-testing-images"
       testgrid-tab-name: "boskos"


### PR DESCRIPTION
the aws-janitor-boskos image is in another directory path.