### PR TITLE
Switch to newer kind - fix bazel build issue

### DIFF
--- a/experiment/kind-conformance-image-e2e.sh
+++ b/experiment/kind-conformance-image-e2e.sh
@@ -25,7 +25,7 @@ set -o xtrace
 # - get some fixes related to Kubernetes's build changing
 # - don't get surprised when kind changes between now and the next stable release
 # We should switch back to a release tag at the next release.
-STABLE_KIND_VERSION=v0.5.1
+STABLE_KIND_VERSION=v0.6.0
 
 # our exit handler (trap)
 cleanup() {
@@ -97,6 +97,10 @@ EOF
     # mark the cluster as up for cleanup
     # even if kind create fails, kind delete can clean up after it
     KIND_IS_UP=true
+
+    KUBECONFIG="${HOME}/.kube/kind-config-default"
+    export KUBECONFIG
+
     # actually create, with:
     # - do not delete created nodes from a failed cluster create (for debugging)
     # - wait up to one minute for the nodes to be "READY"
@@ -128,8 +132,6 @@ run_tests() {
 
   VERSION=$(echo -n "${KUBE_GIT_VERSION}" | cut -f 1 -d '+')
   export VERSION
-  KUBECONFIG=$(kind get kubeconfig-path)
-  export KUBECONFIG
 
   pushd ${PWD}/cluster/images/conformance
 


### PR DESCRIPTION
Trying to fix failure in CI job:
https://testgrid.k8s.io/conformance-all#conformance-image,%20master%20%28dev%29

Pulling in fix in kind:
https://github.com/kubernetes-sigs/kind/pull/963