### PR TITLE
Adjust blackbox prober additional scrape targets.

### DIFF
--- a/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -12,13 +12,12 @@ stringData:
       static_configs:
         - targets:
           - https://prow.k8s.io
-          - https://prow.k8s.io/hook
           - https://monitoring.prow.k8s.io
           - https://testgrid.k8s.io
           - https://gubernator.k8s.io
           - https://gubernator.k8s.io/pr/fejta # Deep health check of someone's PR dashboard.
-          - https://go.k8s.io/triage
-          - https://go.k8s.io/oncall
+          - https://storage.googleapis.com/k8s-gubernator/triage/index.html
+          - https://storage.googleapis.com/test-infra-oncall/oncall.html
       relabel_configs:
         - source_labels: [__address__]
           target_label: __param_target


### PR DESCRIPTION
1. Scraping https://prow.k8s.io/hook results in 405, not 200. (We don't really need to scrape `/hook` anyways since the `hook` service is already monitored for availability in the cluster and the https://prow.k8s.io probe validates that the DNS is working.)
1. The two go.k8s.io probes are failing to follow redirects even though we have explicitly specified that redirects should be followed:
https://github.com/kubernetes/test-infra/blob/b4a6cf72fc4e438db2c94a16e1a6276db098252c/prow/cluster/monitoring/blackbox_prober.yaml#L44
This is due to this blackbox exporter bug https://github.com/prometheus/blackbox_exporter/issues/237 which should be resolved by https://github.com/prometheus/blackbox_exporter/pull/530, but there has not been a release cut since that fix merged: https://github.com/prometheus/blackbox_exporter/releases
Resolving this for now by using the redirect URLs.