### PR TITLE
Add HPA e2e to master blocking dashboard.

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -301,7 +301,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
 
   annotations:
-    testgrid-dashboards: sig-autoscaling-hpa, sig-release-master-blocking
+    testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gke-autoscaling-hpa-cm
 - interval: 30m
   name: ci-kubernetes-e2e-autoscaling-hpa-cpu

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -212,7 +212,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
 
   annotations:
-    testgrid-dashboards: sig-autoscaling-hpa
+    testgrid-dashboards: sig-autoscaling-hpa, sig-release-master-blocking
     testgrid-tab-name: gci-gce-autoscaling-hpa-cm
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-autoscaling-migs
@@ -272,7 +272,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
 
   annotations:
-    testgrid-dashboards: sig-autoscaling-hpa
+    testgrid-dashboards: sig-autoscaling-hpa, sig-release-master-blocking
     testgrid-tab-name: gci-gce-autoscaling-migs-hpa
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa-cm
@@ -301,7 +301,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-master
 
   annotations:
-    testgrid-dashboards: sig-autoscaling-hpa
+    testgrid-dashboards: sig-autoscaling-hpa, sig-release-master-blocking
     testgrid-tab-name: gci-gke-autoscaling-hpa-cm
 - interval: 30m
   name: ci-kubernetes-e2e-autoscaling-hpa-cpu

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -25,6 +25,13 @@ dashboard_groups:
 
 dashboards:
 - name: sig-release-master-blocking
+  dashboard_tab:
+  - name: gci-gce-autoscaling-hpa-cm
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-autoscaling-test-failures@googlegroups.com
+  - name: gci-gce-autoscaling-migs-hpa
+    alert_options:
+      alert_mail_to_addresses: kubernetes-sig-autoscaling-test-failures@googlegroups.com
 - name: sig-release-master-informing
 - name: sig-release-1.17-blocking
 - name: sig-release-1.17-informing


### PR DESCRIPTION
Per https://github.com/kubernetes/test-infra/pull/14001#issue-309463316.
HPA should be a release blocker. It was before being moved to a separate
job for time constraints (#81491).