### PR TITLE
Deprecate mkbuild-cluster and promote gencred in getting started docs 

### DIFF
--- a/gencred/cmd/gencred/main.go
+++ b/gencred/cmd/gencred/main.go
@@ -85,7 +85,7 @@ func mergeConfigs(o options, kubeconfig []byte) ([]byte, error) {
 	}
 
 	loadingRules := clientcmd.ClientConfigLoadingRules{
-		Precedence: []string{tmpFile.Name(), o.output},
+		Precedence: []string{o.output, tmpFile.Name()},
 	}
 
 	mergedConfig, err := loadingRules.Load()

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -86,6 +86,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
  
+ - *November 18, 2019*  The `mkbuild-cluster` command-line utility and `build-cluster`
+   format is deprecated and will be removed in May 2020. Use `gencred` and the `kubeconfig` 
+   format as an alternative.
  - *November 14, 2019* The `slack_reporter` config field has been deprecated in
    favor of the new `slack_reporter_configs` field which allows configuration on a global,
    organization or repo level. `slack_reporter` will be removed in May 2020.

--- a/prow/cmd/mkbuild-cluster/README.md
+++ b/prow/cmd/mkbuild-cluster/README.md
@@ -1,4 +1,5 @@
 # MkBuild-Cluster
+> ### **Deprecated**: use [`gencred`](../../../gencred) instead. `mkbuild-cluster` will be removed May 2020. 
 
 The `mkbuild-cluster` program helps create `cluster.yaml` files that [plank] accepts via the `--build-cluster` flag.
 

--- a/prow/cmd/mkbuild-cluster/main.go
+++ b/prow/cmd/mkbuild-cluster/main.go
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Deprecated:  The `mkbuild-cluster` command-line utility and `build-cluster`
+// format is deprecated and will be removed in May 2020. Use `gencred` and the
+// `kubeconfig` format as an alternative.
 package main
 
 import (

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -403,33 +403,79 @@ For more information on the job environment, see [`jobs.md`](/prow/jobs.md)
 ### Run test pods in different clusters
 
 You may choose to run test pods in a separate cluster entirely. This is a good practice to keep testing isolated from Prow's service components and secrets. It can also be used to furcate job execution to different clusters.
-Create a secret containing a `{"cluster-name": {cluster-details}}` map like this:
+One can use a Kubernetes [`kubeconfig`](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) file (i.e. `Config` object) to instruct Prow components to use the *build* cluster(s).
+All contexts in `kubeconfig` are used as *build* clusters and the [`InClusterConfig`](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) (or `current-context`) is the *default*.
+
+Create a secret containing a `kubeconfig` like this:
 
 ```yaml
-default:
-  endpoint: https://<master-ip>
-  clientCertificate: <base64-encoded cert>
-  clientKey: <base64-encoded key>
-  clusterCaCertificate: <base64-encoded cert>
-other:
-  endpoint: https://<master-ip>
-  clientCertificate: <base64-encoded cert>
-  clientKey: <base64-encoded key>
-  clusterCaCertificate: <base64-encoded cert>
+apiVersion: v1
+clusters:
+- name: default
+  cluster:
+    certificate-authority-data: fake-ca-data-default
+    server: https://1.2.3.4
+- name: other
+  cluster:
+    certificate-authority-data: fake-ca-data-other
+    server: https://5.6.7.8
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+- name: other
+  context:
+    cluster: other
+    user: other
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    token: fake-token-default
+- name: other
+  user:
+    token: fake-token-other
 ```
 
-Use [mkbuild-cluster][5] to determine these values:
+Use [gencred][5] to create the `kubeconfig` file (and credentials) for accessing the cluster(s):
+
+> **NOTE:** `gencred` will merge new entries to the specified `output` file on successive invocations by *default* .
+
+Create a *default* cluster context (if one does not already exist):
+
+> **NOTE:** If executing `gencred` with `bazel` like below, ensure `--output` is an *absolute* path. 
 
 ```sh
-bazel run //prow/cmd/mkbuild-cluster -- \
-  --project=P --zone=Z --cluster=C \
-  --alias=A \
-  --print-entry | tee cluster.yaml
-kubectl create secret generic build-cluster --from-file=cluster.yaml
+bazel run //gencred -- \
+  --context=<kube-context> \
+  --name=default \
+  --output=/tmp/kubeconfig.yaml \
+  --serviceaccount
+```
+
+Create one or more *build* cluster contexts:
+
+> **NOTE:** the `current-context` of the *existing* `kubeconfig` will be preserved.
+
+```sh
+bazel run //gencred -- \
+  --context=<kube-context> \
+  --name=other \
+  --output=/tmp/kubeconfig.yaml \
+  --serviceaccount
+```
+
+Create a secret containing the `kubeconfig.yaml` in the cluster:
+
+```sh
+kubectl --context=<kube-context> create secret generic kubeconfig --from-file=config=/tmp/kubeconfig.yaml
 ```
 
 Mount this secret into the prow components that need it (at minimum: `plank`,
-`sinker` and `deck`) and set the `--build-cluster` flag to the location you mount it at. For
+`sinker` and `deck`) and set the `--kubeconfig` flag to the location you mount it at. For
 instance, you will need to merge the following into the plank deployment:
 
 ```yaml
@@ -437,20 +483,20 @@ spec:
   containers:
   - name: plank
     args:
-    - --build-cluster=/etc/foo/cluster.yaml # basename matches --from-file key
+    - --kubeconfig=/etc/kubeconfig/config # basename matches --from-file key
     volumeMounts:
-    - mountPath: /etc/foo
-      name: cluster
+    - name: kubeconfig
+      mountPath: /etc/kubeconfig
       readOnly: true
   volumes:
-  - name: cluster
+  - name: kubeconfig
     secret:
-      defaultMode: 420
-      secretName: build-cluster # example above contains a cluster.yaml key
+      defaultMode: 0644
+      secretName: kubeconfig # example above contains a `config` key
 ```
 
 Configure jobs to use the non-default cluster with the `cluster:` field.
-The above example `cluster.yaml` defines two clusters: `default` and `other` to schedule jobs, which we can use as follows:
+The above example `kubeconfig.yaml` defines two clusters: `default` and `other` to schedule jobs, which we can use as follows:
 
 ```yaml
 periodics:
@@ -485,35 +531,7 @@ This results in:
 * The `cluster-unspecified` and `default-cluster` jobs run in the `default` cluster.
 * The `cluster-other` job runs in the `other` cluster.
 
-See [mkbuild-cluster][5] for more details about how to create/update `cluster.yaml`.
-
-Alternatively to `cluster.yaml`, one can use [a `kubeconfig` file](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) to instruct prow components to use the build clusters:
-All contexts in `kubeconfig` are used as build clusters and the [`InClusterConfig`](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod) as default.
-For example, it contains a context `other` which is a build cluster:
-
-```bash
-$ kubectl config get-contexts -o name
-other
-```
-
-After creating a secret `build-cluster-kubeconfig` with the `kubconfig` file, we add `--kubconfig` flag to prow component, e.g., plank:
-
-```yaml
-spec:
-  containers:
-  - name: plank
-    args:
-    - --kubeconfig=/etc/foo/kubeconfig
-    volumeMounts:
-    - mountPath: /etc/foo
-      name: kubeconfig
-      readOnly: true
-  volumes:
-  - name: kubeconfig
-    secret:
-      defaultMode: 420
-      secretName: build-cluster-kubeconfig
-```
+See [gencred][5] for more details about how to create/update `kubeconfig.yaml`.
 
 ### Enable merge automation using Tide
 
@@ -554,7 +572,7 @@ a separate namespace.
 [2]: /prow/jobs.md#How-to-configure-new-jobs
 [3]: https://github.com/jetstack/cert-manager
 [4]: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-[5]: /prow/cmd/mkbuild-cluster/
+[5]: /gencred/
 [6]: /prow/cmd/tide/README.md
 [7]: /prow/cmd/tide/config.md
 [8]: https://github.com/kubernetes/test-infra/blob/master/prow/scaling.md#working-around-githubs-limited-acls


### PR DESCRIPTION
Deprecate `mkbuild-cluster` and promote `gencred` in getting started docs. Thanks @hongkailiu for starting this effort in #14996.

crosses most items off of: #14810
one step closer to: #14724 