### PR TITLE
releng: Increase intervals between test build job runs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-release-test.yaml
+++ b/config/jobs/image-pushing/k8s-staging-release-test.yaml
@@ -1,5 +1,7 @@
 periodics:
-- interval: 1h
+# TODO(justaugustus): Decrease interval to 1hr once we cut build over to k8s-infra.
+#                     ref: https://github.com/kubernetes/release/issues/911
+- interval: 4h
   name: ci-kubernetes-prototype-build
   cluster: test-infra-trusted
   decorate: true
@@ -38,7 +40,9 @@ periodics:
     testgrid-tab-name: build-master
     testgrid-alert-email: release-managers@kubernetes.io
 
-- interval: 1h
+# TODO(justaugustus): Decrease interval to 5m once we cut build over to k8s-infra.
+#                     ref: https://github.com/kubernetes/release/issues/911
+- interval: 12h
   name: ci-kubernetes-prototype-build-fast
   cluster: test-infra-trusted
   decorate: true

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -94,7 +94,7 @@ periodics:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     description: 'Ends up running: make quick-release'
 
-- interval: 30m
+- interval: 4h
   name: ci-release-build-packages-debs
   decorate: true
   spec:
@@ -112,7 +112,7 @@ periodics:
     testgrid-dashboards: sig-release-master-informing
     testgrid-tab-name: build-packages-debs
 
-- interval: 30m
+- interval: 4h
   name: ci-release-build-packages-rpms
   decorate: true
   spec:


### PR DESCRIPTION
We had initially run these jobs more frequently to speed up the feedback
loop while testing. The jobs now run stably, so we're decreasing the job frequency.

cc: @kubernetes/release-engineering 
/sig release
/area release-eng
/milestone v1.17
/priority important-soon