### PR TITLE
kops-postsubmit: Pass path to GCB file

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -19,7 +19,8 @@ postsubmits:
               - --project=k8s-staging-kops
               - --scratch-bucket=gs://k8s-staging-kops-gcb
               - --env-passthrough=PULL_BASE_REF
-              - ci/postsubmit/push-to-staging/
+              - --gcb-config=ci/postsubmit/push-to-staging/cloudbuild.yaml
+              - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /creds/service-account.json


### PR DESCRIPTION
The working directory must be the root, so we can upload the full
source to GCB.

Otherwise it only uploads the source