### PR TITLE
Bumping timeout for vpa-updater tests

### DIFF
--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -135,7 +135,7 @@ periodics:
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
-      - --timeout=100
+      - --timeout=105
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
@@ -146,7 +146,7 @@ periodics:
       - --test=false
       - --test-cmd=../vertical-pod-autoscaler/hack/run-e2e.sh
       - --test-cmd-args=updater
-      - --timeout=80m
+      - --timeout=85m
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Currently vpa-updater teats seems flaky. Currently it takes ~76min to run the tests. If anything happens and it takes slightly more than 80min to execute the tests, timeout is thrown.

Bumping timeout to 85min.