### PR TITLE
releng: Add Patch Release/Branch Managers as reviewers for SIG Release

### DIFF
--- a/config/jobs/kubernetes/release/OWNERS
+++ b/config/jobs/kubernetes/release/OWNERS
@@ -5,6 +5,15 @@ approvers:
 - justaugustus
 - tpepper
 
+reviewers:
+- aleksandra-malinowska # Patch Release Team
+- cpanato # Branch Manager
+- dougm # Patch Release Team
+- feiskyer # Patch Release Team
+- hoegaarden # Patch Release Team
+- idealhack # Patch Release Team
+- saschagrunert # Branch Manager
+
 labels:
 - sig/release
 - area/release-eng

--- a/config/jobs/kubernetes/sig-release/OWNERS
+++ b/config/jobs/kubernetes/sig-release/OWNERS
@@ -5,6 +5,15 @@ approvers:
 - justaugustus
 - tpepper
 
+reviewers:
+- aleksandra-malinowska # Patch Release Team
+- cpanato # Branch Manager
+- dougm # Patch Release Team
+- feiskyer # Patch Release Team
+- hoegaarden # Patch Release Team
+- idealhack # Patch Release Team
+- saschagrunert # Branch Manager
+
 labels:
 - sig/release
 - area/release-eng

--- a/config/testgrids/kubernetes/sig-release/OWNERS
+++ b/config/testgrids/kubernetes/sig-release/OWNERS
@@ -5,6 +5,15 @@ approvers:
 - justaugustus
 - tpepper
 
+reviewers:
+- aleksandra-malinowska # Patch Release Team
+- cpanato # Branch Manager
+- dougm # Patch Release Team
+- feiskyer # Patch Release Team
+- hoegaarden # Patch Release Team
+- idealhack # Patch Release Team
+- saschagrunert # Branch Manager
+
 labels:
 - sig/release
 - area/release-eng


### PR DESCRIPTION
SIG Release changes in k/test-infra are primarily Release Engineering
subproject changes. This PR adds the set of Release Managers (Patch
Release Team + Branch Managers), who have already been doing reviews on
k/test-infra, to officially hold the reviewer role over this content.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**On hold until https://github.com/kubernetes/sig-release/pull/868 merges**
/hold

/assign @tpepper @calebamiles 
@kubernetes/sig-release-admins @kubernetes/release-engineering @kubernetes/release-managers 
/milestone v1.18
/priority important-longterm
/kind feature cleanup