### PR TITLE
AWS Janitor - Improve Route53 regex to match dangling records

### DIFF
--- a/maintenance/aws-janitor/resources/route53.go
+++ b/maintenance/aws-janitor/resources/route53.go
@@ -44,17 +44,17 @@ func zoneIsManaged(z *route53.HostedZone) bool {
 }
 
 var managedNameRegexes = []*regexp.Regexp{
-	// e.g. api.e2e-61246-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^api\.e2e-[0-9]+-`),
+	// e.g. api.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^api\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
-	// e.g. api.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^api\.internal\.e2e-[0-9]+-`),
+	// e.g. api.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^api\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
-	// e.g. etcd-b.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^etcd-[a-z]\.internal\.e2e-[0-9]+-`),
+	// e.g. etcd-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^etcd-[a-z]\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 
-	// e.g. etcd-events-b.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.
-	regexp.MustCompile(`^etcd-events-[a-z]\.internal\.e2e-[0-9]+-`),
+	// e.g. etcd-events-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.
+	regexp.MustCompile(`^etcd-events-[a-z]\.internal\.e2e-[0-9a-z]{1,10}-[0-9a-f]{5}\.`),
 }
 
 // resourceRecordSetIsManaged checks if the resource record should be managed (and thus deleted) by us

--- a/maintenance/aws-janitor/resources/route53_test.go
+++ b/maintenance/aws-janitor/resources/route53_test.go
@@ -29,24 +29,24 @@ func TestManagedNames(t *testing.T) {
 		expected bool
 	}{
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("api.e2e-61246-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("api.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("api.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("api.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-b.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-events-b.internal.e2e-61246-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("A"), Name: aws.String("etcd-events-b.internal.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: true,
 		},
 		{
 			// Ignores non-A records
-			rrs:      &route53.ResourceRecordSet{Type: aws.String("CNAME"), Name: aws.String("api.e2e-61246-dba53.test-cncf-aws.k8s.io.")},
+			rrs:      &route53.ResourceRecordSet{Type: aws.String("CNAME"), Name: aws.String("api.e2e-71149fffac-dba53.test-cncf-aws.k8s.io.")},
 			expected: false,
 		},
 		{


### PR DESCRIPTION
The cluster name format used in Kops E2E jobs changed and AWS Janitor has not been cleaning up its Route53 records.
This updates the regex to match the these records.

See the job output here: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1200781290505244672

Fixes #15427