### PR TITLE
Deck: configurable rerun

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -90,6 +90,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
  
+ - *March 16, 2020* The `rerun_auth_config` config field has been deprecated in
+   favor of the new `rerun_auth_configs` field which allows configuration on a global,
+   organization or repo level. `rerun_auth_config` will be removed in May 2020.
  - *November 21, 2019* The boskos metrics component replaced the existing prometheus
    metrics with a single, label-qualified metric. Metrics are now served at `/metrics`
    on port 9090. This actually happened August 5th, but is being documented now. 

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -90,9 +90,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
  
- - *March 16, 2020* The `rerun_auth_config` config field has been deprecated in
+ - *March 19, 2020* The `rerun_auth_config` config field has been deprecated in
    favor of the new `rerun_auth_configs` field which allows configuration on a global,
-   organization or repo level. `rerun_auth_config` will be removed in May 2020.
+   organization or repo level. `rerun_auth_config` will be removed in July 2020.
  - *November 21, 2019* The boskos metrics component replaced the existing prometheus
    metrics with a single, label-qualified metric. Metrics are now served at `/metrics`
    on port 9090. This actually happened August 5th, but is being documented now. 

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -27,6 +27,7 @@ import (
 	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	prowgithub "k8s.io/test-infra/prow/github"
 )
 
@@ -156,7 +157,7 @@ type ProwJobSpec struct {
 	ReporterConfig *ReporterConfig `json:"reporter_config,omitempty"`
 
 	// RerunAuthConfig holds information about which users can rerun the job
-	RerunAuthConfig RerunAuthConfig `json:"rerun_auth_config,omitempty"`
+	RerunAuthConfig *RerunAuthConfig `json:"rerun_auth_config,omitempty"`
 
 	// Hidden specifies if the Job is considered hidden.
 	// Hidden jobs are only shown by deck instances that have the
@@ -192,6 +193,9 @@ type RerunAuthConfig struct {
 // IsSpecifiedUser returns true if AllowAnyone is set to true or if the given user is
 // specified as a permitted GitHubUser
 func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient) (bool, error) {
+	if rac == nil {
+		return false, nil
+	}
 	if rac.AllowAnyone {
 		return true, nil
 	}
@@ -236,6 +240,31 @@ func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient
 		}
 	}
 	return false, nil
+}
+
+// Validate validates the RerunAuthConfig fields.
+func (rac *RerunAuthConfig) Validate() error {
+	if rac == nil {
+		return nil
+	}
+
+	hasWhiteList := len(rac.GitHubUsers) > 0 || len(rac.GitHubTeamIDs) > 0 || len(rac.GitHubTeamSlugs) > 0 || len(rac.GitHubOrgs) > 0
+
+	// If a whitelist is specified, the user probably does not intend for anyone to be able to rerun any job.
+	if rac.AllowAnyone && hasWhiteList {
+		return errors.New("allow anyone is set to true and permitted users or groups are specified")
+	}
+
+	return nil
+}
+
+// IsAllowAnyone checks if anyone can rerun the job.
+func (rac *RerunAuthConfig) IsAllowAnyone() bool {
+	if rac == nil {
+		return false
+	}
+
+	return rac.AllowAnyone
 }
 
 type ReporterConfig struct {

--- a/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
+++ b/prow/apis/prowjobs/v1/zz_generated.deepcopy.go
@@ -275,7 +275,11 @@ func (in *ProwJobSpec) DeepCopyInto(out *ProwJobSpec) {
 		*out = new(ReporterConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	in.RerunAuthConfig.DeepCopyInto(&out.RerunAuthConfig)
+	if in.RerunAuthConfig != nil {
+		in, out := &in.RerunAuthConfig, &out.RerunAuthConfig
+		*out = new(RerunAuthConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -204,7 +204,7 @@ var (
 	traceHandler        = metrics.TraceHandler(simplifier, httpRequestDuration, httpResponseSize)
 )
 
-type authCfgGetter func() *prowapi.RerunAuthConfig
+type authCfgGetter func(*prowapi.Refs) *prowapi.RerunAuthConfig
 
 func init() {
 	prometheus.MustRegister(httpRequestDuration)
@@ -318,6 +318,11 @@ func main() {
 		fallbackHandler = http.NotFound
 	}
 
+	authCfgGetter := func(refs *prowapi.Refs) *prowapi.RerunAuthConfig {
+		rac := cfg().Deck.RerunAuthConfigs.GetRerunAuthConfig(refs)
+		return &rac
+	}
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/" {
 			fallbackHandler(w, r)
@@ -326,18 +331,16 @@ func main() {
 		indexHandler := handleSimpleTemplate(o, cfg, "index.html", struct {
 			SpyglassEnabled bool
 			ReRunCreatesJob bool
-			AllowAnyone     bool
 		}{
 			SpyglassEnabled: o.spyglass,
-			ReRunCreatesJob: o.rerunCreatesJob,
-			AllowAnyone:     cfg().Deck.RerunAuthConfig.AllowAnyone})
+			ReRunCreatesJob: o.rerunCreatesJob})
 		indexHandler(w, r)
 	})
 
 	if runLocal {
 		mux = localOnlyMain(cfg, o, mux)
 	} else {
-		mux = prodOnlyMain(cfg, pluginAgent, o, mux)
+		mux = prodOnlyMain(cfg, pluginAgent, authCfgGetter, o, mux)
 	}
 
 	// signal to the world that we're ready
@@ -374,7 +377,8 @@ func main() {
 
 	// if we allow direct reruns, we must protect against CSRF in all post requests using the cookie secret as a token
 	// for more information about CSRF, see https://github.com/kubernetes/test-infra/blob/master/prow/cmd/deck/csrf.md
-	if o.rerunCreatesJob && csrfToken == nil && !cfg().Deck.RerunAuthConfig.AllowAnyone {
+	empty := prowapi.Refs{}
+	if o.rerunCreatesJob && csrfToken == nil && !authCfgGetter(&empty).IsAllowAnyone() {
 		logrus.Fatal("Rerun creates job cannot be enabled without CSRF protection, which requires --cookie-secret to be exactly 32 bytes")
 		return
 	}
@@ -477,7 +481,7 @@ func (w *pjListingClientWrapper) List(
 }
 
 // prodOnlyMain contains logic only used when running deployed, not locally
-func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options, mux *http.ServeMux) *http.ServeMux {
+func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGetter authCfgGetter, o options, mux *http.ServeMux) *http.ServeMux {
 	prowJobClient, err := o.kubernetes.ProwJobClient(cfg().ProwJobNamespace, false)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error getting ProwJob client for infrastructure cluster.")
@@ -526,8 +530,6 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 		showHidden: o.showHidden,
 	}, podLogClients, cfg)
 	ja.Start()
-
-	cfgGetter := func() *prowapi.RerunAuthConfig { return &cfg().Deck.RerunAuthConfig }
 
 	// setup prod only handlers
 	mux.Handle("/data.js", gziphandler.GzipHandler(handleData(ja, logrus.WithField("handler", "/data.js"))))
@@ -646,7 +648,7 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 		mux.Handle("/github-login/redirect", goa.HandleRedirect(oauthClient, &o.github, secure))
 	}
 
-	mux.Handle("/rerun", gziphandler.GzipHandler(handleRerun(prowJobClient, o.rerunCreatesJob, cfgGetter, goa, &o.github, githubClient, pluginAgent, logrus.WithField("handler", "/rerun"))))
+	mux.Handle("/rerun", gziphandler.GzipHandler(handleRerun(prowJobClient, o.rerunCreatesJob, authCfgGetter, goa, &o.github, githubClient, pluginAgent, logrus.WithField("handler", "/rerun"))))
 
 	// optionally inject http->https redirect handler when behind loadbalancer
 	if o.redirectHTTPTo != "" {
@@ -1326,21 +1328,21 @@ func handleProwJob(prowJobClient prowv1.ProwJobInterface, log *logrus.Entry) htt
 
 // canTriggerJob determines whether the given user can trigger any job.
 func canTriggerJob(user string, pj prowapi.ProwJob, cfg *prowapi.RerunAuthConfig, cli prowgithub.RerunClient, pluginAgent *plugins.ConfigAgent, log *logrus.Entry) (bool, error) {
-	auth, err := cfg.IsAuthorized(user, cli)
-	if auth {
+
+	// Then check config-level rerun auth config.
+	if auth, err := cfg.IsAuthorized(user, cli); err != nil {
+		return false, err
+	} else if auth {
+		return true, err
+	}
+
+	// Check job-level rerun auth config.
+	if auth, err := pj.Spec.RerunAuthConfig.IsAuthorized(user, cli); err != nil {
+		return false, err
+	} else if auth {
 		return true, nil
 	}
-	if err != nil {
-		return false, err
-	}
-	jobPermissions := pj.Spec.RerunAuthConfig
-	auth, err = jobPermissions.IsAuthorized(user, cli)
-	if auth {
-		return true, nil
-	}
-	if err != nil {
-		return false, err
-	}
+
 	if cli == nil {
 		log.Warning("No GitHub token was provided, so we cannot retrieve GitHub teams")
 		return false, nil
@@ -1393,9 +1395,9 @@ func handleRerun(prowJobClient prowv1.ProwJobInterface, createProwJob bool, cfg 
 				http.Error(w, "Direct rerun feature is not enabled. Enable with the '--rerun-creates-job' flag.", http.StatusMethodNotAllowed)
 				return
 			}
-			authConfig := cfg()
+			authConfig := cfg(pj.Spec.Refs)
 			var allowed bool
-			if authConfig.AllowAnyone || pj.Spec.RerunAuthConfig.AllowAnyone {
+			if pj.Spec.RerunAuthConfig.IsAllowAnyone() || authConfig.IsAllowAnyone() {
 				// Skip getting the users login via GH oauth if anyone is allowed to rerun
 				// jobs so that GH oauth doesn't need to be set up for private Prows.
 				allowed = true

--- a/prow/cmd/deck/template/index.html
+++ b/prow/cmd/deck/template/index.html
@@ -6,7 +6,6 @@
 <script type="text/javascript">
   var spyglass = {{.SpyglassEnabled}};
   var rerunCreatesJob = {{.ReRunCreatesJob}};
-  var allowAnyone = {{.AllowAnyone}};
 </script>
 {{end}}
 

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -615,7 +615,7 @@ type Deck struct {
 	GoogleAnalytics string `json:"google_analytics,omitempty"`
 	// Deprecated: RerunAuthConfig specifies who is able to trigger job reruns if that feature is enabled.
 	// The permissions here apply to all jobs.
-	// This option will be removed in favor of RerunAuthConfigs in March 2020.
+	// This option will be removed in favor of RerunAuthConfigs in July 2020.
 	RerunAuthConfig *prowapi.RerunAuthConfig `json:"rerun_auth_config,omitempty"`
 	// RerunAuthConfigs is a map of configs that specify who is able to trigger job reruns. The field
 	// accepts a key of: `org/repo`, `org` or `*` (wildcard) to define what GitHub org (or repo) a particular
@@ -1166,9 +1166,9 @@ func (c *Config) validateComponentConfig() error {
 		}
 	}
 
-	// TODO(@clarketm): Remove in May 2020
+	// TODO(@clarketm): Remove in July 2020
 	if c.Deck.RerunAuthConfig != nil {
-		logrus.Warning("rerun_auth_config will be deprecated in May 2020, and it will be replaced with rerun_auth_configs['*'].")
+		logrus.Warning("rerun_auth_config will be deprecated in July 2020, and it will be replaced with rerun_auth_configs['*'].")
 
 		if c.Deck.RerunAuthConfigs != nil {
 			return errors.New("rerun_auth_config and rerun_auth_configs['*'] are mutually exclusive")

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -158,10 +158,6 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 	if jb.Namespace != nil {
 		namespace = *jb.Namespace
 	}
-	var rerunAuthConfig prowapi.RerunAuthConfig
-	if jb.RerunAuthConfig != nil {
-		rerunAuthConfig = *jb.RerunAuthConfig
-	}
 	return prowapi.ProwJobSpec{
 		Job:             jb.Name,
 		Agent:           prowapi.ProwJobAgent(jb.Agent),
@@ -177,7 +173,7 @@ func specFromJobBase(jb config.JobBase) prowapi.ProwJobSpec {
 		PipelineRunSpec: jb.PipelineRunSpec,
 
 		ReporterConfig:  jb.ReporterConfig,
-		RerunAuthConfig: rerunAuthConfig,
+		RerunAuthConfig: jb.RerunAuthConfig,
 		Hidden:          jb.Hidden,
 	}
 }

--- a/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-defaulted-decoration-prow-job.yaml
@@ -50,7 +50,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-defaulted-decoration
   type: presubmit
 status:

--- a/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-explicit-decoration-prow-job.yaml
@@ -50,7 +50,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-explicit-decoration
   type: presubmit
 status:

--- a/prow/test/data/kubernetes-no-decoration-prow-job.yaml
+++ b/prow/test/data/kubernetes-no-decoration-prow-job.yaml
@@ -36,7 +36,6 @@ spec:
       sha: pullsha
     repo: test-repo
   report: true
-  rerun_auth_config: {}
   rerun_command: /test kubernetes-no-decoration
   type: presubmit
 status:


### PR DESCRIPTION
fix #15415 (proposal)
motive: https://github.com/istio/test-infra/pull/2122

**Usage:**

There is no enigmatic inheritance. The `rerun_auth_config` key with the **highest** specificity (`job` -> `org/repo` -> `org` -> `wildcard`) is honored.

```yaml
rerun_auth_configs:

  # wildcard
  '*':
    allow_anyone: true

  # org 1
  istio:
    github_team_slugs:
    - org: istio
      slug: maintainers

  # org 2
  helm:
    github_team_slugs:
    - org: helm
      slug: developers

  # org 3
  kubernetes:
    github_orgs:
    - kubernetes
    - kubernetes-sigs

  # org/repo
  clarketm/tools:
    github_users:
      - clarketm

```

> **Note:** this is_backwards compatible with **all** *existing* Deck deployments and rerun configurations. Support for the deprecated `rerun_auth_config` will be removed in **May 2020**.