### PR TITLE
Update KubectlCommand() for Azure

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -995,7 +995,9 @@ func (c Cluster) IsUp() error {
 	return isUp(c)
 }
 
-func (_ Cluster) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+func (c Cluster) KubectlCommand() (*exec.Cmd, error) {
+	return exec.Command("kubectl"), nil
+}
 
 // BuildTester returns a standard ginkgo-script tester or a custom one if testCcm is enabled
 func (c *Cluster) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {


### PR DESCRIPTION
Returning nil in `KubectlCommand()` means that kubekins-e2e will use [./cluster/kubectl.sh](https://github.com/kubernetes/kubernetes/blob/master/cluster/kubectl.sh) as the default kubectl command, which requires a compiled kubectl binary.

Using the [pre-installed kubectl](https://github.com/kubernetes/test-infra/blob/master/images/bootstrap/Dockerfile#L67) allows us to skip the `--build=bazel` step in jobs such as azuredisk-csi-driver-e2e and azurefile-csi-driver-e2e, which does not require building Kubernetes from source. This will cut down the test duration of azuredisk-csi-driver-e2e and azurefile-csi-driver-e2e by 10-15 minutes.

Also, ./cluster/kubectl.sh is being [deprecated](https://github.com/kubernetes/kubernetes/blob/master/cluster/kubectl.sh#L21-L30) soon.

/assign @feiskyer 
/cc @andyzhangx 