### PR TITLE
Move and fix kubeflow-periodic-v07 tests

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -13,12 +13,9 @@ periodics:
       - name: REPO_OWNER
         value: kubeflow
       - name: REPO_NAME
-        value: kubeflow
-      # TODO(https://github.com/kubeflow/testing/issues/498)
-      # This job needs to be moved over to kubeflow/kfctl v0.7-branch
-      # once it exists.
+        value: kfctl
       - name: BRANCH_NAME
-        value: master`
+        value: v0.7-branch
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-7 release


### PR DESCRIPTION
* The branch name had an unintentional backtick in the name
* v0.7-branch now exists on kubeflow/kfctl so that's where tests should
  be defined.

Related to: kubeflow/testing#498