### PR TITLE
ci-k8sio-backup: fix service account file location

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1244,7 +1244,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191021-b891e54-master
       command:
-      - "./infra/gcp/backup_tools/backup.sh /etc/k8s-artifacts-prod-bak-service-account"
+      - "./infra/gcp/backup_tools/backup.sh /etc/k8s-artifacts-prod-bak-service-account/service-account.json"
       volumeMounts:
       - name: k8s-artifacts-prod-bak-service-account-creds
         mountPath: /etc/k8s-artifacts-prod-bak-service-account


### PR DESCRIPTION
This should have been in #14904. The service account file was purposely
left out in that PR to wait for test-infra oncall to create the secret.

/assign @BenTheElder 