### PR TITLE
Add user agent to request metrics

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -197,7 +197,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	}
 
 	ghmetrics.CollectGitHubTokenMetrics(authHeaderHash, apiVersion, resp.Header, reqStartTime, responseTime)
-	ghmetrics.CollectGitHubRequestMetrics(authHeaderHash, req.URL.Path, strconv.Itoa(resp.StatusCode), roundTripTime.Seconds())
+	ghmetrics.CollectGitHubRequestMetrics(authHeaderHash, req.URL.Path, strconv.Itoa(resp.StatusCode), req.Header.Get("User-Agent"), roundTripTime.Seconds())
 
 	return resp, nil
 }

--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -54,7 +54,7 @@ var ghRequestDurationHistVec = prometheus.NewHistogramVec(
 		Help:    "GitHub request duration by API path.",
 		Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 	},
-	[]string{"token_hash", "path", "status"},
+	[]string{"token_hash", "path", "status", "user_agent"},
 )
 
 var muxTokenUsage, muxRequestMetrics sync.Mutex
@@ -94,8 +94,8 @@ func CollectGitHubTokenMetrics(tokenHash, apiVersion string, headers http.Header
 
 // CollectGitHubRequestMetrics publishes the number of requests by API path to
 // `github_requests` on prometheus.
-func CollectGitHubRequestMetrics(tokenHash, path, statusCode string, roundTripTime float64) {
-	ghRequestDurationHistVec.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "status": statusCode}).Observe(roundTripTime)
+func CollectGitHubRequestMetrics(tokenHash, path, statusCode, userAgent string, roundTripTime float64) {
+	ghRequestDurationHistVec.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "status": statusCode, "user_agent": userAgent}).Observe(roundTripTime)
 }
 
 // timestampStringToTime takes a unix timestamp and returns a `time.Time`

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -207,7 +207,7 @@ var (
 				Help:    "http request duration in seconds",
 				Buckets: []float64{0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 20},
 			},
-			[]string{"path", "method", "status"},
+			[]string{"path", "method", "status", "user_agent"},
 		),
 		httpResponseSize: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -215,7 +215,7 @@ var (
 				Help:    "http response size in bytes",
 				Buckets: []float64{16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432},
 			},
-			[]string{"path", "method", "status"},
+			[]string{"path", "method", "status", "user_agent"},
 		),
 	}
 )
@@ -251,7 +251,7 @@ func traceHandler(h http.Handler) http.Handler {
 		trw := &traceResponseWriter{ResponseWriter: w, statusCode: http.StatusOK}
 		h.ServeHTTP(trw, r)
 		latency := time.Since(t)
-		labels := prometheus.Labels{"path": simplifier.Simplify(r.URL.Path), "method": r.Method, "status": strconv.Itoa(trw.statusCode)}
+		labels := prometheus.Labels{"path": simplifier.Simplify(r.URL.Path), "method": r.Method, "status": strconv.Itoa(trw.statusCode), "user_agent": r.Header.Get("User-Agent")}
 		deckMetrics.httpRequestDuration.With(labels).Observe(latency.Seconds())
 		deckMetrics.httpResponseSize.With(labels).Observe(float64(trw.size))
 	})


### PR DESCRIPTION
When debugging errant behavior from clients against GitHub or Deck, it
is often useful to know from where the requests originate. A simple way
to identify the requester without exposing identifying information is to
use the user agent header.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>