### PR TITLE
add ci-signal team to the rerun config

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -62,6 +62,7 @@ deck:
       - clarketm
     github_team_ids:
       - 2009231 #test-infra-admins
+      - 3523872 #ci-signal
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
There are a lot of cases that `ci-signal` team is investigating a job failure with specific people and after the fix PR is merged the job needs to rerun in order to validate the fix and take quick actions if the fix is not correct.

However, with this patch, we grant `ci-signal` team to be able to rerun all of the jobs and not only the jobs that exist in the `sig-release` dashboard which they are responsible for.

@justaugustus Is this acceptable? 

/cc @kubernetes/ci-signal @kubernetes/release-team-leads 