### PR TITLE
Add a grafana dashboard for boskos resource usage.

### DIFF
--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -72,6 +72,7 @@ k8s_objects(
         ":prometheusrule_crd",
         ":servicemonitor_crd",
         "//prow/cluster/monitoring/mixins/prometheus_out:prow_prometheusrule",
+        "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-deck",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-ghproxy",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-hook",

--- a/prow/cluster/monitoring/grafana_deployment.yaml
+++ b/prow/cluster/monitoring/grafana_deployment.yaml
@@ -66,6 +66,9 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/prow
           name: grafana-dashboard-prow
           readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/boskos
+          name: grafana-dashboard-boskos
+          readOnly: false
         - mountPath: /grafana-dashboard-definitions/0/deck
           name: grafana-dashboard-deck
           readOnly: false
@@ -102,6 +105,9 @@ spec:
       - name: grafana-dashboard-prow
         configMap:
           name: grafana-dashboard-prow
+      - name: grafana-dashboard-boskos
+        configMap:
+          name: grafana-dashboard-boskos
       - name: grafana-dashboard-deck
         configMap:
           name: grafana-dashboard-deck

--- a/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
@@ -6,6 +6,16 @@ load("//def:configmap.bzl", "k8s_configmap")
 #   bazel run //prow/cluster/monitoring/mixins/dashboards_out:grafana-configmaps.apply
 
 k8s_configmap(
+    name = "grafana-dashboard-boskos",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    data = {
+        "boskos.json": "//prow/cluster/monitoring/mixins/grafana_dashboards:boskos",
+    },
+    namespace = "prow-monitoring",
+    visibility = ["//visibility:public"],
+)
+
+k8s_configmap(
     name = "grafana-dashboard-deck",
     cluster = "{STABLE_PROW_CLUSTER}",
     data = {

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
@@ -1,6 +1,21 @@
 load("@io_bazel_rules_jsonnet//jsonnet:jsonnet.bzl", "jsonnet_library", "jsonnet_to_json")
 
 jsonnet_to_json(
+    name = "boskos",
+    src = "boskos.jsonnet",
+    outs = ["boskos.json"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
+)
+
+jsonnet_to_json(
     name = "deck",
     src = "deck.jsonnet",
     outs = ["deck.json"],

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -1,0 +1,47 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+
+
+local dashboardConfig = {
+        uid: 'wSrfvNxWz',
+    };
+
+dashboard.new(
+        'Boskos Resource Usage',
+        time_from='now-1d',
+        schemaVersion=18,
+      )
+.addPanels([
+    graphPanel.new(
+        '%s usage status' % resource.friendly,
+        description='The number of %ss in each state.' % resource.friendly,
+        datasource='prometheus',
+        stack=true,
+        fill=3,
+        linewidth=0,
+        aliasColors={'busy': '#ff0000', 'cleaning': '#00eeff', 'dirty': '#ff8000', 'free': '#00ff00', 'leased': '#ee00ff', 'other': '#aaaaff', 'toBeDeleted': '#fafa00', 'tombstone': '#cccccc'}
+    )
+    .addTarget(prometheus.target(
+        'sum(boskos_resources{type="%s"}) by (state)' % resource.type,
+        legendFormat='{{state}}',
+    ))
+    {gridPos: {
+        h: 9,
+        w: 24,
+        x: 0,
+        y: 0,
+    }}
+      for resource in [
+        {type: "aws-account", friendly: "AWS account"},
+        {type: "gce-project", friendly: "GCE project"},
+        {type: "gke-project", friendly: "GKE project"},
+        {type: "gpu-project", friendly: "GPU project"},
+        {type: "ingress-project", friendly: "Ingress project"},
+        {type: "istio-project", friendly: "Istio project"},
+        {type: "scalability-project", friendly: "Scalability project"},
+        {type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+      ]
+  ])
++ dashboardConfig


### PR DESCRIPTION
__Questions:__ 
1. The `leased` and `other` states were not previously graphed and at a glance they are always 0. Should I remove these from the graphs?
1. I set the default time range to the past day of results. Is that value useful?
1. Do we care what order the graphs are in?
1. Are the colors OK? (I didn't use the automatic colors to ensure that the color schemes are consistent between the graphs.)

Here is what it looks like:
![boskos-dashboard](https://user-images.githubusercontent.com/5334145/69286875-3d0f1a80-0ba9-11ea-8d41-cc44ad2a6833.png)

/assign @hongkailiu @stevekuznetsov 
/cc @sebastienvas 
/area boskos

fixes #15303 
