### PR TITLE
Allow connecting to 9090 port in gke test clusters

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -39,7 +39,7 @@ import (
 
 const (
 	defaultPool   = "default"
-	e2eAllow      = "tcp:22,tcp:80,tcp:8080,tcp:30000-32767,udp:30000-32767"
+	e2eAllow      = "tcp:22,tcp:80,tcp:8080,tcp:9090,tcp:30000-32767,udp:30000-32767"
 	defaultCreate = "container clusters create --quiet"
 )
 


### PR DESCRIPTION
The 9090 port is the default prometheus port which is used by some of our testing tools, e.g. ClusterLoader2.
What we realized recently is that it's impossible to connect to Prometheus in private GKE clusters and changing the e2eAllow here fix that.
