### PR TITLE
Downgrade pipeline CRD existence warnings to info and clarify.

### DIFF
--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -157,7 +157,7 @@ func main() {
 		var bc *pipelineConfig
 		bc, err = newPipelineConfig(cfg, interrupts.Context().Done())
 		if apierrors.IsNotFound(err) {
-			logrus.WithError(err).Warnf("Ignoring %s: knative pipeline CRD not deployed", context)
+			logrus.WithError(err).Infof("Ignoring cluster context %s: tekton pipeline CRD not deployed", context)
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
fixes https://github.com/kubernetes/test-infra/issues/13832
We shouldn't be warning about this, it is entirely appropriate to have some build clusters without pipeline CRD deployed. It is only actually problematic to try to run a pipeline prowjob in a cluster that doesn't have the pipeline CRD deployed and if that happens we will still emit errors.
/assign @fejta 