### PR TITLE
Allow GitHub orgs to be used to authorize rerun

### DIFF
--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -371,6 +371,11 @@ func (in *RerunAuthConfig) DeepCopyInto(out *RerunAuthConfig) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.GitHubOrgs != nil {
+		in, out := &in.GitHubOrgs, &out.GitHubOrgs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1092,7 +1092,7 @@ func validateJobBase(v JobBase, jobType prowapi.ProwJobType, podNamespace string
 	if v.Spec == nil || len(v.Spec.Containers) == 0 {
 		return nil // jenkins jobs have no spec
 	}
-	if v.RerunAuthConfig != nil && v.RerunAuthConfig.AllowAnyone && (len(v.RerunAuthConfig.GitHubUsers) > 0 || len(v.RerunAuthConfig.GitHubTeamIDs) > 0 || len(v.RerunAuthConfig.GitHubTeamSlugs) > 0) {
+	if v.RerunAuthConfig != nil && v.RerunAuthConfig.AllowAnyone && (len(v.RerunAuthConfig.GitHubUsers) > 0 || len(v.RerunAuthConfig.GitHubTeamIDs) > 0 || len(v.RerunAuthConfig.GitHubTeamSlugs) > 0 || len(v.RerunAuthConfig.GitHubOrgs) > 0) {
 		return errors.New("allow anyone is set to true and permitted users or groups are specified")
 	}
 	if err := v.UtilityConfig.Validate(); err != nil {
@@ -1308,7 +1308,7 @@ func parseProwConfig(c *Config) error {
 
 	// If a whitelist is specified, the user probably does not intend for anyone to be able
 	// to rerun any job.
-	if c.Deck.RerunAuthConfig.AllowAnyone && (len(c.Deck.RerunAuthConfig.GitHubUsers) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamIDs) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamSlugs) > 0) {
+	if c.Deck.RerunAuthConfig.AllowAnyone && (len(c.Deck.RerunAuthConfig.GitHubUsers) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamIDs) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamSlugs) > 0 || len(c.Deck.RerunAuthConfig.GitHubOrgs) > 0) {
 		return fmt.Errorf("allow_anyone is set to true and authorized users or teams are specified.")
 	}
 

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -790,10 +790,12 @@ func TestCreateRefs(t *testing.T) {
 func TestSpecFromJobBase(t *testing.T) {
 	permittedGroups := []int{1234, 5678}
 	permittedUsers := []string{"authorized_user", "another_authorized_user"}
+	permittedOrgs := []string{"kubernetes", "kubernetes-sigs"}
 	rerunAuthConfig := prowapi.RerunAuthConfig{
 		AllowAnyone:   false,
 		GitHubTeamIDs: permittedGroups,
 		GitHubUsers:   permittedUsers,
+		GitHubOrgs:    permittedOrgs,
 	}
 	testCases := []struct {
 		name    string
@@ -837,6 +839,9 @@ func TestSpecFromJobBase(t *testing.T) {
 				}
 				if pj.RerunAuthConfig.GitHubUsers == nil {
 					return errors.New("Expected RerunAuthConfig.GitHubUsers to be non-nil")
+				}
+				if pj.RerunAuthConfig.GitHubOrgs == nil {
+					return errors.New("Expected RerunAuthConfig.GitHubOrgs to be non-nil")
 				}
 				return nil
 			},


### PR DESCRIPTION
Allow GitHub orgs to be used to authorize rerun. Istio has a *private* GitHub org, `istio-private`, where we want *any* member of the org to be able to rerun jobs.

I plan to follow-up with a PR containing a modification (i.e. flag) to `deck` to authz rerun of jobs if user is a member of any of the configured `HiddenRepos` orgs. #15396