### PR TITLE
Update Tide alerts to use heartbeat metric instead of loop period.

### DIFF
--- a/prow/cluster/monitoring/mixins/grafana_dashboards/tide.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/tide.jsonnet
@@ -136,10 +136,10 @@ dashboard.new(
         legend_rightSide=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'max(syncdur and (changes(syncdur[1h]) > 0))',
+        'max(syncdur and (changes(syncdur[10m]) > 0))',
         legendFormat='Sync time',
     )).addTarget(prometheus.target(
-        'max(statusupdatedur and (changes(statusupdatedur[1h]) > 0))',
+        'max(statusupdatedur and (changes(statusupdatedur[10m]) > 0))',
         legendFormat='Status update time',
     )), gridPos={
     h: 9,

--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -5,33 +5,31 @@
         name: 'Tide progress',
         rules: [
           {
-            alert: 'TideSyncLoopDuration',
+            alert: 'Sync controller heartbeat',
             expr: |||
-              avg_over_time(syncdur{job="tide"}[15m]) > 120
+              sum(increase(tidesyncheartbeat{controller="sync"}[15m])) < 1
             |||,
-            'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'The Tide sync controllers loop period has averaged more than 2 minutes for the last 15 mins. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
+              message: 'The Tide "sync" controller has not synced in 15 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
             },
           },
           {
-            alert: 'TideStatusUpdateLoopDuration',
+            alert: 'Status-update controller heartbeat',
             expr: |||
-              avg_over_time(statusupdatedur{job="tide"}[15m]) > 120
+              sum(increase(tidesyncheartbeat{controller="status-update"}[30m])) < 1
             |||,
-            'for': '5m',
             labels: {
               severity: 'warning',
             },
             annotations: {
-              message: 'The Tide status update controllers loop period has averaged more than 2 minutes for the last 15 mins. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
+              message: 'The Tide "status-update" controller has not synced in 30 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
             },
           },
           {
-            alert: 'TidePoolErrorRateIndividual',
+            alert: 'TidePool error rate: individual',
             expr: |||
               (max(sum(increase(tidepoolerrors{org!="kubeflow"}[10m])) by (org, repo, branch)) or vector(0)) >= 3
             |||,
@@ -44,7 +42,7 @@
             },
           },
           {
-            alert: 'TidePoolErrorRateMultiple',
+            alert: 'TidePool error rate: multiple',
             expr: |||
               (count(sum(increase(tidepoolerrors[10m])) by (org, repo) >= 3) or vector(0)) >= 3
             |||,

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -187,9 +187,9 @@ var (
 			"branch",
 		}),
 
-		// Don't use the sync period gauges, they are deprecated. Use the sync
-		// heartbeat counter instead.
-		// Remove these gauges after March 2020
+		// Use the sync heartbeat counter to monitor for liveness. Use the duration
+		// gauges for precise sync duration graphs since the prometheus scrape
+		// period is likely much larger than the loop periods.
 		syncDuration: prometheus.NewGauge(prometheus.GaugeOpts{
 			Name: "syncdur",
 			Help: "The duration of the last loop of the sync controller.",


### PR DESCRIPTION
Follow up to https://github.com/kubernetes/test-infra/pull/15391

I changed my mind and now think we should keep the sync duration gauges instead of replacing them entirely with the heartbeat metrics. My reasoning is that 
1. The heartbeat tells us how often we are syncing, not how long the sync actually took. These only align when the time it takes to sync is longer than the configured sync period.
1. The prometheus scrape period may be equal to or larger than Tide's controller sync periods which causes prometheus' rate extrapolation to produce increasingly inaccurate results.
1. (bonus) We won't break any existing uses of the metric.

/assign @stevekuznetsov 

Another idea I just had: Instead of only setting the sync duration gauges when the sync completes, we could also update the gauges in a separate thread every few seconds based on the sync start time. This would make the gauges rise when Tide is stuck instead of incorrectly reporting the previous sync duration until the stuck sync completes. Let me know if that would be preferable to the heartbeat metric.