### PR TITLE
fix: v1/v2 e2e tests after kubebuilder refactor

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -18,7 +18,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: kubebuilder
-  - name: pull-kubebuilder-e2e
+  - name: pull-kubebuilder-e2e-v1
     decorate: true
     always_run: true
     optional: true
@@ -31,7 +31,7 @@ presubmits:
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
-        - test_e2e.sh
+        - test_e2e_v1.sh
         resources:
           requests:
             cpu: 4000m


### PR DESCRIPTION
Kubebuilder changed the single `test_e2e.sh` to two tests covering v1/v2 with file naming changes. This PR points the WIP presubmit to v1. Once we validate this actually works, I will add v2. 

