### PR TITLE
Add basic auth support of boskos

### DIFF
--- a/boskos/aws-janitor/cmd/aws-janitor-boskos/main.go
+++ b/boskos/aws-janitor/cmd/aws-janitor-boskos/main.go
@@ -34,6 +34,8 @@ import (
 
 var (
 	boskosURL          = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	username           = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile       = flag.String("password-file", "", "The path to password file used to access the Boskos server")
 	region             = flag.String("region", "", "The region to clean (otherwise defaults to all regions)")
 	sweepCount         = flag.Int("sweep-count", 5, "Number of times to sweep the resources")
 	sweepSleep         = flag.String("sweep-sleep", "30s", "The duration to pause between sweeps")
@@ -54,8 +56,10 @@ func main() {
 	}
 
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-
-	boskos := client.NewClient("AWSJanitor", *boskosURL)
+	boskos, err := client.NewClient("AWSJanitor", *boskosURL, *username, *passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	if err := run(boskos); err != nil {
 		logrus.WithError(err).Error("Janitor failure")
 	}

--- a/boskos/cleaner/cmd/main.go
+++ b/boskos/cleaner/cmd/main.go
@@ -41,11 +41,15 @@ var (
 	kubeClientOptions crds.KubernetesClientOptions
 
 	boskosURL    string
+	username     string
+	passwordFile string
 	cleanerCount int
 )
 
 func init() {
 	flag.StringVar(&boskosURL, "boskos-url", "http://boskos", "Boskos Server URL")
+	flag.StringVar(&username, "username", "", "Username used to access the Boskos server")
+	flag.StringVar(&passwordFile, "password-file", "", "The path to password file used to access the Boskos server")
 	flag.IntVar(&cleanerCount, "cleaner-count", defaultCleanerCount, "Number of threads running cleanup")
 	kubeClientOptions.AddFlags(flag.CommandLine)
 }
@@ -64,7 +68,10 @@ func main() {
 	st, _ := ranch.NewStorage(nil, resStorage, "")
 
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	client := client.NewClient(defaultOwner, boskosURL)
+	client, err := client.NewClient(defaultOwner, boskosURL, username, passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	cleaner := cleaner.NewCleaner(cleanerCount, client, defaultBoskosRetryPeriod, st)
 
 	cleaner.Start()

--- a/boskos/client/BUILD.bazel
+++ b/boskos/client/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/storage:go_default_library",
+        "//prow/config/secret:go_default_library",
         "@com_github_google_uuid//:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/boskos/client/client_test.go
+++ b/boskos/client/client_test.go
@@ -73,7 +73,10 @@ func TestAcquire(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		c := NewClient("user", ts.URL)
+		c, err := NewClient("user", ts.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
 		res, err := c.Acquire("t", "s", "d")
 
 		if !AreErrorsEqual(err, tc.expectErr) {
@@ -136,11 +139,13 @@ func TestRelease(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		defer ts.Close()
 
-		c := NewClient("user", ts.URL)
+		c, err := NewClient("user", ts.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
 		for _, r := range tc.resources {
 			c.storage.Add(common.Resource{Name: r})
 		}
-		var err error
 		if tc.res == "" {
 			err = c.ReleaseAll("d")
 		} else {
@@ -199,12 +204,14 @@ func TestUpdate(t *testing.T) {
 	for _, tc := range testcases {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 		defer ts.Close()
-		c := NewClient("user", ts.URL)
+		c, err := NewClient("user", ts.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
 		for _, r := range tc.resources {
 			c.storage.Add(common.Resource{Name: r})
 		}
 
-		var err error
 		if tc.res == "" {
 			err = c.UpdateAll("s")
 		} else {
@@ -223,7 +230,10 @@ func TestReset(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	c := NewClient("user", ts.URL)
+	c, err := NewClient("user", ts.URL, "", "")
+	if err != nil {
+		t.Fatalf("failed to create the Boskos client")
+	}
 	rmap, err := c.Reset("t", "s", time.Minute, "d")
 	if err != nil {
 		t.Errorf("Error in reset : %v", err)
@@ -249,7 +259,10 @@ func TestMetric(t *testing.T) {
 		},
 	}
 
-	c := NewClient("user", ts.URL)
+	c, err := NewClient("user", ts.URL, "", "")
+	if err != nil {
+		t.Fatalf("failed to create the Boskos client")
+	}
 	metric, err := c.Metric("t")
 	if err != nil {
 		t.Errorf("Error in reset : %v", err)

--- a/boskos/cmd/cli/cli.go
+++ b/boskos/cmd/cli/cli.go
@@ -33,8 +33,10 @@ import (
 
 type options struct {
 	// common, used to create the client
-	serverURL string
-	ownerName string
+	serverURL    string
+	username     string
+	passwordFile string
+	ownerName    string
 
 	c *client.Client
 
@@ -44,8 +46,13 @@ type options struct {
 	heartbeat heartbeatOptions
 }
 
-func (o *options) initializeClient() {
-	o.c = client.NewClient(o.ownerName, o.serverURL)
+func (o *options) initializeClient() error {
+	c, err := client.NewClient(o.ownerName, o.serverURL, o.username, o.passwordFile)
+	if err != nil {
+		return err
+	}
+	o.c = c
+	return nil
 }
 
 type acquireOptions struct {
@@ -93,6 +100,8 @@ scripts with a simple interface.`,
 		Args: cobra.NoArgs,
 	}
 	root.PersistentFlags().StringVar(&options.serverURL, "server-url", "", "URL of the Boskos server")
+	root.PersistentFlags().StringVar(&options.username, "username", "", "Username used to access the Boskos server")
+	root.PersistentFlags().StringVar(&options.passwordFile, "password-file", "", "The path to password file used to access the Boskos server")
 	root.PersistentFlags().StringVar(&options.ownerName, "owner-name", "", "Name identifying the user of this client")
 	for _, flag := range []string{"server-url", "owner-name"} {
 		if err := root.MarkPersistentFlagRequired(flag); err != nil {
@@ -123,7 +132,10 @@ Examples:
   # Acquire one new "my-thing" and mark it old when leasing, block until successfully leased
   $ boskosctl acquire --type my-thing --state new --target-state old --timeout 30s`,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.initializeClient()
+			if err := options.initializeClient(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to initialize the Boskos client: %v\n", err)
+				return
+			}
 			acquireFunc := options.c.Acquire
 			if options.acquire.timeout != 0*time.Second {
 				acquireFunc = func(rtype, state, dest string) (resource *common.Resource, e error) {
@@ -182,7 +194,10 @@ Examples:
   # Release a lease on "my-thing" and mark it dirty when releasing
   $ boskosctl release --name my-thing --target-state dirty`,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.initializeClient()
+			if err := options.initializeClient(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to initialize the Boskos client: %v\n", err)
+				return
+			}
 			err := options.c.Release(options.release.name, options.release.targetState)
 			if err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "failed to release resource %q: %v\n", options.release.name, err)
@@ -217,7 +232,10 @@ Examples:
   # Check metrics for "my-thing"
   $ boskosctl metrics --type my-thing`,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.initializeClient()
+			if err := options.initializeClient(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to initialize the Boskos client: %v\n", err)
+				return
+			}
 			metric, err := options.c.Metric(options.metrics.requestedType)
 			if err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "failed to get metrics for resource %q: %v\n", options.metrics.requestedType, err)
@@ -263,7 +281,10 @@ Examples:
   # Send periodic heartbeat for the lease with custom period and timeout
   $ boskosctl heartbeat --resource "${resource}" --period 3s --timeout 1h`,
 		Run: func(cmd *cobra.Command, args []string) {
-			options.initializeClient()
+			if err := options.initializeClient(); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "failed to initialize the Boskos client: %v\n", err)
+				return
+			}
 			var resource common.Resource
 			if err := json.Unmarshal([]byte(options.heartbeat.resourceJSON), &resource); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "failed to parse resource: %v\n", err)

--- a/boskos/cmd/cli/cli_test.go
+++ b/boskos/cmd/cli/cli_test.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 
@@ -42,6 +43,20 @@ type response struct {
 }
 
 func TestCommand(t *testing.T) {
+
+	file, err := ioutil.TempFile("", "test")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer func() {
+		if err := os.Remove(file.Name()); err != nil {
+			t.Fatalf("Failed to remove temp file: %v", err)
+		}
+	}()
+	if err := ioutil.WriteFile(file.Name(), []byte("secret"), 0755); err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
 	var testCases = []struct {
 		name           string
 		args           []string
@@ -67,8 +82,10 @@ Flags:
       --type string           Type of resource to acquire
 
 Global Flags:
-      --owner-name string   Name identifying the user of this client
-      --server-url string   URL of the Boskos server
+      --owner-name string      Name identifying the user of this client
+      --password-file string   The path to password file used to access the Boskos server
+      --server-url string      URL of the Boskos server
+      --username string        Username used to access the Boskos server
 
 `,
 		},
@@ -84,6 +101,24 @@ Global Flags:
 			expectedCalls: []request{{
 				method: http.MethodPost,
 				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				body:   []byte{},
+			}},
+			expectedOutput: `{"type":"thing","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"old","owner":"test","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}
+`,
+		},
+		{
+			name: "normal acquire sends a request with basic auth and succeeds",
+			args: []string{"acquire", "--state=new", "--type=thing", "--target-state=old", "--username=test", fmt.Sprintf("--password-file=%s", file.Name())},
+			responses: map[string]response{
+				"/acquire": {
+					code: http.StatusOK,
+					data: []byte(`{"type":"thing","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"old","owner":"test","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}`),
+				},
+			},
+			expectedCalls: []request{{
+				method: http.MethodPost,
+				url:    url.URL{Path: "/acquire", RawQuery: `dest=old&owner=test&state=new&type=thing`},
+				header: map[string][]string{"Authorization": {"Basic dGVzdDpzZWNyZXQ="}},
 				body:   []byte{},
 			}},
 			expectedOutput: `{"type":"thing","name":"87527b0c-eac2-4f83-9a03-791b2239e093","state":"old","owner":"test","lastupdate":"2019-07-24T23:30:40.094116858Z","userdata":{}}
@@ -171,8 +206,10 @@ Flags:
       --target-state string   Move resource to this state after releasing
 
 Global Flags:
-      --owner-name string   Name identifying the user of this client
-      --server-url string   URL of the Boskos server
+      --owner-name string      Name identifying the user of this client
+      --password-file string   The path to password file used to access the Boskos server
+      --server-url string      URL of the Boskos server
+      --username string        Username used to access the Boskos server
 
 `,
 		},
@@ -223,8 +260,10 @@ Flags:
       --type string   Type of resource to get metics for
 
 Global Flags:
-      --owner-name string   Name identifying the user of this client
-      --server-url string   URL of the Boskos server
+      --owner-name string      Name identifying the user of this client
+      --password-file string   The path to password file used to access the Boskos server
+      --server-url string      URL of the Boskos server
+      --username string        Username used to access the Boskos server
 
 `,
 		},
@@ -288,8 +327,10 @@ Flags:
       --timeout duration   How long to send heartbeats for (default 5h0m0s)
 
 Global Flags:
-      --owner-name string   Name identifying the user of this client
-      --server-url string   URL of the Boskos server
+      --owner-name string      Name identifying the user of this client
+      --password-file string   The path to password file used to access the Boskos server
+      --server-url string      URL of the Boskos server
+      --username string        Username used to access the Boskos server
 
 `,
 		},
@@ -416,9 +457,14 @@ failed to send heartbeat for resource "87527b0c-eac2-4f83-9a03-791b2239e093": st
 				t.Errorf("%s: request %d: incorrect content-type header, expected %s, saw %s", testCase.name, i, expected, actual)
 			}
 
+			if expected, actual := testCase.expectedCalls[i].header.Get("Authorization"), request.header.Get("Authorization"); expected != actual {
+				t.Errorf("%s: request %d: incorrect Authorization header, expected %s, saw %s", testCase.name, i, expected, actual)
+			}
+
 			if expected, actual := testCase.expectedCalls[i].body, request.body; !reflect.DeepEqual(expected, actual) {
 				t.Errorf("%s: request %d: incorrect body: %s", testCase.name, i, diff.StringDiff(string(expected), string(actual)))
 			}
 		}
+		server.Close()
 	}
 }

--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -36,6 +36,8 @@ var (
 	updateFrequency time.Duration
 	janitorPath     = flag.String("janitor-path", "/bin/gcp_janitor.py", "Path to janitor binary path")
 	boskosURL       = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	username        = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile    = flag.String("password-file", "", "The path to password file used to access the Boskos server")
 )
 
 func init() {
@@ -50,7 +52,10 @@ func main() {
 	extraJanitorFlags := flag.CommandLine.Args()
 
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	boskos := client.NewClient("Janitor", *boskosURL)
+	boskos, err := client.NewClient("Janitor", *boskosURL, *username, *passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	logrus.Info("Initialized boskos client!")
 
 	if len(rTypes) == 0 {

--- a/boskos/mason/fake-mason/main.go
+++ b/boskos/mason/fake-mason/main.go
@@ -44,6 +44,8 @@ const (
 
 var (
 	boskosURL         = flag.String("boskos-url", "http://boskos", "Boskos Server URL")
+	username          = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile      = flag.String("password-file", "", "The path to password file used to access the Boskos server")
 	cleanerCount      = flag.Int("cleaner-count", defaultCleanerCount, "Number of threads running cleanup")
 	kubeClientOptions crds.KubernetesClientOptions
 )
@@ -76,7 +78,10 @@ func main() {
 
 	flag.Parse()
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	client := client.NewClient(defaultOwner, *boskosURL)
+	client, err := client.NewClient(defaultOwner, *boskosURL, *username, *passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	mason := mason.NewMason(*cleanerCount, client, defaultBoskosRetryPeriod, defaultBoskosSyncPeriod, st)
 
 	// Registering Masonable Converters

--- a/boskos/metrics/metrics.go
+++ b/boskos/metrics/metrics.go
@@ -39,6 +39,9 @@ var (
 		Name: "boskos_resources",
 		Help: "Number of resources recorded in Boskos",
 	}, []string{"type", "state"})
+	boskosURL         string
+	username          string
+	passwordFile      string
 	resources, states common.CommaSeparatedStrings
 	defaultStates     = []string{
 		common.Busy,
@@ -52,6 +55,9 @@ var (
 )
 
 func init() {
+	flag.StringVar(&boskosURL, "boskos-url", "http://boskos", "Boskos Server URL")
+	flag.StringVar(&username, "username", "", "Username used to access the Boskos server")
+	flag.StringVar(&passwordFile, "password-file", "", "The path to password file used to access the Boskos server")
 	flag.Var(&resources, "resource-type", "comma-separated list of resources need to have metrics collected.")
 	flag.Var(&states, "resource-state", "comma-separated list of states need to have metrics collected.")
 	prometheus.MustRegister(resourceMetric)
@@ -59,7 +65,10 @@ func init() {
 
 func main() {
 	logrusutil.ComponentInit("boskos-metrics")
-	boskos := client.NewClient("Metrics", "http://boskos")
+	boskos, err := client.NewClient("Metrics", boskosURL, username, passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	logrus.Infof("Initialzied boskos client!")
 
 	flag.Parse()

--- a/boskos/reaper/reaper.go
+++ b/boskos/reaper/reaper.go
@@ -28,6 +28,8 @@ import (
 var (
 	rTypes         common.CommaSeparatedStrings
 	boskosURL      = flag.String("boskos-url", "http://boskos", "Boskos URL")
+	username       = flag.String("username", "", "Username used to access the Boskos server")
+	passwordFile   = flag.String("password-file", "", "The path to password file used to access the Boskos server")
 	expiryDuration = flag.Duration("expire", 30*time.Minute, "The expiry time (in minutes) after which reaper will reset resources.")
 	targetState    = flag.String("target-state", common.Dirty, "The state to move resources to when reaped.")
 )
@@ -38,7 +40,10 @@ func init() {
 
 func main() {
 	logrus.SetFormatter(&logrus.JSONFormatter{})
-	boskos := client.NewClient("Reaper", *boskosURL)
+	boskos, err := client.NewClient("Reaper", *boskosURL, *username, *passwordFile)
+	if err != nil {
+		logrus.WithError(err).Fatal("unable to create a Boskos client")
+	}
 	logrus.Infof("Initialized boskos client!")
 	flag.Parse()
 

--- a/boskos/server_client_test.go
+++ b/boskos/server_client_test.go
@@ -66,7 +66,10 @@ func TestAcquireUpdate(t *testing.T) {
 		r := MakeTestRanch([]common.Resource{tc.resource})
 		boskos := makeTestBoskos(r)
 		owner := "owner"
-		client := client.NewClient(owner, boskos.URL)
+		client, err := client.NewClient(owner, boskos.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
 		userData := common.UserDataFromMap(common.UserDataMap{"test": "new"})
 
 		newState := "acquired"
@@ -149,7 +152,10 @@ func TestAcquireByState(t *testing.T) {
 	for _, tc := range testcases {
 		r := MakeTestRanch(tc.resources)
 		boskos := makeTestBoskos(r)
-		client := client.NewClient(owner, boskos.URL)
+		client, err := client.NewClient(owner, boskos.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
 		receivedRes, err := client.AcquireByState(tc.state, newState, tc.names)
 		boskos.Close()
 		if !reflect.DeepEqual(err, tc.err) {
@@ -217,8 +223,11 @@ func TestClientServerUpdate(t *testing.T) {
 	for _, tc := range testcases {
 		r := MakeTestRanch([]common.Resource{tc.resource})
 		boskos := makeTestBoskos(r)
-		client := client.NewClient(owner, boskos.URL)
-		_, err := client.Acquire(rType, initialState, finalState)
+		client, err := client.NewClient(owner, boskos.URL, "", "")
+		if err != nil {
+			t.Fatalf("failed to create the Boskos client")
+		}
+		_, err = client.Acquire(rType, initialState, finalState)
 		if err != nil {
 			t.Errorf("failed to acquire resource")
 		}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -53,7 +53,7 @@ var (
 	terminate = time.NewTimer(time.Duration(0)) // terminate testing at this time.
 	verbose   = false
 	timeout   = time.Duration(0)
-	boskos    = client.NewClient(os.Getenv("JOB_NAME"), "http://boskos.test-pods.svc.cluster.local.")
+	boskos, _ = client.NewClient(os.Getenv("JOB_NAME"), "http://boskos.test-pods.svc.cluster.local.", "", "")
 	control   = process.NewControl(timeout, interrupt, terminate, verbose)
 )
 


### PR DESCRIPTION
Sometimes, we need to expose the boskos service because pods may request resources on different build clusters. Auth protection is needed in this case to avoid resources from being abused.

/cc @stevekuznetsov @bbguimaraes 