### PR TITLE
Kops: Update e2e job image to pickup --host fix

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -68,7 +68,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191031-df9cbb4-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)


### PR DESCRIPTION
Same as #15080 but for the Kops E2E presubmit job. #15080 only updated a presubmit job for kubernetes/kubernetes. This updates the Kops E2E presubmit job which is currently failing. The updated image includes #14989. 