### PR TITLE
fix: yamllint errors, typo in kubebuilder presubmit; dind docs

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -45,7 +45,7 @@ presubmits:
         - make
         - test-check
 
-  # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
+    # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
     annotations:
       testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-cloud-provider-check
@@ -105,7 +105,7 @@ presubmits:
       testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run Kubernetes e2e tests for cloud-provider-azure."
       testgrid-num-columns-recent: '30'
-# pull-cloud-provider-azure-e2e-ccm runs Azure specific e2e tests.
+  # pull-cloud-provider-azure-e2e-ccm runs Azure specific e2e tests.
   - name: pull-cloud-provider-azure-e2e-ccm
     always_run: true
     branches:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -75,7 +75,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: verify
-    # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
+  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
   - name: pull-cluster-api-provider-aws-make-conformance
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -49,7 +49,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make
-    # conformance test against kubernetes master branch with `kind` + cluster-api-provider-gcp
+  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-gcp
   - name: pull-cluster-api-provider-gcp-make-conformance
     labels:
       preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -19,7 +19,7 @@ periodics:
       args:
       - ./scripts/e2e/e2e.sh
       - "ova"
-        # we need privileged mode in order to do docker in docker
+      # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
   annotations:

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -115,10 +115,10 @@ periodics:
         privileged: true
     resources:
       requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
+        # these are both a bit below peak usage during build
+        # this is mostly for building kubernetes
         memory: "9000Mi"
-          # during the tests more like 3-20m is used
+        # during the tests more like 3-20m is used
         cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
@@ -151,10 +151,10 @@ periodics:
         privileged: true
     resources:
       requests:
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
+        # these are both a bit below peak usage during build
+        # this is mostly for building kubernetes
         memory: "9000Mi"
-          # during the tests more like 3-20m is used
+        # during the tests more like 3-20m is used
         cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - /usr/local/bin/runner.sh 
+        - /usr/local/bin/runner.sh
         - test_e2e.sh
         resources:
           requests:

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -30,7 +30,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
-        - /usr/local/bin/runner.sh
+        - runner.sh
         - test_e2e.sh
         resources:
           requests:

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -29,7 +29,8 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
         command:
-        - /usr/local/bin/runner
+        # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
+        - /usr/local/bin/runner.sh 
         - test_e2e.sh
         resources:
           requests:

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -56,8 +56,8 @@ presubmits:
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true
-    # This job executes test which checks if migration from Service Catalog v2 to v3 is working.
-    # Can be removed when support for v2 will be ended.
+  # This job executes test which checks if migration from Service Catalog v2 to v3 is working.
+  # Can be removed when support for v2 will be ended.
   - name: pull-service-catalog-test-migration
     decorate: true
     decoration_config:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -37,7 +37,7 @@ postsubmits:
       - name: pusher-docker-config
         secret:
           secretName: sig-storage-local-static-provisioner-pusher
-  # A postsubmit job to build release image on release tags.
+    # A postsubmit job to build release image on release tags.
     annotations:
       testgrid-dashboards: sig-storage-local-static-provisioner
       testgrid-tab-name: master-canary-build

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -159,7 +159,7 @@ presubmits:
       testgrid-dashboards: vmware-presubmits-cloud-provider-vsphere, presubmits-cloud-provider-vsphere-blocking
       testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
 
-    # Executes the unit tests.
+  # Executes the unit tests.
   - name: pull-cloud-provider-vsphere-unit-test
     decorate: true
     branches:

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -137,7 +137,7 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
 
-# kubectl skew tests
+  # kubectl skew tests
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: aws

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
 
-# Kubernetes conformance e2e tests against EKS 1.13 build.
+  # Kubernetes conformance e2e tests against EKS 1.13 build.
   annotations:
     testgrid-dashboards: sig-aws-eks-periodics
     description: Kubernetes e2e correctness tests against EKS 1.13 build
@@ -52,7 +52,7 @@ periodics:
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Slow\]|\[Serial\] --minStartupPods=8
       - --timeout=180m
 
-# Kubernetes performance e2e tests against EKS 1.13 build.
+  # Kubernetes performance e2e tests against EKS 1.13 build.
   annotations:
     testgrid-dashboards: sig-aws-eks-periodics
     description: Kubernetes conformance e2e tests against EKS 1.13 build

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
@@ -27,9 +27,9 @@ periodics:
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
 
-# The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
-# The non -parallel form of the test includes Serial and Disruptive, so it must run serially;
-# we skip Slow tests though so that the runtime is reasonable.
+  # The -parallel form of the test includes Slow tests, but skips Serial and Disruptive.
+  # The non -parallel form of the test includes Serial and Disruptive, so it must run serially;
+  # we skip Slow tests though so that the runtime is reasonable.
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-cluster

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -49,7 +49,7 @@ periodics:
       - --extra-publish-file=k8s-master
       - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
-        # docker-in-docker needs privileged mode
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
       resources:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -129,7 +129,7 @@ periodics:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--scenario=execute"
       - "--"
-            # the script must run from kubernetes, but we're checking out kind
+      # the script must run from kubernetes, but we're checking out kind
       - "bash"
       - "--"
       - "-c"

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -27,20 +27,20 @@ presubmits:
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--scenario=execute"
         - "--"
-            # the script must run from kubernetes, but we're checking out kind
+        # the script must run from kubernetes, but we're checking out kind
         - "bash"
         - "--"
         - "-c"
         - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
-          # we need privileged mode in order to do docker in docker
+        # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
         resources:
           requests:
-              # these are both a bit below peak usage during build
-              # this is mostly for building kubernetes
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
             memory: "9000Mi"
-              # during the tests more like 3-20m is used
+            # during the tests more like 3-20m is used
             cpu: 2000m
     annotations:
       testgrid-create-test-group: 'true'
@@ -108,7 +108,7 @@ presubmits:
       testgrid-num-failures-to-alert: "15"
 
 periodics:
-  # conformance test using image against kubernetes master branch with `kind`
+# conformance test using image against kubernetes master branch with `kind`
 - interval: 1h
   name: ci-kubernetes-conformance-image-test
   labels:
@@ -134,15 +134,15 @@ periodics:
       - "--"
       - "-c"
       - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
-          # we need privileged mode in order to do docker in docker
+      # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
       resources:
         requests:
-              # these are both a bit below peak usage during build
-              # this is mostly for building kubernetes
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
           memory: "9000Mi"
-              # during the tests more like 3-20m is used
+          # during the tests more like 3-20m is used
           cpu: 2000m
   # conformance test using image against kubernetes 1.14 branch with `kind`
   annotations:
@@ -171,20 +171,20 @@ periodics:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--scenario=execute"
       - "--"
-            # the script must run from kubernetes, but we're checking out kind
+      # the script must run from kubernetes, but we're checking out kind
       - "bash"
       - "--"
       - "-c"
       - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
-          # we need privileged mode in order to do docker in docker
+      # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
       resources:
         requests:
-              # these are both a bit below peak usage during build
-              # this is mostly for building kubernetes
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
           memory: "9000Mi"
-              # during the tests more like 3-20m is used
+          # during the tests more like 3-20m is used
           cpu: 2000m
   annotations:
     testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
@@ -212,20 +212,20 @@ periodics:
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--scenario=execute"
       - "--"
-            # the script must run from kubernetes, but we're checking out kind
+      # the script must run from kubernetes, but we're checking out kind
       - "bash"
       - "--"
       - "-c"
       - "cd ./../../k8s.io/kubernetes && source ./../test-infra/experiment/kind-conformance-image-e2e.sh"
-          # we need privileged mode in order to do docker in docker
+      # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
       resources:
         requests:
-              # these are both a bit below peak usage during build
-              # this is mostly for building kubernetes
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
           memory: "9000Mi"
-              # during the tests more like 3-20m is used
+          # during the tests more like 3-20m is used
           cpu: 2000m
   annotations:
     testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -58,7 +58,7 @@ periodics:
         value: "n"
       securityContext:
         privileged: true
-# coverage for same tests that run in ci-kubernetes-e2e-gci-gce
+  # coverage for same tests that run in ci-kubernetes-e2e-gci-gce
   annotations:
     testgrid-dashboards: sig-testing-canaries
     description: build instrumented kubernetes, run conformance tests, generate line coverage using gopherage

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -590,7 +590,7 @@ presets:
 # docker-in-docker (with images/bootstrap) preset
 # NOTE: using this also requires using that image,
 # ensuring you run your test under either the ENTRYPOINT or:
-# /usr/local/bin/runner my-test-command --foo --bar
+# /usr/local/bin/runner.sh my-test-command --foo --bar
 # AND setting the following on your PodSpec:
 # securityContext:
 #   privileged: true


### PR DESCRIPTION
Docker in docker requires that the jobs start up using the provided runner in `/usr/local/bin/runner.sh`. Update the doc comment to reflect the correct filepath, and update Kubebuilder to use the runner.