### PR TITLE
Remove dedicated 4.1 dashboards and add in integration 4.3 dashboards.

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -1,37 +1,25 @@
 test_groups:
 # OpenShift Dedicated integration
-- name: osd-int-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.1
 - name: osd-int-4.2
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2
-- name: osd-upgrade-int-4.1-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.1-4.1
-- name: osd-upgrade-int-4.1-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.1-4.2
+- name: osd-int-4.3
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2
 - name: osd-upgrade-int-4.2-4.2
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2-4.2
+- name: osd-upgrade-int-4.2-4.3
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2-4.2
+- name: osd-upgrade-int-4.3-4.3
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2-4.2
 
 # OpenShift Dedicated staging
-- name: osd-stage-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.1
 - name: osd-stage-4.2
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.2
-- name: osd-upgrade-stage-4.1-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.1-4.1
-- name: osd-upgrade-stage-4.1-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.1-4.2
 - name: osd-upgrade-stage-4.2-4.2
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.2-4.2
 
 # OpenShift Dedicated production
-- name: osd-prod-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.1
 - name: osd-prod-4.2
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.2
-- name: osd-upgrade-prod-4.1-4.1
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.1-4.1
-- name: osd-upgrade-prod-4.1-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.1-4.2
 - name: osd-upgrade-prod-4.2-4.2
   gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-4.2-4.2
 
@@ -39,26 +27,6 @@ dashboards:
 # OpenShift Dedicated integration dashboard
 - name: redhat-osd-int
   dashboard_tab:
-  - name: osd-int-4.1
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.1 integration cluster.
-    test_group_name: osd-int-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
   - name: osd-int-4.2
     description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 integration cluster.
     test_group_name: osd-int-4.2
@@ -79,29 +47,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.1-4.1
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in integration.
-    test_group_name: osd-upgrade-int-4.1-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.1-4.2
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in integration.
-    test_group_name: osd-upgrade-int-4.1-4.2
+  - name: osd-int-4.3
+    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.3 integration cluster.
+    test_group_name: osd-int-4.3
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -139,73 +87,53 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osd-upgrade-int-4.2-4.3
+    description: Runs upgrade tests between OpenShift Dedicated 4.2 and 4.3 in integration.
+    test_group_name: osd-upgrade-int-4.2-4.3
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osd-upgrade-int-4.3-4.3
+    description: Runs upgrade tests between OpenShift Dedicated 4.3 and 4.3 in integration.
+    test_group_name: osd-upgrade-int-4.3-4.3
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
 
 # OpenShift Dedicated staging dashboard
 - name: redhat-osd-stage
   dashboard_tab:
-  - name: osd-stage-4.1
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.1 staging cluster.
-    test_group_name: osd-stage-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
   - name: osd-stage-4.2
     description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 staging cluster.
     test_group_name: osd-stage-4.2
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-stage-4.1-4.1
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in staging.
-    test_group_name: osd-upgrade-stage-4.1-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-stage-4.1-4.2
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in staging.
-    test_group_name: osd-upgrade-stage-4.1-4.2
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -247,69 +175,9 @@ dashboards:
 # OpenShift Dedicated production dashboard
 - name: redhat-osd-prod
   dashboard_tab:
-  - name: osd-prod-4.1
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.1 production cluster.
-    test_group_name: osd-prod-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
   - name: osd-prod-4.2
     description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 production cluster.
     test_group_name: osd-prod-4.2
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-prod-4.1-4.1
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 patch releases in production.
-    test_group_name: osd-upgrade-prod-4.1-4.1
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-prod-4.1-4.2
-    description: Runs upgrade tests between OpenShift Dedicated 4.1 and 4.2 in production.
-    test_group_name: osd-upgrade-prod-4.1-4.2
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
Now that 4.1 cluster image sets will no longer be generated in OSD, 4.1
related dashboards have been removed. 4.3 dashboards have been added for
integration, as it's the only place that 4.3 bits currently exist.