### PR TITLE
Deck rbac: Allow watching prowjobs

### DIFF
--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -17,6 +17,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
       # Required when deck runs with `--rerun-creates-job=true`
       - create
 ---


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/15074 I updated deck to use a cache for ProwJobs but forgot to update the RBAC to allow watching them, this PR fixes that.

/assign @stevekuznetsov 