### PR TITLE
update kubekins image to 1.16 for dualstack

### DIFF
--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -35,7 +35,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191106-09649c7-1.16
       args:
       - --job=$(JOB_NAME)
       - --repo=k8s.io/kubernetes=master


### PR DESCRIPTION
With go version upgraded to v1.13.4 in kubekin-e2e-master, make WHAT=cmd/hyperkube will no longer work on ≤ release-1.16 k8s branches. This PR downgrades kubekins-e2e images from master to 1.16 for jobs that are testing on release-1.16 k8s.

/assign @MrHohn 
