### PR TITLE
Add `--rerun-hidden-only` flag to use hidden orgs to authz rerun

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -238,6 +238,17 @@ func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient
 	return false, nil
 }
 
+// Validate returns true if the RerunAuthConfig is valid.
+func (rac *RerunAuthConfig) Validate() bool {
+	hasRestriction := len(rac.GitHubUsers) > 0 || len(rac.GitHubTeamIDs) > 0 || len(rac.GitHubTeamSlugs) > 0 || len(rac.GitHubOrgs) > 0
+
+	if rac.AllowAnyone && hasRestriction {
+		return false
+	}
+
+	return true
+}
+
 type ReporterConfig struct {
 	Slack *SlackReporterConfig `json:"slack,omitempty"`
 }

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -255,3 +255,51 @@ func TestRefsToString(t *testing.T) {
 		}
 	}
 }
+
+func TestRerunAuthConfigValidate(t *testing.T) {
+	var testCases = []struct {
+		name   string
+		config *RerunAuthConfig
+		valid  bool
+	}{
+		{
+			name:   "valid - disallow all",
+			config: &RerunAuthConfig{AllowAnyone: false},
+			valid:  true,
+		},
+		{
+			name:   "valid - no restrictions",
+			config: &RerunAuthConfig{},
+			valid:  true,
+		},
+		{
+			name:   "valid - allow any",
+			config: &RerunAuthConfig{AllowAnyone: true},
+			valid:  true,
+		},
+		{
+			name:   "valid - restrict orgs",
+			config: &RerunAuthConfig{GitHubOrgs: []string{"istio"}},
+			valid:  true,
+		},
+		{
+			name:   "valid - restrict orgs and users",
+			config: &RerunAuthConfig{GitHubOrgs: []string{"istio", "kubernetes"}, GitHubUsers: []string{"clarketm", "scoobydoo"}},
+			valid:  true,
+		},
+		{
+			name:   "invalid - allow any and has restriction",
+			config: &RerunAuthConfig{AllowAnyone: true, GitHubOrgs: []string{"istio"}},
+			valid:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			if actual := tc.config.Validate(); actual != tc.valid {
+				t.Errorf("Expected %v, got %v", tc.valid, actual)
+			}
+		})
+	}
+}

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -556,6 +556,18 @@ type Deck struct {
 	RerunAuthConfig prowapi.RerunAuthConfig `json:"rerun_auth_config,omitempty"`
 }
 
+// HiddenOrgs is a list of orgs that should not be displayed by Deck.
+func (d *Deck) HiddenOrgs() []string {
+	orgs := sets.String{}
+
+	for _, orgrepo := range d.HiddenRepos {
+		org := strings.Split(orgrepo, "/")[0]
+		orgs.Insert(org)
+	}
+
+	return orgs.List()
+}
+
 // ExternalAgentLog ensures an external agent like Jenkins can expose
 // its logs in prow.
 type ExternalAgentLog struct {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1104,7 +1104,7 @@ func validateJobBase(v JobBase, jobType prowapi.ProwJobType, podNamespace string
 	if v.Spec == nil || len(v.Spec.Containers) == 0 {
 		return nil // jenkins jobs have no spec
 	}
-	if v.RerunAuthConfig != nil && v.RerunAuthConfig.AllowAnyone && (len(v.RerunAuthConfig.GitHubUsers) > 0 || len(v.RerunAuthConfig.GitHubTeamIDs) > 0 || len(v.RerunAuthConfig.GitHubTeamSlugs) > 0 || len(v.RerunAuthConfig.GitHubOrgs) > 0) {
+	if v.RerunAuthConfig != nil && !v.RerunAuthConfig.Validate() {
 		return errors.New("allow anyone is set to true and permitted users or groups are specified")
 	}
 	if err := v.UtilityConfig.Validate(); err != nil {
@@ -1320,7 +1320,7 @@ func parseProwConfig(c *Config) error {
 
 	// If a whitelist is specified, the user probably does not intend for anyone to be able
 	// to rerun any job.
-	if c.Deck.RerunAuthConfig.AllowAnyone && (len(c.Deck.RerunAuthConfig.GitHubUsers) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamIDs) > 0 || len(c.Deck.RerunAuthConfig.GitHubTeamSlugs) > 0 || len(c.Deck.RerunAuthConfig.GitHubOrgs) > 0) {
+	if !c.Deck.RerunAuthConfig.Validate() {
 		return fmt.Errorf("allow_anyone is set to true and authorized users or teams are specified.")
 	}
 


### PR DESCRIPTION
Dependent on #15393

Add `--rerun-hidden-only` flag to use hidden orgs to authz rerun.