### PR TITLE
Fix boskos metrics service, use new URI path, and document break.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -86,6 +86,10 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
  
+ - *November 21, 2019* The boskos metrics component replaced the existing prometheus
+   metrics with a single, label-qualified metric. Metrics are now served at `/metrics`
+   on port 9090. This actually happened August 5th, but is being documented now. 
+   Details: https://github.com/kubernetes/test-infra/pull/13767
  - *November 18, 2019*  The `mkbuild-cluster` command-line utility and `build-cluster`
    format is deprecated and will be removed in May 2020. Use `gencred` and the `kubeconfig` 
    format as an alternative.

--- a/prow/cluster/boskos-metrics.yaml
+++ b/prow/cluster/boskos-metrics.yaml
@@ -24,7 +24,7 @@ spec:
   - name: default
     protocol: TCP
     port: 80
-    targetPort: 8080
+    targetPort: 9090
   loadBalancerIP: 104.197.27.114
   type: LoadBalancer
 ---

--- a/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -6,7 +6,7 @@ metadata:
 stringData:
   prometheus-additional.yaml: |
     - job_name: k8s-prow-builds-boskos
-      metrics_path: /prometheus
+      metrics_path: /metrics
       static_configs:
         - targets:
             - "104.197.27.114"


### PR DESCRIPTION
Adjustments for breaking change to boskos metrics made here: https://github.com/kubernetes/test-infra/pull/13767

/assign @michelle192837 