### PR TITLE
Label cache results with paths

### DIFF
--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -24,6 +24,8 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+
+	"k8s.io/test-infra/ghproxy/ghmetrics"
 )
 
 // requestCoalescer allows concurrent requests for the same URI to share a
@@ -127,7 +129,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}()
 
-	cacheCounter.WithLabelValues(string(cacheMode)).Inc()
+	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path)
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
 	}

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -77,16 +77,6 @@ func CacheModeIsFree(mode CacheResponseMode) bool {
 	return false
 }
 
-// cacheCounter provides the 'ghcache_responses' counter vec that is indexed
-// by the cache response mode.
-var cacheCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Name: "ghcache_responses",
-		Help: "How many cache responses of each cache response mode there are.",
-	},
-	[]string{"mode"},
-)
-
 // outboundConcurrencyGauge provides the 'concurrent_outbound_requests' gauge that
 // is global to the proxy.
 var outboundConcurrencyGauge = prometheus.NewGauge(prometheus.GaugeOpts{
@@ -102,7 +92,7 @@ var pendingOutboundConnectionsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 })
 
 func init() {
-	prometheus.MustRegister(cacheCounter)
+
 	prometheus.MustRegister(outboundConcurrencyGauge)
 	prometheus.MustRegister(pendingOutboundConnectionsGauge)
 }


### PR DESCRIPTION
When investigating a cahce efficiency drop or a token use surge, it is
necessary to know what paths the cache is missing on.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @hongkailiu 