### PR TITLE
Buildlog lense default regex: Never require leading space/linestart

### DIFF
--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -41,7 +41,7 @@ The `spyglass` block has the following properties:
 | `testgrid_config` | No | `gs://k8s-testgrid/config` | If you have a TestGrid instance available, `testgrid_config` should point to the TestGrid config proto on GCS. If omitted, no TestGrid link will be visible.
 | `testgrid_root` | No | `https://testgrid.k8s.io/` | If you have a TestGrid instance available, `testgrid_root` should point to the root of the TestGrid web interface. If omitted, no TestGrid link will be visible.
 | `announcement` | No | `"Remember: friendship is magic!"` | If announcement is set, the string will appear at the top of the page. `announcement` is parsed as a Go template. The only value provided is `.ArtifactPath`, which is of the form `gcs-bucket/path/to/job/root/`.
-| `lenses` | Yes | (see below) | `lenses` configures the lenses you want, when they should be visible, what artifacts they should receive, and  
+| `lenses` | Yes | (see below) | `lenses` configures the lenses you want, when they should be visible, what artifacts they should receive, and
 
 #### Configuring Lenses
 
@@ -78,7 +78,7 @@ deck:
     announcement: "The old job viewer has been deprecated."
     lenses:
     - lens:
-        name: metadata   
+        name: metadata
       required_files:
       - started.json
       optional_files:
@@ -89,8 +89,8 @@ deck:
           highlight_regexes:
           - timed out
           - 'ERROR:'
-          - (\s|^)(FAIL|Failure \[)\b
-          - (\s|^)panic\b
+          - (FAIL|Failure \[)\b
+          - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
             - build-log.txt

--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -63,7 +63,7 @@ func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config 
 
 // defaultErrRE matches keywords and glog error messages.
 // It is only used if higlight_regexes is not specified in the lens config.
-var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(\s|^)(FAIL|Failure \[)\b|(\s|^)panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
+var defaultErrRE = regexp.MustCompile(`timed out|ERROR:|(FAIL|Failure \[)\b|panic\b|^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]`)
 
 func init() {
 	lenses.RegisterLens(Lens{})

--- a/prow/spyglass/lenses/buildlog/lens_test.go
+++ b/prow/spyglass/lenses/buildlog/lens_test.go
@@ -193,3 +193,19 @@ func TestGroupLines(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkHighlightLines(b *testing.B) {
+	lorem := []string{
+		"Lorem ipsum dolor sit amet",
+		"consectetur adipiscing elit",
+		"sed do eiusmod tempor incididunt ut labore et dolore magna aliqua",
+		"Ut enim ad minim veniam",
+		"quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat",
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur",
+		"Excepteur sint occaecat cupidatat non proident",
+		"sunt in culpa qui officia deserunt mollit anim id est laborum",
+	}
+	b.Run("HighlightLines", func(b *testing.B) {
+		_ = highlightLines(lorem, 0, "artifact", defaultErrRE)
+	})
+}


### PR DESCRIPTION
After learning last week that Deck needs quite a bit of CPU I looked into it and found at that its mostly spend deserializing things and doing regex. This PR attempts to make the latter better.

Note:
* I do realize the change here changes what the regex matches on but I _think_ that should be fine
* I know very little about regex and found the slow ones by just benchmarking.

Below some benchmarking I did with the added `BenchmarkHighlightLines` and the file linked in it.

```
$ benchstat old.txt new.txt 
name                             old time/op  new time/op  delta
HighlightLines/HighlightLines-4   2.13s ± 3%   1.35s ± 2%  -36.49%  (p=0.000 n=10+10)
```

/assign @Katharine 