### PR TITLE
Improve GitHub request error alerts and dashboard

### DIFF
--- a/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
@@ -10,7 +10,7 @@ local legendConfig = {
             sideWidth: 250,
         },
     };
-    
+
 local dashboardConfig = {
         uid: 'd72fe8d0400b2912e319b1e95d0ab1b3',
     };
@@ -221,6 +221,23 @@ dashboard.new(
     ) + legendConfig)
     .addTarget(prometheus.target(
         'sum(rate(github_request_duration_count{job="ghproxy"}[${range}])) by (status)',
+         legendFormat='{{status}}',
+    )), gridPos={
+    h: 9,
+    w: 24,
+    x: 0,
+    y: 18,
+  })
+.addPanel(
+    (graphPanel.new(
+        'Request Rates: Overview by path for ${status} with ${range}',
+        description='GitHub request rates by path.',
+        datasource='prometheus',
+        legend_alignAsTable=true,
+        legend_rightSide=true,
+    ) + legendConfig)
+    .addTarget(prometheus.target(
+        'sum(rate(github_request_duration_count{status="${status}",job="ghproxy"}[${range}])) by (path)',
          legendFormat='{{status}}',
     )), gridPos={
     h: 9,

--- a/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -5,21 +5,29 @@
         name: 'ghproxy',
         rules: [
           {
-            alert: 'ghproxy-status-code-abnormal-%sXX' % code_prefix,
-            // excluding 404 because it does not indicate any error in the system
+            alert: 'ghproxy-specific-status-code-abnormal',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"%s..", status!="404"}[5m])) / sum(rate(github_request_duration_count{status!="404"}[5m])) * 100 > 5
-            ||| % code_prefix,
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) > .1
+            |||,
             labels: {
               severity: 'slack',
             },
             annotations: {
-              message: 'ghproxy has {{ $value | humanize }}%% of status code %sXX in the last 5 minutes.' % code_prefix,
+              message: '{{ $value | humanizePercentage }} of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}.',
             },
-          }
-          for code_prefix in ['4', '5']
-        ] +
-        [
+          },
+          {
+            alert: 'ghproxy-global-status-code-abnormal',
+            expr: |||
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) > .03
+            |||,
+            labels: {
+              severity: 'slack',
+            },
+            annotations: {
+              message: '{{ $value | humanizePercentage }} of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}.',
+            },
+          },
           {
             alert: 'ghproxy-running-out-github-tokens-in-a-hour',
             // check 30% of the capacity (5000): 1500


### PR DESCRIPTION
Instead of one global alert, there are now two:

 - when the global percentage of requests through the proxy is comprised
of abnormal (4xx or 5xx but not 404 or 410) codes at a proportion of
more than 3%
 - when the rate of abnormal codes for a specific path is a larger
proportion than 10%

Looking at historical metrics, these firing does indicate some sort of
issue that needed attention.

Also added is a dasboard of requests for a code by path, to diagnose
what requests are failing when an error code is high.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @hongkailiu 