### PR TITLE
verify-owners: use repo fullName in SkipCollaborators check

### DIFF
--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -122,7 +122,7 @@ func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 
 	var skipTrustedUserCheck bool
 	for _, r := range pc.PluginConfig.Owners.SkipCollaborators {
-		if r == pre.Repo.Name {
+		if r == pre.Repo.FullName {
 			skipTrustedUserCheck = true
 			break
 		}
@@ -146,7 +146,7 @@ func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) e
 
 	var skipTrustedUserCheck bool
 	for _, r := range pc.PluginConfig.Owners.SkipCollaborators {
-		if r == e.Repo.Name {
+		if r == e.Repo.FullName {
 			skipTrustedUserCheck = true
 			break
 		}


### PR DESCRIPTION
The repos are specified in `skip_collaborators` as `org/repo` name, so
we should use the fullName while checking the name.

https://github.com/kubernetes/test-infra/blob/a94035ee3f6361410095e770ba22a969e1aedbe0/config/prow/plugins.yaml#L33-L35

Ref: https://developer.github.com/v3/repos/#get

This will make `verify-owners` skip the trusted user check in contributor-playground (https://github.com/kubernetes-sigs/contributor-playground/pull/389). Note that `verify-owners` will still be enabled on the repo to ensure that we fail if an OWNERS file is incorrectly formatted.

/cc @cblecker @petr-muller @guineveresaenger 
/assign @cblecker 