### PR TITLE
Add k8s.io/release repo to pull-kubernetes-e2e-azure-disk-*

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -54,7 +54,7 @@ presubmits:
         - "--up=true"
         - "--down=true"
         - "--deployment=acsengine"
-        - "--build=host-go" # build kubectl binary
+        - "--build=quick" # build kubectl binary
         - "--provider=skeleton" # noop
         - "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aks-engine-azure"
         - "--ginkgo-parallel=30"
@@ -96,6 +96,7 @@ presubmits:
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
         - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
         - "--repo=sigs.k8s.io/azuredisk-csi-driver"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=460"
@@ -106,7 +107,7 @@ presubmits:
         - "--up=true"
         - "--down=true"
         - "--deployment=acsengine"
-        - "--build=host-go"
+        - "--build=quick"
         - "--provider=skeleton"
         - "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-azure-disk"
         - "--ginkgo-parallel=1"
@@ -148,6 +149,7 @@ presubmits:
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
         - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--repo=k8s.io/release"
         - "--repo=sigs.k8s.io/azuredisk-csi-driver"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--timeout=460"
@@ -158,7 +160,7 @@ presubmits:
         - "--up=true"
         - "--down=true"
         - "--deployment=acsengine"
-        - "--build=host-go"
+        - "--build=quick"
         - "--provider=skeleton"
         - "--stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-azure-disk-vmss"
         - "--ginkgo-parallel=1"


### PR DESCRIPTION
Added `k8s.io/release` repo to pull-kubernetes-e2e-azure-disk-* and changed the build method to quick so k8s tarball can be generated and uploaded to GS bucket via release script.

Addresses CI failure in https://github.com/kubernetes/kubernetes/pull/85475.

/assign @andyzhangx 