### PR TITLE
git: don't ask users to concatenate repo identifiers

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -358,7 +358,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment *github.Issue
 
 	// Clone the repo, checkout the target branch.
 	startClone := time.Now()
-	r, err := s.gc.Clone(org + "/" + repo)
+	r, err := s.gc.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -146,7 +146,8 @@ func (c *Client) unlockRepo(repo string) {
 // In that case, it must do a full git mirror clone. For large repos, this can
 // take a while. Once that is done, it will do a git fetch instead of a clone,
 // which will usually take at most a few seconds.
-func (c *Client) Clone(repo string) (*Repo, error) {
+func (c *Client) Clone(organization, repository string) (*Repo, error) {
+	repo := organization + "/" + repository
 	c.lockRepo(repo)
 	defer c.unlockRepo(repo)
 

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -51,7 +51,7 @@ func TestClone(t *testing.T) {
 	}
 
 	// Fresh clone, will be a cache miss.
-	r1, err := c.Clone("foo/bar")
+	r1, err := c.Clone("foo", "bar")
 	if err != nil {
 		t.Fatalf("Cloning the first time: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestClone(t *testing.T) {
 	}()
 
 	// Clone from the same org.
-	r2, err := c.Clone("foo/baz")
+	r2, err := c.Clone("foo", "baz")
 	if err != nil {
 		t.Fatalf("Cloning another repo in the same org: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestClone(t *testing.T) {
 	if err := lg.AddCommit("foo", "bar", map[string][]byte{"second": {}}); err != nil {
 		t.Fatalf("Adding second commit: %v", err)
 	}
-	r3, err := c.Clone("foo/bar")
+	r3, err := c.Clone("foo", "bar")
 	if err != nil {
 		t.Fatalf("Cloning a second time: %v", err)
 	}
@@ -113,7 +113,7 @@ func TestCheckoutPR(t *testing.T) {
 	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	r, err := c.Clone("foo/bar")
+	r, err := c.Clone("foo", "bar")
 	if err != nil {
 		t.Fatalf("Cloning: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestMergeCommitsExistBetween(t *testing.T) {
 	if err := lg.MakeFakeRepo("foo", "bar"); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	r, err := c.Clone("foo/bar")
+	r, err := c.Clone("foo", "bar")
 	if err != nil {
 		t.Fatalf("Cloning: %v", err)
 	}
@@ -367,7 +367,7 @@ func TestMergeAndCheckout(t *testing.T) {
 				}
 			}
 
-			clonedRepo, err := c.Clone(org + "/" + repo)
+			clonedRepo, err := c.Clone(org, repo)
 			if err != nil {
 				t.Fatalf("Cloning failed: %v", err)
 			}

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -178,7 +178,7 @@ func handle(ghc githubClient, gc *git.Client, log *logrus.Entry, e *github.Gener
 
 	// Clone the repo, checkout the PR.
 	startClone := time.Now()
-	r, err := gc.Clone(e.Repo.FullName)
+	r, err := gc.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -225,7 +225,7 @@ func handle(minimumConfidence float64, ghc githubClient, gc *git.Client, log *lo
 
 	// Clone the repo, checkout the PR.
 	startClone := time.Now()
-	r, err := gc.Clone(e.Repo.FullName)
+	r, err := gc.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/mergecommitblocker/mergecommitblocker.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker.go
@@ -83,7 +83,7 @@ func handle(ghc githubClient, gc *git.Client, cp pruneClient, log *logrus.Entry,
 	)
 
 	// Clone the repo, checkout the PR.
-	r, err := gc.Clone(fmt.Sprintf("%s/%s", org, repo))
+	r, err := gc.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -241,7 +241,7 @@ func FilterChanges(cfg plugins.ConfigUpdater, changes []github.PullRequestChange
 }
 
 type gitClient interface {
-	Clone(repo string) (*git.Repo, error)
+	Clone(org, repo string) (*git.Repo, error)
 	Clean() error
 }
 
@@ -294,7 +294,7 @@ func handle(gc githubClient, gitClient gitClient, kc corev1.ConfigMapsGetter, bu
 		indent = "   " // three spaces for sub bullets
 	}
 
-	gitRepo, err := gitClient.Clone(fmt.Sprintf("%s/%s", org, repo))
+	gitRepo, err := gitClient.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -221,7 +221,7 @@ func handle(ghc githubClient, gc *git.Client, roc repoownersClient, log *logrus.
 	}
 
 	// Clone the repo, checkout the PR.
-	r, err := gc.Clone(info.repoFullName)
+	r, err := gc.Clone(org, repo)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -549,7 +549,7 @@ func TestParseOwnersFile(t *testing.T) {
 				Patch:    test.patch,
 			}
 
-			r, err := c.Clone("org/repo")
+			r, err := c.Clone("org", "repo")
 			if err != nil {
 				t.Fatalf("error cloning the repo: %v", err)
 			}

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -189,7 +189,7 @@ func (c *Client) LoadRepoAliases(org, repo, base string) (RepoAliases, error) {
 	entry, ok := c.cache[fullName]
 	if !ok || entry.sha != sha {
 		// entry is non-existent or stale.
-		gitRepo, err := c.git.Clone(cloneRef)
+		gitRepo, err := c.git.Clone(org, repo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to clone %s: %v", cloneRef, err)
 		}
@@ -223,7 +223,7 @@ func (c *Client) LoadRepoOwners(org, repo, base string) (RepoOwner, error) {
 	defer c.lock.Unlock()
 	entry, ok := c.cache[fullName]
 	if !ok || entry.sha != sha || entry.owners == nil || !entry.matchesMDYAML(mdYaml) {
-		gitRepo, err := c.git.Clone(cloneRef)
+		gitRepo, err := c.git.Clone(org, repo)
 		if err != nil {
 			return nil, fmt.Errorf("failed to clone %s: %v", cloneRef, err)
 		}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -863,7 +863,7 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker) ([]PullReq
 	}
 	sp.log.Debugf("of %d possible PRs, %d are passing tests", len(sp.prs), len(candidates))
 
-	r, err := c.gc.Clone(sp.org + "/" + sp.repo)
+	r, err := c.gc.Clone(sp.org, sp.repo)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
git: don't ask users to concatenate repo identifiers

The git client eventually wants to know the organization and repository
that it's going to be cloning anyway, the callers have the organization
and repository as separate bits of data, there is no utility in asking
users to concatenate the identifier.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---
depends on #15361 
/assign @cjwagner @fejta @alvaroaleman 