### PR TITLE
fix pipeline rbac (allow patch prowjob)

### DIFF
--- a/prow/cluster/pipeline_rbac.yaml
+++ b/prow/cluster/pipeline_rbac.yaml
@@ -33,6 +33,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 
 ---
 

--- a/prow/cmd/pipeline/dev.yaml
+++ b/prow/cmd/pipeline/dev.yaml
@@ -50,6 +50,7 @@ rules:
   - list
   - watch
   - update
+  - patch
 
 ---
 


### PR DESCRIPTION
I made pipeline use patch instead of update (see https://github.com/kubernetes/test-infra/pull/15295).
I forgot to update rbac.
This pull request fixes it.