### PR TITLE
Kops - Increase node instance type used by VPC CNI test

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -416,7 +416,7 @@ periodics:
       - --env=KUBE_SSH_USER=admin
       - --extract=ci/latest
       - --ginkgo-parallel
-      - --kops-args=--networking=amazon-vpc-routed-eni
+      - --kops-args=--networking=amazon-vpc-routed-eni --node-size=m5.large
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws
       - --test_args=--ginkgo.flakeAttempts=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort


### PR DESCRIPTION
The VPC CNI uses IPs on the EC2 instances themselves. The default t2.mediums were hitting their ENI per instance and IP per ENI limit.

See https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-vpc-cni/1196585826587250690

Example:

`I1119 00:42:58.498]     pod "hostpath-symlink-prep-provisioning-7575" failed with status: {Phase:Failed Conditions:[] Message:Pod Node didn't have enough resource: pods, requested: 1, used: 17, capacity: 17 Reason:OutOfpods NominatedNodeName: HostIP: PodIP: PodIPs:[] StartTime:2019-11-19 00:42:51 +0000 UTC InitContainerStatuses:[] ContainerStatuses:[] QOSClass: EphemeralContainerStatuses:[]}`

Based on the [Kops IP logic](https://github.com/kubernetes/kops/blob/master/hack/machine_types/vpc_ip_resource_limit.go) we should get an additional 4 pods per node (x3 nodes) with m5.larges.