### PR TITLE
Switch config_updater configuration to use new format.

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -369,7 +369,9 @@ config_updater:
   maps:
     label_sync/labels.yaml:
       name: label-config
-      namespace: test-pods
+      clusters:
+        test-infra-trusted:
+          - test-pods
     config/prow/config.yaml:
       name: config
     config/prow/plugins.yaml:


### PR DESCRIPTION
Seeing tons of warnings like:
> 'namespace' and 'additional_namespaces' are deprecated for config-updater plugin, use 'clusters' instead

/assign @hongkailiu @stevekuznetsov 