### PR TITLE
Update Cluster API related jobs to use kubekins-e2e 1.16 images

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
       - "./scripts/ci-aws-cred-test.sh"
   annotations:
@@ -35,7 +35,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -67,7 +67,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -259,7 +259,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -289,7 +289,7 @@ postsubmits:
       - release-0.4
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -35,7 +35,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -67,7 +67,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "make"
@@ -137,7 +137,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -31,7 +31,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -55,7 +55,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -75,7 +75,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       command:
       - "./scripts/ci-test.sh"
       resources:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -34,7 +34,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         resources:
           requests:
             memory: "6Gi"
@@ -51,7 +51,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - "runner.sh"
         - "make"
@@ -69,7 +69,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -90,7 +90,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         command:
         - runner.sh
         - ./scripts/ci-integration.sh


### PR DESCRIPTION
We are not ready to consume the go v1.13 bump yet, so switch to the kubekins-e2e 1.16 image instead

/assign @dims @vincepri 