### PR TITLE
fix checkconfig strict for "slack_reporter"

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1053,7 +1053,6 @@ func (c *Config) validateComponentConfig() error {
 		}
 
 		c.SlackReporterConfigs = map[string]SlackReporter{"*": *c.SlackReporter}
-		c.SlackReporter = nil
 	}
 
 	if c.SlackReporterConfigs != nil {


### PR DESCRIPTION
For some reason setting `c.SlackReporter = nil` breaks `checkconfig` (when `slack_reporter` is defined in Prow config) while omitting does not; there is a bug somewhere in the `checkconfig` logic. This is a workaround. 

example: https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_test-infra/2102/pull-test-infra-prow-checkconfig/3124/build-log.txt

issue: #15316

/assign @alvaroaleman @fejta 