### PR TITLE
Kops - unpin Kubernetes 1.15 from E2E presubmit job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -82,7 +82,6 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.15.txt
         - --extract=ci/latest-1.15
         - --ginkgo-parallel
         - --kops-build

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -82,7 +82,7 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --extract=ci/latest-1.15
+        - --extract=ci/latest
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws


### PR DESCRIPTION
Now that the Kops E2E presubmit job is working and the [periodic job that tests ci/latest](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws) is green, we can stop pinning the presubmit job to use Kubernetes 1.15 and instead just use latest.

This reverts commits cacf4b4 and 0d8c685.