### PR TITLE
ci-k8sio-backup: fix command invocation

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1244,7 +1244,9 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191021-b891e54-master
       command:
-      - "./infra/gcp/backup_tools/backup.sh /etc/k8s-artifacts-prod-bak-service-account/service-account.json"
+      - infra/gcp/backup_tools/backup.sh
+      args:
+      - /etc/k8s-artifacts-prod-bak-service-account/service-account.json
       volumeMounts:
       - name: k8s-artifacts-prod-bak-service-account-creds
         mountPath: /etc/k8s-artifacts-prod-bak-service-account


### PR DESCRIPTION
The argument to the command needs to be in a separate "args" field.

/cc @BenTheElder 