### PR TITLE
peribolos: Avoid creating archived repos 

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1049,14 +1049,19 @@ func configureRepos(opt options, client repoClient, orgName string, orgConfig or
 
 	var allErrors []error
 	for wantName, wantRepo := range orgConfig.Repos {
-		repoLogger := logrus.WithField("repoExists", wantName)
+		repoLogger := logrus.WithField("repo", wantName)
 		repoExists, err := repoExists(byName, wantName, wantRepo.Previously)
 		if err != nil {
 			allErrors = append(allErrors, err)
 			continue
 		}
 		if repoExists == nil {
-			repoLogger.Info("repoExists does not exist, creating")
+			if wantRepo.Archived != nil && *wantRepo.Archived {
+				repoLogger.Errorf("repo does not exist but is configured as archived: not creating")
+				allErrors = append(allErrors, fmt.Errorf("nonexistent repo configured as archived: %s", wantName))
+				continue
+			}
+			repoLogger.Info("repo does not exist, creating")
 			created, err := client.CreateRepo(orgName, false, newRepoCreateRequest(wantName, wantRepo))
 			if err != nil {
 				allErrors = append(allErrors, err)
@@ -1066,16 +1071,16 @@ func configureRepos(opt options, client repoClient, orgName string, orgConfig or
 		}
 
 		if repoExists != nil {
-			repoLogger.Info("repoExists exists, considering an update")
+			repoLogger.Info("repo exists, considering an update")
 			delta := newRepoUpdateRequest(*repoExists, wantName, wantRepo)
 			if deltaErrors := sanitizeRepoDelta(opt, &delta); len(deltaErrors) > 0 {
 				for _, err := range deltaErrors {
-					repoLogger.WithError(err).Error("requested repoExists change is not allowed, removing from delta")
+					repoLogger.WithError(err).Error("requested repo change is not allowed, removing from delta")
 				}
 				allErrors = append(allErrors, deltaErrors...)
 			}
 			if delta.Defined() {
-				repoLogger.Info("repoExists exists and differs from desired state, updating")
+				repoLogger.Info("repo exists and differs from desired state, updating")
 				if _, err := client.UpdateRepo(orgName, repoExists.Name, delta); err != nil {
 					allErrors = append(allErrors, err)
 				}

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2907,6 +2907,17 @@ func TestConfigureRepos(t *testing.T) {
 			repos:         []github.FullRepo{{Repo: github.Repo{Name: "CAMELCASE", Description: newDescription}}},
 			expectedRepos: []github.Repo{{Name: "CamelCase", Description: newDescription}},
 		},
+		{
+			description: "avoid creating archived repo",
+			orgConfig: org.Config{
+				Repos: map[string]org.Repo{
+					oldName: {Archived: &yes},
+				},
+			},
+			repos:         []github.FullRepo{},
+			expectError:   true,
+			expectedRepos: []github.Repo{},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
Builds on https://github.com/kubernetes/test-infra/pull/15151, therefore draft.

Non-existent repository configured to be created and archived right away does not make sense, so error out on that condition.