### PR TITLE
Cherrypicker: respond to pull request label events on merged PRs.

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -229,7 +229,7 @@ func (s *Server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 
 func (s *Server) handlePullRequest(l *logrus.Entry, pre github.PullRequestEvent) error {
 	// Only consider newly merged PRs
-	if pre.Action != github.PullRequestActionClosed {
+	if pre.Action != github.PullRequestActionClosed && pre.Action != github.PullRequestActionLabeled {
 		return nil
 	}
 


### PR DESCRIPTION
`cherrypicker` now responds to: `pull_request` event -> `labeled` action and will cherrypick on labeling even after the PR is merged. From what I gather from the consumer, this is the *expected* behavior of the plugin.

See for example of use-case:
https://github.com/istio/istio.io/pull/5690
https://github.com/istio/istio/pull/18608

closes #14244

cc @geeknoid @howardjohn 