### PR TITLE
Add job info tags to Azure resource groups

### DIFF
--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -231,6 +231,7 @@ func (az *AzureClient) EnsureResourceGroup(ctx context.Context, name, location s
 	// Tags for correlating resource groups with prow jobs on testgrid
 	tags["buildID"] = stringPointer(os.Getenv("BUILD_ID"))
 	tags["jobName"] = stringPointer(os.Getenv("JOB_NAME"))
+	tags["creationTimestamp"] = stringPointer(time.Now().UTC().Format(time.RFC3339))
 
 	response, err := az.groupsClient.CreateOrUpdate(ctx, name, resources.Group{
 		Name:      &name,

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 	"time"
 
 	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
@@ -222,9 +223,14 @@ func (az *AzureClient) DeployTemplate(ctx context.Context, resourceGroupName, de
 func (az *AzureClient) EnsureResourceGroup(ctx context.Context, name, location string, managedBy *string) (resourceGroup *resources.Group, err error) {
 	var tags map[string]*string
 	group, err := az.groupsClient.Get(ctx, name)
-	if err == nil {
+	if err == nil && group.Tags != nil {
 		tags = group.Tags
+	} else {
+		tags = make(map[string]*string)
 	}
+	// Tags for correlating resource groups with prow jobs on testgrid
+	tags["buildID"] = stringPointer(os.Getenv("BUILD_ID"))
+	tags["jobName"] = stringPointer(os.Getenv("JOB_NAME"))
 
 	response, err := az.groupsClient.CreateOrUpdate(ctx, name, resources.Group{
 		Name:      &name,
@@ -295,4 +301,8 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 	c.groupsClient.Authorizer = authorizer
 
 	return c
+}
+
+func stringPointer(s string) *string {
+	return &s
 }


### PR DESCRIPTION
Currently, there are a lot of stale resource groups in the upstream Azure subscription and it is difficult to figure out which jobs created them because they all have a kubetest prefix, followed by a unique identifier that doesn't mean anything.

This PR adds `jobName` and `buildID` tags to the resource groups so we can easily figure out which jobs create them if they are still a problem in the future.

/assign @feiskyer
/cc @adelina-t 