### PR TITLE
further increase the timeout for migration test

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
 - name: ci-aws-ebs-csi-driver-migration-test-latest
   decorate: true
   decoration_config:
-    timeout: 4h
+    timeout: 5h45m
   interval: 6h
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -121,7 +121,7 @@ presubmits:
     always_run: false
     decorate: true
     decoration_config:
-      timeout: 4h
+      timeout: 5h45m
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
further increase the timeout for migration test to be 5h45m since 4h is not enough

/cc @wongma7 @gyuho 