### PR TITLE
kubetest: fix localCluster.Down()

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -219,6 +219,7 @@ func (n localCluster) Down() error {
 		"kube-controller-manager",
 		"kube-proxy",
 		"kube-scheduler",
+		"kube-apiserver",
 		"kubelet",
 	}
 	// create docker client
@@ -229,7 +230,10 @@ func (n localCluster) Down() error {
 	// make sure all containers are removed
 	removeAllContainers(cli)
 	for _, p := range processes {
-		err = control.FinishRunning(exec.Command("pkill", p))
+		// -f is required to match against the complete command line
+		// (/proc/pid/cmdline), otherwise process name longer than 15
+		// characters cannot be matched, see https://linux.die.net/man/1/pkill.
+		err = control.FinishRunning(exec.Command("pkill", "-f", p))
 		if err != nil {
 			log.Printf("unable to kill kubernetes process %q: %v", p, err)
 		}


### PR DESCRIPTION
- add kube-apiserver
- add -f to match against the complete command line, see https://linux.die.net/man/1/pkill

kube-controller-manager which is longer than 15 characters will not be matched by pkill because pkill has a limitation on process name if `-f` is not used (see https://linux.die.net/man/1/pkill).