### PR TITLE
Pipeline : Cleanup PipelineResources created by prow

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -22,7 +22,8 @@ const (
 // ProwYAML represents the content of a .prow.yaml file
 // used to version Presubmits inside the tested repo.
 type ProwYAML struct {
-	Presubmits []Presubmit `json:"presubmits"`
+	Presubmits  []Presubmit  `json:"presubmits"`
+	Postsubmits []Postsubmit `json:"postsubmits"`
 }
 
 // ProwYAMLGetter is used to retrieve a ProwYAML. Tests should provide
@@ -109,17 +110,31 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 	if err := defaultPresubmits(p.Presubmits, c, identifier); err != nil {
 		return err
 	}
+	if err := defaultPostsubmits(p.Postsubmits, c, identifier); err != nil {
+		return err
+	}
 	if err := validatePresubmits(append(p.Presubmits, c.PresubmitsStatic[identifier]...), c.PodNamespace); err != nil {
+		return err
+	}
+	if err := validatePostsubmits(append(p.Postsubmits, c.PostsubmitsStatic[identifier]...), c.PodNamespace); err != nil {
 		return err
 	}
 
 	var errs []error
-	for _, ps := range p.Presubmits {
-		if ps.Branches != nil || ps.SkipBranches != nil {
-			errs = append(errs, fmt.Errorf("job %q contains branchconfig. This is not allowed for jobs in %q", ps.Name, inRepoConfigFileName))
+	for _, pre := range p.Presubmits {
+		if pre.Branches != nil || pre.SkipBranches != nil {
+			errs = append(errs, fmt.Errorf("job %q contains branchconfig. This is not allowed for presubmit jobs in %q", pre.Name, inRepoConfigFileName))
 		}
-		if !c.InRepoConfigAllowsCluster(ps.Cluster, identifier) {
-			errs = append(errs, fmt.Errorf("cluster %q is not allowed for repository %q", ps.Cluster, identifier))
+		if !c.InRepoConfigAllowsCluster(pre.Cluster, identifier) {
+			errs = append(errs, fmt.Errorf("cluster %q is not allowed for repository %q", pre.Cluster, identifier))
+		}
+	}
+	for _, post := range p.Postsubmits {
+		if post.Branches != nil || post.SkipBranches != nil {
+			errs = append(errs, fmt.Errorf("job %q contains branchconfig. This is not allowed for postsubmit jobs in %q", post.Name, inRepoConfigFileName))
+		}
+		if !c.InRepoConfigAllowsCluster(post.Cluster, identifier) {
+			errs = append(errs, fmt.Errorf("cluster %q is not allowed for repository %q", post.Cluster, identifier))
 		}
 	}
 


### PR DESCRIPTION
This pull request adds support for cleaning up `PipelineResource`s created by prow.

What was done in this pull request :
- Add code to get/delete a pipeline resource in the reconcilier
- When deleting a PipelineRun, loop through the resources, if the pipeline resource was created by prow delete it
- Adapted existing tests
- Added unit tests to check that pipeline resources are correctly deleted
- Added unit tests to check that pipeline resources not created by prow are not deleted
