### PR TITLE
Skip pod anti-affinity test until 1.17 is released

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -462,13 +462,14 @@ periodics:
       - --acsengine-hyperkube=True
       - --acsengine-location=westus2
       - --acsengine-public-key=$KUBE_SSH_PUBLIC_KEY_PATH
-      - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-serial.json
+      - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-serial.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.43.0/aks-engine-v0.43.0-linux-amd64.tar.gz
-      # Skip three kinds of test cases:
+      # Skip four kinds of test cases:
       # 1. regular resource usage tracking, haven't found the cause of the failures.
       # 2. validates MaxPods limit number of pods that are allowed to run, related to issue kubernetes/kubernetes#80177
       # 3. Checks that the node becomes unreachable, the external IP is unavailable since the corresponding configuration in aks-engine is set to false.
-      - --test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|Checks\sthat\sthe\snode\sbecomes\sunreachable --minStartupPods=8
+      # 4. Pod should be scheduled to node that don't match the PodAntiAffinity terms, fixed by https://github.com/kubernetes/kubernetes/pull/80780 and should be re-enabled in 1.17
+      - --test_args=--ginkgo.flakeAttempts=2 --num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|Checks\sthat\sthe\snode\sbecomes\sunreachable|Pod\sshould\sbe\sscheduled\sto\snode\sthat\sdon.t\smatch\sthe\sPodAntiAffinity\sterms --minStartupPods=8
       - --timeout=600m
       securityContext:
         privileged: true


### PR DESCRIPTION
 https://github.com/kubernetes/test-infra/pull/15177 causes a regression, where one of the tests started failing as shown in https://testgrid.k8s.io/provider-azure-master#cloud-provider-azure-serial. I've verified that https://github.com/kubernetes/kubernetes/pull/80780 fixed that particular test case and it should be skipped until we upgrade k8s to 1.17.

/assign @feiskyer 