### PR TITLE
Add network proxy E2E job

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -24,3 +24,28 @@ periodics:
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-proto
+
+- interval: 24h
+  name: ci-kubernetes-e2e-gci-gce-network-proxy
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=25
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=50m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20191126-9d3c810-master
+  annotations:
+    testgrid-dashboards: sig-api-machinery-network-proxy

--- a/config/testgrids/kubernetes/sig-api-machinery/config.yaml
+++ b/config/testgrids/kubernetes/sig-api-machinery/config.yaml
@@ -5,6 +5,7 @@ dashboard_groups:
     - sig-api-machinery-kube-storage-version-migrator
     - sig-api-machinery-structured-merge-diff
     - sig-api-machinery-kubebuilder
+    - sig-api-machinery-network-proxy
 
 dashboards:
 - name: sig-api-machinery-gce-gke
@@ -52,3 +53,4 @@ dashboards:
 - name: sig-api-machinery-kube-storage-version-migrator
 - name: sig-api-machinery-structured-merge-diff
 - name: sig-api-machinery-kubebuilder
+- name: sig-api-machinery-network-proxy


### PR DESCRIPTION
This job runs our E2E tests with the `ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE` flag turned on. 

The flag forces the apiserver to communicate with the cluster via network proxy instead of ssh tunnels.