### PR TITLE
Consolidate warnings on branches w/required contexts

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -101,7 +101,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatalf("Failed to load --config-path=%s", o.config)
 	}
-	cfg.BranchProtectionWarnings(logrus.NewEntry(logrus.StandardLogger()))
+	cfg.BranchProtectionWarnings(logrus.NewEntry(logrus.StandardLogger()), cfg.PresubmitsStatic)
 
 	secretAgent := &secret.Agent{}
 	if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -341,7 +341,7 @@ func (c *Controller) Sync() error {
 		tideMetrics.syncHeartbeat.WithLabelValues("sync").Inc()
 	}()
 	defer c.changedFiles.prune()
-	c.config().BranchProtectionWarnings(c.logger)
+	c.config().BranchProtectionWarnings(c.logger, c.config().PresubmitsStatic)
 
 	c.logger.Debug("Building tide pool.")
 	prs := make(map[string]PullRequest)


### PR DESCRIPTION
Branchprotector and Tide now consolidate warnings on unprotected
branches which have one or more required contexts. These warnings are
combined with the existing aggregated warning on unprotected branches.

