### PR TITLE
tide: Make sure status descriptions fit 140 characters

### DIFF
--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -248,7 +248,49 @@ func TestExpectedStatus(t *testing.T) {
 			},
 
 			state: github.StatusPending,
-			desc:  "Not mergeable. Waiting for retest of Job [bar]",
+			desc:  "Not mergeable. Retesting: bar",
+		},
+		{
+			name:    "long list of not up-to-date contexts results in shortened message",
+			inPool:  true,
+			baseref: "baseref",
+			requiredContexts: []string{
+				strings.Repeat("very-long-context", 8),
+				strings.Repeat("also-long-content", 8),
+			},
+			prowJobs: []runtime.Object{
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "123"},
+					Spec: prowapi.ProwJobSpec{
+						Context: strings.Repeat("very-long-context", 8),
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "1234"},
+					Spec: prowapi.ProwJobSpec{
+						Context: strings.Repeat("also-long-content", 8),
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+			},
+
+			state: github.StatusPending,
+			desc:  "Not mergeable. Retesting 2 jobs.",
 		},
 	}
 


### PR DESCRIPTION
fixes #15250 

Added a very simple remedy for now: either include a full list of missing contexts, or say "Retesting X jobs". There's certainly some room for further improvement in how the messages are assembled, but I'd like to limit this PR to fix the immediate issue. I also shortened the actual description template from `Waiting for retest of Jobs ...` to `Retesting: ...`. Space is precious in description and I think the more left the meat is in the description, the better.

I also added an ellipsizing guard before the client call with a warning in the log, resulting in us not ever calling GH API wrong with whatever is returned from `expectedStatus`. I considered adding it to the client layer, but I like it not having opinions, and I like not ever producing a bad description in Tide too.

/cc @alvaroaleman @stevekuznetsov 
