### PR TITLE
Allow PR mixing DCO sign-off and trusted commits

### DIFF
--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -117,47 +117,43 @@ type commentPruner interface {
 	PruneComments(shouldPrune func(github.IssueComment) bool)
 }
 
-// checkTrustedUser checks are all commits from a trusted user
-func checkTrustedUser(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollaborators bool, trustedOrg, org, repo string, number int) (bool, error) {
-	allCommits, err := gc.ListPRCommits(org, repo, number)
-	if err != nil {
-		return false, fmt.Errorf("error listing commits for pull request: %v", err)
-	}
+// filterTrustedUsers checks whether the commits are from a trusted user and returns those that are not
+func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollaborators bool, trustedOrg, org, repo string, allCommits []github.RepositoryCommit) ([]github.RepositoryCommit, error) {
+	untrustedCommits := make([]github.RepositoryCommit, 0, len(allCommits))
 
 	for _, commit := range allCommits {
 		trusted, err := trigger.TrustedUser(gc, !skipDCOCheckForCollaborators, trustedOrg, commit.Author.Login, org, repo)
 		if err != nil {
-			return false, fmt.Errorf("Error checking is member trusted: %v", err)
+			return nil, fmt.Errorf("Error checking is member trusted: %v", err)
 		}
 		if !trusted {
 			l.Debugf("Member %s is not trusted", commit.Author.Login)
-			return false, nil
+			untrustedCommits = append(untrustedCommits, commit)
 		}
 	}
 
-	return true, nil
+	l.Debugf("Unsigned commits from untrusted users: %d", len(untrustedCommits))
+	return untrustedCommits, nil
 }
 
 // checkCommitMessages will perform the actual DCO check by retrieving all
 // commits contained within the PR with the given number.
 // *All* commits in the pull request *must* match the 'testRe' in order to pass.
-func checkCommitMessages(gc gitHubClient, l *logrus.Entry, org, repo string, number int) ([]github.GitCommit, error) {
+func checkCommitMessages(gc gitHubClient, l *logrus.Entry, org, repo string, number int) ([]github.RepositoryCommit, error) {
 	allCommits, err := gc.ListPRCommits(org, repo, number)
 	if err != nil {
 		return nil, fmt.Errorf("error listing commits for pull request: %v", err)
 	}
 	l.Debugf("Found %d commits in PR", len(allCommits))
 
-	var commitsMissingDCO []github.GitCommit
+	var commitsMissingDCO []github.RepositoryCommit
 	for _, commit := range allCommits {
 		if !testRe.MatchString(commit.Commit.Message) {
-			c := commit.Commit
-			c.SHA = commit.SHA
-			commitsMissingDCO = append(commitsMissingDCO, c)
+			commitsMissingDCO = append(commitsMissingDCO, commit)
 		}
 	}
 
-	l.Debugf("All commits in PR have DCO signoff: %t", len(commitsMissingDCO) == 0)
+	l.Debugf("Commits in PR missing DCO signoff: %d", len(commitsMissingDCO))
 	return commitsMissingDCO, nil
 }
 
@@ -203,14 +199,14 @@ func checkExistingLabels(gc gitHubClient, l *logrus.Entry, org, repo string, num
 
 // takeAction will take appropriate action on the pull request according to its
 // current state.
-func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo string, pr github.PullRequest, commitsMissingDCO []github.GitCommit, existingStatus string, hasYesLabel, hasNoLabel, addComment, trustedUser bool) error {
+func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo string, pr github.PullRequest, commitsMissingDCO []github.RepositoryCommit, existingStatus string, hasYesLabel, hasNoLabel, addComment bool) error {
 	targetURL := fmt.Sprintf("https://github.com/%s/%s/blob/master/CONTRIBUTING.md", org, repo)
 
 	signedOff := len(commitsMissingDCO) == 0
 
 	// handle the 'all commits signed off' case by adding appropriate labels
 	// TODO: clean-up old comments?
-	if signedOff || trustedUser {
+	if signedOff {
 		if hasNoLabel {
 			l.Debugf("Removing %q label", dcoNoLabel)
 			// remove 'dco-signoff: no' label
@@ -290,20 +286,18 @@ func takeAction(gc gitHubClient, cp commentPruner, l *logrus.Entry, org, repo st
 func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.Entry, org, repo string, pr github.PullRequest, addComment bool) error {
 	l := log.WithField("pr", pr.Number)
 
-	var err error
-	var trustedUser bool
-	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators {
-		trustedUser, err = checkTrustedUser(gc, l, config.SkipDCOCheckForCollaborators, config.TrustedOrg, org, repo, pr.Number)
-		if err != nil {
-			l.WithError(err).Infof("Error running trusted org member check against commits in PR")
-			return err
-		}
-	}
-
 	commitsMissingDCO, err := checkCommitMessages(gc, l, org, repo, pr.Number)
 	if err != nil {
 		l.WithError(err).Infof("Error running DCO check against commits in PR")
 		return err
+	}
+
+	if config.SkipDCOCheckForMembers || config.SkipDCOCheckForCollaborators {
+		commitsMissingDCO, err = filterTrustedUsers(gc, l, config.SkipDCOCheckForCollaborators, config.TrustedOrg, org, repo, commitsMissingDCO)
+		if err != nil {
+			l.WithError(err).Infof("Error running trusted org member check against commits in PR")
+			return err
+		}
 	}
 
 	existingStatus, err := checkExistingStatus(gc, l, org, repo, pr.Head.SHA)
@@ -318,11 +312,11 @@ func handle(config plugins.Dco, gc gitHubClient, cp commentPruner, log *logrus.E
 		return err
 	}
 
-	return takeAction(gc, cp, l, org, repo, pr, commitsMissingDCO, existingStatus, hasYesLabel, hasNoLabel, addComment, trustedUser)
+	return takeAction(gc, cp, l, org, repo, pr, commitsMissingDCO, existingStatus, hasYesLabel, hasNoLabel, addComment)
 }
 
-// MardkownSHAList prints the list of commits in a markdown-friendly way.
-func MarkdownSHAList(org, repo string, list []github.GitCommit) string {
+// MarkdownSHAList prints the list of commits in a markdown-friendly way.
+func MarkdownSHAList(org, repo string, list []github.RepositoryCommit) string {
 	lines := make([]string, len(list))
 	lineFmt := "- [%s](https://github.com/%s/%s/commits/%s) %s"
 	for i, commit := range list {
@@ -337,7 +331,7 @@ func MarkdownSHAList(org, repo string, list []github.GitCommit) string {
 		}
 
 		// get the first line of the commit
-		message := strings.Split(commit.Message, "\n")[0]
+		message := strings.Split(commit.Commit.Message, "\n")[0]
 
 		lines[i] = fmt.Sprintf(lineFmt, shortSHA, org, repo, commit.SHA, message)
 	}

--- a/prow/plugins/dco/dco_test.go
+++ b/prow/plugins/dco/dco_test.go
@@ -294,6 +294,39 @@ Instructions for interacting with me using PR comments are available [here](http
 			expectedStatus: github.StatusSuccess,
 		},
 		{
+			name: "should add label and update status context if one commit is signed-off and another is from a trusted user",
+			config: plugins.Dco{
+				SkipDCOCheckForMembers: true,
+				TrustedOrg:             "kubernetes",
+			},
+			pullRequestEvent: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{Number: 3, Head: github.PullRequestBranch{SHA: "sha"}},
+			},
+			commits: []github.RepositoryCommit{
+				{
+					SHA:    "sha",
+					Commit: github.GitCommit{Message: "not signed off"},
+					Author: github.User{
+						Login: "test",
+					},
+				},
+				{
+					SHA:    "sha2",
+					Commit: github.GitCommit{Message: "Signed-off-by: someone"},
+					Author: github.User{
+						Login: "contributor",
+					},
+				},
+			},
+			issueState: "open",
+			hasDCONo:   false,
+			hasDCOYes:  false,
+
+			addedLabel:     fmt.Sprintf("/#3:%s", dcoYesLabel),
+			expectedStatus: github.StatusSuccess,
+		},
+		{
 			name: "should fail dco check as one unsigned commit is from member not from the trusted org",
 			config: plugins.Dco{
 				SkipDCOCheckForMembers: true,

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -110,12 +110,10 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 	}
 	log.Debugf("Found %d commits in PR", len(allCommits))
 
-	var invalidCommits []github.GitCommit
+	var invalidCommits []github.RepositoryCommit
 	for _, commit := range allCommits {
 		if closeIssueRegex.MatchString(commit.Commit.Message) || atMentionRegex.MatchString(commit.Commit.Message) {
-			c := commit.Commit
-			c.SHA = commit.SHA
-			invalidCommits = append(invalidCommits, c)
+			invalidCommits = append(invalidCommits, commit)
 		}
 	}
 


### PR DESCRIPTION
Current logic requires one of the following:
 - all commits have DCO sign-off
 - all commits come from trusted users

This change allows PRs that contain a mix of commits that are either
signed-off or come from trusted users.

Signed-off-by: Kamil Domański <kamil@domanski.co>