### PR TITLE
make kind pr blocking in kubernetes/kubernetes

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -220,7 +220,7 @@ presubmits:
           type: Directory
 
   - name: pull-kubernetes-e2e-kind
-    optional: true
+    optional: false
     always_run: true
     decorate: true
     skip_branches:


### PR DESCRIPTION
This has been stable for some time now (Edit: O(months)) with about 75% of the test cases compared to `pull-kubernetes-e2e-gce` with a higher pass rate, less flakes, and typically less than half the run-time. 
It is also possible to replicate locally.

Holding for lazy consensus.
/hold