### PR TITLE
Add slack notifications for apimachinery staging repos

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -200,6 +200,22 @@ slack:
     whitelist:
     - k8s-ci-robot
   - repos:
+    - kubernetes/api
+    - kubernetes/apiextensions-apiserver
+    - kubernetes/apimachinery
+    - kubernetes/apiserver
+    - kubernetes/client-go
+    - kubernetes/code-generator
+    - kubernetes/component-base
+    - kubernetes/kube-aggregator
+    - kubernetes/kube-controller-manager
+    - kubernetes/sample-apiserver
+    - kubernetes/sample-controller
+    channels:
+    - sig-api-machinery
+    whitelist:
+    - k8s-publishing-bot
+  - repos:
     - kubernetes/kubernetes
     channels:
     - kubernetes-dev


### PR DESCRIPTION
Ref: https://kubernetes.slack.com/archives/C0EG7JC6T/p1573488530031700

A branch seems to have been accidentally created for k/apimachinery so it would be nice to have slack notifications for new branch creations that aren't made by publishing-bot.

/cc @kubernetes/owners @sttts @fejta @ncdc @liggitt 
/assign @deads2k @lavalamp @fedebongio 
/hold
for sign off from sig apimachinery leads