### PR TITLE
Explicitly disable autoupgrade for GKE custom image

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -311,6 +311,9 @@ func (g *gkeDeployer) Up() error {
 	if strings.ToUpper(g.image) == "CUSTOM" {
 		args = append(args, "--image-family="+g.imageFamily)
 		args = append(args, "--image-project="+g.imageProject)
+		// gcloud enables node auto-upgrade by default, which doesn't work with CUSTOM image.
+		// We disable auto-upgrade explicitly here.
+		args = append(args, "--no-enable-autoupgrade")
 	}
 	if g.subnetwork != "" {
 		args = append(args, "--subnetwork="+g.subnetwork)


### PR DESCRIPTION
auto-upgrade was enabled by default in [gcloud 271.0.0 (2019-11-12)](https://cloud.google.com/sdk/docs/release-notes), which stops CUSTOM image nodes from getting provisioned.

```
ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Auto_upgrade and auto_repair are not supported on CUSTOM.
```

This pull explicitly disables auto-upgrade when provisioning GKE nodes using custom image.

/cc @krzyzacy @yguo0905