### PR TITLE
feature: run scheduler benchmark tests in presubmit CI checks

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -152,6 +152,32 @@ presubmits:
           requests:
             memory: "6Gi"
 
+  - name: pull-kubernetes-e2e-scheduler-performance
+    always_run: true
+    max_concurrency: 12
+    decorate: true
+    annotations:
+      testgrid-create-test-group: "true"
+    branches:
+    - master
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    decoration_config:
+      timeout: 1h55m
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191127-ee0721a-master
+        command:
+        - ./hack/jenkins/benchmark-dockerized.sh
+        args:
+        - ./test/integration/scheduler_perf
+        env:
+        - name: KUBE_TIMEOUT
+          value: --timeout=1h50m
+
   - name: pull-kubernetes-kubemark-e2e-gce-big
     always_run: true
     skip_report: false

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -759,6 +759,9 @@ dashboards:
   - name: pull-kubernetes-e2e-gce-storage-disruptive
     test_group_name: pull-kubernetes-e2e-gce-storage-disruptive
     base_options: width=10
+  - name: pull-kubernetes-e2e-scheduler-performance
+    test_group_name: pull-kubernetes-e2e-scheduler-performance
+    base_options: width=10
 
 - name: presubmits-cloud-provider-vsphere-blocking
 - name: vmware-presubmits-cloud-provider-vsphere
@@ -776,6 +779,9 @@ dashboards:
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-large-performance
     test_group_name: pull-kubernetes-e2e-gce-large-performance
+    base_options: width=10
+  - name: pull-kubernetes-e2e-scheduler-performance
+    test_group_name: pull-kubernetes-e2e-scheduler-performance
     base_options: width=10
   - name: pull-kubernetes-kubemark-e2e-gce-big
     test_group_name: pull-kubernetes-kubemark-e2e-gce-big


### PR DESCRIPTION
Run scheduler benchmark tests in presubmit CI checks.

Ref: kubernetes/kubernetes#85686