### PR TITLE
Make Prow aware of the "issues" events' "transferred" action.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -610,6 +610,8 @@ const (
 	IssueActionPinned IssueEventAction = "pinned"
 	// IssueActionUnpinned means the issue was unpinned.
 	IssueActionUnpinned IssueEventAction = "unpinned"
+	// IssueActionTransferred means the issue was transferred to another repo.
+	IssueActionTransferred IssueEventAction = "transferred"
 )
 
 // IssueEvent represents an issue event from a webhook payload (not from the events API).

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -37,6 +37,7 @@ var (
 		github.IssueActionReopened:     true,
 		github.IssueActionPinned:       true,
 		github.IssueActionUnpinned:     true,
+		github.IssueActionTransferred:  true,
 	}
 	nonCommentPullRequestActions = map[github.PullRequestEventAction]bool{
 		github.PullRequestActionAssigned:             true,


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/issues/14803
Previously Prow's generic comment handling was warning that it was receiving an unrecognized event action type and wasn't sure if that action should be treated as a generic comment event. This PR enumerates the `transferred` action as a non-comment action.

/assign @BenTheElder 