### PR TITLE
Bump replicas for non-gke boskos janitors

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -43,7 +43,7 @@ metadata:
     app: boskos-janitor-nongke
   namespace: test-pods
 spec:
-  replicas: 8
+  replicas: 12 # 12 distributed janitor instances for non-gke
   selector:
     matchLabels:
       app: boskos-janitor-nongke


### PR DESCRIPTION
follow up of discussion in https://github.com/kubernetes/test-infra/issues/14697#issuecomment-551305183

bump from 8 to 12