### PR TITLE
update aws-janitor-boskos to v20191030-8fcb048b7

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -92,6 +92,6 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-aws
-        image: gcr.io/k8s-prow/boskos/aws-janitor-boskos:v20191029-3656cc1b6
+        image: gcr.io/k8s-prow/boskos/aws-janitor-boskos:v20191030-8fcb048b7
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.


### PR DESCRIPTION
we had a bunch of changes go into this container for helping with the
cleanup issues on AWS.