### PR TITLE
Enable release notes plugin cloud-provider-openstack

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -548,6 +548,7 @@ plugins:
 
   kubernetes/cloud-provider-openstack:
   - override
+  - release-note
 
   kubernetes/community:
   - blockade


### PR DESCRIPTION
This PR enables release notes plugin for cloud-provider-openstack repo