### PR TITLE
Remove uniqueness checking on files in ConfigUpdater

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -965,7 +965,6 @@ type ConfigMapID struct {
 
 func validateConfigUpdater(updater *ConfigUpdater) error {
 	updater.SetDefaults()
-	files := sets.NewString()
 	configMapKeys := map[ConfigMapID]sets.String{}
 	for file, config := range updater.Maps {
 		for cluster, namespaces := range config.Clusters {
@@ -975,10 +974,6 @@ func validateConfigUpdater(updater *ConfigUpdater) error {
 					Namespace: namespace,
 					Cluster:   cluster,
 				}
-				if files.Has(file) {
-					return fmt.Errorf("file %s listed more than once in config updater config", file)
-				}
-				files.Insert(file)
 
 				key := config.Key
 				if key == "" {

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -1199,6 +1199,18 @@ func TestValidateConfigUpdater(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name: "a cm with additional namespaces",
+			cu: &ConfigUpdater{
+				Maps: map[string]ConfigMapSpec{
+					"ci-operator/templates/openshift/installer/cluster-launch-installer-src.yaml": {
+						Name:                 "prow-job-cluster-launch-installer-src",
+						AdditionalNamespaces: []string{"ci-stg"},
+					},
+				},
+			},
+			expected: nil,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
`files` are keys from a map `updater.Maps` defined as
`map[string]ConfigMapSpec`.

Originally, it checked if a file show showed up more than once
in the config, which was not even possible when it has already
become a map (redundant but not a bug).

The PR [1] introduced `clusters` config-updater plugin and added
`updater.SetDefaults()` into function `validateConfigUpdater`.

By mistake, the recurrences of the key `file` were checked in the
inner loop. It became a bug. We remove the check because it should
not happen in reality.

[1]. #15028

Found by rehearsal
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/pr-logs/pull/openshift_release/5779/rehearse-5779-pull-ci-openshift-release-master-config/2

/cc @stevekuznetsov @droslean 
