### PR TITLE
kubeadm-presubmits.yaml: do not double clone the kubeadm repo

### DIFF
--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -29,10 +29,6 @@ presubmits:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
-    - org: kubernetes
-      repo: kubeadm
-      base_ref: master
-      path_alias: k8s.io/kubeadm
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191108-9467d02-master


### PR DESCRIPTION
A presubmit targetting e.g. kuberentes/kubeadm
already clones the kubeadm repository.

/priority important-longterm
/kind failing-test
/assign @fabriziopandini 
