### PR TITLE
Sort pending contexts when displaying them from tide

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -280,6 +280,7 @@ func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.Q
 }
 
 func retestingStatus(retested []string) string {
+	sort.Strings(retested)
 	all := fmt.Sprintf(statusNotInPool, fmt.Sprintf(" Retesting: %s", strings.Join(retested, " ")))
 	if len(all) > maxStatusDescriptionLength {
 		s := ""

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -251,6 +251,112 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  "Not mergeable. Retesting: bar",
 		},
 		{
+			name:             "missing passing up-to-date contexts",
+			inPool:           true,
+			baseref:          "baseref",
+			requiredContexts: []string{"foo", "bar", "baz"},
+			prowJobs: []runtime.Object{
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "123"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "foo",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.SuccessState,
+					},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "1234"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "bar",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "12345"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "baz",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+			},
+
+			state: github.StatusPending,
+			desc:  "Not mergeable. Retesting: bar baz",
+		},
+		{
+			name:             "missing passing up-to-date contexts with different ordering",
+			inPool:           true,
+			baseref:          "baseref",
+			requiredContexts: []string{"foo", "bar", "baz"},
+			prowJobs: []runtime.Object{
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "123"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "foo",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.SuccessState,
+					},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "1234"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "baz",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+				&prowapi.ProwJob{
+					ObjectMeta: metav1.ObjectMeta{Name: "12345"},
+					Spec: prowapi.ProwJobSpec{
+						Context: "bar",
+						Refs: &prowapi.Refs{
+							BaseSHA: "baseref",
+							Pulls:   []prowapi.Pull{{SHA: "head"}},
+						},
+						Type: prowapi.PresubmitJob,
+					},
+					Status: prowapi.ProwJobStatus{
+						State: prowapi.PendingState,
+					},
+				},
+			},
+
+			state: github.StatusPending,
+			desc:  "Not mergeable. Retesting: bar baz",
+		},
+		{
 			name:    "long list of not up-to-date contexts results in shortened message",
 			inPool:  true,
 			baseref: "baseref",


### PR DESCRIPTION
When a list of contexts is presented as pending from the tide status
controller, we need to sort the contexts in the list so that we do not
attempt to update the message with a different but equivalent
permutation of the pending contexts on every sync loop.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

fixes https://github.com/kubernetes/test-infra/issues/15299

/assign @alvaroaleman @cjwagner 