### PR TITLE
Add prometheus alerts for the blackbox prober.

### DIFF
--- a/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -11,6 +11,7 @@ stringData:
         module: [http_2xx]
       static_configs:
         - targets:
+          # ATTENTION: Keep this in sync with the list in mixins/prometheus/prober_alerts.libsonnet
           - https://prow.k8s.io
           - https://monitoring.prow.k8s.io
           - https://testgrid.k8s.io

--- a/prow/cluster/monitoring/blackbox_prober.yaml
+++ b/prow/cluster/monitoring/blackbox_prober.yaml
@@ -37,7 +37,7 @@ data:
     modules:
       http_2xx:
         prober: http
-        timeout: 5s
+        timeout: 8s
         http:
           # valid_status_codes defaults to 2xx
           method: GET

--- a/prow/cluster/monitoring/mixins/prometheus/prober_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prober_alerts.libsonnet
@@ -1,0 +1,34 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'Blackbox Prober',
+        rules: [
+          {
+            alert: 'Site unavailable: %s' % target,
+            expr: |||
+              min(probe_success{instance="%s"}) == 0
+            ||| % target,
+            'for': '2m', # I think this needs to be at least the scrape_interval and 2*evaluation_interval (which both default to 1m) in order to ignore individual probe failures.
+            labels: {
+              severity: 'critical',
+            },
+            annotations: {
+              message: 'The blackbox_exporter HTTP probe has detected that the following site has been unhealthy (not 2xx HTTP response) for at least 2 minutes: <%s|%s>.' % [target, target],
+            },
+          }
+          for target in [
+          # ATTENTION: Keep this in sync with the list in ../../additional-scrape-configs_secret.yaml
+            'https://prow.k8s.io',
+            'https://monitoring.prow.k8s.io',
+            'https://testgrid.k8s.io',
+            'https://gubernator.k8s.io',
+            'https://gubernator.k8s.io/pr/fejta', # Deep health check of someone's PR dashboard.
+            'https://storage.googleapis.com/k8s-gubernator/triage/index.html',
+            'https://storage.googleapis.com/test-infra-oncall/oncall.html'
+          ]
+        ],
+      },
+    ],
+  },
+}

--- a/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -3,4 +3,5 @@
 (import 'configmap_alerts.libsonnet') +
 (import 'hook_alert.libsonnet') +
 (import 'sinker_alerts.libsonnet') +
-(import 'tide_alerts.libsonnet')
+(import 'tide_alerts.libsonnet') +
+(import 'prober_alerts.libsonnet')


### PR DESCRIPTION
All the scrape targets seem to be working now with the exception of what appear to be occasional individual probe failures. I increased the probe timeout by a few seconds, but also tried to make the alerts tolerant to individual probe failures.
/assign @hongkailiu @stevekuznetsov 
/hold