### PR TITLE
Use pod utilities for CAPA CI conformance presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -32,6 +32,7 @@ presubmits:
     decorate: true
     labels:
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
@@ -42,24 +43,9 @@ presubmits:
         command:
         - "runner.sh"
         - "./scripts/ci-make.sh"
-        volumeMounts:
-        - mountPath: /lib/modules
-          name: modules
-          readOnly: true
-        - mountPath: /sys/fs/cgroup
-          name: cgroup
         resources:
           requests:
             memory: "6Gi"
-      volumes:
-      - name: modules
-        hostPath:
-          path: /lib/modules
-          type: Directory
-      - name: cgroup
-        hostPath:
-          path: /sys/fs/cgroup
-          type: Directory
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make
@@ -73,25 +59,22 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: true
     optional: true
+    decorate: true
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: cluster-api
+        base_ref: master
+        path_alias: "sigs.k8s.io/cluster-api"
+      - org: kubernetes-sigs
+        repo: image-builder
+        base_ref: master
+        path_alias: "sigs.k8s.io/image-builder"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
-          args:
-            - "--job=$(JOB_NAME)"
-            - "--root=/go/src"
-            - "--repo=k8s.io/kubernetes=master"
-            - "--repo=sigs.k8s.io/cluster-api=master"
-            - "--repo=sigs.k8s.io/image-builder=master"
-            - "--repo=sigs.k8s.io/cluster-api-provider-gcp=$(PULL_REFS)"
-            - "--repo=sigs.k8s.io/kind=master"
-            - "--service-account=/etc/service-account/service-account.json"
-            - "--upload=gs://kubernetes-jenkins/pr-logs"
-            - "--scenario=execute"
-            - "--"
-            - "bash"
-            - "--"
-            - "-c"
-            - "cd ./../../sigs.k8s.io/cluster-api-provider-gcp && scripts/ci-e2e.sh"
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
           # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
@@ -104,4 +87,4 @@ presubmits:
               cpu: 2000m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
-      testgrid-tab-name: pr-e2e
+      testgrid-tab-name: pr-conformance


### PR DESCRIPTION
Also switch pull-cluster-api-provider-gcp-make to use `preset-kind-volume-mounts` while we are here