### PR TITLE
Add SlackReporterConfigs to ProwConfig

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -85,7 +85,10 @@ state and no claims of backwards compatibility are made for any external API.
 Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
-
+ 
+ - *November 14, 2019* The `slack_reporter` config field has been deprecated in
+   favor of the new `slack_reporter_configs` field which allows configuration on a global,
+   organization or repo level. `slack_reporter` will be removed in May 2020.
  - *November 7, 2019*  The `plank.allow_cancellations` and `jenkins_operators.allow_cancellations`
     settings are deprecated and will be removed and set to always `true` in March 2020.
  - *October 7, 2019* Prow will drop support for the deprecated knative-builds in

--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -105,25 +105,57 @@ spec:
 
 Additionally, in order for it to work with Prow you must add the following to your `config.yaml`:
 
+> **NOTE:** `slack_reporter_configs` is a map of `org`, `org/repo`, or `*` (i.e. catch-all wildcard) to a set of slack reporter configs. 
+
+```yaml
+slack_reporter_configs:
+
+  # Wildcard (i.e. catch-all) slack config
+  "*":
+    # default: None
+    job_types_to_report: 
+      - presubmit
+      - postsubmit
+    # default: None
+    job_states_to_report:
+      - failure
+      - error
+    # required
+    channel: my-slack-channel
+    # The template shown below is the default
+    report_template: "Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>"
+
+  # "org/repo" slack config
+  istio/proxy:
+    job_types_to_report:
+      - presubmit
+    job_states_to_report:
+      - error
+    channel: istio-proxy-channel
+
+  # "org" slack config
+  istio:
+    job_types_to_report:
+      - periodic
+    job_states_to_report:
+      - failure
+    channel: istio-channel
 ```
-slack_reporter:
-  # Default: None
-  job_types_to_report:
-  - presubmit
-  - postsubmit
-  - periodic
-  - batch
-  # Default: None
-  job_states_to_report:
-  - triggered
-  - pending
-  - success
-  - failure
-  - aborted
-  - error
-  channel: my-slack-channel
-  # The template shown below is the default
-  report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>'
+
+The Slack `channel` can be overridden at the ProwJob level via the `reporter_config.slack.channel` field:
+```yaml
+postsubmits:
+  some-org/some-repo:
+    - name: example-job
+      decorate: true
+      reporter_config:
+        slack:
+          channel: 'override-channel-name'
+      spec:
+        containers:
+          - image: alpine
+            command:
+              - echo
 ```
 
 ## Implementation details

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/pjutil"
 
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobinformer "k8s.io/test-infra/prow/client/informers/externalversions"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
@@ -179,11 +180,11 @@ func main() {
 	var controllers []*crier.Controller
 
 	if o.slackWorkers > 0 {
-		if cfg().SlackReporter == nil {
+		if cfg().SlackReporter == nil && cfg().SlackReporterConfigs == nil {
 			logrus.Fatal("slackreporter is enabled but has no config")
 		}
-		slackConfig := func() *config.SlackReporter {
-			return cfg().SlackReporter
+		slackConfig := func(refs *prowapi.Refs) config.SlackReporter {
+			return cfg().SlackReporterConfigs.GetSlackReporter(refs)
 		}
 		slackReporter, err := slackreporter.New(slackConfig, o.dryrun, o.slackTokenFile)
 		if err != nil {


### PR DESCRIPTION
Provide a mechanism to route ProwJob status message to different Slack channels by `org`, `org/repo`, or *global default*. Istio has both *private* and *public* repos and the Slack messages need to route to different Slack channels based on GitHub `organization`. This approach also allows `job_types_to_report`, `job_states_to_report`, `report_template`, and of course `channel` to be configurable.

```yaml
slack_reporter_configs:

  # Wildcard (i.e. catch-all) slack config
  "*":
    job_types_to_report:
      - presubmit
      - postsubmit
    job_states_to_report:
      - failure
      - error
    channel: my-slack-channel
    report_template: "Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>"

  # "istio/proxy" slack config
  istio/proxy:
    job_types_to_report:
      - presubmit
    job_states_to_report:
      - error
    channel: istio-proxy-channel

  # "istio" slack config
  istio:
    job_types_to_report:
      - periodic
    job_states_to_report:
      - failure
    channel: istio-channel
```

> **Note:** existing `slack_reporter` is supported until May 2020.

/assign @alvaroaleman 