### PR TITLE
Configvalidation: Do not require clone_uri shen ssh key is set

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -17,7 +17,6 @@ limitations under the License.
 package config
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"regexp"
@@ -448,20 +447,16 @@ func (u *UtilityConfig) Validate() error {
 		// Trim user from uri if exists.
 		cloneURI = cloneURI[strings.Index(cloneURI, "@")+1:]
 
-		if u.DecorationConfig != nil && len(u.DecorationConfig.SSHKeySecrets) > 0 {
-			if len(u.CloneURI) == 0 {
-				return errors.New("SSH key secrets provided but no clone_uri has been found")
+		if len(u.CloneURI) != 0 {
+			uri, err := url.Parse(cloneURI)
+			if err != nil {
+				return fmt.Errorf("couldn't parse uri from clone_uri: %v", err)
 			}
-		}
 
-		uri, err := url.Parse(cloneURI)
-		if err != nil {
-			return fmt.Errorf("couldn't parse uri from clone_uri: %v", err)
-		}
-
-		if u.DecorationConfig != nil && u.DecorationConfig.OauthTokenSecret != nil {
-			if uri.Scheme != schemeHTTP && uri.Scheme != schemeHTTPS {
-				return fmt.Errorf("scheme must be http or https when OAuth secret is specified: %s", cloneURI)
+			if u.DecorationConfig != nil && u.DecorationConfig.OauthTokenSecret != nil {
+				if uri.Scheme != schemeHTTP && uri.Scheme != schemeHTTPS {
+					return fmt.Errorf("scheme must be http or https when OAuth secret is specified: %s", cloneURI)
+				}
 			}
 		}
 

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -959,7 +959,8 @@ func TestUtilityConfigValidation(t *testing.T) {
 			},
 		},
 		{
-			id: "ssh_keys specified but clone_uri is empty, error",
+			id:    "ssh_keys specified but clone_uri is empty, no error",
+			valid: true,
 			uc: UtilityConfig{
 				DecorationConfig: &prowapi.DecorationConfig{
 					SSHKeySecrets: []string{"ssh-secret"},


### PR DESCRIPTION
Currently, when a ssh key is configured in `default_decoration_configs["*"]`, we require a clone_uri on all jobs, even if they do not clone any repos, which is misleading at best.

This PR removes this requirement.

Ideally, we would be checking if the `job.Spec.Refs != nil` and if thats the case require the `clone_uri` to be present, but unfortuantely the info if the job has primary refs is not available at all in any of the config/job structs.

/assign @stevekuznetsov @droslean 