### PR TITLE
Add kubeflow pipelines frontend unit tests to prow

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -299,6 +299,14 @@ presubmits:
       description: Presubmits for kubeflow/kfctl.
       testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
+  - name: kubeflow-pipeline-frontend-test
+    always_run: false
+    decorate: true
+    spec:
+      containers:
+      - image: node:12
+        command:
+        - cd ./frontend && npm ci && npm run test:ci
   - name: kubeflow-pipeline-e2e-test
     always_run: true
     decorate: true


### PR DESCRIPTION
Note, currently this is not marked as always run.
After I verified it works, I will make that change in a separate PR.

Addresses the problem in https://github.com/kubeflow/pipelines/issues/1653
Original travis test set up: https://github.com/kubeflow/pipelines/blob/0a873a99d919f1d591aaf90d04708cba1277c25f/.travis.yml#L17