### PR TITLE
Load hidden repos dynamically

### DIFF
--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -495,7 +495,10 @@ func TestTide(t *testing.T) {
 		},
 	})
 	ta := tideAgent{
-		path:         s.URL,
+		path: s.URL,
+		hiddenRepos: func() []string {
+			return []string{}
+		},
 		updatePeriod: func() time.Duration { return time.Minute },
 	}
 	if err := ta.updatePools(); err != nil {
@@ -556,7 +559,10 @@ func TestTideHistory(t *testing.T) {
 	}))
 
 	ta := tideAgent{
-		path:         s.URL,
+		path: s.URL,
+		hiddenRepos: func() []string {
+			return []string{}
+		},
 		updatePeriod: func() time.Duration { return time.Minute },
 	}
 	if err := ta.updateHistory(); err != nil {
@@ -872,10 +878,12 @@ func TestListProwJobs(t *testing.T) {
 			shouldError: testCase.listErr,
 		}
 		lister := filteringProwJobLister{
-			client:      fakeProwJobClient,
-			hiddenRepos: testCase.hiddenRepos,
-			hiddenOnly:  testCase.hiddenOnly,
-			showHidden:  testCase.showHidden,
+			client: fakeProwJobClient,
+			hiddenRepos: func() sets.String {
+				return testCase.hiddenRepos
+			},
+			hiddenOnly: testCase.hiddenOnly,
+			showHidden: testCase.showHidden,
 		}
 
 		filtered, err := lister.ListProwJobs(testCase.selector)

--- a/prow/cmd/deck/tide_test.go
+++ b/prow/cmd/deck/tide_test.go
@@ -212,10 +212,12 @@ func TestFilterHidden(t *testing.T) {
 		t.Logf("running scenario %q", test.name)
 
 		ta := &tideAgent{
-			hiddenRepos: test.hiddenRepos,
-			hiddenOnly:  test.hiddenOnly,
-			showHidden:  test.showHidden,
-			log:         logrus.WithField("agent", "tide"),
+			hiddenRepos: func() []string {
+				return test.hiddenRepos
+			},
+			hiddenOnly: test.hiddenOnly,
+			showHidden: test.showHidden,
+			log:        logrus.WithField("agent", "tide"),
 		}
 
 		gotQueries := ta.filterHiddenQueries(test.queries)


### PR DESCRIPTION
Configuration for hidden repos needs to be reloaded to continue being
valid. We should also not be logging every time we ignore something,
this generates gigabytes of logs a day.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner @alvaroaleman @petr-muller @droslean 