### PR TITLE
Always enable kubeflow-pipelines-frontend-test

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -300,7 +300,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-frontend-test
-    always_run: false
+    always_run: true
     decorate: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
After https://github.com/kubeflow/pipelines/pull/2637 is merged, we can always run kubeflow-pipelines-frontend-test as presubmit test.

@jlewi Can you help me approve? Thanks in advance!