### PR TITLE
Fix clone uri validation when no ssh key is configured

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -444,9 +444,9 @@ func (u *UtilityConfig) Validate() error {
 				return errors.New("SSH key secrets provided but no clone_uri has been found")
 			}
 
-			// Trim user from uri if exists.
-			cloneURI = cloneURI[strings.Index(cloneURI, "@")+1:]
 		}
+		// Trim user from uri if exists.
+		cloneURI = cloneURI[strings.Index(cloneURI, "@")+1:]
 
 		if _, err := url.Parse(cloneURI); err != nil {
 			return fmt.Errorf("couldn't parse uri from clone_uri: %v", err)

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -1011,6 +1011,27 @@ func TestUtilityConfigValidation(t *testing.T) {
 			},
 		},
 		{
+			id:    "all of clone_uri are valid, no error",
+			valid: true,
+			uc: UtilityConfig{
+				CloneURI: "git@github.com:kubermatic/grpc-connector.git",
+				ExtraRefs: []prowapi.Refs{
+					{
+						Org:      "org1",
+						Repo:     "repo1",
+						BaseSHA:  "master",
+						CloneURI: "github.com:org1/repo1.git",
+					},
+					{
+						Org:      "org2",
+						Repo:     "repo2",
+						BaseSHA:  "master",
+						CloneURI: "git@github.com:org2/repo2.git",
+					},
+				},
+			},
+		},
+		{
 			id: "ssh_keys specified and one of the clone_uri is invalid, error",
 			uc: UtilityConfig{
 				CloneURI: "git@github.com:kubernetes/test-infra.git",


### PR DESCRIPTION
Currently, we only trim ssh clone uris to pass the `url.Parse` parsing when there is also a ssh key configured.

Unfortunately, this is not always the case, as there can be a ssh key in a different level of the `default_decoration_configs`, e.G. in the global default (`default_decoration_configs["*"]`)