### PR TITLE
github: Addess differences in Repo structures

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -140,7 +140,7 @@ type client interface {
 	RemoveBranchProtection(org, repo, branch string) error
 	UpdateBranchProtection(org, repo, branch string, config github.BranchProtectionRequest) error
 	GetBranches(org, repo string, onlyProtected bool) ([]github.Branch, error)
-	GetRepo(owner, name string) (github.Repo, error)
+	GetRepo(owner, name string) (github.FullRepo, error)
 	GetRepos(org string, user bool) ([]github.Repo, error)
 	ListCollaborators(org, repo string) ([]github.User, error)
 	ListRepoTeams(org, repo string) ([]github.Team, error)

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -84,17 +84,17 @@ type fakeClient struct {
 	teams             []github.Team
 }
 
-func (c fakeClient) GetRepo(org string, repo string) (github.Repo, error) {
+func (c fakeClient) GetRepo(org string, repo string) (github.FullRepo, error) {
 	r, ok := c.repos[org]
 	if !ok {
-		return github.Repo{}, fmt.Errorf("Unknown org: %s", org)
+		return github.FullRepo{}, fmt.Errorf("Unknown org: %s", org)
 	}
 	for _, item := range r {
 		if item.Name == repo {
-			return item, nil
+			return github.FullRepo{Repo: item}, nil
 		}
 	}
-	return github.Repo{}, fmt.Errorf("Unknown repo: %s", repo)
+	return github.FullRepo{}, fmt.Errorf("Unknown repo: %s", repo)
 }
 
 func (c fakeClient) GetRepos(org string, user bool) ([]github.Repo, error) {

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -210,6 +210,7 @@ type dumpClient interface {
 	ListTeams(org string) ([]github.Team, error)
 	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
 	ListTeamRepos(id int) ([]github.Repo, error)
+	GetRepo(owner, name string) (github.FullRepo, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 }
 
@@ -343,20 +344,24 @@ func dumpOrgConfig(client dumpClient, orgName string, ignoreSecretTeams bool) (*
 	}
 	logrus.Debugf("Found %d repos", len(repos))
 	out.Repos = make(map[string]org.Repo, len(repos))
-	for idx, repo := range repos {
-		logrus.WithField("repo", repo.FullName).Debug("Recording repo.")
-		out.Repos[repos[idx].Name] = pruneRepoDefaults(org.Repo{
-			Description:      &repos[idx].Description,
-			HomePage:         &repos[idx].Homepage,
-			Private:          &repos[idx].Private,
-			HasIssues:        &repos[idx].HasIssues,
-			HasProjects:      &repos[idx].HasProjects,
-			HasWiki:          &repos[idx].HasWiki,
-			AllowMergeCommit: &repos[idx].AllowMergeCommit,
-			AllowSquashMerge: &repos[idx].AllowSquashMerge,
-			AllowRebaseMerge: &repos[idx].AllowRebaseMerge,
-			Archived:         &repos[idx].Archived,
-			DefaultBranch:    &repos[idx].DefaultBranch,
+	for _, repo := range repos {
+		full, err := client.GetRepo(orgName, repo.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get repo: %v", err)
+		}
+		logrus.WithField("repo", full.FullName).Debug("Recording repo.")
+		out.Repos[full.Name] = pruneRepoDefaults(org.Repo{
+			Description:      &full.Description,
+			HomePage:         &full.Homepage,
+			Private:          &full.Private,
+			HasIssues:        &full.HasIssues,
+			HasProjects:      &full.HasProjects,
+			HasWiki:          &full.HasWiki,
+			AllowMergeCommit: &full.AllowMergeCommit,
+			AllowSquashMerge: &full.AllowSquashMerge,
+			AllowRebaseMerge: &full.AllowRebaseMerge,
+			Archived:         &full.Archived,
+			DefaultBranch:    &full.DefaultBranch,
 		})
 	}
 
@@ -883,9 +888,10 @@ func configureOrg(opt options, client github.Client, orgName string, orgConfig o
 }
 
 type repoClient interface {
+	GetRepo(orgName, repo string) (github.FullRepo, error)
 	GetRepos(orgName string, isUser bool) ([]github.Repo, error)
-	CreateRepo(owner string, isUser bool, repo github.RepoCreateRequest) (*github.Repo, error)
-	UpdateRepo(owner, name string, repo github.RepoUpdateRequest) (*github.Repo, error)
+	CreateRepo(owner string, isUser bool, repo github.RepoCreateRequest) (*github.FullRepo, error)
+	UpdateRepo(owner, name string, repo github.RepoUpdateRequest) (*github.FullRepo, error)
 }
 
 func newRepoCreateRequest(name string, definition org.Repo) github.RepoCreateRequest {
@@ -941,7 +947,7 @@ func validateRepos(repos map[string]org.Repo) error {
 
 // newRepoUpdateRequest creates a minimal github.RepoUpdateRequest instance
 // needed to update the current repo into the target state.
-func newRepoUpdateRequest(current github.Repo, name string, repo org.Repo) github.RepoUpdateRequest {
+func newRepoUpdateRequest(current github.FullRepo, name string, repo org.Repo) github.RepoUpdateRequest {
 	setString := func(current string, want *string) *string {
 		if want != nil && *want != current {
 			return want
@@ -993,8 +999,8 @@ func sanitizeRepoDelta(opt options, delta *github.RepoUpdateRequest) []error {
 	return errs
 }
 
-func repoExists(repos map[string]github.Repo, name string, previousNames []string) (*github.Repo, error) {
-	var ret *github.Repo
+func repoExists(repos map[string]github.FullRepo, name string, previousNames []string) (*github.FullRepo, error) {
+	var ret *github.FullRepo
 	for _, name := range append([]string{name}, previousNames...) {
 		if repo, exists := repos[strings.ToLower(name)]; exists {
 			switch {
@@ -1019,9 +1025,13 @@ func configureRepos(opt options, client repoClient, orgName string, orgConfig or
 		return fmt.Errorf("failed to get repos: %v", err)
 	}
 	logrus.Debugf("Found %d repositories", len(repoList))
-	byName := make(map[string]github.Repo, len(repoList))
+	byName := make(map[string]github.FullRepo, len(repoList))
 	for _, repo := range repoList {
-		byName[strings.ToLower(repo.Name)] = repo
+		full, err := client.GetRepo(orgName, repo.Name)
+		if err != nil {
+			return fmt.Errorf("failed to get details about repo: %v", err)
+		}
+		byName[strings.ToLower(full.Name)] = full
 	}
 
 	var allErrors []error

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -49,7 +49,7 @@ type githubClient interface {
 	GetPullRequest(org, repo string, number int) (*github.PullRequest, error)
 	GetPullRequestPatch(org, repo string, number int) ([]byte, error)
 	GetPullRequests(org, repo string) ([]github.PullRequest, error)
-	GetRepo(owner, name string) (github.Repo, error)
+	GetRepo(owner, name string) (github.FullRepo, error)
 	IsMember(org, user string) (bool, error)
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
@@ -509,7 +509,7 @@ func waitForRepo(owner, name string, ghc githubClient) error {
 				continue
 			}
 			ghErr = ""
-			if repoExists(owner+"/"+name, []github.Repo{repo}) {
+			if repoExists(owner+"/"+name, []github.Repo{repo.Repo}) {
 				return nil
 			}
 		case <-after:

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -78,10 +78,10 @@ func (f *fghc) IsMember(org, user string) (bool, error) {
 	return f.isMember, nil
 }
 
-func (f *fghc) GetRepo(owner, name string) (github.Repo, error) {
+func (f *fghc) GetRepo(owner, name string) (github.FullRepo, error) {
 	f.Lock()
 	defer f.Unlock()
-	return github.Repo{}, nil
+	return github.FullRepo{}, nil
 }
 
 var expectedFmt = `title=%q body=%q head=%s base=%s`

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -136,7 +136,7 @@ type CommitClient interface {
 
 // RepositoryClient interface for repository related API actions
 type RepositoryClient interface {
-	GetRepo(owner, name string) (Repo, error)
+	GetRepo(owner, name string) (FullRepo, error)
 	GetRepos(org string, isUser bool) ([]Repo, error)
 	GetBranches(org, repo string, onlyProtected bool) ([]Branch, error)
 	GetBranchProtection(org, repo, branch string) (*BranchProtection, error)
@@ -153,8 +153,8 @@ type RepositoryClient interface {
 	ListCollaborators(org, repo string) ([]User, error)
 	CreateFork(owner, repo string) error
 	ListRepoTeams(org, repo string) ([]Team, error)
-	CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (*Repo, error)
-	UpdateRepo(owner, name string, repo RepoUpdateRequest) (*Repo, error)
+	CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (*FullRepo, error)
+	UpdateRepo(owner, name string, repo RepoUpdateRequest) (*FullRepo, error)
 }
 
 // TeamClient interface for team related API actions
@@ -1659,10 +1659,10 @@ func (c *client) ListStatuses(org, repo, ref string) ([]Status, error) {
 // GetRepo returns the repo for the provided owner/name combination.
 //
 // See https://developer.github.com/v3/repos/#get
-func (c *client) GetRepo(owner, name string) (Repo, error) {
+func (c *client) GetRepo(owner, name string) (FullRepo, error) {
 	c.log("GetRepo", owner, name)
 
-	var repo Repo
+	var repo FullRepo
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s", owner, name),
@@ -1673,7 +1673,7 @@ func (c *client) GetRepo(owner, name string) (Repo, error) {
 
 // CreateRepo creates a new repository
 // See https://developer.github.com/v3/repos/#create
-func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (*Repo, error) {
+func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (*FullRepo, error) {
 	c.log("CreateRepo", owner, isUser, repo)
 
 	if repo.Name == nil || *repo.Name == "" {
@@ -1689,7 +1689,7 @@ func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (
 	if !isUser {
 		path = fmt.Sprintf("/orgs/%s/repos", owner)
 	}
-	var retRepo Repo
+	var retRepo FullRepo
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        path,
@@ -1701,7 +1701,7 @@ func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (
 
 // UpdateRepo edits an existing repository
 // See https://developer.github.com/v3/repos/#edit
-func (c *client) UpdateRepo(owner, name string, repo RepoUpdateRequest) (*Repo, error) {
+func (c *client) UpdateRepo(owner, name string, repo RepoUpdateRequest) (*FullRepo, error) {
 	c.log("UpdateRepo", owner, name, repo)
 
 	if c.fake {
@@ -1711,7 +1711,7 @@ func (c *client) UpdateRepo(owner, name string, repo RepoUpdateRequest) (*Repo, 
 	}
 
 	path := fmt.Sprintf("/repos/%s/%s", owner, name)
-	var retRepo Repo
+	var retRepo FullRepo
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        path,
@@ -3182,7 +3182,7 @@ func (c *client) GetColumnProjectCards(columnID int) ([]ProjectCard, error) {
 	var cards []ProjectCard
 	err := c.readPaginatedResults(
 		path,
-		//projects api requies the accept header to be set this way
+		// projects api requies the accept header to be set this way
 		"application/vnd.github.inertia-preview+json",
 		func() interface{} {
 			return &[]ProjectCard{}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1985,7 +1985,7 @@ func TestCreateRepo(t *testing.T) {
 		statusCode  int
 
 		expectError bool
-		expectRepo  *Repo
+		expectRepo  *FullRepo
 	}{
 		{
 			description: "create repo as user",
@@ -1997,9 +1997,11 @@ func TestCreateRepo(t *testing.T) {
 				},
 			},
 			statusCode: http.StatusCreated,
-			expectRepo: &Repo{
-				Name:        "users-repository",
-				Description: "CREATED",
+			expectRepo: &FullRepo{
+				Repo: Repo{
+					Name:        "users-repository",
+					Description: "CREATED",
+				},
 			},
 		},
 		{
@@ -2012,9 +2014,11 @@ func TestCreateRepo(t *testing.T) {
 				},
 			},
 			statusCode: http.StatusCreated,
-			expectRepo: &Repo{
-				Name:        "orgs-repository",
-				Description: "CREATED",
+			expectRepo: &FullRepo{
+				Repo: Repo{
+					Name:        "orgs-repository",
+					Description: "CREATED",
+				},
 			},
 		},
 		{
@@ -2084,7 +2088,7 @@ func TestUpdateRepo(t *testing.T) {
 		statusCode  int
 
 		expectError bool
-		expectRepo  *Repo
+		expectRepo  *FullRepo
 	}{
 		{
 			description: "Update repository",
@@ -2095,10 +2099,12 @@ func TestUpdateRepo(t *testing.T) {
 				Archived: &yes,
 			},
 			statusCode: http.StatusOK,
-			expectRepo: &Repo{
-				Name:        "repository",
-				Description: "UPDATED",
-				Archived:    true,
+			expectRepo: &FullRepo{
+				Repo: Repo{
+					Name:        "repository",
+					Description: "UPDATED",
+					Archived:    true,
+				},
 			},
 		},
 		{

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -297,30 +297,42 @@ type PullRequestChange struct {
 	PreviousFilename string `json:"previous_filename"`
 }
 
-// Repo contains general repository information.
-// See also https://developer.github.com/v3/repos/#get
+// Repo contains general repository information: it includes fields available
+// in repo records returned by GH "List" methods but not those returned by GH
+// "Get" method.
+// See also https://developer.github.com/v3/repos/#list-organization-repositories
 type Repo struct {
-	Owner            User   `json:"owner"`
-	Name             string `json:"name"`
-	FullName         string `json:"full_name"`
-	HTMLURL          string `json:"html_url"`
-	Fork             bool   `json:"fork"`
-	DefaultBranch    string `json:"default_branch"`
-	Archived         bool   `json:"archived"`
-	Private          bool   `json:"private"`
-	Description      string `json:"description"`
-	Homepage         string `json:"homepage"`
-	HasIssues        bool   `json:"has_issues"`
-	HasProjects      bool   `json:"has_projects"`
-	HasWiki          bool   `json:"has_wiki"`
-	AllowSquashMerge bool   `json:"allow_squash_merge"`
-	AllowMergeCommit bool   `json:"allow_merge_commit"`
-	AllowRebaseMerge bool   `json:"allow_rebase_merge"`
+	Owner         User   `json:"owner"`
+	Name          string `json:"name"`
+	FullName      string `json:"full_name"`
+	HTMLURL       string `json:"html_url"`
+	Fork          bool   `json:"fork"`
+	DefaultBranch string `json:"default_branch"`
+	Archived      bool   `json:"archived"`
+	Private       bool   `json:"private"`
+	Description   string `json:"description"`
+	Homepage      string `json:"homepage"`
+	HasIssues     bool   `json:"has_issues"`
+	HasProjects   bool   `json:"has_projects"`
+	HasWiki       bool   `json:"has_wiki"`
 	// Permissions reflect the permission level for the requester, so
 	// on a repository GET call this will be for the user whose token
 	// is being used, if listing a team's repos this will be for the
 	// team's privilege level in the repo
 	Permissions RepoPermissions `json:"permissions"`
+}
+
+// Repo contains detailed repository information, including items
+// that are not available in repo records returned by GH "List" methods
+// but are in those returned by GH "Get" method.
+// See https://developer.github.com/v3/repos/#list-organization-repositories
+// See https://developer.github.com/v3/repos/#get
+type FullRepo struct {
+	Repo
+
+	AllowSquashMerge bool `json:"allow_squash_merge,omitempty"`
+	AllowMergeCommit bool `json:"allow_merge_commit,omitempty"`
+	AllowRebaseMerge bool `json:"allow_rebase_merge,omitempty"`
 }
 
 // RepoRequest contains metadata used in requests to create or update a Repo.
@@ -352,7 +364,7 @@ type RepoCreateRequest struct {
 	LicenseTemplate   *string `json:"license_template,omitempty"`
 }
 
-func (r RepoRequest) ToRepo() *Repo {
+func (r RepoRequest) ToRepo() *FullRepo {
 	setString := func(dest, src *string) {
 		if src != nil {
 			*dest = *src
@@ -364,7 +376,7 @@ func (r RepoRequest) ToRepo() *Repo {
 		}
 	}
 
-	var repo Repo
+	var repo FullRepo
 	setString(&repo.Name, r.Name)
 	setString(&repo.Description, r.Description)
 	setString(&repo.Homepage, r.Homepage)
@@ -395,7 +407,7 @@ type RepoUpdateRequest struct {
 	Archived      *bool   `json:"archived,omitempty"`
 }
 
-func (r RepoUpdateRequest) ToRepo() *Repo {
+func (r RepoUpdateRequest) ToRepo() *FullRepo {
 	repo := r.RepoRequest.ToRepo()
 	if r.DefaultBranch != nil {
 		repo.DefaultBranch = *r.DefaultBranch


### PR DESCRIPTION
GitHub Repositories API unfortunately returns slightly different fields
in repo representations in different API methods. Specifically, the
Repository data returned by the "List"-like methods [1,2,3,4] is missing
the `allow_*_merge` and `allow_merge_commit` fields present in data
returned by "Get/Create/Update" methods [5,6,7]. This means that
github client `GetRepo` needs to return slightly different structure
(also used as input to `Create/UpdateRepo`) than `GetRepos`; the latter
does not have these fields (previously, these fields were always false).

This has some non-trivial blast radius, especially in Peribolos, which
needs a list of all repositories, complete with all fields. Previously
it used a single call of `GetRepos`, resulting in dumping incorrect
config. Now it needs to call `GetRepos` to get a list of all repos,
followed by a single `GetRepo` call for each repo, to obtain missing
fields.

[1] https://developer.github.com/v3/repos/#list-your-repositories
[2] https://developer.github.com/v3/repos/#list-user-repositories
[3] https://developer.github.com/v3/repos/#list-organization-repositories
[4] https://developer.github.com/v3/repos/#list-all-public-repositories
[5] https://developer.github.com/v3/repos/#create
[6] https://developer.github.com/v3/repos/#get
[7] https://developer.github.com/v3/repos/#edit