### PR TITLE
Skip private security forks in branch protector

### DIFF
--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -319,10 +319,6 @@ func GetOrg(org string) (string, bool) {
 	return org, false
 }
 
-// securityForkNameRE is a regexp matching repos that are temporary security forks
-// https://help.github.com/en/github/managing-security-vulnerabilities/collaborating-in-a-temporary-private-fork-to-resolve-a-security-vulnerability
-var securityForkNameRE = regexp.MustCompile(`^[\w-]+-ghsa-[\w-]+$`)
-
 // loadRepos read what (filtered) repos exist under an org
 func loadRepos(org string, gc client) ([]string, error) {
 	org, isUser := GetOrg(org)
@@ -337,7 +333,7 @@ func loadRepos(org string, gc client) ([]string, error) {
 			continue
 		}
 		// Skip private security forks as they can't be modified in this way
-		if r.Private && securityForkNameRE.MatchString(r.Name) {
+		if r.Private && github.SecurityForkNameRE.MatchString(r.Name) {
 			continue
 		}
 		rl = append(rl, r.Name)

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -19,9 +19,14 @@ package github
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// SecurityForkNameRE is a regexp matching repos that are temporary security forks
+// https://help.github.com/en/github/managing-security-vulnerabilities/collaborating-in-a-temporary-private-fork-to-resolve-a-security-vulnerability
+var SecurityForkNameRE = regexp.MustCompile(`^[\w-]+-ghsa-[\w-]+$`)
 
 // HasLabel checks if label is in the label set "issueLabels".
 func HasLabel(label string, issueLabels []Label) bool {


### PR DESCRIPTION
- Move SecurityForkNameRE to github client helpers
- Skip private security forks in branch protector
- Fix broken "TestIgnoreArchivedRepos" test
- Add test for "TestIgnorePrivateSecurityRepos"

/assign @BenTheElder 