### PR TITLE
Enable mutation detection in alpha jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -3679,6 +3679,8 @@ periodics:
       - --extract=ci/k8s-beta
       - --timeout=180m
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      # Panic if anything mutates a shared informer cache
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
@@ -4005,6 +4007,8 @@ periodics:
       - --extract=ci/k8s-stable1
       - --timeout=180m
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      # Panic if anything mutates a shared informer cache
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
@@ -4330,6 +4334,8 @@ periodics:
       - --extract=ci/k8s-stable2
       - --timeout=180m
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      # Panic if anything mutates a shared informer cache
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
@@ -4656,6 +4662,8 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+      # Panic if anything mutates a shared informer cache
+      - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191112-9f04410-master

--- a/experiment/test_config.yaml
+++ b/experiment/test_config.yaml
@@ -586,6 +586,8 @@ jobs:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
       --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
@@ -638,6 +640,8 @@ jobs:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
       --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
@@ -689,6 +693,8 @@ jobs:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
       --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
@@ -740,6 +746,8 @@ jobs:
     - --env=KUBE_PROXY_DAEMONSET=true
     - --env=ENABLE_POD_PRIORITY=true
     - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
+    # Panic if anything mutates a shared informer cache
+    - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true


### PR DESCRIPTION
start by enabling mutation detection in alpha jobs where they won't block master, to start recovering from https://github.com/kubernetes/kubernetes/issues/85349

we want this enabled for these tests in general to catch issues with alpha features the main e2e's won't catch

cc @BenTheElder @Katharine 