### PR TITLE
Deprecate "slack_reporter" in Prow config

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -91,13 +91,14 @@ type JobConfig struct {
 
 // ProwConfig is config for all prow controllers
 type ProwConfig struct {
-	Tide                 Tide                 `json:"tide,omitempty"`
-	Plank                Plank                `json:"plank,omitempty"`
-	Sinker               Sinker               `json:"sinker,omitempty"`
-	Deck                 Deck                 `json:"deck,omitempty"`
-	BranchProtection     BranchProtection     `json:"branch-protection,omitempty"`
-	Gerrit               Gerrit               `json:"gerrit,omitempty"`
-	GitHubReporter       GitHubReporter       `json:"github_reporter,omitempty"`
+	Tide             Tide             `json:"tide,omitempty"`
+	Plank            Plank            `json:"plank,omitempty"`
+	Sinker           Sinker           `json:"sinker,omitempty"`
+	Deck             Deck             `json:"deck,omitempty"`
+	BranchProtection BranchProtection `json:"branch-protection,omitempty"`
+	Gerrit           Gerrit           `json:"gerrit,omitempty"`
+	GitHubReporter   GitHubReporter   `json:"github_reporter,omitempty"`
+	// Deprecated: this option will be removed in May 2020.
 	SlackReporter        *SlackReporter       `json:"slack_reporter,omitempty"`
 	SlackReporterConfigs SlackReporterConfigs `json:"slack_reporter_configs,omitempty"`
 	InRepoConfig         InRepoConfig         `json:"in_repo_config"`


### PR DESCRIPTION
I added an [announcement](https://github.com/kubernetes/test-infra/pull/15159) but forgot to *deprecate* the actual struct field in accordance with [Golang conventions](https://github.com/golang/go/wiki/Deprecated) 😞.