### PR TITLE
ci-cluster-api-provider-aws-make-conformance-stable should be using a…

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -165,6 +165,8 @@ periodics:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-experimental
         env:
+          - name: CI_VERSION
+            value: "v1.16.3"
           - name: CAPI_BRANCH
             value: "stable"
           - name: BOSKOS_HOST


### PR DESCRIPTION
… fixed kubernetes version

let's use 1.16.3 which is the latest currently