### PR TITLE
Add 'ci-cert-manager-release' dashboard to testgrid

### DIFF
--- a/config/testgrids/cert-manager/groups.yaml
+++ b/config/testgrids/cert-manager/groups.yaml
@@ -1,4 +1,5 @@
 dashboard_groups:
 - dashboard_names:
   - jetstack-cert-manager-master
+  - jetstack-cert-manager-release
   name: jetstack

--- a/config/testgrids/cert-manager/jetstack-cert-manager-release.yaml
+++ b/config/testgrids/cert-manager/jetstack-cert-manager-release.yaml
@@ -1,0 +1,28 @@
+dashboards:
+- name: jetstack-cert-manager-release
+  dashboard_tab:
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'Release E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-release-next
+    description: End-to-end tests against the upcoming release branch
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-release-next
+
+# These are periodic jobs that target cert-manager release branches
+test_groups:
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-release-next
+  name: ci-cert-manager-release-next


### PR DESCRIPTION
The recently added job can be found here: https://github.com/jetstack/testing/pull/312

/cc @JoshVanL