### PR TITLE
Inrepoconfig validation: Allow absent .prow.yaml

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -995,7 +995,10 @@ func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 func validateInRepoConfig(cfg *config.Config, filePath, repoIdentifier string) error {
 	data, err := ioutil.ReadFile(filePath)
 	if err != nil {
-		return fmt.Errorf("failed to read file %q: %v", filePath, err)
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read file %q: %v", filePath, err)
+		}
+		return nil
 	}
 
 	prowYAML := &config.ProwYAML{}


### PR DESCRIPTION
Currently we fail if its not there, forcing ppl to use the feature once the verification exists :grimacing: 