### PR TITLE
Update last job requiring --build=host-go for 1.17

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -111,7 +111,7 @@ periodics:
       - "--down=true"
       - "--deployment=acsengine"
       - "--provider=skeleton"
-      - "--build=bazel"
+      - "--build=host-go"
       - "--acsengine-admin-username=azureuser"
       - "--acsengine-admin-password=AdminPassw0rd"
       - "--acsengine-creds=$AZURE_CREDENTIALS"


### PR DESCRIPTION
This is a follow-on to #15191 .

This fixed the staging job `ci-kubernetes-e2e-aks-engine-azure-master-staging-windows`, so let's put it on the master job `ci-kubernetes-e2e-aks-engine-azure-master-windows`.

Fixed results for -staging: https://testgrid.k8s.io/sig-windows#aks-engine-azure-windows-master-staging

/assign @adelina-t 
/sig windows