### PR TITLE
kubetest: only one pattern can be provided for pkill

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -228,9 +228,11 @@ func (n localCluster) Down() error {
 	}
 	// make sure all containers are removed
 	removeAllContainers(cli)
-	err = control.FinishRunning(exec.Command("pkill", processes...))
-	if err != nil {
-		log.Printf("unable to kill kubernetes processes: %v", err)
+	for _, p := range processes {
+		err = control.FinishRunning(exec.Command("pkill", p))
+		if err != nil {
+			log.Printf("unable to kill kubernetes process %q: %v", p, err)
+		}
 	}
 	err = control.FinishRunning(exec.Command("pkill", "etcd"))
 	if err != nil {


### PR DESCRIPTION
it fails with the following error:

```
W1111 05:17:25.024] 2019/11/11 05:17:25 process.go:153: Running: pkill cloud-controller-manager hyperkube kube-controller-manager kube-proxy kube-scheduler kubelet
W1111 05:17:25.032] pkill: only one pattern can be provided
W1111 05:17:25.032] Try `pkill --help' for more information.
W1111 05:17:25.034] 2019/11/11 05:17:25 process.go:155: Step 'pkill cloud-controller-manager hyperkube kube-controller-manager kube-proxy kube-scheduler kubelet' finished in 10.078801ms
W1111 05:17:25.035] 2019/11/11 05:17:25 local.go:233: unable to kill kubernetes processes: error during pkill cloud-controller-manager hyperkube kube-controller-manager kube-proxy kube-scheduler kubelet: exit status 2
```

xref: https://github.com/kubernetes/test-infra/pull/13851