### PR TITLE
Tide status controller: get baseSHA if not available

### DIFF
--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -512,6 +512,8 @@ func TestAccumulate(t *testing.T) {
 }
 
 type fgc struct {
+	err error
+
 	prs       []PullRequest
 	refs      map[string]string
 	merged    int
@@ -524,7 +526,7 @@ type fgc struct {
 }
 
 func (f *fgc) GetRef(o, r, ref string) (string, error) {
-	return f.refs[o+"/"+r+" "+ref], nil
+	return f.refs[o+"/"+r+" "+ref], f.err
 }
 
 func (f *fgc) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {


### PR DESCRIPTION
This PR changes the tide status controller to look up the baseSHA for a given org/repo/branch combination if its not in the baseSHAs map.

This happens if there is no merge pool for the org/repo/branch combination. The only case in which we still need the baseSHA is if inrepoconfig is enabled. Hence, this is only done in the baseSHAGetter passed to inrepoconfig and will not increase the github token usage if that feature is not enabled.