### PR TITLE
boskos: ranch: correctly identify owners in errors

### DIFF
--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -253,7 +253,7 @@ func (r *Ranch) Release(name, dest, owner string) error {
 		return &ResourceNotFound{name}
 	}
 	if owner != res.Owner {
-		return &OwnerNotMatch{owner: owner, request: res.Owner}
+		return &OwnerNotMatch{request: owner, owner: res.Owner}
 	}
 
 	res.Owner = ""
@@ -296,7 +296,7 @@ func (r *Ranch) Update(name, owner, state string, ud *common.UserData) error {
 		return &ResourceNotFound{name}
 	}
 	if owner != res.Owner {
-		return &OwnerNotMatch{owner: owner, request: res.Owner}
+		return &OwnerNotMatch{request: owner, owner: res.Owner}
 	}
 	if state != res.State {
 		return &StateNotMatch{res.State, state}

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -376,7 +376,7 @@ func TestRelease(t *testing.T) {
 			resName:     "res",
 			owner:       "user",
 			dest:        "d",
-			expectErr:   &OwnerNotMatch{"merlin", "user"},
+			expectErr:   &OwnerNotMatch{"user", "merlin"},
 			expectedRes: common.NewResource("res", "t", "s", "merlin", startTime),
 		},
 		{
@@ -554,7 +554,7 @@ func TestUpdate(t *testing.T) {
 			resName:   "res",
 			owner:     "user",
 			state:     "s",
-			expectErr: &OwnerNotMatch{"merlin", "user"},
+			expectErr: &OwnerNotMatch{"user", "merlin"},
 		},
 		{
 			name: "wrong state",


### PR DESCRIPTION
The owner of the resource stored in etcd is the actual owner of the
resource, regardless of what the request coming in is saying. The log
messages today are backwards as they take the request from the client as
correct.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @bbguimaraes @sebastienvas @krzyzacy 