### PR TITLE
re-introduce backup job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1242,11 +1242,19 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191108-9467d02-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191115-01e3204-1.17
       command:
       - infra/gcp/backup_tools/backup.sh
-      args:
-      - /etc/k8s-artifacts-prod-bak-service-account/service-account.json
+      env:
+      # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
+      # here anyway in case the underlying image changes (the backup.sh script
+      # needs it to be defined).
+      - name: GOPATH
+        value: /go
+      - name: GCRANE_REF
+        value: 7683b4ee5f6150cb47a791309f781c522b95a58f # Known-good commit from 2019-10-23
+      - name: GOOGLE_APPLICATION_CREDENTIALS
+        value: /etc/k8s-artifacts-prod-bak-service-account/service-account.json
       volumeMounts:
       - name: k8s-artifacts-prod-bak-service-account-creds
         mountPath: /etc/k8s-artifacts-prod-bak-service-account
@@ -1257,3 +1265,6 @@ periodics:
         secretName: k8s-artifacts-prod-bak-service-account
   annotations:
     testgrid-dashboards: sig-release-misc
+    # TODO: enable alerting once the job has stabilized
+    # testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+    # testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1230,3 +1230,30 @@ periodics:
         secretName: k8s-artifacts-prod-service-account
   annotations:
     testgrid-dashboards: sig-release-misc
+  # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
+- interval: 1h
+  cluster: test-infra-trusted
+  max_concurrency: 1
+  name: ci-k8sio-backup
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191108-9467d02-master
+      command:
+      - infra/gcp/backup_tools/backup.sh
+      args:
+      - /etc/k8s-artifacts-prod-bak-service-account/service-account.json
+      volumeMounts:
+      - name: k8s-artifacts-prod-bak-service-account-creds
+        mountPath: /etc/k8s-artifacts-prod-bak-service-account
+        readOnly: true
+    volumes:
+    - name: k8s-artifacts-prod-bak-service-account-creds
+      secret:
+        secretName: k8s-artifacts-prod-bak-service-account
+  annotations:
+    testgrid-dashboards: sig-release-misc


### PR DESCRIPTION
Hopefully this will get the backup job running again.

The logic for the backup job itself lives at: https://github.com/kubernetes/k8s.io/blob/master/infra/gcp/backup_tools/backup.sh

/hold

/cc @thockin @justinsb