### PR TITLE
WIP implement a logrus formatter to can spam

### DIFF
--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -19,7 +19,10 @@ package logrusutil
 
 import (
 	"bytes"
+	"crypto/md5"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -125,4 +128,117 @@ func NewCensoringFormatter(f logrus.Formatter, getSecrets func() sets.String) Ce
 		getSecrets: getSecrets,
 		delegate:   f,
 	}
+}
+
+// SpamCanFormatter is a logrus.Formatter that wraps another formatter
+// and ensures that repeated entries are not re-logged
+type SpamCanFormatter struct {
+	mu               sync.Mutex
+	observedHashes   map[string]struct{}
+	repeatedEntries  map[string]repeatedEntry
+	wrappedFormatter logrus.Formatter
+	logger           *logrus.Logger
+}
+
+// NewSpamCanFormatter returns a new SpamCanFormatter wrapping logger and formatterToWrap
+// It should be the top formatter in the wrapped chain of formatters
+func NewSpamCanFormatter(logger *logrus.Logger, formatterToWrap logrus.Formatter) *SpamCanFormatter {
+	return &SpamCanFormatter{
+		wrappedFormatter: formatterToWrap,
+		logger:           logger,
+	}
+}
+
+type repeatedEntry struct {
+	entry         *logrus.Entry
+	firstObserved time.Time
+	count         int
+}
+
+// Flush logs all repeated entries with a warning about having been repeated
+// and clears them from memory
+// This should be called periodically
+func (s *SpamCanFormatter) Flush() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, repeatEntry := range s.repeatedEntries {
+		s.logger.WithField("repeatedEntry", repeatEntry.entry).Warnf("entry repeated %d times since %v", repeatEntry.count, repeatEntry.firstObserved)
+	}
+	// separate loops because go will optimize this idiom
+	for k := range s.observedHashes {
+		delete(s.observedHashes, k)
+	}
+	for k := range s.repeatedEntries {
+		delete(s.repeatedEntries, k)
+	}
+}
+
+// Format implements logrus.Formatter
+func (s *SpamCanFormatter) Format(entry *logrus.Entry) {
+	hash, err := hashEntry(entry)
+	if err != nil {
+		s.logger.WithError(err).Warn("Failed to hash log entry")
+	}
+	if err != nil || !s.observe(hash, entry) {
+		s.wrappedFormatter.Format(entry)
+	}
+}
+
+// haveSeen returns true if we have seen this entry hash since the last flush
+func (s *SpamCanFormatter) haveSeen(hash string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, seen := s.observedHashes[hash]
+	return seen
+}
+
+// observe records an entry by hash and returns if we have previously recorded
+// observing an entry the first time will return false, repeated observations
+// of the same hash will return true and start counting the repeats
+func (s *SpamCanFormatter) observe(hash string, entry *logrus.Entry) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, seen := s.observedHashes[hash]
+	if !seen {
+		s.observedHashes[hash] = struct{}{}
+		return false
+	}
+	// we have seen it before, so record it as a repeated entry
+	repeatEntry, alreadyRecorded := s.repeatedEntries[hash]
+	if !alreadyRecorded {
+		// create a new entry if this is the first time
+		repeatEntry = repeatedEntry{
+			entry:         entry,
+			firstObserved: time.Now(),
+			count:         1,
+		}
+	}
+	// increment count and update
+	repeatEntry.count++
+	s.repeatedEntries[hash] = repeatEntry
+	return true
+}
+
+func hashEntry(entry *logrus.Entry) (string, error) {
+	data := make(logrus.Fields, len(entry.Data))
+	for k, v := range entry.Data {
+		data[k] = v
+	}
+	trimmedEntry := &logrus.Entry{
+		Logger:  entry.Logger,
+		Data:    data,
+		Time:    time.Unix(0, 0), // we don't want timestamps to vary
+		Level:   entry.Level,
+		Message: entry.Message,
+		Caller:  entry.Caller,
+	}
+	formatted, err := trimmedEntry.String()
+	if err != nil {
+		return "", err
+	}
+	// NOTE: md5 because the collision chance is not super high still
+	// and we don't need to be cryptographically secure, just fast and
+	// noting repeats
+	hashed := md5.Sum([]byte(formatted))
+	return string(hashed[:]), nil
 }


### PR DESCRIPTION
This PR implements a logrus formatter to track repeated log entries, only logging them the first time and retaining them the second time to be logged when it is flushed (along with a count, and the time it first occurred).

It is relatively space efficient, as it only stores the hash until we see a repeat, and then we will store the count, entry, and hash until we flush.

This would still need to be wired up as the top level formatter in components, probably behind a flag that controls the flush (and spam avoidance) interval. We would also probably want a final flush on exit to ensure we log these.

