### PR TITLE
Make Prow aware of the rest of the "issues" events' actions.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -598,6 +598,8 @@ const (
 	IssueActionOpened IssueEventAction = "opened"
 	// IssueActionEdited means issue body was edited.
 	IssueActionEdited IssueEventAction = "edited"
+	// IssueActionDeleted means the issue was deleted.
+	IssueActionDeleted IssueEventAction = "deleted"
 	// IssueActionMilestoned means the milestone was added/changed.
 	IssueActionMilestoned IssueEventAction = "milestoned"
 	// IssueActionDemilestoned means a milestone was removed.
@@ -612,6 +614,10 @@ const (
 	IssueActionUnpinned IssueEventAction = "unpinned"
 	// IssueActionTransferred means the issue was transferred to another repo.
 	IssueActionTransferred IssueEventAction = "transferred"
+	// IssueActionLocked means the issue was locked.
+	IssueActionLocked IssueEventAction = "locked"
+	// IssueActionUnlocked means the issue was unlocked.
+	IssueActionUnlocked IssueEventAction = "unlocked"
 )
 
 // IssueEvent represents an issue event from a webhook payload (not from the events API).

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -38,6 +38,9 @@ var (
 		github.IssueActionPinned:       true,
 		github.IssueActionUnpinned:     true,
 		github.IssueActionTransferred:  true,
+		github.IssueActionDeleted:      true,
+		github.IssueActionLocked:       true,
+		github.IssueActionUnlocked:     true,
 	}
 	nonCommentPullRequestActions = map[github.PullRequestEventAction]bool{
 		github.PullRequestActionAssigned:             true,


### PR DESCRIPTION
More of the same https://github.com/kubernetes/test-infra/pull/15179

I started a slow query of the logs for more coercion failures and forgot about it while it was running. It identified a few more unhandled actions. I also added the other actions that are now listed in the API docs. I didn't see an coercion problems for any event types besides `issues`.

/assign @BenTheElder 