### PR TITLE
job history: improve log message

### DIFF
--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -212,11 +212,12 @@ func (bucket gcsBucket) listBuildIDs(root string) ([]int64, error) {
 			return ids, fmt.Errorf("failed to list GCS directories: %v", err)
 		}
 		for _, dir := range dirs {
-			i, err := strconv.ParseInt(path.Base(dir), 10, 64)
+			leaf := path.Base(dir)
+			i, err := strconv.ParseInt(leaf, 10, 64)
 			if err == nil {
 				ids = append(ids, i)
 			} else {
-				logrus.Warningf("unrecognized directory name (expected int64): %s", dir)
+				logrus.WithField("gcs-path", dir).Warningf("unrecognized directory name (expected int64): %s", leaf)
 			}
 		}
 	} else {


### PR DESCRIPTION
I've spent some time investigating these and was misguided by the
message as it logs different value than is actually tried to be
converted. Log the actual leaf directory and also the full path, in a
log field.

xref: https://github.com/openshift/release/issues/6124