### PR TITLE
Add a version package, populate it and use it

### DIFF
--- a/boskos/metrics/metrics.go
+++ b/boskos/metrics/metrics.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("boskos-metrics")
+	logrusutil.ComponentInit()
 	boskos := client.NewClient("Metrics", "http://boskos")
 	logrus.Infof("Initialzied boskos client!")
 

--- a/experiment/resultstore/main.go
+++ b/experiment/resultstore/main.go
@@ -102,7 +102,7 @@ func parseOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("storeship")
+	logrusutil.ComponentInit()
 
 	opt := parseOptions()
 	for {

--- a/experiment/tracer/main.go
+++ b/experiment/tracer/main.go
@@ -73,7 +73,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("tracer")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -125,7 +125,7 @@ func flagOptions() *options {
 }
 
 func main() {
-	logrusutil.ComponentInit("ghproxy")
+	logrusutil.ComponentInit()
 
 	o := flagOptions()
 	flag.Parse()

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -64,7 +64,7 @@ var diskCheckInterval = flag.Duration("disk-check-interval", time.Second*10,
 var promMetrics *prometheusMetrics
 
 func init() {
-	logrusutil.ComponentInit("greenhouse")
+	logrusutil.ComponentInit()
 
 	logrus.SetOutput(os.Stdout)
 	promMetrics = initMetrics()

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -680,7 +680,7 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEnd
 // It took about 10 minutes to process all my 8 repos with all wanted "kubernetes" labels (70+)
 // Next run takes about 22 seconds to check if all labels are correct on all repos
 func main() {
-	logrusutil.ComponentInit("label_sync")
+	logrusutil.ComponentInit()
 
 	flag.Parse()
 	if *debug {

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -107,7 +107,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("migratestatus")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -155,6 +155,7 @@ filegroup(
         "//prow/statusreconciler:all-srcs",
         "//prow/test:all-srcs",
         "//prow/tide:all-srcs",
+        "//prow/version:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -57,7 +57,7 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("admission")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/artifact-uploader/main.go
+++ b/prow/cmd/artifact-uploader/main.go
@@ -151,7 +151,7 @@ func (o *Options) Run() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("artifact-uploader")
+	logrusutil.ComponentInit()
 
 	o := newOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -90,7 +90,7 @@ func (e *Errors) add(err error) {
 }
 
 func main() {
-	logrusutil.ComponentInit("branchprotector")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -159,7 +159,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("checkconfig")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("clonerefs")
+	logrusutil.ComponentInit()
 
 	o := &clonerefs.Options{}
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -76,7 +76,7 @@ func (o *options) Validate() error {
 
 func main() {
 	var errors int
-	logrusutil.ComponentInit("config-bootstrapper")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -156,7 +156,7 @@ func parseOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("crier")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -305,7 +305,7 @@ func v(fragment string, children ...simplifypath.Node) simplifypath.Node {
 }
 
 func main() {
-	logrusutil.ComponentInit("deck")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("entrypoint")
+	logrusutil.ComponentInit()
 
 	o := entrypoint.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/exporter/main.go
+++ b/prow/cmd/exporter/main.go
@@ -68,7 +68,7 @@ func mustRegister(component string, lister lister) *prometheus.Registry {
 }
 
 func main() {
-	logrusutil.ComponentInit("exporter")
+	logrusutil.ComponentInit()
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("gcsupload")
+	logrusutil.ComponentInit()
 
 	o := gcsupload.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -213,7 +213,7 @@ func (st *syncTime) Update(newState client.LastSyncState) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("gerrit")
+	logrusutil.ComponentInit()
 
 	defer interrupts.WaitForGracefulShutdown()
 

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -91,7 +91,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
-	logrusutil.ComponentInit("hook")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -72,7 +72,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("horologium")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("initupload")
+	logrusutil.ComponentInit()
 
 	o := initupload.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -122,7 +122,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("jenkins-operator")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -147,7 +147,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("peribolos")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -108,7 +108,7 @@ func newPipelineConfig(cfg rest.Config, stop <-chan struct{}) (*pipelineConfig, 
 }
 
 func main() {
-	logrusutil.ComponentInit("pipeline")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -84,7 +84,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("plank")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("sidecar")
+	logrusutil.ComponentInit()
 
 	o := sidecar.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -88,7 +88,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("sinker")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -87,7 +87,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("status-reconciler")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -86,7 +86,7 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("pubsub-subscriber")
+	logrusutil.ComponentInit()
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(flagOptions.configPath, flagOptions.jobConfigPath); err != nil {

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -105,7 +105,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
-	logrusutil.ComponentInit("tide")
+	logrusutil.ComponentInit()
 
 	defer interrupts.WaitForGracefulShutdown()
 

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -270,7 +270,7 @@ func (f fallbackHandler) getURL(jobName string) string {
 }
 
 func main() {
-	logrusutil.ComponentInit("tot")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -37,6 +37,7 @@ def prow_image(
         goarch = "amd64",
         goos = "linux",
         pure = "on",
+        x_defs = {"k8s.io/test-infra/prow/version.Name": name},
     )
 
     container_image(

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
     deps = [
         "//ghproxy/ghcache:go_default_library",
         "//prow/errorutil:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",

--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/logrusutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/version"
 )
 
 // DefaultFieldsFormatter wraps another logrus.Formatter, injecting
@@ -49,11 +50,11 @@ func Init(formatter *DefaultFieldsFormatter) {
 }
 
 // ComponentInit is a syntax sugar for easier Init
-func ComponentInit(component string) {
+func ComponentInit() {
 	Init(
 		&DefaultFieldsFormatter{
 			PrintLineNumber: true,
-			DefaultFields:   logrus.Fields{"component": component},
+			DefaultFields:   logrus.Fields{"component": version.Name},
 		},
 	)
 }

--- a/prow/version/BUILD.bazel
+++ b/prow/version/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "k8s.io/test-infra/prow/version",
+    visibility = ["//visibility:public"],
+    x_defs = {"Version": "{DOCKER_TAG}"},
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/version/doc.go
+++ b/prow/version/doc.go
@@ -1,0 +1,13 @@
+// version holds variables that identify a Prow binary's name and version
+package version
+
+var (
+	// Name is the colloquial identifier for the compiled component
+	Name = "unset"
+	// Version is a concatenation of the commit SHA and date for the build
+	Version = "0"
+)
+
+func UserAgent() string {
+	return Name + "/" + Version
+}


### PR DESCRIPTION
Add a version package, populate it and use it

The new package `k8s.io/test-infra/version` holds two variables:

 - Name: the name of the component that is compiled
 - Version: the version of the component, matching the image version

These variables should be used in the components when they expose their
identities and versions, such as in logging component strings or in the
User-Agent header.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta 