### PR TITLE
Update kubekins-e2e images to 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -64,7 +64,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=release-1.16"
@@ -116,7 +116,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes=release-1.16"
@@ -195,7 +195,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -254,7 +254,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -315,7 +315,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -374,7 +374,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -433,7 +433,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -496,7 +496,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -555,7 +555,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -614,7 +614,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -673,7 +673,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16
@@ -744,7 +744,7 @@ periodics:
     description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled."
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=release-1.16

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -228,7 +228,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"


### PR DESCRIPTION
With go version upgraded to v1.13.4 in kubekin-e2e-master, `make WHAT=cmd/hyperkube` will no longer work on ≤ release-1.16 k8s branches. This PR downgrades kubekins-e2e images from master to 1.16 for jobs that are testing on release-1.16 k8s. 

/assign @feiskyer for cloud-provider-azure jobs
/assign @PatrickLang for windows job