### PR TITLE
Bump the test frequency for migration beta

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -2,8 +2,8 @@ periodics:
 - name: ci-aws-ebs-csi-driver-migration-test-latest
   decorate: true
   decoration_config:
-    timeout: 5h45m
-  interval: 6h
+    timeout: 1h20m
+  interval: 1h30m
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -120,8 +120,6 @@ presubmits:
   - name: pull-aws-ebs-csi-driver-migration-test-latest
     always_run: false
     decorate: true
-    decoration_config:
-      timeout: 5h45m
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
Bump the test frequency for migration beta at 1.17 so we can get more test signal.

/cc @gyuho 