### PR TITLE
Fix a typo in a ghproxy alert

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -7,25 +7,25 @@
           {
             alert: 'ghproxy-specific-status-code-abnormal',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) > .1
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
             |||,
             labels: {
               severity: 'slack',
             },
             annotations: {
-              message: '{{ $value | humanizePercentage }} of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9>' % $._config.grafanaDashboardIDs['ghproxy.json'],
             },
           },
           {
             alert: 'ghproxy-global-status-code-abnormal',
             expr: |||
-              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) > .03
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
             |||,
             labels: {
               severity: 'slack',
             },
             annotations: {
-              message: '{{ $value | humanizePercentage }} of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8|grafana>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+              message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8|grafana>' % $._config.grafanaDashboardIDs['ghproxy.json'],
             },
           },
           {


### PR DESCRIPTION
`humanizePercentage` function was introduced in [prometheus 2.11.0](https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#2110--2019-07-09)

We are using `v2.7.1`.

https://github.com/kubernetes/test-infra/blob/70e88a1a94808ecf9c8e7d6be660e69ef8e4928c/prow/cluster/monitoring/prow_prometheus.yaml#L35

/assign @stevekuznetsov 
