### PR TITLE
Revert "Merge pull request #15133 from cblecker/autobump"

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -43,7 +43,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
@@ -69,7 +69,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src

--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
@@ -46,7 +46,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes"
@@ -81,7 +81,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --root=/go/src

--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -41,7 +41,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - sh
         - -c
@@ -85,7 +85,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - sh
         - -c
@@ -129,7 +129,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - sh
         - -c
@@ -173,7 +173,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - sh
         - -c
@@ -222,7 +222,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -248,7 +248,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-windows-cri
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -32,7 +32,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -63,7 +63,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -93,7 +93,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -124,7 +124,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -155,7 +155,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -186,7 +186,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -217,7 +217,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -247,7 +247,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -276,7 +276,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -306,7 +306,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -336,7 +336,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -371,7 +371,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=800m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gke-cos-containerd

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=github.com/helm/charts=$(PULL_REFS)"
         - "--root=/go/src/"
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test=false
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-apps
     testgrid-tab-name: charts-gce

--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -199,7 +199,7 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         imagePullPolicy: Always
         command:
         - "./test/tools/project-cleaner/project_cleaner.sh"

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -251,7 +251,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -306,7 +306,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -321,7 +321,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ./test/upgrade-tests.sh
         args:
@@ -366,7 +366,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -379,7 +379,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -422,7 +422,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -465,7 +465,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -508,7 +508,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -551,7 +551,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -594,7 +594,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -637,7 +637,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -680,7 +680,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -723,7 +723,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -766,7 +766,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -809,7 +809,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -852,7 +852,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -895,7 +895,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -938,7 +938,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -987,7 +987,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -1036,7 +1036,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -1085,7 +1085,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -1134,7 +1134,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -99,7 +99,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -142,7 +142,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -179,7 +179,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -222,7 +222,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -259,7 +259,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -302,7 +302,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -339,7 +339,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -43,7 +43,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -62,7 +62,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -82,7 +82,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -104,7 +104,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -128,7 +128,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -59,7 +59,7 @@ presubmits:
       preset-cloudprovider-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -87,7 +87,7 @@ presubmits:
       preset-cloudprovider-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -116,7 +116,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -59,7 +59,7 @@ presubmits:
       preset-cloudprovider-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -87,7 +87,7 @@ presubmits:
       preset-cloudprovider-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -116,7 +116,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -64,7 +64,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=release-1.16"
@@ -116,7 +116,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=release-1.16"
@@ -165,7 +165,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -195,7 +195,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -254,7 +254,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -315,7 +315,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -374,7 +374,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -433,7 +433,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -496,7 +496,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -555,7 +555,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -614,7 +614,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -673,7 +673,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -744,7 +744,7 @@ periodics:
     description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled."
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16

--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
       command:
       - "./scripts/ci-aws-cred-test.sh"
   annotations:
@@ -35,7 +35,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -67,7 +67,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -110,7 +110,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: CAPI_BRANCH
             value: "master"
@@ -163,7 +163,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -216,7 +216,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -259,7 +259,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -289,7 +289,7 @@ postsubmits:
       - release-0.4
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -35,7 +35,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -67,7 +67,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "runner.sh"
         - "make"
@@ -100,7 +100,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -137,7 +137,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -37,7 +37,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -70,7 +70,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "runner.sh"
         - "make"
@@ -88,7 +88,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         imagePullPolicy: Always
         command:
         - "./hack/verify-bazel.sh"
@@ -105,7 +105,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-test.sh"
@@ -122,7 +122,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-build.sh"
@@ -139,7 +139,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         imagePullPolicy: Always
         command:
         - "./hack/verify_boilerplate.py"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -34,7 +34,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-digitalocean
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -61,7 +61,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: "CAPI_BRANCH"
             value: "master"
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: "CAPI_BRANCH"
             value: "stable"
@@ -165,7 +165,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         env:
           - name: "CAPI_BRANCH"
             value: "stable"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -76,7 +76,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -17,7 +17,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -32,7 +32,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -79,7 +79,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - hack/check-format.sh
     annotations:
@@ -95,7 +95,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - hack/check-lint.sh
     annotations:
@@ -111,7 +111,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - hack/check-vet.sh
     annotations:
@@ -164,7 +164,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - hack/verify-crds.sh
     annotations:
@@ -182,7 +182,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             cpu: "500m"
@@ -209,7 +209,7 @@ presubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             cpu: "1000m"
@@ -243,7 +243,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             cpu: "1000m"
@@ -274,7 +274,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -31,7 +31,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -55,7 +55,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -75,7 +75,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - "./scripts/ci-test.sh"
       resources:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -34,7 +34,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -51,7 +51,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "runner.sh"
         - "make"
@@ -69,7 +69,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -90,7 +90,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - ./scripts/ci-integration.sh

--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "./hack/verify-all.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -75,7 +75,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.5.0"
       - "--root=/go/src"
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.4.0"
       - "--root=/go/src"
@@ -66,7 +66,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -95,7 +95,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -131,7 +131,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - ./hack/ci/push-latest-cli.sh
@@ -29,7 +29,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - ./hack/ci/build-all.sh
@@ -24,7 +24,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - make
@@ -40,7 +40,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - runner.sh
         - ./hack/verify/all.sh
@@ -66,7 +66,7 @@ presubmits:
       timeout: 40m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20191106-0490589-master
+      - image: gcr.io/k8s-testimages/krte:v20191020-6567e5c-master
         command:
         - wrapper.sh
         - bash
@@ -116,7 +116,7 @@ presubmits:
       nodeSelector:
         dedicated: "ubuntu"
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -163,7 +163,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -204,7 +204,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -245,7 +245,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"

--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -15,7 +15,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -64,7 +64,7 @@ periodics:
     nodeSelector:
       dedicated: "ubuntu"
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -111,7 +111,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -152,7 +152,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -193,7 +193,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -234,7 +234,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -14,7 +14,7 @@ periodics:
       preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - ./hack/ci/push-latest-cli.sh
@@ -34,7 +34,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - make
@@ -58,7 +58,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -108,7 +108,7 @@ periodics:
     nodeSelector:
       dedicated: "ubuntu"
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -157,7 +157,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -210,7 +210,7 @@ periodics:
     nodeSelector:
       dedicated: "ubuntu"
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -345,7 +345,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -387,7 +387,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         - test
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -54,7 +54,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -6,6 +6,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "./hack/ci/test.sh"

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -46,7 +46,7 @@ presubmits:
     optional: true
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -72,7 +72,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -87,7 +87,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -103,7 +103,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -119,7 +119,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -135,7 +135,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -151,7 +151,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -167,7 +167,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -56,7 +56,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -74,7 +74,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -136,7 +136,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -49,7 +49,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -97,7 +97,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -140,7 +140,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -184,7 +184,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -228,7 +228,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -272,7 +272,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - go
       args:
@@ -32,7 +32,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - bash
       - -c

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - go
         args:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - bash
         - -c

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -44,7 +44,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -100,7 +100,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -121,7 +121,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "make"
         args:
@@ -140,7 +140,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "make"
         args:
@@ -166,7 +166,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "make"
         args:
@@ -191,7 +191,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -27,7 +27,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -34,7 +34,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
+++ b/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -29,7 +29,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -27,7 +27,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-gkespec
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-serial
@@ -91,7 +91,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-gkespec
@@ -123,7 +123,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-serial
@@ -155,7 +155,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-gkespec
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-serial
@@ -219,7 +219,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-gkespec
@@ -251,7 +251,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-serial
@@ -283,7 +283,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-gkespec
@@ -315,7 +315,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-serial
@@ -347,7 +347,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-gkespec
@@ -379,7 +379,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-serial
@@ -411,7 +411,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-gkespec
@@ -443,7 +443,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-serial
@@ -475,7 +475,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-gkespec
@@ -507,7 +507,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-serial
@@ -538,7 +538,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -569,7 +569,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -600,7 +600,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -631,7 +631,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -662,7 +662,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -693,7 +693,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -724,7 +724,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -755,7 +755,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -786,7 +786,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -817,7 +817,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -848,7 +848,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -879,7 +879,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -910,7 +910,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -941,7 +941,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -972,7 +972,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -1003,7 +1003,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1034,7 +1034,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1065,7 +1065,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1096,7 +1096,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1127,7 +1127,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1158,7 +1158,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1189,7 +1189,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1220,7 +1220,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1251,7 +1251,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1283,7 +1283,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1316,7 +1316,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1348,7 +1348,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1380,7 +1380,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1413,7 +1413,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1446,7 +1446,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1479,7 +1479,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1514,7 +1514,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sbeta-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -1546,7 +1546,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1579,7 +1579,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1611,7 +1611,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1643,7 +1643,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1676,7 +1676,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1709,7 +1709,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1742,7 +1742,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1777,7 +1777,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable1-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -1809,7 +1809,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -1842,7 +1842,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -1874,7 +1874,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -1906,7 +1906,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -1939,7 +1939,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -1972,7 +1972,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -2005,7 +2005,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -2040,7 +2040,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable2-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -2072,7 +2072,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2105,7 +2105,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2137,7 +2137,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2169,7 +2169,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2202,7 +2202,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2235,7 +2235,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2268,7 +2268,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2303,7 +2303,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu1-k8sstable3-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -2335,7 +2335,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2368,7 +2368,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2400,7 +2400,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2432,7 +2432,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2465,7 +2465,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2498,7 +2498,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2531,7 +2531,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2566,7 +2566,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sbeta-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -2598,7 +2598,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2631,7 +2631,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2663,7 +2663,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2695,7 +2695,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2728,7 +2728,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2761,7 +2761,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2794,7 +2794,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2829,7 +2829,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable1-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -2861,7 +2861,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -2894,7 +2894,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -2926,7 +2926,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -2958,7 +2958,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -2991,7 +2991,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -3024,7 +3024,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -3057,7 +3057,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -3092,7 +3092,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable2-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -3124,7 +3124,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3157,7 +3157,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3189,7 +3189,7 @@ periodics:
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-flaky
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3221,7 +3221,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-reboot
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3254,7 +3254,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3287,7 +3287,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3320,7 +3320,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-updown
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3355,7 +3355,7 @@ periodics:
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gcp-zone=us-west1-b
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-ubuntu2-k8sstable3-gpu
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -3382,7 +3382,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.17-blocking
@@ -3410,7 +3410,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.17-blocking
@@ -3439,7 +3439,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.17-informing
@@ -3468,7 +3468,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-1.17-informing
@@ -3497,7 +3497,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.17-informing
@@ -3529,7 +3529,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-generated
@@ -3559,7 +3559,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-generated
@@ -3591,7 +3591,7 @@ periodics:
       - --ginkgo-parallel=30
       - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-default
     testgrid-dashboards: sig-release-generated
@@ -3622,7 +3622,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-generated
@@ -3653,7 +3653,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-generated
@@ -3682,7 +3682,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.17-blocking
@@ -3709,7 +3709,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.16-blocking
@@ -3737,7 +3737,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.16-blocking
@@ -3766,7 +3766,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.16-informing
@@ -3795,7 +3795,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-1.16-informing
@@ -3824,7 +3824,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.16-informing
@@ -3856,7 +3856,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-generated
@@ -3886,7 +3886,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-generated
@@ -3917,7 +3917,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-default
     testgrid-dashboards: sig-release-generated
@@ -3948,7 +3948,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-generated
@@ -3979,7 +3979,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-generated
@@ -4007,7 +4007,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.16-blocking
@@ -4034,7 +4034,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.15-blocking
@@ -4062,7 +4062,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.15-blocking
@@ -4090,7 +4090,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.15-informing
@@ -4119,7 +4119,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-1.15-informing
@@ -4148,7 +4148,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.15-informing
@@ -4180,7 +4180,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-generated
@@ -4210,7 +4210,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-generated
@@ -4241,7 +4241,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-default
     testgrid-dashboards: sig-release-generated
@@ -4272,7 +4272,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-generated
@@ -4303,7 +4303,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-generated
@@ -4331,7 +4331,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.15-blocking
@@ -4359,7 +4359,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.14-blocking
@@ -4386,7 +4386,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.14-blocking
@@ -4414,7 +4414,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.14-informing
@@ -4443,7 +4443,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-1.14-informing
@@ -4472,7 +4472,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.14-informing
@@ -4504,7 +4504,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-generated
@@ -4534,7 +4534,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-generated
@@ -4565,7 +4565,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-default
     testgrid-dashboards: sig-release-generated
@@ -4596,7 +4596,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-generated
@@ -4627,7 +4627,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gke-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-generated
@@ -4655,7 +4655,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       - --env=KUBE_FEATURE_GATES=AllAlpha=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.14-blocking

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -68,7 +68,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -128,7 +128,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -190,7 +190,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -255,7 +255,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
       args:
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
@@ -285,7 +285,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "./kinder/hack/verify-all.sh"
   - name: pull-kubeadm-operator-verify
@@ -18,7 +18,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         - "./operator/hack/verify-all.sh"

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -150,7 +150,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       - name: ZONE
         value: us-central1-a

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -72,7 +72,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -109,7 +109,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -181,7 +181,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:
@@ -217,7 +217,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - go
         args:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -29,7 +29,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-proto

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/kubernetes-sigs/application=master
       - --upload=gs://kubernetes-jenkins/logs/
@@ -57,7 +57,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 
   annotations:
@@ -81,7 +81,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -38,7 +38,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -69,7 +69,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -100,7 +100,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -131,7 +131,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -184,7 +184,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -209,7 +209,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -244,7 +244,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -269,7 +269,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -298,7 +298,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=420m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -324,7 +324,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     # TODO: add to release blocking dashboards once run is successful

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -44,4 +44,4 @@ presubmits:
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=400m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -78,7 +78,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -107,7 +107,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -135,7 +135,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 # kubectl skew tests
   annotations:
@@ -165,7 +165,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -192,7 +192,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -220,7 +220,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-cli-master
@@ -254,7 +254,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -282,7 +282,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -309,7 +309,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\]  --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -337,7 +337,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -363,7 +363,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -391,7 +391,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -418,7 +418,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -445,7 +445,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -471,7 +471,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -502,7 +502,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -532,7 +532,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -563,7 +563,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -594,7 +594,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -625,7 +625,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -655,7 +655,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -687,7 +687,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -717,7 +717,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -748,7 +748,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -778,7 +778,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -809,7 +809,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -839,7 +839,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.12-1.13-gci-kubectl-skew-serial

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -36,7 +36,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       imagePullPolicy: Always
       args:
       - --timeout=320

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kubernetes-e2e-aws-eks-1-13: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         imagePullPolicy: Always
         args:
         - --root=/go/src

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -21,7 +21,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -48,7 +48,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -282,7 +282,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -309,7 +309,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -336,7 +336,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -364,7 +364,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
       - --timeout=30m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -392,7 +392,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -419,7 +419,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
@@ -446,7 +446,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
@@ -473,7 +473,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -38,7 +38,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -28,4 +28,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
@@ -19,7 +19,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:HAMaster\] --minStartupPods=8
       - --timeout=220m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gce-min-node-permissions

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -55,7 +55,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -86,7 +86,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -135,7 +135,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(StorageVersionHash|Audit|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource|CSIInlineVolume)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -167,7 +167,7 @@ periodics:
       - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-default
@@ -199,7 +199,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=70m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-alpha-enabled-default
@@ -227,7 +227,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource|CSIInlineVolume)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-alpha-features
@@ -253,7 +253,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-flaky
@@ -279,7 +279,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.flakeAttempts=1 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-single-flake-attempt
@@ -304,7 +304,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce
     testgrid-tab-name: gce-cos-master-reboot
@@ -331,7 +331,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-serial
@@ -360,7 +360,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-slow
@@ -393,7 +393,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gce-multizone
@@ -423,7 +423,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gce-gci
@@ -453,7 +453,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.15
@@ -483,7 +483,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.14
@@ -512,7 +512,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.13
@@ -541,7 +541,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.12

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
@@ -38,7 +38,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -68,7 +68,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -97,7 +97,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:(DynamicKubeletConfig|ExpandCSIVolumes|ExpandInUseVolumes|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -127,7 +127,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -155,7 +155,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -185,7 +185,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -213,7 +213,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -241,7 +241,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -270,7 +270,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -298,7 +298,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --timeout=30m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -327,7 +327,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -354,7 +354,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -382,7 +382,7 @@ periodics:
       - --provider=gke
       - --test_args=--gce-multizone=true --gce-multimaster=true --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke
@@ -410,7 +410,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gci
@@ -442,7 +442,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=800m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-soak
@@ -454,7 +454,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/ostromart/istio=k8s-prow-test
       - --timeout=90

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-pull-gce-device-plugin-gpu: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -68,7 +68,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -54,7 +54,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -84,7 +84,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -114,7 +114,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -144,7 +144,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -174,7 +174,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -205,7 +205,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -236,7 +236,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-master-1.13-cluster-downgrade

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -41,4 +41,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gke.yaml
@@ -23,7 +23,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu
@@ -53,7 +53,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-1.16
@@ -83,7 +83,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverAcceleratorMonitoring\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'
@@ -111,7 +111,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-p100
@@ -141,7 +141,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-p100-1.16
@@ -171,7 +171,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-p100-1.15
@@ -201,7 +201,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-p100-1.14
@@ -231,7 +231,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-1.15
@@ -261,7 +261,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-device-plugin-gpu-1.14
@@ -292,7 +292,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-num-failures-to-alert: '12'
     testgrid-alert-stale-results-hours: '24'

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster
@@ -52,7 +52,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-parallel
@@ -81,7 +81,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new
@@ -111,7 +111,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new-parallel
@@ -139,7 +139,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master
@@ -168,7 +168,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master-parallel
@@ -197,7 +197,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster
@@ -227,7 +227,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster-parallel
@@ -255,7 +255,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster
@@ -283,7 +283,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster-new
@@ -311,7 +311,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-master
@@ -341,7 +341,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster
@@ -372,7 +372,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster-parallel

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
@@ -25,7 +25,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
 # The non -parallel form of the test includes Serial and Disruptive, so it must run serially;
@@ -60,7 +60,7 @@ periodics:
       - --timeout=1200m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -93,7 +93,7 @@ periodics:
       - --timeout=1200m
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -125,7 +125,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -156,7 +156,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -187,7 +187,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -219,7 +219,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -251,7 +251,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -282,7 +282,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -313,7 +313,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -344,7 +344,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -375,7 +375,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -407,7 +407,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -438,7 +438,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -469,7 +469,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -500,7 +500,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -531,7 +531,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -562,7 +562,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -594,7 +594,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -625,7 +625,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-upgrade
@@ -658,7 +658,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-master-gci-new-downgrade-cluster-parallel

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kind.yaml
@@ -34,7 +34,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -121,7 +121,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -208,7 +208,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -295,7 +295,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       env:
       # for bazel caching
       - name: REPO_OWNER
@@ -382,7 +382,7 @@ periodics:
     path_alias: sigs.k8s.io/kind
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       # for bazel caching
       - name: REPO_OWNER

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:InfluxdbMonitoring\]
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -41,7 +41,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:PrometheusMonitoring\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -93,7 +93,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -119,7 +119,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -146,7 +146,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -173,7 +173,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -200,7 +200,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -227,7 +227,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -254,7 +254,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -281,7 +281,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
   annotations:
     testgrid-dashboards: google-gke-stackdriver
@@ -309,7 +309,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-stackdriver

--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -938,7 +938,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-gci-gce-netd
@@ -965,7 +965,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -997,7 +997,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-ubuntu-gce-netd
@@ -1025,7 +1025,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1061,7 +1061,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-containerd-gce-netd
@@ -1094,7 +1094,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1130,7 +1130,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-containerd-gce-calico

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -92,7 +92,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -114,7 +114,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -142,7 +142,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=340
       - --bare
@@ -173,7 +173,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=340
       - --bare
@@ -205,7 +205,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=340
       - --bare
@@ -233,7 +233,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=340
       - --bare

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -43,7 +43,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gce-alpha-api
@@ -71,7 +71,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance
@@ -98,7 +98,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance
@@ -123,7 +123,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -149,7 +149,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance-nodecache
@@ -177,7 +177,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance-nodecache
@@ -203,7 +203,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -227,7 +227,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress
@@ -255,7 +255,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gci-gce-ingress-manual-network
@@ -285,7 +285,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: ip-alias
@@ -313,7 +313,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
@@ -338,7 +338,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -362,7 +362,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -386,7 +386,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
@@ -411,7 +411,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
@@ -437,7 +437,7 @@ periodics:
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gke, sig-network-gke
     testgrid-tab-name: gci-gke-ingress
@@ -467,7 +467,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:NetworkPolicy\] --minStartupPods=8
       - --gke-create-command=container clusters create --enable-network-policy
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gke
     testgrid-tab-name: gci-gke-network-policy
@@ -494,4 +494,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\]\sServices --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -45,7 +45,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -63,7 +63,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/containerd/containerd=release/1.2
       - --repo=github.com/containerd/cri=release/1.2
@@ -82,7 +82,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/containerd/containerd=release/1.3
       - --repo=github.com/containerd/cri=release/1.3
@@ -121,7 +121,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci
@@ -181,7 +181,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.3
@@ -212,7 +212,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
@@ -223,7 +223,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -283,7 +283,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -313,7 +313,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -373,7 +373,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -424,7 +424,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: soak-gci-gce
@@ -434,7 +434,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -468,7 +468,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-device-plugin-gpu
@@ -500,7 +500,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-multizone
@@ -528,7 +528,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-stackdriver
@@ -556,7 +556,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci
@@ -585,7 +585,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-alpha-features
@@ -612,7 +612,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-es-logging
@@ -637,7 +637,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-flaky
@@ -665,7 +665,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-containerd
     testgrid-tab-name: e2e-gci-ingress
@@ -695,7 +695,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-ip-alias
@@ -722,7 +722,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-proto
@@ -747,7 +747,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-reboot
@@ -774,7 +774,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging
@@ -805,7 +805,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging-k8s-resources
@@ -830,7 +830,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-serial
@@ -856,7 +856,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-slow
@@ -880,7 +880,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-statefulset
@@ -908,7 +908,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
@@ -919,7 +919,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -949,7 +949,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -979,7 +979,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1009,7 +1009,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1039,7 +1039,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1087,7 +1087,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
@@ -1114,7 +1114,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
@@ -1125,7 +1125,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1154,7 +1154,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1191,7 +1191,7 @@ periodics:
   spec:
     containers:
     - name: ci-cri-containerd-cri-validation-windows
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -35,7 +35,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -14,7 +14,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -41,7 +41,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -71,7 +71,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -102,7 +102,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -140,7 +140,7 @@ periodics:
     testgrid-tab-name: node-kubelet-features
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -167,7 +167,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -197,7 +197,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -227,7 +227,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=320
@@ -257,7 +257,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -286,7 +286,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -74,7 +74,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m     # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -89,7 +89,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -123,7 +123,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -35,7 +35,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "./test-e2e/e2e-entrypoint-from-container.sh"
         env:
@@ -61,7 +61,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -26,7 +26,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       name: ""
       resources: {}
 - annotations:
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       name: ""
       resources: {}
 - annotations:
@@ -90,7 +90,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       name: ""
       resources: {}
 - annotations:
@@ -152,7 +152,7 @@ periodics:
         value: release-1.14
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       imagePullPolicy: Always
       name: ""
       resources:
@@ -186,7 +186,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       name: ""
       resources:
         requests:
@@ -221,7 +221,7 @@ periodics:
         value: kubernetes
       - name: REPO_NAME
         value: kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       name: ""
       resources:
         requests:
@@ -279,7 +279,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       name: ""
       resources: {}
 - annotations:
@@ -322,7 +322,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       name: ""
       resources: {}
   tags:
@@ -364,7 +364,7 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 postsubmits:
   kubernetes/kubernetes:
@@ -392,7 +392,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.14.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -422,7 +422,7 @@ postsubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -462,7 +462,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -503,7 +503,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -545,7 +545,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -587,7 +587,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -621,7 +621,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -646,7 +646,7 @@ presubmits:
         - --
         - --build=//... -//vendor/...
         - --release=//build/release-tars
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -675,7 +675,7 @@ presubmits:
         - --test-args=--build_tag_filters=-e2e,-integration
         - --test-args=--test_tag_filters=-e2e,-integration
         - --test-args=--flaky_test_attempts=3
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -697,7 +697,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: main
         resources: {}
   - always_run: true
@@ -749,7 +749,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:
@@ -795,7 +795,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
 - annotations:
@@ -90,7 +90,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
 - annotations:
@@ -121,7 +121,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
 - annotations:
@@ -197,7 +197,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
   tags:
@@ -237,7 +237,7 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       name: ""
       resources: {}
 - annotations:
@@ -334,7 +334,7 @@ periodics:
         value: release-1.15
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       imagePullPolicy: Always
       name: ""
       resources:
@@ -378,7 +378,7 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 postsubmits:
   kubernetes/kubernetes:
@@ -406,7 +406,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -482,7 +482,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -524,7 +524,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -566,7 +566,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -604,7 +604,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -653,7 +653,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources: {}
   - always_run: false
@@ -692,7 +692,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -726,7 +726,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -770,7 +770,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -824,7 +824,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: ""
         resources:
           requests:
@@ -897,6 +897,6 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         name: main
         resources: {}

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
 - annotations:
@@ -90,7 +90,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
 - annotations:
@@ -122,7 +122,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
 - annotations:
@@ -201,7 +201,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
   tags:
@@ -241,7 +241,7 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.16.txt
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       name: ""
       resources: {}
 - annotations:
@@ -338,7 +338,7 @@ periodics:
         value: release-1.16
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -382,7 +382,7 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 
 postsubmits:
   kubernetes/kubernetes:
@@ -410,7 +410,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.16.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -486,7 +486,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -528,7 +528,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -570,7 +570,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -608,7 +608,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -653,7 +653,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources: {}
   - always_run: false
@@ -692,7 +692,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -726,7 +726,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -767,7 +767,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -821,7 +821,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: ""
         resources:
           requests:
@@ -894,6 +894,6 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         name: main
         resources: {}

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -30,7 +30,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -59,7 +59,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -91,7 +91,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -125,7 +125,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -157,7 +157,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -248,7 +248,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
   tags:
@@ -288,7 +288,7 @@ periodics:
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-periodic.txt
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 - annotations:
@@ -385,7 +385,7 @@ periodics:
         value: release-1.17
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       imagePullPolicy: Always
       name: ""
       resources:
@@ -427,7 +427,7 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
       name: ""
       resources: {}
 postsubmits:
@@ -456,7 +456,7 @@ postsubmits:
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
         - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.17.txt
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -533,7 +533,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -571,7 +571,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -616,7 +616,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources: {}
   - always_run: false
@@ -655,7 +655,7 @@ presubmits:
         - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -697,7 +697,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -739,7 +739,7 @@ presubmits:
         - --stage-suffix=pull-kubernetes-e2e-gke-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -773,7 +773,7 @@ presubmits:
           --flakeAttempts=2
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -814,7 +814,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -877,7 +877,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: ""
         resources:
           requests:
@@ -954,7 +954,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: main
         resources: {}
         securityContext:
@@ -974,7 +974,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         name: main
         resources: {}
   - always_run: true
@@ -1003,7 +1003,7 @@ presubmits:
           value: release-1.17
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -12,7 +12,7 @@ periodics:
     testgrid-tab-name: gce-private-cluster-correctness
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=300
       - --bare
@@ -47,7 +47,7 @@ periodics:
 #    testgrid-tab-name: max-persistent-vol-per-pod
 #  spec:
 #    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 #        args:
 #          - --repo=k8s.io/kubernetes=master
 #          - --repo=k8s.io/perf-tests=master
@@ -89,7 +89,7 @@ periodics:
 #    testgrid-tab-name: max-persistent-vol-per-node
 #  spec:
 #    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 #        args:
 #          - --repo=k8s.io/kubernetes=master
 #          - --repo=k8s.io/perf-tests=master
@@ -130,7 +130,7 @@ periodics:
     testgrid-tab-name: storage
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -169,7 +169,7 @@ periodics:
     testgrid-tab-name: calico
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: "calico"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -10,7 +10,7 @@ periodics:
     testgrid-tab-name: node-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -45,7 +45,7 @@ periodics:
     testgrid-tab-name: node-containerd-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -93,7 +93,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -156,7 +156,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -217,7 +217,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -282,7 +282,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -334,7 +334,7 @@ periodics:
     testgrid-tab-name: kubemark-100-benchmark
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -361,7 +361,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -383,7 +383,7 @@ periodics:
     testgrid-tab-name: kube-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -418,7 +418,7 @@ periodics:
     testgrid-tab-name: node-local-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -52,7 +52,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -99,7 +99,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -147,7 +147,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -169,7 +169,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -241,7 +241,7 @@ presubmits:
       preset-e2e-kubemark-gce-scale: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -336,7 +336,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -400,7 +400,7 @@ presubmits:
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
             - --use-logexporter
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
           resources:
             requests:
               memory: "6Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -34,7 +34,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=210m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           cpu: 6
@@ -97,7 +97,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           cpu: 6
@@ -124,7 +124,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -45,7 +45,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -86,7 +86,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -145,7 +145,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -186,7 +186,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -226,7 +226,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         resources:
           requests:
             memory: "6Gi"
@@ -265,7 +265,7 @@ periodics:
       - --stage=gs://kubernetes-release-pull/ci/ci-kubernetes-e2e-gce-iscsi
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           memory: "6Gi"
@@ -301,7 +301,7 @@ periodics:
       - --stage=gs://kubernetes-release-pull/ci/ci-kubernetes-e2e-gce-iscsi-serial
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           memory: "6Gi"

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -73,7 +73,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -103,7 +103,7 @@ postsubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - bash
         args:
@@ -210,7 +210,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - bash
       args:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -70,7 +70,7 @@ presubmits:
       nodeSelector:
         dedicated: "ubuntu"
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         env:
         # enable IPV6 in bootstrap image
         - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -119,7 +119,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -161,7 +161,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -202,7 +202,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -23,7 +23,7 @@ periodics:
     timeout: 6h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - bash
@@ -86,7 +86,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - bash
@@ -141,7 +141,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       command:
       - runner.sh
       - bash

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -20,7 +20,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - make
         - verify
@@ -46,7 +46,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         args:
         - make
         - verify
@@ -72,7 +72,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         args:
         - make
         - verify
@@ -98,7 +98,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - make
         - verify
@@ -130,7 +130,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -24,7 +24,7 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         command:
         - runner.sh
         - kubetest
@@ -97,7 +97,7 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         command:
         - runner.sh
         - kubetest
@@ -170,7 +170,7 @@ presubmits:
       path_alias: sigs.k8s.io/kind
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         command:
         - runner.sh
         - kubetest
@@ -235,7 +235,7 @@ presubmits:
     path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20191106-0490589-master
+      - image: gcr.io/k8s-testimages/krte:v20191020-6567e5c-master
         command:
         - wrapper.sh
         - bash
@@ -341,7 +341,7 @@ presubmits:
       nodeSelector:
         dedicated: "ubuntu"
       containers:
-      - image: gcr.io/k8s-testimages/krte:v20191106-0490589-master
+      - image: gcr.io/k8s-testimages/krte:v20191020-6567e5c-master
         command:
         - wrapper.sh
         - bash

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -54,7 +54,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       args:
       - "--timeout=140"
       - "--bare"

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -18,7 +18,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -51,7 +51,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -85,7 +85,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -119,7 +119,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -195,7 +195,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: OVERRIDE_NODE_BINARY_TAR_URL
         value: "https://storage.googleapis.com/kubernetes-release/release/v1.15.3/kubernetes-node-windows-amd64.tar.gz"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           memory: "8Gi"
@@ -97,7 +97,7 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
@@ -138,7 +138,7 @@ periodics:
       env:
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows
     testgrid-tab-name: gce-windows-master-alpha-features
@@ -174,7 +174,7 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\] --ginkgo.skip=\[Flaky\]|\[LinuxOnly\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=240m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   annotations:
     testgrid-dashboards: google-windows
     testgrid-tab-name: windows-gce-serial
@@ -225,7 +225,7 @@ presubmits:
         - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
         - --test-cmd-args=--node-os-distro=windows
         - --timeout=150m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
+++ b/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
         command:
         - "./hack/verify-all.sh"
     annotations:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -55,7 +55,7 @@ periodics:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
       - --janitor-path=boskos/janitor/gcp_janitor.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
       resources:
         requests:
           cpu: 5
@@ -80,7 +80,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
       resources:
         requests:
           cpu: 5
@@ -106,7 +106,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
       resources:
         requests:
           cpu: 5

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -46,7 +46,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-experimental
         command:
         - ./hack/verify-file-perms.sh
     annotations:

--- a/experiment/generate_tests.py
+++ b/experiment/generate_tests.py
@@ -45,7 +45,7 @@ PROW_CONFIG_TEMPLATE = """
       containers:
       - args:
         env:
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
 """
 
 

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -920,23 +920,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.17
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.17
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.17
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.16
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.16
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.15
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.15
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.15
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.14
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.14
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-1.14
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Found a bunch of issues with the bump go1.13. Reverting the image bump.

This reverts commit 18ebde7a5da8f6cd7f1293685130a1a48606b38a, reversing
changes made to 09649c747d4a61e907c4d432f4394634f5153f23.