### PR TITLE
Switch CAPA CI jobs to use pod utils as bootstrap.py is deprecated

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -83,7 +83,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-release-0-4
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: ci-cluster-api-provider-aws-conformance-master
+- name: ci-cluster-api-provider-aws-make-conformance-master
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   interval: 3h
   max_concurrency: 5
@@ -97,22 +97,19 @@ periodics:
     preset-aws-credential: "true"
   branches:
     - master
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
-        args:
-          - "--repo=k8s.io/kubernetes=master"
-          - "--repo=sigs.k8s.io/image-builder=master"
-          - "--repo=sigs.k8s.io/cluster-api-provider-aws=master"
-          - "--root=/go/src"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--scenario=execute"
-          - "--"
-          - "bash"
-          - "--"
-          - "-c"
-          - "cd ./../../sigs.k8s.io/cluster-api-provider-aws && scripts/ci-conformance.sh"
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
         env:
           - name: CAPI_BRANCH
             value: "master"
@@ -120,6 +117,10 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
           - name: AWS_REGION
             value: "us-west-2"
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
         resources:
@@ -134,7 +135,7 @@ periodics:
     testgrid-tab-name: capa-conformance-master
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-- name: ci-cluster-api-provider-aws-conformance-release-0-4
+- name: ci-cluster-api-provider-aws-make-conformance-stable
   path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   interval: 3h
   max_concurrency: 5
@@ -148,22 +149,19 @@ periodics:
     preset-aws-credential: "true"
   branches:
     - release-0.4
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
-        args:
-          - "--repo=k8s.io/kubernetes=master"
-          - "--repo=sigs.k8s.io/image-builder=master"
-          - "--repo=sigs.k8s.io/cluster-api-provider-aws=release-0.4"
-          - "--root=/go/src"
-          - "--service-account=/etc/service-account/service-account.json"
-          - "--upload=gs://kubernetes-jenkins/logs"
-          - "--scenario=execute"
-          - "--"
-          - "bash"
-          - "--"
-          - "-c"
-          - "cd ./../../sigs.k8s.io/cluster-api-provider-aws && scripts/ci-conformance.sh"
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -171,6 +169,10 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
           - name: AWS_REGION
             value: "us-west-2"
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+        # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
         resources:
@@ -183,6 +185,59 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: capa-conformance-stable
+    testgrid-num-columns-recent: '20'
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+- name: ci-cluster-api-provider-aws-make-conformance-stable-k8s-ci-artifacts
+  path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  interval: 3h
+  max_concurrency: 5
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  branches:
+    - release-0.4
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: image-builder
+    base_ref: master
+    path_alias: "sigs.k8s.io/image-builder"
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
+        env:
+          - name: CAPI_BRANCH
+            value: "stable"
+          - name: BOSKOS_HOST
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: AWS_REGION
+            value: "us-west-2"
+        command:
+          - "runner.sh"
+          - "./scripts/ci-conformance.sh"
+          - "--use-ci-artifacts"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: capa-conformance-stable-k8s-master
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
 postsubmits:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -76,7 +76,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: verify
     # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
-  - name: pull-cluster-api-provider-aws-conformance
+  - name: pull-cluster-api-provider-aws-make-conformance
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -85,33 +85,31 @@ presubmits:
       preset-aws-credential: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: true
     optional: true
+    decorate: true
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
-          args:
-            - "--job=$(JOB_NAME)"
-            - "--root=/go/src"
-            - "--repo=k8s.io/kubernetes=master"
-            - "--repo=sigs.k8s.io/cluster-api=master"
-            - "--repo=sigs.k8s.io/image-builder=master"
-            - "--repo=sigs.k8s.io/cluster-api-provider-aws=$(PULL_REFS)"
-            - "--repo=sigs.k8s.io/kind=master"
-            - "--service-account=/etc/service-account/service-account.json"
-            - "--upload=gs://kubernetes-jenkins/pr-logs"
-            - "--scenario=execute"
-            - "--"
-            - "bash"
-            - "--"
-            - "-c"
-            - "cd ./../../sigs.k8s.io/cluster-api-provider-aws && scripts/ci-conformance.sh"
-          # we need privileged mode in order to do docker in docker
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
           env:
             - name: BOSKOS_HOST
               value: "boskos.test-pods.svc.cluster.local"
             - name: AWS_REGION
               value: "us-west-2"
+          # we need privileged mode in order to do docker in docker
           securityContext:
             privileged: true
           resources:


### PR DESCRIPTION
This went easier since we made similar changes in CAPG ( 🤞 )