### PR TITLE
Revert "Revert "Merge pull request #14963 from wking/require-blocking-bugzilla""

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -508,6 +508,23 @@ func validateBug(bug bugzilla.Bug, dependents []bugzilla.Bug, options plugins.Bu
 		}
 	}
 
+	if len(dependents) == 0 {
+		switch {
+		case options.DependentBugStates != nil && options.DependentBugTargetRelease != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting the %q release and in one of the following states: %s, but no dependents were found", bug.ID, endpoint, bug.ID, *options.DependentBugTargetRelease, expected))
+		case options.DependentBugStates != nil:
+			valid = false
+			expected := strings.Join(prettyStates(*options.DependentBugStates), ", ")
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug in one of the following states: %s, but no dependents were found", bug.ID, endpoint, bug.ID, expected))
+		case options.DependentBugTargetRelease != nil:
+			valid = false
+			errors = append(errors, fmt.Sprintf("expected "+bugLink+" to depend on a bug targeting the %q release, but no dependents were found", bug.ID, endpoint, bug.ID, *options.DependentBugTargetRelease))
+		default:
+		}
+	}
+
 	return valid, errors
 }
 

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1173,7 +1173,8 @@ func TestValidateBug(t *testing.T) {
 			name:    "dependent status requirement with no dependent bugs means a valid bug",
 			bug:     bugzilla.Bug{DependsOn: []int{}},
 			options: plugins.BugzillaBranchOptions{DependentBugStates: &verified},
-			valid:   true,
+			valid:   false,
+			why:     []string{"expected [Bugzilla bug 0](bugzilla.com/show_bug.cgi?id=0) to depend on a bug in one of the following states: VERIFIED, but no dependents were found"},
 		},
 		{
 			name:       "not matching dependent bug status requirement means an invalid bug",


### PR DESCRIPTION
This reverts commit 704d2d480d36f85139b2510733d49138cc1f97f2, #15386.

OCS wants the guard in the mid/long term, but not right now.  To unblock them for the next few hours, we reverted the blocking-bug requirement.  Now I'm adding an opt-out knob (#15387), so revert the reversion ;).