### PR TITLE
Update boskos components to v20191108-9467d02d9.

### DIFF
--- a/prow/cluster/boskos-metrics.yaml
+++ b/prow/cluster/boskos-metrics.yaml
@@ -46,7 +46,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: metrics
-        image: gcr.io/k8s-testimages/metrics:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/metrics:v20191108-9467d02d9
         args:
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account
         ports:

--- a/prow/cluster/boskos-reaper_deployment.yaml
+++ b/prow/cluster/boskos-reaper_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-testimages/reaper:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/reaper:v20191108-9467d02d9
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account

--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-testimages/boskos:v20190621-ff01381
+        image: gcr.io/k8s-prow/boskos/boskos:v20191108-9467d02d9
         args:
         - --config=/etc/config/config
         - --namespace=test-pods


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/11957#issuecomment-557178064

Switches boskos components to use the images that are automatically published to `gcr.io/k8s-prow` instead of the old `gcr.io/k8s-testimages`. Since we weren't updating properly for a while this bump includes 5 months of boskos changes and should be monitored when deployed.

Note that the janitor deployment is already using the up to date image from `gcr.io/k8s-prow`.
/assign @michelle192837 