### PR TITLE
Enable Slack reporter for k8s Prow Crier deployment

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -66,6 +66,18 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
+slack_reporter:
+  job_types_to_report:
+    - postsubmit
+    - periodic
+    - batch
+  job_states_to_report:
+    - failure
+    - error
+  channel: test-failures
+  # The template shown below is the default
+  report_template: 'Job {{.Spec.Job}} of type {{.Spec.Type}} ended with state {{.Status.State}}. <{{.Status.URL}}|View logs>'
+
 branch-protection:
   allow_disabled_policies: true  # TODO(fejta): remove, needed by k/website
   orgs:

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --slack-token-file=/etc/slack/token
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -48,6 +49,9 @@ spec:
           readOnly: true
         - name: oauth
           mountPath: /etc/github
+          readOnly: true
+        - name: slack
+          mountPath: /etc/slack
           readOnly: true
       volumes:
       - name: config
@@ -59,3 +63,6 @@ spec:
       - name: oauth
         secret:
           secretName: oauth-token
+      - name: slack
+        secret:
+          secretName: slack-token

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -39,6 +39,7 @@ spec:
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
+        - --slack-workers=1
         - --slack-token-file=/etc/slack/token
         volumeMounts:
         - name: config


### PR DESCRIPTION
Apply config to enable Slack reporter as described in https://github.com/kubernetes/test-infra/issues/14740

Reports will go to the `#test-failures` channel