### PR TITLE
Re-introduce GitHub alerts but don't route them to Slack

### DIFF
--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -95,6 +95,7 @@ filegroup(
         ":package-srcs",
         "//prow/cluster/monitoring/mixins/dashboards_out:all-srcs",
         "//prow/cluster/monitoring/mixins/grafana_dashboards:all-srcs",
+        "//prow/cluster/monitoring/mixins/lib:all-srcs",
         "//prow/cluster/monitoring/mixins/prometheus:all-srcs",
         "//prow/cluster/monitoring/mixins/prometheus_out:all-srcs",
         "//prow/cluster/monitoring/mixins/vendor/grafonnet:all-srcs",

--- a/prow/cluster/monitoring/mixins/Makefile
+++ b/prow/cluster/monitoring/mixins/Makefile
@@ -20,11 +20,11 @@ SHELL=/bin/bash -o pipefail
 all: grafana-dashboards prow_prometheusrule.yaml
 
 grafana-dashboards:
-	for name in deck ghproxy hook plank prow sinker tide; do echo "Generating $${name}.json ..."; jsonnet -J vendor/ "grafana_dashboards/$${name}.jsonnet" > "./dashboards_out/$${name}.json"; done
+	for name in deck ghproxy hook plank prow sinker tide; do echo "Generating $${name}.json ..."; jsonnet -J vendor/ -J lib/ "grafana_dashboards/$${name}.jsonnet" > "./dashboards_out/$${name}.json"; done
 
 prow_prometheusrule.yaml:
 	@echo "Generating prow_prometheusrule.yaml ..."
-	jsonnet  ./prometheus/prow_prometheusrule.jsonnet | gojsontoyaml > prometheus_out/$@
+	jsonnet -J lib/ ./prometheus/prow_prometheusrule.jsonnet | gojsontoyaml > prometheus_out/$@
 
 clean-vendor:
 	rm -rfv ./vendor

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
@@ -4,63 +4,105 @@ jsonnet_to_json(
     name = "deck",
     src = "deck.jsonnet",
     outs = ["deck.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "ghproxy",
     src = "ghproxy.jsonnet",
     outs = ["ghproxy.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "hook",
     src = "hook.jsonnet",
     outs = ["hook.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "plank",
     src = "plank.jsonnet",
     outs = ["plank.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "prow",
     src = "prow.jsonnet",
     outs = ["prow.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "tide",
     src = "tide.jsonnet",
     outs = ["tide.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 jsonnet_to_json(
     name = "sinker",
     src = "sinker.jsonnet",
     outs = ["sinker.json"],
-    imports = ["../vendor/"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
     visibility = ["//visibility:public"],
-    deps = ["//prow/cluster/monitoring/mixins/vendor/grafonnet"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
 )
 
 filegroup(

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
@@ -1,3 +1,4 @@
+local config =  import 'config.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local graphPanel = grafana.graphPanel;
@@ -10,9 +11,9 @@ local legendConfig = {
             sideWidth: 250,
         },
     };
-    
+
 local dashboardConfig = {
-        uid: 'd72fe8d0400b2912e319b1e95d0ab1b3',
+        uid: config._config.grafanaDashboardIDs['ghproxy.json'],
     };
 
 local histogramQuantileTarget(phi) = prometheus.target(
@@ -222,6 +223,23 @@ dashboard.new(
     .addTarget(prometheus.target(
         'sum(rate(github_request_duration_count{job="ghproxy"}[${range}])) by (status)',
          legendFormat='{{status}}',
+    )), gridPos={
+    h: 9,
+    w: 24,
+    x: 0,
+    y: 18,
+  })
+.addPanel(
+    (graphPanel.new(
+        'Request Rates: Overview by path for ${status} with ${range}',
+        description='GitHub request rates by path.',
+        datasource='prometheus',
+        legend_alignAsTable=true,
+        legend_rightSide=true,
+    ) + legendConfig)
+    .addTarget(prometheus.target(
+        'sum(rate(github_request_duration_count{status="${status}",job="ghproxy"}[${range}])) by (path)',
+         legendFormat='{{path}}',
     )), gridPos={
     h: 9,
     w: 24,

--- a/prow/cluster/monitoring/mixins/lib/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/lib/BUILD.bazel
@@ -1,23 +1,9 @@
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json")
 
 jsonnet_library(
-    name = "prom_lib",
+    name = "lib",
     srcs = glob(["*.libsonnet"]),
-)
-
-jsonnet_to_json(
-    name = "prow_prometheusrule",
-    src = "prow_prometheusrule.jsonnet",
-    outs = ["prow_prometheusrule.yaml"],
-    imports = [
-        "../lib/",
-        "../vendor/",
-    ],
     visibility = ["//visibility:public"],
-    deps = [
-        ":prom_lib",
-        "//prow/cluster/monitoring/mixins/lib",
-    ],
 )
 
 filegroup(

--- a/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -1,0 +1,8 @@
+{
+  _config+:: {
+    // Grafana dashboard IDs are necessary for stable links for dashboards
+    grafanaDashboardIDs: {
+      'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
+    },
+  },
+}

--- a/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -10,7 +10,7 @@
               sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
             |||,
             labels: {
-              severity: 'slack',
+              severity: 'warning',
             },
             annotations: {
               message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9>' % $._config.grafanaDashboardIDs['ghproxy.json'],
@@ -22,7 +22,7 @@
               sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
             |||,
             labels: {
-              severity: 'slack',
+              severity: 'warning',
             },
             annotations: {
               message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8|grafana>' % $._config.grafanaDashboardIDs['ghproxy.json'],
@@ -38,7 +38,7 @@
             |||,
             'for': '5m',
             labels: {
-              severity: 'slack',
+              severity: 'warning',
             },
             annotations: {
               message: 'token {{ $labels.token_hash }} will run out of API quota before the next reset.',

--- a/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -1,3 +1,4 @@
+(import 'config.libsonnet') +
 (import 'ci_absent_alerts.libsonnet') +
 (import 'prow_monitoring_absent_alerts.libsonnet') +
 (import 'configmap_alerts.libsonnet') +


### PR DESCRIPTION
Revert "Merge pull request #15276 from stevekuznetsov/skuznets/revert-ghmetrics"

This reverts commit af9aee87749c616883e4e411fc78e8ef4f0067ca, reversing
changes made to 9e15c062bf5a9b6401bd5849a66365655cf1675f.

---

Change GHMetrics alerts to warning level

Right now this means that the alerts are not sent anywhere. We should
figure out a good place to send them, like a #prow-alerts channel.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/assign @fejta 