### PR TITLE
Add heartbeat metrics to Tide controllers to replace the sync duration metrics.

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -503,6 +503,7 @@ func (sc *statusController) sync(pool map[string]PullRequest, blocks blockers.Bl
 		duration := time.Since(sc.lastSyncStart)
 		sc.logger.WithField("duration", duration.String()).Info("Statuses synced.")
 		tideMetrics.statusUpdateDuration.Set(duration.Seconds())
+		tideMetrics.syncHeartbeat.WithLabelValues("status-update").Inc()
 	}()
 
 	sc.setStatuses(sc.search(), pool, blocks, baseSHAs, requiredContexts)


### PR DESCRIPTION
We should be using heartbeat counters instead of sync duration gauges so that prometheus can alert when Tide gets stuck instead of if/when Tide recovers from being stuck. 
/assign @stevekuznetsov @alvaroaleman 