### PR TITLE
add quotation mark for filter flag in janitor

### DIFF
--- a/boskos/janitor/gcp_janitor.py
+++ b/boskos/janitor/gcp_janitor.py
@@ -164,7 +164,7 @@ def collect(project, age, resource, filt, clear_all):
     cmd.extend([
         'list',
         '--format=json(name,creationTimestamp.date(tz=UTC),zone,region,isManaged)',
-        '--filter=%s' % filt,
+        '--filter="%s"' % filt,
         '--project=%s' % project])
     log('%r' % cmd)
 
@@ -289,7 +289,7 @@ def clean_gke_cluster(project, age, filt):
         cmd = [
             'gcloud', 'container', '-q', 'clusters', 'list',
             '--project=%s' % project,
-            '--filter=%s' % filt,
+            '--filter="%s"' % filt,
             '--format=json(name,createTime,zone)'
         ]
         log('running %s' % cmd)

--- a/scenarios/kubernetes_janitor.py
+++ b/scenarios/kubernetes_janitor.py
@@ -72,7 +72,7 @@ def clean_project(project, hours=24, dryrun=False, ratelimit=None, filt=None):
     if VERBOSE:
         cmd.append('--verbose')
     if filt:
-        cmd.append('--filter=%s' % filt)
+        cmd.append('--filter="%s"' % filt)
 
     try:
         check(*cmd)


### PR DESCRIPTION
Filter flag can be a string with space and currently it will cause problem
for this kind of filter flag, ex. 'name~^prow- AND location=us-central1-a'.