### PR TITLE
git: use an accessor for the directory

### DIFF
--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -86,7 +86,7 @@ func TestClone(t *testing.T) {
 		}
 	}()
 	log := exec.Command("git", "log", "--oneline")
-	log.Dir = r3.Dir
+	log.Dir = r3.Directory()
 	if b, err := log.CombinedOutput(); err != nil {
 		t.Fatalf("git log: %v, %s", err, string(b))
 	} else {
@@ -133,7 +133,7 @@ func TestCheckoutPR(t *testing.T) {
 	if err := r.CheckoutPullRequest(123); err != nil {
 		t.Fatalf("Checking out PR: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(r.Dir, "wow")); err != nil {
+	if _, err := os.Stat(filepath.Join(r.Directory(), "wow")); err != nil {
 		t.Errorf("Didn't find file in PR after checking out: %v", err)
 	}
 }
@@ -242,7 +242,7 @@ func TestMergeCommitsExistBetween(t *testing.T) {
 			t.Fatalf("Checking out PR: %v", err)
 		}
 		// verify the content is up to dated
-		ouchPath := filepath.Join(r.Dir, "ouch")
+		ouchPath := filepath.Join(r.Directory(), "ouch")
 		if _, err := os.Stat(ouchPath); err != nil {
 			t.Fatalf("Didn't find file 'ouch' in PR %d after merging: %v", tt.prNum, err)
 		}

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -127,7 +127,7 @@ func uniqProblems(problems []string) []string {
 func problemsInFiles(r *git.Repo, files map[string]string) (map[string][]string, error) {
 	problems := make(map[string][]string)
 	for f := range files {
-		src, err := ioutil.ReadFile(filepath.Join(r.Dir, f))
+		src, err := ioutil.ReadFile(filepath.Join(r.Directory(), f))
 		if err != nil {
 			return nil, err
 		}

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -147,7 +147,7 @@ func problemsInFiles(r *git.Repo, files map[string]string) (map[string]map[int]l
 	l := new(lint.Linter)
 	for f, patch := range files {
 		problems[f] = make(map[int]lint.Problem)
-		src, err := ioutil.ReadFile(filepath.Join(r.Dir, f))
+		src, err := ioutil.ReadFile(filepath.Join(r.Directory(), f))
 		if err != nil {
 			lintErrorComments = append(lintErrorComments, github.DraftReviewComment{
 				Path: f,

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -317,7 +317,7 @@ func handle(gc githubClient, gitClient gitClient, kc corev1.ConfigMapsGetter, bu
 			log.WithError(err).Errorf("Failed to find configMap client")
 			continue
 		}
-		if err := Update(&OSFileGetter{Root: gitRepo.Dir}, configMapClient, cm.Name, cm.Namespace, data, metrics, logger); err != nil {
+		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, cm.Name, cm.Namespace, data, metrics, logger); err != nil {
 			return err
 		}
 		updated = append(updated, message(cm.Name, cm.Cluster, cm.Namespace, data, indent))

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -242,7 +242,7 @@ func handle(ghc githubClient, gc *git.Client, roc repoownersClient, log *logrus.
 
 	// If OWNERS_ALIASES file exists, get all aliases.
 	// If the file was modified, check for non trusted users in the newly added owners.
-	nonTrustedUsers, repoAliases, err := nonTrustedUsersInOwnersAliases(ghc, log, triggerConfig, org, repo, r.Dir, modifiedOwnerAliasesFile.Patch, ownerAliasesModified, skipTrustedUserCheck)
+	nonTrustedUsers, repoAliases, err := nonTrustedUsersInOwnersAliases(ghc, log, triggerConfig, org, repo, r.Directory(), modifiedOwnerAliasesFile.Patch, ownerAliasesModified, skipTrustedUserCheck)
 	if err != nil {
 		return err
 	}
@@ -255,7 +255,7 @@ func handle(ghc githubClient, gc *git.Client, roc repoownersClient, log *logrus.
 	}
 
 	for _, c := range modifiedOwnersFiles {
-		path := filepath.Join(r.Dir, c.Filename)
+		path := filepath.Join(r.Directory(), c.Filename)
 		msg, owners := parseOwnersFile(oc, path, c, log, labelsBlackList)
 		if msg != nil {
 			wrongOwnersFiles[c.Filename] = *msg

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -559,7 +559,7 @@ func TestParseOwnersFile(t *testing.T) {
 				}
 			}()
 
-			path := filepath.Join(r.Dir, "OWNERS")
+			path := filepath.Join(r.Directory(), "OWNERS")
 			message, _ := parseOwnersFile(&fakeOwnersClient{}, path, change, &logrus.Entry{}, []string{})
 			if message != nil {
 				if test.errLine == 0 {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -198,7 +198,7 @@ func (c *Client) LoadRepoAliases(org, repo, base string) (RepoAliases, error) {
 			return nil, err
 		}
 
-		entry.aliases = loadAliasesFrom(gitRepo.Dir, log)
+		entry.aliases = loadAliasesFrom(gitRepo.Directory(), log)
 		entry.sha = sha
 		c.cache[fullName] = entry
 	}
@@ -255,7 +255,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 
 			if entry.aliases == nil || entry.sha != sha {
 				// aliases must be loaded
-				entry.aliases = loadAliasesFrom(gitRepo.Dir, log)
+				entry.aliases = loadAliasesFrom(gitRepo.Directory(), log)
 			}
 
 			dirBlacklistPatterns := c.ownersDirBlacklist().DirBlacklist(org, repo)
@@ -269,7 +269,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 				dirBlacklist = append(dirBlacklist, re)
 			}
 
-			entry.owners, err = loadOwnersFrom(gitRepo.Dir, mdYaml, entry.aliases, dirBlacklist, log)
+			entry.owners, err = loadOwnersFrom(gitRepo.Directory(), mdYaml, entry.aliases, dirBlacklist, log)
 			if err != nil {
 				return nil, fmt.Errorf("failed to load RepoOwners for %s: %v", fullName, err)
 			}


### PR DESCRIPTION
When an interface is ferried around, member field access will not be
possible.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @fejta @alvaroaleman 