### PR TITLE
Support `/unhold` as an alias to `/hold cancel`

### DIFF
--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -39,7 +39,7 @@ const (
 
 var (
 	labelRe       = regexp.MustCompile(`(?mi)^/hold(\s.*)?$`)
-	labelCancelRe = regexp.MustCompile(`(?mi)^/hold\s+cancel\s*$`)
+	labelCancelRe = regexp.MustCompile(`(?mi)^/(hold\s+cancel|unhold)\s*$`)
 )
 
 type hasLabelFunc func(label string, issueLabels []github.Label) bool
@@ -54,11 +54,11 @@ func helpProvider(config *plugins.Configuration, enabledRepos []string) (*plugin
 		Description: "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",
 	}
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/hold [cancel]",
+		Usage:       "/[un]hold [cancel]",
 		Description: "Adds or removes the `" + labels.Hold + "` Label which is used to indicate that the PR should not be automatically merged.",
 		Featured:    false,
 		WhoCanUse:   "Anyone can use the /hold command to add or remove the '" + labels.Hold + "' Label.",
-		Examples:    []string{"/hold", "/hold cancel"},
+		Examples:    []string{"/hold", "/hold cancel", "/unhold"},
 	})
 	return pluginHelp, nil
 }

--- a/prow/plugins/hold/hold_test.go
+++ b/prow/plugins/hold/hold_test.go
@@ -98,6 +98,27 @@ func TestHandle(t *testing.T) {
 			shouldLabel:   false,
 			shouldUnlabel: false,
 		},
+		{
+			name:          "requested unhold",
+			body:          "/unhold",
+			hasLabel:      true,
+			shouldLabel:   false,
+			shouldUnlabel: true,
+		},
+		{
+			name:          "requested unhold with whitespace",
+			body:          "/unhold    ",
+			hasLabel:      true,
+			shouldLabel:   false,
+			shouldUnlabel: true,
+		},
+		{
+			name:          "requested unhold, Label already gone",
+			body:          "/unhold",
+			hasLabel:      false,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Support `/unhold` as an alias to `/hold cancel` for removing the `do-not-merge/hold` label. 

Maybe I am not alone...
https://github.com/GoogleCloudPlatform/oss-test-infra/pull/133#issuecomment-550709194
https://github.com/istio/test-infra/pull/2010#issuecomment-546654885
https://github.com/kubernetes/test-infra/pull/14927#issuecomment-546096166