### PR TITLE
Clean up slashes in job names.

### DIFF
--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -146,7 +146,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 	cmd := exec.Command("gcloud", args...)
 
 	if o.logDir != "" {
-		p := path.Join(o.logDir, jobName+".log")
+		p := path.Join(o.logDir, strings.Replace(jobName, "/", "-", -1)+".log")
 		f, err := os.Create(p)
 
 		if err != nil {


### PR DESCRIPTION
Ensure we don't try putting the log file in an unexpected directory due to there being a stray forward slash in the job name.