### PR TITLE
Copy kops presubmit OWNERS to kops periodics OWNERS

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- justinsb
+- chrislovecnm
+- mikesplain
+- granular-ryanbonham
+- rifelpet
+- rdrgmnzs


### PR DESCRIPTION
An extension of #15355, this allows the approvers from the kops repo to approve changes to the Kops periodic jobs