### PR TITLE
disable auto approval of PRs in kubernetes-sigs/cluster-api-provider-vsphere

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -89,6 +89,10 @@ approve:
   - helm/charts
   require_self_approval: false
   lgtm_acts_as_approve: true
+- repos:
+  - kubernetes-sigs/cluster-api-provider-vsphere
+  require_self_approval: true
+  lgtm_acts_as_approve: false
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:


### PR DESCRIPTION
As per https://github.com/kubernetes-sigs/cluster-api-provider-vsphere/issues/657 -- we'd like to disable auto approval for PRs. 

Signed-off-by: Andrew Sy Kim <kiman@vmware.com>