### PR TITLE
git: remove redundant argument in push

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -81,7 +81,7 @@ type Server struct {
 
 	gc *git.Client
 	// Used for unit testing
-	push func(repo, newBranch string) error
+	push func(newBranch string) error
 	ghc  githubClient
 	log  *logrus.Entry
 
@@ -427,7 +427,7 @@ func (s *Server) handle(l *logrus.Entry, requestor string, comment *github.Issue
 		push = s.push
 	}
 	// Push the new branch in the bot's fork.
-	if err := push(repo, newBranch); err != nil {
+	if err := push(newBranch); err != nil {
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
 		s.log.WithFields(l.Data).Info(resp)
 		return s.createComment(org, repo, num, comment, resp)

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -235,7 +235,7 @@ func TestCherryPickIC(t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(repo, newBranch string) error { return nil },
+		push:           func(newBranch string) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -373,7 +373,7 @@ func TestCherryPickPR(t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(repo, newBranch string) error { return nil },
+		push:           func(newBranch string) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -514,7 +514,7 @@ func TestCherryPickPRWithLabels(t *testing.T) {
 		s := &Server{
 			botName:        botName,
 			gc:             c,
-			push:           func(repo, newBranch string) error { return nil },
+			push:           func(newBranch string) error { return nil },
 			ghc:            ghc,
 			tokenGenerator: getSecret,
 			log:            logrus.StandardLogger().WithField("client", "cherrypicker"),

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -366,12 +366,12 @@ func (r *Repo) Am(path string) error {
 
 // Push pushes over https to the provided owner/repo#branch using a password
 // for basic auth.
-func (r *Repo) Push(repo, branch string) error {
+func (r *Repo) Push(branch string) error {
 	if r.user == "" || r.pass == "" {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
-	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, repo, branch)
-	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, github, r.user, repo)
+	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, r.repo, branch)
+	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, github, r.user, r.repo)
 	co := r.gitCommand("push", remote, branch)
 	out, err := co.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
The single caller of `Push()` provides the same repository name to push
to as was used to clone in the first place; this is a reasonable
restriction to this functionality as well. This parameter is removed.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

depends on #15362 
/assign @cjwagner @fejta @alvaroaleman 