### PR TITLE
Fix optional argument

### DIFF
--- a/testgrid/cmd/transfigure/transfigure.sh
+++ b/testgrid/cmd/transfigure/transfigure.sh
@@ -88,8 +88,8 @@ parse-args() {
   testgrid_config=$(readlink -m "$4")
   testgrid_subdir="$5"
   remote_fork_repo=${6:-"test-infra"}
-  user="$7"
-  email="$8"
+  user=${7:-""}
+  email=${8:-""}
 
   if [[ ! -f ${token} ]]; then
     echo "ERROR: [github_token] ${token} must be a file path." >&2


### PR DESCRIPTION
An unset optional argument leads to a script terminating: https://prow.istio.io/view/gcs/istio-prow/logs/post-test-infra-upload-testgrid-config/1190349260122492965

Now set to explicitly set the variable to `""` if not set.