### PR TITLE
[aws-janitor] Clean up janitor output

### DIFF
--- a/maintenance/aws-janitor/resources/addresses.go
+++ b/maintenance/aws-janitor/resources/addresses.go
@@ -42,7 +42,7 @@ func (Addresses) MarkAndSweep(sess *session.Session, acct string, region string,
 	for _, addr := range resp.Addresses {
 		a := &address{Account: acct, Region: region, ID: *addr.AllocationId}
 		if set.Mark(a) {
-			klog.Warningf("%s: deleting %T: %v", a.ARN(), addr, addr)
+			klog.Warningf("%s: deleting %T: %s", a.ARN(), addr, a.ID)
 
 			if addr.AssociationId != nil {
 				klog.Warningf("%s: disassociating %T from active instance", a.ARN(), addr)
@@ -54,7 +54,7 @@ func (Addresses) MarkAndSweep(sess *session.Session, acct string, region string,
 
 			_, err := svc.ReleaseAddress(&ec2.ReleaseAddressInput{AllocationId: addr.AllocationId})
 			if err != nil {
-				klog.Warningf("%v: delete failed: %v", a.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", a.ARN(), err)
 			}
 		}
 	}

--- a/maintenance/aws-janitor/resources/asg.go
+++ b/maintenance/aws-janitor/resources/asg.go
@@ -39,7 +39,7 @@ func (AutoScalingGroups) MarkAndSweep(sess *session.Session, acct string, region
 		for _, asg := range page.AutoScalingGroups {
 			a := &autoScalingGroup{ID: *asg.AutoScalingGroupARN, Name: *asg.AutoScalingGroupName}
 			if set.Mark(a) {
-				klog.Warningf("%s: deleting %T: %v", a.ARN(), asg, asg)
+				klog.Warningf("%s: deleting %T: %s", a.ARN(), asg, a.Name)
 				toDelete = append(toDelete, a)
 			}
 		}
@@ -57,7 +57,7 @@ func (AutoScalingGroups) MarkAndSweep(sess *session.Session, acct string, region
 		}
 
 		if _, err := svc.DeleteAutoScalingGroup(deleteInput); err != nil {
-			klog.Warningf("%v: delete failed: %v", asg.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", asg.ARN(), err)
 		}
 	}
 
@@ -65,14 +65,14 @@ func (AutoScalingGroups) MarkAndSweep(sess *session.Session, acct string, region
 	// resources, so this just makes the rest go more smoothly (and
 	// prevents a second pass).
 	for _, asg := range toDelete {
-		klog.Warningf("%v: waiting for delete", asg.ARN())
+		klog.Warningf("%s: waiting for delete", asg.ARN())
 
 		describeInput := &autoscaling.DescribeAutoScalingGroupsInput{
 			AutoScalingGroupNames: []*string{aws.String(asg.Name)},
 		}
 
 		if err := svc.WaitUntilGroupNotExists(describeInput); err != nil {
-			klog.Warningf("%v: wait failed: %v", asg.ARN(), err)
+			klog.Warningf("%s: wait failed: %v", asg.ARN(), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/clean.go
+++ b/maintenance/aws-janitor/resources/clean.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -46,7 +47,7 @@ func CleanAll(sess *session.Session, region string) error {
 	} else {
 		regionList = []string{region}
 	}
-	klog.Infof("Regions: %+v", regionList)
+	klog.Infof("Regions: %s", strings.Join(regionList, ", "))
 
 	var errs []error
 

--- a/maintenance/aws-janitor/resources/cloud_formation_stacks.go
+++ b/maintenance/aws-janitor/resources/cloud_formation_stacks.go
@@ -48,7 +48,7 @@ func (CloudFormationStacks) MarkAndSweep(sess *session.Session, acct string, reg
 				name: aws.StringValue(stack.StackName),
 			}
 			if set.Mark(o) {
-				klog.Warningf("%s: deleting %T: %v", o.ARN(), o, o)
+				klog.Warningf("%s: deleting %T: %s", o.ARN(), o, o.name)
 				toDelete = append(toDelete, o)
 			}
 		}
@@ -61,7 +61,7 @@ func (CloudFormationStacks) MarkAndSweep(sess *session.Session, acct string, reg
 
 	for _, o := range toDelete {
 		if err := o.delete(svc); err != nil {
-			klog.Warningf("%v: delete failed: %v", o.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", o.ARN(), err)
 		}
 	}
 	return nil

--- a/maintenance/aws-janitor/resources/dhcp_options.go
+++ b/maintenance/aws-janitor/resources/dhcp_options.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -73,16 +74,16 @@ func (DHCPOptions) MarkAndSweep(sess *session.Session, acct string, region strin
 
 		dh := &dhcpOption{Account: acct, Region: region, ID: *dhcp.DhcpOptionsId}
 		if set.Mark(dh) {
-			klog.Warningf("%s: deleting %T: %v", dh.ARN(), dhcp, dhcp)
+			klog.Warningf("%s: deleting %T: %s", dh.ARN(), dhcp, dh.ID)
 
 			if _, err := svc.DeleteDhcpOptions(&ec2.DeleteDhcpOptionsInput{DhcpOptionsId: dhcp.DhcpOptionsId}); err != nil {
-				klog.Warningf("%v: delete failed: %v", dh.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", dh.ARN(), err)
 			}
 		}
 	}
 
 	if len(defaults) > 1 {
-		klog.Errorf("Found more than one default-looking DHCP option set: %v", defaults)
+		klog.Errorf("Found more than one default-looking DHCP option set: %s", strings.Join(defaults, ", "))
 	}
 
 	return nil

--- a/maintenance/aws-janitor/resources/elb.go
+++ b/maintenance/aws-janitor/resources/elb.go
@@ -39,7 +39,7 @@ func (LoadBalancers) MarkAndSweep(sess *session.Session, account string, region 
 		for _, lb := range page.LoadBalancerDescriptions {
 			a := &loadBalancer{region: region, account: account, name: *lb.LoadBalancerName}
 			if set.Mark(a) {
-				klog.Warningf("%s: deleting %T: %v", a.ARN(), lb, lb)
+				klog.Warningf("%s: deleting %T: %s", a.ARN(), a, a.name)
 				toDelete = append(toDelete, a)
 			}
 		}
@@ -56,7 +56,7 @@ func (LoadBalancers) MarkAndSweep(sess *session.Session, account string, region 
 		}
 
 		if _, err := svc.DeleteLoadBalancer(deleteInput); err != nil {
-			klog.Warningf("%v: delete failed: %v", lb.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", lb.ARN(), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/iam_instance_profiles.go
+++ b/maintenance/aws-janitor/resources/iam_instance_profiles.go
@@ -17,7 +17,6 @@ limitations under the License.
 package resources
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -51,13 +50,13 @@ func (IAMInstanceProfiles) MarkAndSweep(sess *session.Session, acct string, regi
 			}
 
 			if !managed {
-				klog.Infof("ignoring unmanaged profile %s", aws.StringValue(p.Arn))
+				klog.Infof("%s: ignoring unmanaged profile", aws.StringValue(p.Arn))
 				continue
 			}
 
 			o := &iamInstanceProfile{profile: p}
 			if set.Mark(o) {
-				klog.Warningf("%s: deleting %T: %v", o.ARN(), o, o)
+				klog.Warningf("%s: deleting %T: %s", o.ARN(), o, o.ARN())
 				toDelete = append(toDelete, o)
 			}
 		}
@@ -70,7 +69,7 @@ func (IAMInstanceProfiles) MarkAndSweep(sess *session.Session, acct string, regi
 
 	for _, o := range toDelete {
 		if err := o.delete(svc); err != nil {
-			klog.Warningf("%v: delete failed: %v", o.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", o.ARN(), err)
 		}
 	}
 	return nil
@@ -118,7 +117,7 @@ func (p iamInstanceProfile) delete(svc *iam.IAM) error {
 		}
 
 		if _, err := svc.RemoveRoleFromInstanceProfile(request); err != nil {
-			return fmt.Errorf("error removing role %q: %v", aws.StringValue(role.RoleName), err)
+			return errors.Wrapf(err, "error removing role %q", aws.StringValue(role.RoleName))
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/instance.go
+++ b/maintenance/aws-janitor/resources/instance.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -55,7 +56,7 @@ func (Instances) MarkAndSweep(sess *session.Session, acct string, region string,
 				}
 
 				if set.Mark(i) {
-					klog.Warningf("%s: deleting %T: %v", i.ARN(), inst, inst)
+					klog.Warningf("%s: deleting %T: %s", i.ARN(), inst, i.InstanceID)
 					toDelete = append(toDelete, inst.InstanceId)
 				}
 			}
@@ -71,7 +72,7 @@ func (Instances) MarkAndSweep(sess *session.Session, acct string, region string,
 		// TODO(zmerlynn): In theory this should be split up into
 		// blocks of 1000, but burn that bridge if it ever happens...
 		if _, err := svc.TerminateInstances(&ec2.TerminateInstancesInput{InstanceIds: toDelete}); err != nil {
-			klog.Warningf("Termination failed: %v (for %v)", err, toDelete)
+			klog.Warningf("Termination failed for instances: %s : %v", strings.Join(aws.StringValueSlice(toDelete), ", "), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/internet_gateways.go
+++ b/maintenance/aws-janitor/resources/internet_gateways.go
@@ -59,7 +59,7 @@ func (InternetGateways) MarkAndSweep(sess *session.Session, acct string, region 
 
 		if set.Mark(i) {
 			isDefault := false
-			klog.Warningf("%s: deleting %T: %v", i.ARN(), ig, ig)
+			klog.Warningf("%s: deleting %T: %s", i.ARN(), ig, i.ID)
 
 			for _, att := range ig.Attachments {
 				if att.VpcId == defaultVpc.VpcId {
@@ -73,12 +73,12 @@ func (InternetGateways) MarkAndSweep(sess *session.Session, acct string, region 
 				}
 
 				if _, err := svc.DetachInternetGateway(detachReq); err != nil {
-					klog.Warningf("%v: detach from %v failed: %v", i.ARN(), *att.VpcId, err)
+					klog.Warningf("%s: detach from %s failed: %v", i.ARN(), *att.VpcId, err)
 				}
 			}
 
 			if isDefault {
-				klog.Infof("%s: skipping delete as IGW is the default for the VPC %T: %v", i.ARN(), ig, ig)
+				klog.Infof("%s: skipping delete as IGW is the default for the VPC %T: %s", i.ARN(), ig, i.ID)
 				continue
 			}
 
@@ -87,7 +87,7 @@ func (InternetGateways) MarkAndSweep(sess *session.Session, acct string, region 
 			}
 
 			if _, err := svc.DeleteInternetGateway(deleteReq); err != nil {
-				klog.Warningf("%v: delete failed: %v", i.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", i.ARN(), err)
 			}
 		}
 	}

--- a/maintenance/aws-janitor/resources/launch_configs.go
+++ b/maintenance/aws-janitor/resources/launch_configs.go
@@ -38,7 +38,7 @@ func (LaunchConfigurations) MarkAndSweep(sess *session.Session, acct string, reg
 		for _, lc := range page.LaunchConfigurations {
 			l := &launchConfiguration{ID: *lc.LaunchConfigurationARN, Name: *lc.LaunchConfigurationName}
 			if set.Mark(l) {
-				klog.Warningf("%s: deleting %T: %v", l.ARN(), lc, lc)
+				klog.Warningf("%s: deleting %T: %s", l.ARN(), lc, l.Name)
 				toDelete = append(toDelete, l)
 			}
 		}
@@ -55,7 +55,7 @@ func (LaunchConfigurations) MarkAndSweep(sess *session.Session, acct string, reg
 		}
 
 		if _, err := svc.DeleteLaunchConfiguration(deleteReq); err != nil {
-			klog.Warningf("%v: delete failed: %v", lc.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", lc.ARN(), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/nat_gateway.go
+++ b/maintenance/aws-janitor/resources/nat_gateway.go
@@ -48,7 +48,7 @@ func (NATGateway) MarkAndSweep(sess *session.Session, acct string, region string
 			if set.Mark(g) {
 				inp := &ec2.DeleteNatGatewayInput{NatGatewayId: gw.NatGatewayId}
 				if _, err := svc.DeleteNatGateway(inp); err != nil {
-					klog.Warningf("%v: delete failed: %v", g.ARN(), err)
+					klog.Warningf("%s: delete failed: %v", g.ARN(), err)
 				}
 			}
 		}

--- a/maintenance/aws-janitor/resources/route53.go
+++ b/maintenance/aws-janitor/resources/route53.go
@@ -98,7 +98,7 @@ func (Route53ResourceRecordSets) MarkAndSweep(sess *session.Session, acct string
 
 					o := &route53ResourceRecordSet{zone: z, obj: rrs}
 					if set.Mark(o) {
-						klog.Warningf("%s: deleting %T: %v", o.ARN(), rrs, rrs)
+						klog.Warningf("%s: deleting %T: %s", o.ARN(), rrs, *rrs.Name)
 						toDelete = append(toDelete, o)
 					}
 				}
@@ -181,7 +181,7 @@ func (Route53ResourceRecordSets) ListAll(sess *session.Session, acct, region str
 				return true
 			})
 			if err != nil {
-				klog.Errorf("couldn't describe route53 resources for %q in %q zone %q: %v", acct, region, *z.Id, err)
+				errors.Wrapf(err, "couldn't describe route53 resources for %q in %q zone %q", acct, region, *z.Id)
 			}
 
 		}

--- a/maintenance/aws-janitor/resources/route_tables.go
+++ b/maintenance/aws-janitor/resources/route_tables.go
@@ -56,25 +56,25 @@ func (RouteTables) MarkAndSweep(sess *session.Session, acct string, region strin
 		r := &routeTable{Account: acct, Region: region, ID: *rt.RouteTableId}
 		if set.Mark(r) {
 			for _, assoc := range rt.Associations {
-				klog.Infof("%v: disassociating from %v", r.ARN(), *assoc.SubnetId)
+				klog.Infof("%s: disassociating from %s", r.ARN(), *assoc.SubnetId)
 
 				disReq := &ec2.DisassociateRouteTableInput{
 					AssociationId: assoc.RouteTableAssociationId,
 				}
 
 				if _, err := svc.DisassociateRouteTable(disReq); err != nil {
-					klog.Warningf("%v: disassociation from subnet %v failed: %v", r.ARN(), *assoc.SubnetId, err)
+					klog.Warningf("%s: disassociation from subnet %s failed: %v", r.ARN(), *assoc.SubnetId, err)
 				}
 			}
 
-			klog.Warningf("%s: deleting %T: %v", r.ARN(), rt, rt)
+			klog.Warningf("%s: deleting %T: %s", r.ARN(), rt, r.ID)
 
 			deleteReq := &ec2.DeleteRouteTableInput{
 				RouteTableId: rt.RouteTableId,
 			}
 
 			if _, err := svc.DeleteRouteTable(deleteReq); err != nil {
-				klog.Warningf("%v: delete failed: %v", r.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", r.ARN(), err)
 			}
 		}
 	}

--- a/maintenance/aws-janitor/resources/security_groups.go
+++ b/maintenance/aws-janitor/resources/security_groups.go
@@ -67,7 +67,7 @@ func (SecurityGroups) MarkAndSweep(sess *session.Session, acct string, region st
 		addRefs(ingress, *sg.GroupId, acct, sg.IpPermissions)
 		addRefs(egress, *sg.GroupId, acct, sg.IpPermissionsEgress)
 		if set.Mark(s) {
-			klog.Warningf("%s: deleting %T: %v", s.ARN(), sg, sg)
+			klog.Warningf("%s: deleting %T: %s", s.ARN(), sg, s.ID)
 			toDelete = append(toDelete, s)
 		}
 	}
@@ -76,7 +76,7 @@ func (SecurityGroups) MarkAndSweep(sess *session.Session, acct string, region st
 
 		// Revoke all ingress rules.
 		for _, ref := range ingress[sg.ID] {
-			klog.Infof("%v: revoking reference from %v", sg.ARN(), ref.id)
+			klog.Infof("%s: revoking reference from %s", sg.ARN(), ref.id)
 
 			revokeReq := &ec2.RevokeSecurityGroupIngressInput{
 				GroupId:       aws.String(ref.id),
@@ -84,13 +84,13 @@ func (SecurityGroups) MarkAndSweep(sess *session.Session, acct string, region st
 			}
 
 			if _, err := svc.RevokeSecurityGroupIngress(revokeReq); err != nil {
-				klog.Warningf("%v: failed to revoke ingress reference from %v: %v", sg.ARN(), ref.id, err)
+				klog.Warningf("%v: failed to revoke ingress reference from %s: %v", sg.ARN(), ref.id, err)
 			}
 		}
 
 		// Revoke all egress rules.
 		for _, ref := range egress[sg.ID] {
-			klog.Infof("%v: revoking reference from %v", sg.ARN(), ref.id)
+			klog.Infof("%s: revoking reference from %s", sg.ARN(), ref.id)
 
 			revokeReq := &ec2.RevokeSecurityGroupEgressInput{
 				GroupId:       aws.String(ref.id),
@@ -98,7 +98,7 @@ func (SecurityGroups) MarkAndSweep(sess *session.Session, acct string, region st
 			}
 
 			if _, err := svc.RevokeSecurityGroupEgress(revokeReq); err != nil {
-				klog.Warningf("%v: failed to revoke egress reference from %v: %v", sg.ARN(), ref.id, err)
+				klog.Warningf("%s: failed to revoke egress reference from %s: %v", sg.ARN(), ref.id, err)
 			}
 		}
 
@@ -108,7 +108,7 @@ func (SecurityGroups) MarkAndSweep(sess *session.Session, acct string, region st
 		}
 
 		if _, err := svc.DeleteSecurityGroup(deleteReq); err != nil {
-			klog.Warningf("%v: delete failed: %v", sg.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", sg.ARN(), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/subnets.go
+++ b/maintenance/aws-janitor/resources/subnets.go
@@ -50,9 +50,9 @@ func (Subnets) MarkAndSweep(sess *session.Session, acct string, region string, s
 	for _, sub := range resp.Subnets {
 		s := &subnet{Account: acct, Region: region, ID: *sub.SubnetId}
 		if set.Mark(s) {
-			klog.Warningf("%s: deleting %T: %v", s.ARN(), sub, sub)
+			klog.Warningf("%s: deleting %T: %s", s.ARN(), sub, s.ID)
 			if _, err := svc.DeleteSubnet(&ec2.DeleteSubnetInput{SubnetId: sub.SubnetId}); err != nil {
-				klog.Warningf("%v: delete failed: %v", s.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", s.ARN(), err)
 			}
 		}
 	}

--- a/maintenance/aws-janitor/resources/volumes.go
+++ b/maintenance/aws-janitor/resources/volumes.go
@@ -39,7 +39,7 @@ func (Volumes) MarkAndSweep(sess *session.Session, acct string, region string, s
 		for _, vol := range page.Volumes {
 			v := &volume{Account: acct, Region: region, ID: *vol.VolumeId}
 			if set.Mark(v) {
-				klog.Warningf("%s: deleting %T: %v", v.ARN(), vol, vol)
+				klog.Warningf("%s: deleting %T: %s", v.ARN(), vol, v.ID)
 				toDelete = append(toDelete, v)
 			}
 		}
@@ -56,7 +56,7 @@ func (Volumes) MarkAndSweep(sess *session.Session, acct string, region string, s
 		}
 
 		if _, err := svc.DeleteVolume(deleteReq); err != nil {
-			klog.Warningf("%v: delete failed: %v", vol.ARN(), err)
+			klog.Warningf("%s: delete failed: %v", vol.ARN(), err)
 		}
 	}
 

--- a/maintenance/aws-janitor/resources/vpcs.go
+++ b/maintenance/aws-janitor/resources/vpcs.go
@@ -49,7 +49,7 @@ func (VPCs) MarkAndSweep(sess *session.Session, acct string, region string, set 
 	for _, vp := range resp.Vpcs {
 		v := &vpc{Account: acct, Region: region, ID: *vp.VpcId}
 		if set.Mark(v) {
-			klog.Warningf("%s: deleting %T: %v", v.ARN(), vp, vp)
+			klog.Warningf("%s: deleting %T: %s", v.ARN(), vp, v.ID)
 
 			if vp.DhcpOptionsId != nil && *vp.DhcpOptionsId != "default" {
 				disReq := &ec2.AssociateDhcpOptionsInput{
@@ -58,12 +58,12 @@ func (VPCs) MarkAndSweep(sess *session.Session, acct string, region string, set 
 				}
 
 				if _, err := svc.AssociateDhcpOptions(disReq); err != nil {
-					klog.Warningf("%v: disassociating DHCP option set %v failed: %v", v.ARN(), vp.DhcpOptionsId, err)
+					klog.Warningf("%s: disassociating DHCP option set %s failed: %v", v.ARN(), *vp.DhcpOptionsId, err)
 				}
 			}
 
 			if _, err := svc.DeleteVpc(&ec2.DeleteVpcInput{VpcId: vp.VpcId}); err != nil {
-				klog.Warningf("%v: delete failed: %v", v.ARN(), err)
+				klog.Warningf("%s: delete failed: %v", v.ARN(), err)
 			}
 		}
 	}


### PR DESCRIPTION
Clean up janitor output

- Formats region list into a comma separated string
- Outputs resource names/ids instead of dumping full aws resources
- Wrap errors that previously weren't wrapped

/assign @dims @justinsb 