### PR TITLE
Use kubekins-e2e image everywhere possible

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -150,7 +150,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - "make"
         args:
@@ -171,7 +171,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - "make"
         args:
@@ -195,7 +195,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         command:
         - "make"
         args:
@@ -226,7 +226,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         resources:
           requests:
             cpu: "1000m"
@@ -257,7 +257,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/cloud-provider-vsphere/ci:v1.0.0-40-g6a93718
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
         resources:
           requests:
             cpu: "1000m"


### PR DESCRIPTION
This patch replaces the CPI "CI" image with the kubekins-e2e image. The
Docker-in-Docker functionality in the CI image was no longer working,
and wit the improvements to GOPROXY support, the CI Image is no longer
strictly necessary. This way we get a constantly supported base image
that is already maintained.

The exception here is that the periodic conformance tests still use the
CI image as those have additional dependencies on sk8.

/assign @frapposelli @figo @yastij 
/cc @dvonthenen 

Additional context here: https://github.com/kubernetes/test-infra/pull/14666#issuecomment-539721464