### PR TITLE
Inrepoconfig: Add validation

### DIFF
--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -19,6 +19,8 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
+	"os"
 	"reflect"
 	"regexp"
 	"testing"
@@ -1109,6 +1111,31 @@ func TestOptions(t *testing.T) {
 			},
 			expectedError: false,
 		},
+		{
+			name: "prow-yaml-path gets defaulted",
+			args: []string{
+				"--config-path=prow/config.yaml",
+				"--plugin-config=prow/plugins/plugin.yaml",
+				"--job-config-path=config/jobs/org/job.yaml",
+				"--prow-yaml-repo-name=my/repo",
+			},
+			expectedOptions: &options{
+				configPath:       "prow/config.yaml",
+				pluginConfig:     "prow/plugins/plugin.yaml",
+				jobConfigPath:    "config/jobs/org/job.yaml",
+				prowYAMLRepoName: "my/repo",
+				prowYAMLPath:     "/home/prow/go/src/github.com/my/repo/.prow.yaml",
+				github:           defaultGitHubOptions,
+			},
+			expectedError: false,
+		},
+		{
+			name: "prow-yaml-path without prow-yaml-repo-name is invalid",
+			args: []string{
+				"--prow-yaml-path=my-file",
+			},
+			expectedError: true,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -1178,5 +1205,55 @@ func TestValidateJobExtraRefs(t *testing.T) {
 					diff.ObjectGoPrintDiff(tc.expected, err))
 			}
 		})
+	}
+}
+
+func TestValidateInRepoConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		prowYAMLData []byte
+		expectedErr  string
+	}{
+		{
+			name:         "Valid prowYAML, no err",
+			prowYAMLData: []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
+		},
+		{
+			name:         "Invalid prowYAML, err",
+			prowYAMLData: []byte(`presubmits: [{"name": "hans"}]`),
+			expectedErr:  "failed to validate .prow.yaml: invalid presubmit job hans: kubernetes jobs require a spec",
+		},
+	}
+
+	for _, tc := range testCases {
+		tempFile, err := ioutil.TempFile("/tmp", "prow-test")
+		if err != nil {
+			t.Fatalf("failed to get tempfile: %v", err)
+		}
+		defer func() {
+			if err := tempFile.Close(); err != nil {
+				t.Errorf("failed to close tempFile: %v", err)
+			}
+			if err := os.Remove(tempFile.Name()); err != nil {
+				t.Errorf("failed to remove tempfile: %v", err)
+			}
+		}()
+
+		if _, err := tempFile.Write(tc.prowYAMLData); err != nil {
+			t.Fatalf("failed to write to tempfile: %v", err)
+		}
+
+		cfg := &config.Config{
+			ProwConfig: config.ProwConfig{PodNamespace: "my-ns"},
+		}
+		err = validateInRepoConfig(cfg, tempFile.Name(), "my/repo")
+		var errString string
+		if err != nil {
+			errString = err.Error()
+		}
+
+		if errString != tc.expectedErr {
+			t.Errorf("expected error %q does not match actual error %q", tc.expectedErr, errString)
+		}
 	}
 }

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -99,7 +99,7 @@ func defaultProwYAMLGetter(
 		return nil, fmt.Errorf("failed to unmarshal %q: %v", inRepoConfigFileName, err)
 	}
 
-	if err := defaultAndValidateProwYAML(c, prowYAML, identifier); err != nil {
+	if err := DefaultAndValidateProwYAML(c, prowYAML, identifier); err != nil {
 		return nil, err
 	}
 
@@ -107,7 +107,7 @@ func defaultProwYAMLGetter(
 	return prowYAML, nil
 }
 
-func defaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error {
+func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error {
 	if err := defaultPresubmits(p.Presubmits, c, identifier); err != nil {
 		return err
 	}

--- a/prow/plugins/trigger/BUILD.bazel
+++ b/prow/plugins/trigger/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -52,12 +52,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	}
 
 	refGetter := config.NewRefGetterForGitHubPullRequest(c.GitHubClient, org, repo, number)
-
-	presubmits, err := c.Config.GetPresubmits(c.GitClient, org+"/"+repo, refGetter.BaseSHA, refGetter.HeadSHA)
-	if err != nil {
-		return fmt.Errorf("failed to get presubmits: %v", err)
-	}
-
+	presubmits := getPresubmits(c.Logger, c.GitClient, c.Config, org+"/"+repo, refGetter.BaseSHA, refGetter.HeadSHA)
 	// Skip comments not germane to this plugin
 	if !pjutil.RetestRe.MatchString(gc.Body) && !pjutil.OkToTestRe.MatchString(gc.Body) && !pjutil.TestAllRe.MatchString(gc.Body) {
 		matched := false

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -47,10 +47,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		return pr.PullRequest.Head.SHA, nil
 	}
 
-	presubmits, err := c.Config.GetPresubmits(c.GitClient, org+"/"+repo, baseSHAGetter, headSHAGetter)
-	if err != nil {
-		return fmt.Errorf("failed to get presubmits: %v", err)
-	}
+	presubmits := getPresubmits(c.Logger, c.GitClient, c.Config, org+"/"+repo, baseSHAGetter, headSHAGetter)
 	if len(presubmits) == 0 {
 		return nil
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -263,3 +263,15 @@ func skipRequested(c Client, pr *github.PullRequest, skippedJobs []config.Presub
 	}
 	return errorutil.NewAggregate(errors...)
 }
+
+func getPresubmits(log *logrus.Entry, gc *git.Client, cfg *config.Config, orgRepo string, baseSHAGetter, headSHAGetter config.RefGetter) []config.Presubmit {
+
+	presubmits, err := cfg.GetPresubmits(gc, orgRepo, baseSHAGetter, headSHAGetter)
+	if err != nil {
+		// Fall back to static presubmits to avoid deadlocking when a presubmit is used to verify
+		// inrepoconfig. Tide will still respect errors here and not merge.
+		log.WithError(err).Debug("Failed to get presubmits")
+		presubmits = cfg.PresubmitsStatic[orgRepo]
+	}
+	return presubmits
+}


### PR DESCRIPTION
Towards #13370, with this PR inrepoconfig can be validated via the checkconfig tool and with that, the feature becomes usable, albeit being completely undocumented so far.

/assign @stevekuznetsov 