### PR TITLE
Pass --noupdatelatest flag to ci build jobs

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -126,6 +126,8 @@ def main(args):
         push_build_args.append('--extra-publish-file=%s' % args.extra_publish_file)
     if args.allow_dup:
         push_build_args.append('--allow-dup')
+    if args.skip_update_latest:
+        push_build_args.append('--noupdatelatest')
 
     for key, value in env.items():
         os.environ[key] = value
@@ -159,6 +161,8 @@ if __name__ == '__main__':
         '--extra-publish-file', help='Additional version file uploads to')
     PARSER.add_argument(
         '--allow-dup', action='store_true', help='Allow overwriting if the build exists on gcs')
+    PARSER.add_argument(
+        '--skip-update-latest', action='store_true', help='Do not update the latest file')
     PARSER.add_argument(
         '--push-build-script', default='../release/push-build.sh', help='location of push-build.sh')
     ARGS = PARSER.parse_args()


### PR DESCRIPTION
Needed for presubmit build jobs.
latest*.txt files should be updated only in postsubmits

/cc @mm4tt @krzyzacy @fejta