### PR TITLE
Revert "Merge pull request #15326 from stevekuznetsov/skuznets/remove…

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -3,7 +3,48 @@
     groups+: [
       {
         name: 'ghproxy',
-        rules: [],
+        rules: [
+          {
+            alert: 'ghproxy-specific-status-code-abnormal',
+            expr: |||
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status,path) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) by (path) * 100 > 10
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+            },
+          },
+          {
+            alert: 'ghproxy-global-status-code-abnormal',
+            expr: |||
+              sum(rate(github_request_duration_count{status=~"[45]..",status!="404",status!="410"}[5m])) by (status) / ignoring(status) group_left sum(rate(github_request_duration_count[5m])) * 100 > 3
+            |||,
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8|grafana>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+            },
+          },
+          {
+            alert: 'ghproxy-running-out-github-tokens-in-a-hour',
+            // check 30% of the capacity (5000): 1500
+            expr: |||
+              github_token_usage{job="ghproxy"} <  1500
+              and
+              predict_linear(github_token_usage{job="ghproxy"}[1h], 1 * 3600) < 0
+            |||,
+            'for': '5m',
+            labels: {
+              severity: 'warning',
+            },
+            annotations: {
+              message: 'token {{ $labels.token_hash }} will run out of API quota before the next reset.',
+            },
+          }
+        ],
       },
     ],
   },


### PR DESCRIPTION
…-alerts-entirely"

This reverts commit c63b8635455e82fe204f91048591f261fd00efd1, reversing
changes made to 5a31c68eff9ad349103e9f2a2f37f480f5540464.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

During KubeCon, Katharine and I are pretty sure we determined that the routing issue was due to the fact that the API token used for Slack was _only_ for #testing-ops. That secret has been changed in prod so I am generally sure this will work as expected. On-call should merge this and let me know when they're doing it, so I can revert if it doesn't.