### PR TITLE
Tweak component READMEs

### DIFF
--- a/gopherage/README.md
+++ b/gopherage/README.md
@@ -1,7 +1,5 @@
-
-<p align="center"><img src="docs/gopherage.png" width="300" /></p>
-
 # Gopherage
 
-`gopherage` is a tool for manipulating Go coverage files.
+<p align="center"><img src="docs/gopherage.png" width="300" alt="Gopherage logo"/></p>
 
+`gopherage` is a tool for manipulating Go coverage files.

--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -1,3 +1,5 @@
+# [Gubernator](//gubernator.k8s.io/)
+
 Gubernator is a frontend for displaying Kubernetes test results stored in GCS.
 
 It runs on Google App Engine, and parses JSON and junit.xml results for display.

--- a/prow/README.md
+++ b/prow/README.md
@@ -8,7 +8,7 @@ not make any attempt to preserve backwards compatibility.
 
 For a brief overview of how Prow runs jobs take a look at ["Life of a Prow Job"](/prow/life_of_a_prow_job.md).
 
-For a sequence diagram of common usage and interactions flow, click [here](https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/docs/pr-interactions-sequence.svg?sanitize=true).
+To see common Prow usage and interactions flow, see the pull request interactions [sequence diagram](https://raw.githubusercontent.com/kubernetes/test-infra/master/prow/docs/pr-interactions-sequence.svg?sanitize=true).
 
 #### Functions and Features
 * Job execution for testing, batch processing, artifact publishing.

--- a/prow/README.md
+++ b/prow/README.md
@@ -1,4 +1,4 @@
-![prow logo](logo_horizontal_solid.png)
+# ![Prow](logo_horizontal_solid.png)
 
 Prow is a Kubernetes based CI/CD system. Jobs can be triggered by various types of events and report their status to many different services. In addition to job execution, Prow provides GitHub automation in the form of policy enforcement, chat-ops via `/foo` style commands, and automatic PR merging.
 

--- a/velodrome/README.md
+++ b/velodrome/README.md
@@ -1,5 +1,8 @@
+[Velodrome](http://velodrome.k8s.io/)
+=========
+
 Overview
-========
+--------
 
 Velodrome is the dashboard, monitoring and metrics for Kubernetes Developer
 Productivity. It is hosted at:
@@ -29,7 +32,7 @@ productivity. It has the following components:
     tokens
 
 GitHub statistics
-=================
+-----------------
 
 Here is how the github statistics are communicating between each other:
 
@@ -42,7 +45,7 @@ GitHub* <= Fetcher -> Cloud SQL* <= Transform -> InfluxDb
 ```
 
 Other metrics/monitoring components
-===================================
+-----------------------------------
 
 One can set-up monitoring components in two different ways:
 
@@ -60,7 +63,7 @@ As an example, the token counter measures the usage of our github-tokens, and
 has a new value every hour. We can push the new value to InfluxDB.
 
 Naming convention
-=================
+-----------------
 
 To disambiguate how each word is used, let's give a description of the naming
 convention used by velodrome:


### PR DESCRIPTION
Hello from SIG Docs :smile:

This PR will:
- Tweak accessibility for HTML `alt` attributes in READMEs
- Aim to make component READMEs more consistent

I wanted to hyperlink to the main heading of the Prow README, only there wasn't one. So I decided to try a bit of tidying up.