### PR TITLE
Trim user from url even if decoration_config is empty.

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -439,13 +439,13 @@ type UtilityConfig struct {
 
 func (u *UtilityConfig) Validate() error {
 	cloneURIValidate := func(cloneURI string) error {
+		// Trim user from uri if exists.
+		cloneURI = cloneURI[strings.Index(cloneURI, "@")+1:]
+
 		if u.DecorationConfig != nil && len(u.DecorationConfig.SSHKeySecrets) > 0 {
 			if len(u.CloneURI) == 0 {
 				return errors.New("SSH key secrets provided but no clone_uri has been found")
 			}
-
-			// Trim user from uri if exists.
-			cloneURI = cloneURI[strings.Index(cloneURI, "@")+1:]
 		}
 
 		if _, err := url.Parse(cloneURI); err != nil {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -958,7 +958,6 @@ func TestUtilityConfigValidation(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			id: "ssh_keys specified but clone_uri is empty, error",
 			uc: UtilityConfig{
@@ -1032,6 +1031,13 @@ func TestUtilityConfigValidation(t *testing.T) {
 					SSHKeySecrets: []string{"ssh-secret"},
 				},
 			},
+		},
+		{
+			id: "clone_uri contains a user and decoration config is nil, no error",
+			uc: UtilityConfig{
+				CloneURI: "git@github.com:kubernetes/test-infra.git",
+			},
+			valid: true,
 		},
 	}
 


### PR DESCRIPTION
In case of a URL contains a user and the decoration config was empty, we weren't trimming the user and the parsing was failing.
This PR is fixing that.

/cc @stevekuznetsov 