### PR TITLE
Update aws-janitor image to the latest version

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -19,7 +19,7 @@ periodics:
       env:
       - name: AWS_SHARED_CREDENTIALS_FILE
         value: /workspace/.aws/credentials
-      image: gcr.io/k8s-test-infra-aws/aws-janitor:v20190114-57d0fe238
+      image: gcr.io/k8s-prow/boskos/aws-janitor:v20191202-3ab85226c
       volumeMounts:
       - mountPath: /workspace/.aws
         name: aws-cred


### PR DESCRIPTION
This is a different repo because we're now using the images created by the postsubmit job and bazel

See the [image push logs](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-boskos/1201582235539476480#1:build-log.txt%3A142) and #15423
