### PR TITLE
Increase the timeout for migration test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -1,6 +1,8 @@
 periodics:
 - name: ci-aws-ebs-csi-driver-migration-test-latest
   decorate: true
+  decoration_config:
+    timeout: 4h
   interval: 6h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -120,6 +120,8 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-migration-test-latest
     always_run: false
     decorate: true
+    decoration_config:
+      timeout: 4h
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Increase the timeout for migration test since it take longer time when inline volume e2e test is enabled.

/cc @wongma7 @gyuho 