### PR TITLE
Add a separate containerd windows build job.

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -442,10 +442,26 @@ periodics:
       - --scenario=execute
       - --
       - ./test/build.sh
-      - ./test/windows/build.sh
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: build
+- name: ci-cri-containerd-windows-build
+  interval: 30m
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191115-01e3204-master
+      args:
+      - --repo=github.com/containerd/cri=master
+      - --root=/go/src
+      - --upload=gs://kubernetes-jenkins/logs
+      - --scenario=execute
+      - --
+      - ./test/windows/build.sh
+  annotations:
+    testgrid-dashboards: sig-node-containerd
+    testgrid-tab-name: windows-build
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cron: "30 1-23/3 * * *"
   labels:


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/15311 doesn't work.

Instead of using shell, I think we may just want to separate the build. :)

Signed-off-by: Lantao Liu <lantaol@google.com>