### PR TITLE
Tide status controller: Pass on required contexts from main controller

### DIFF
--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -375,6 +375,7 @@ func (c *Controller) Sync() error {
 	c.sc.blocks = blocks
 	c.sc.poolPRs = poolPRMap(filteredPools)
 	c.sc.baseSHAs = baseSHAMap(filteredPools)
+	c.sc.requiredContexts = requiredContextsMap(filteredPools)
 	select {
 	case c.sc.newPoolPending <- true:
 	default:
@@ -573,6 +574,20 @@ func poolPRMap(subpoolMap map[string]*subpool) map[string]PullRequest {
 		}
 	}
 	return prs
+}
+
+func requiredContextsMap(subpoolMap map[string]*subpool) map[string][]string {
+	requiredContextsMap := map[string][]string{}
+	for _, sp := range subpoolMap {
+		for _, pr := range sp.prs {
+			requiredContextsSet := sets.String{}
+			for _, requiredJob := range sp.presubmits[int(pr.Number)] {
+				requiredContextsSet.Insert(requiredJob.Context)
+			}
+			requiredContextsMap[prKey(&pr)] = requiredContextsSet.List()
+		}
+	}
+	return requiredContextsMap
 }
 
 type simpleState string

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -514,6 +514,7 @@ type fgc struct {
 	refs      map[string]string
 	merged    int
 	setStatus bool
+	statuses  map[string]github.Status
 	mergeErrs map[int]error
 
 	expectedSHA    string
@@ -551,6 +552,10 @@ func (f *fgc) Merge(org, repo string, number int, details github.MergeDetails) e
 func (f *fgc) CreateStatus(org, repo, ref string, s github.Status) error {
 	switch s.State {
 	case github.StatusSuccess, github.StatusError, github.StatusPending, github.StatusFailure:
+		if f.statuses == nil {
+			f.statuses = map[string]github.Status{}
+		}
+		f.statuses[org+"/"+repo+"/"+ref] = s
 		f.setStatus = true
 		return nil
 	}


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/15265

This PR makes tide pass on required presubmits from the main controller onto the status controller. This is done so the status controller can consider presubmits that have a `run_if_changed` directive, those are currently completely invisible to it, as it doesn't know anything about what files a given PR touches.