### PR TITLE
Azure: support custom k8s components for 1.17+

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "anywhere_test.go",
+        "azure_test.go",
         "dump_test.go",
         "extract_test.go",
         "kubernetes_test.go",

--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -95,7 +95,7 @@ var (
 	aksAzureEnv            = flag.String("aksengine-azure-env", "AzurePublicCloud", "The target Azure cloud")
 	aksIdentitySystem      = flag.String("aksengine-identity-system", "azure_ad", "identity system (default:`azure_ad`, `adfs`)")
 	aksCustomCloudURL      = flag.String("aksengine-custom-cloud-url", "", "management portal URL to use in custom Azure cloud (i.e Azure Stack etc)")
-	aksCustomK8sComponents = flag.Bool("aksengine-custom-k8s-comopnents", false, "Set to True if you want to build individual components from a k8s branch and deploy them via aks-engine")
+	aksCustomK8sComponents = flag.Bool("aksengine-custom-k8s-components", false, "Set to True if you want to build individual components from a k8s branch and deploy them via aks-engine")
 	testCcm                = flag.Bool("test-ccm", false, "Set to True if you want kubetest to run e2e tests for ccm")
 	// Azure File CSI Driver flag
 	testAzureFileCSIDriver = flag.Bool("test-azure-file-csi-driver", false, "Set to True if you want kubetest to run e2e tests for Azure File CSI driver")
@@ -384,7 +384,7 @@ func checkParams() error {
 		return fmt.Errorf("--aksengine-cnm cannot be true without --aksengine-ccm also being true")
 	}
 	if *aksHyperKube && *aksCustomK8sComponents {
-		return fmt.Errorf("--aksengine-custom-k8s-comopnents and --aksengine-hyperkube cannot be true at the same time. For k8s 1.17 and onward, use --aksengine-custom-k8s-comopnents. Otherwise, use --aksengine-hyperkube")
+		return fmt.Errorf("--aksengine-custom-k8s-components and --aksengine-hyperkube cannot be true at the same time. For k8s 1.17 and onward, use --aksengine-custom-k8s-components. Otherwise, use --aksengine-hyperkube")
 	}
 
 	return nil
@@ -766,6 +766,7 @@ func (c *Cluster) dockerLogin() error {
 
 func dockerPush(image string) error {
 	log.Printf("Pushing docker image %s", image)
+
 	cmd := exec.Command("docker", "push", image)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("failed to push %s: %v", image, err)
@@ -780,7 +781,7 @@ func getDockerImage(imageName string) string {
 func (c *Cluster) buildAzureCloudComponents() error {
 	log.Println("Building cloud controller manager and cloud node manager.")
 
-	// Set environment variables for building cloud comopnents' images
+	// Set environment variables for building cloud components' images
 	if err := os.Setenv("IMAGE_REGISTRY", imageRegistry); err != nil {
 		return err
 	}

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -122,6 +122,11 @@ type KubernetesConfig struct {
 	DNSServiceIP                     string            `json:"dnsServiceIP,omitempty"`
 	OutboundRuleIdleTimeoutInMinutes int32             `json:"outboundRuleIdleTimeoutInMinutes,omitempty"`
 	ClusterSubnet                    string            `json:"clusterSubnet,omitempty"`
+	CustomKubeAPIServerImage         string            `json:"customKubeAPIServerImage,omitempty"`
+	CustomKubeControllerManagerImage string            `json:"customKubeControllerManagerImage,omitempty"`
+	CustomKubeProxyImage             string            `json:"customKubeProxyImage,omitempty"`
+	CustomKubeSchedulerImage         string            `json:"customKubeSchedulerImage,omitempty"`
+	CustomKubeBinaryURL              string            `json:"customKubeBinaryURL,omitempty"`
 }
 
 type OrchestratorProfile struct {

--- a/kubetest/azure_test.go
+++ b/kubetest/azure_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"testing"
+)
+
+var deploytMethodMap = map[aksDeploymentMethod]string{
+	normal:              "normal",
+	customHyperkube:     "custom hyperkube",
+	customK8sComponents: "custom k8s components",
+}
+
+func TestGetDeploymentMethod(t *testing.T) {
+	testCases := []struct {
+		desc                         string
+		k8sRelease                   string
+		customK8s                    bool
+		expectedAKSDeploytmentMethod aksDeploymentMethod
+	}{
+		{
+			desc:                         "k8s 1.16 without custom k8s",
+			k8sRelease:                   "1.16",
+			customK8s:                    false,
+			expectedAKSDeploytmentMethod: normal,
+		},
+		{
+			desc:                         "k8s 1.17 without custom k8s",
+			k8sRelease:                   "1.17",
+			customK8s:                    false,
+			expectedAKSDeploytmentMethod: normal,
+		},
+		{
+			desc:                         "k8s 1.16 with custom k8s",
+			k8sRelease:                   "1.16",
+			customK8s:                    true,
+			expectedAKSDeploytmentMethod: customHyperkube,
+		},
+		{
+			desc:                         "k8s 1.17 with custom k8s",
+			k8sRelease:                   "1.17",
+			customK8s:                    true,
+			expectedAKSDeploytmentMethod: customK8sComponents,
+		},
+		{
+			desc:                         "using k8s release instead of k8s version",
+			k8sRelease:                   "1.17.0",
+			customK8s:                    true,
+			expectedAKSDeploytmentMethod: normal,
+		},
+		{
+			desc:                         "using an invalid k8s version",
+			k8sRelease:                   "invalid",
+			customK8s:                    true,
+			expectedAKSDeploytmentMethod: normal,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.customK8s {
+				aksDeployCustomK8s = boolPointer(true)
+			} else {
+				aksDeployCustomK8s = boolPointer(false)
+			}
+			aksDeploymentMethod := getAKSDeploymentMethod(tc.k8sRelease)
+			if aksDeploymentMethod != tc.expectedAKSDeploytmentMethod {
+				t.Fatalf("Expected '%s' deployment method, but got '%s'", deploytMethodMap[tc.expectedAKSDeploytmentMethod], deploytMethodMap[aksDeploymentMethod])
+			}
+		})
+	}
+}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -418,6 +418,10 @@ func acquireKubernetes(o *options, d deployer) error {
 		// kind deployer manages build
 		if k, ok := d.(*kind.Deployer); ok {
 			err = control.XMLWrap(&suite, "Build", k.Build)
+		} else if c, ok := d.(*Cluster); ok { // Azure deployer
+			err = control.XMLWrap(&suite, "Build", func() error {
+				return c.Build(o.build)
+			})
 		} else {
 			err = control.XMLWrap(&suite, "Build", o.build.Build)
 		}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -420,7 +420,7 @@ func acquireKubernetes(o *options, d deployer) error {
 			err = control.XMLWrap(&suite, "Build", k.Build)
 		} else if c, ok := d.(*Cluster); ok { // Azure deployer
 			err = control.XMLWrap(&suite, "Build", func() error {
-				return c.Build(o.build)
+				return c.BuildK8s(o.build)
 			})
 		} else {
 			err = control.XMLWrap(&suite, "Build", o.build.Build)


### PR DESCRIPTION
Follow-up PR for https://github.com/Azure/aks-engine/pull/2333. With hyperkube support removed in aks-engine for k8s 1.17+, this PR adds support for custom kube-apiserver, kube-controller-manager, kube-proxy and kube-scheduler and custom kube binary.

Related docs:
- https://github.com/Azure/aks-engine/blob/master/docs/topics/kubernetes-developers.md
- https://gist.github.com/chewong/d39e40bf2dab184c650abac2139c8b23

/assign @feiskyer 
