### PR TITLE
Increase timeout for scheduler benchmark.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -347,8 +347,8 @@ periodics:
   tags:
   - "perfDashPrefix: scheduler-benchmark"
   - "perfDashJobType: benchmark"
-  interval: 2h
-  annotations:
+  interval: 6h
+  annotation:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: scheduler
   decorate: true
@@ -358,7 +358,7 @@ periodics:
     base_ref: master
     path_alias: k8s.io/kubernetes
   decoration_config:
-    timeout: 1h55m
+    timeout: 5h55m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master
@@ -368,7 +368,7 @@ periodics:
       - ./test/integration/scheduler_perf
       env:
       - name: KUBE_TIMEOUT
-        value: --timeout=1h50m
+        value: --timeout=5h50m
 
 - name: ci-benchmark-kube-dns-master
   interval: 2h


### PR DESCRIPTION
The scheduler benchmark often times out, see [dashboard](http://perf-dash.k8s.io/#/?jobname=scheduler-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkResults&benchmark=BenchmarkSchedulingV%2F5000Nodes%2F1000Pods-8&metricName=time).
This is an attempt to mitigate it by increasing timeouts. We believe 4 test runs per day is enough for the scheduler so we set the timeout to 6h.

Meanwhile, we are working on refactoring the benchmark tests to make it run faster.

cc @ahg-g , @Huang-Wei , @alculquicondor 