### PR TITLE
add cluster subnet to azure helper

### DIFF
--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -121,6 +121,7 @@ type KubernetesConfig struct {
 	ServiceCidr                      string            `json:"serviceCidr,omitempty"`
 	DNSServiceIP                     string            `json:"dnsServiceIP,omitempty"`
 	OutboundRuleIdleTimeoutInMinutes int32             `json:"outboundRuleIdleTimeoutInMinutes,omitempty"`
+	ClusterSubnet                    string            `json:"clusterSubnet,omitempty"`
 }
 
 type OrchestratorProfile struct {


### PR DESCRIPTION
- Add `clusterSubnet` to azure kubernetes config as this needs to be parsed for dualstack.

/assign @feiskyer 
