### PR TITLE
[CAPA/CAPG] Ensure correct working directory

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -97,6 +97,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  - org: kubernetes-sigs
     repo: image-builder
     base_ref: master
     path_alias: "sigs.k8s.io/image-builder"
@@ -104,10 +108,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-aws
-    base_ref: master
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
@@ -150,6 +150,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: release-0.4
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  - org: kubernetes-sigs
     repo: image-builder
     base_ref: master
     path_alias: "sigs.k8s.io/image-builder"
@@ -157,10 +161,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-aws
-    base_ref: release-0.4
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
@@ -203,6 +203,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-aws
+    base_ref: release-0.4
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  - org: kubernetes-sigs
     repo: image-builder
     base_ref: master
     path_alias: "sigs.k8s.io/image-builder"
@@ -210,10 +214,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-aws
-    base_ref: release-0.4
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -44,6 +44,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-gcp
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+  - org: kubernetes-sigs
     repo: cluster-api
     base_ref: master
     path_alias: "sigs.k8s.io/cluster-api"
@@ -55,10 +59,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: master
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
@@ -96,6 +96,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-gcp
+    base_ref: release-0.2
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+  - org: kubernetes-sigs
     repo: cluster-api
     base_ref: master
     path_alias: "sigs.k8s.io/cluster-api"
@@ -107,10 +111,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: release-0.2
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental
@@ -148,6 +148,10 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
+    repo: cluster-api-provider-gcp
+    base_ref: release-0.2
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+  - org: kubernetes-sigs
     repo: cluster-api
     base_ref: master
     path_alias: "sigs.k8s.io/cluster-api"
@@ -159,10 +163,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: cluster-api-provider-gcp
-    base_ref: release-0.2
-    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191103-6816af1-experimental


### PR DESCRIPTION
```
periodic jobs will have the working directory set to the root of the repo specified by the first ref in extra_refs (if specified). See the extra_refs field if you need to clone more than one repo.
```