### PR TITLE
peribolos: dump more repo fields

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -355,6 +355,8 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 			AllowMergeCommit: &repos[idx].AllowMergeCommit,
 			AllowSquashMerge: &repos[idx].AllowSquashMerge,
 			AllowRebaseMerge: &repos[idx].AllowRebaseMerge,
+			Archived:         &repos[idx].Archived,
+			DefaultBranch:    &repos[idx].DefaultBranch,
 		}
 	}
 

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -1731,6 +1731,7 @@ func TestDumpOrgConfig(t *testing.T) {
 	repoName := "project"
 	repoDescription := "awesome testing project"
 	repoHomepage := "https://www.somewhe.re/something/"
+	master := "master-branch"
 	cases := []struct {
 		name              string
 		orgOverride       string
@@ -1830,7 +1831,17 @@ func TestDumpOrgConfig(t *testing.T) {
 				7: {{Name: "pull-repo", Permissions: github.RepoPermissions{Pull: true}}, {Name: "admin-repo", Permissions: github.RepoPermissions{Admin: true}}},
 			},
 			repos: []github.Repo{
-				{Name: repoName, Description: repoDescription, Homepage: repoHomepage, Private: false, HasIssues: true, HasProjects: true, HasWiki: true},
+				{
+					Name:          repoName,
+					Description:   repoDescription,
+					Homepage:      repoHomepage,
+					Private:       false,
+					HasIssues:     true,
+					HasProjects:   true,
+					HasWiki:       true,
+					Archived:      true,
+					DefaultBranch: master,
+				},
 			},
 			expected: org.Config{
 				Metadata: org.Metadata{
@@ -1896,6 +1907,8 @@ func TestDumpOrgConfig(t *testing.T) {
 						AllowMergeCommit: &no,
 						AllowRebaseMerge: &no,
 						AllowSquashMerge: &no,
+						Archived:         &yes,
+						DefaultBranch:    &master,
 					},
 				},
 			},


### PR DESCRIPTION
Previously the fields used in repo edit call were not dumped, this
commit fixes that.