### PR TITLE
Kops - add E2E periodic job for testing the AWS VPC CNI provider

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -397,6 +397,35 @@ periodics:
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-weave
+
+- interval: 24h
+  name: ci-kubernetes-e2e-kops-aws-vpc-cni
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=e2e-kops-aws-vpc-cni.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=ci/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=amazon-vpc-routed-eni
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
+      - --provider=aws
+      - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191105-e60677a-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-vpc-cni
+
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce
   labels:


### PR DESCRIPTION
I realized we aren't actually testing the AWS VPC CNI so this adds a periodic job to mimic the other CNI-specific periodics.
Copied from the weave job definition.