### PR TITLE
Switch k8s master CI to go1.13.4

### DIFF
--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
 substitutions:
   _GIT_TAG: '12345'
   _CONFIG: master
-  _GO_VERSION: 1.12.12
+  _GO_VERSION: 1.13.4
   _K8S_RELEASE: stable
   _BAZEL_VERSION: 0.23.2
   _UPGRADE_DOCKER: 'false'

--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -3,13 +3,13 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.16':

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
 substitutions:
   _GIT_TAG: '12345'
   _CONFIG: master
-  _GO_VERSION: 1.12.12
+  _GO_VERSION: 1.13.4
   _K8S_RELEASE: stable
   _BAZEL_VERSION: 0.23.2
   _UPGRADE_DOCKER: 'false'

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,18 +1,18 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: latest-1.17
     BAZEL_VERSION: 0.23.2
   '1.16':


### PR DESCRIPTION
Changes CI for master to run using go1.13.4 (I think)

Prereq for green runs on https://github.com/kubernetes/kubernetes/pull/82809

Once master switches to go1.13.4, other PRs will fail verify checks until https://github.com/kubernetes/kubernetes/pull/82809 merges.
