### PR TITLE
Increase timeouts for ci-benchmark-scheduler-master

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -361,7 +361,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   decoration_config:
-    timeout: 55m
+    timeout: 1h55m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191031-df9cbb4-master
@@ -371,7 +371,7 @@ periodics:
       - ./test/integration/scheduler_perf
       env:
       - name: KUBE_TIMEOUT
-        value: --timeout=40m
+        value: --timeout=1h50m
 
 - name: ci-benchmark-kube-dns-master
   interval: 2h


### PR DESCRIPTION
The job doesn't fail anymore on build but now fails on timeout.
Increasing the timeouts x2, we can decrease later once we know how much time the benchmark really needs.