### PR TITLE
[aws janitor] Use pod utilities on periodic prow job

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -3,32 +3,17 @@ periodics:
   name: maintenance-ci-aws-janitor
   labels:
     preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
   spec:
     containers:
-    - args:
-      - --bare
-      - --timeout=60
-      - --service-account=/etc/service-account/service-account.json
-      - --upload=gs://kubernetes-jenkins/logs
-      - --scenario=execute
-      - --
-      - /aws-janitor
-      - --
+    - command:
+      - /app/boskos/aws-janitor/app.binary
+      args:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
-      env:
-      - name: AWS_SHARED_CREDENTIALS_FILE
-        value: /workspace/.aws/credentials
       image: gcr.io/k8s-prow/boskos/aws-janitor:v20191213-13d9d67ad
-      volumeMounts:
-      - mountPath: /workspace/.aws
-        name: aws-cred
-        readOnly: true
-    volumes:
-    - name: aws-cred
-      secret:
-        defaultMode: 256
-        secretName: aws-cred-new
   annotations:
     testgrid-dashboards: sig-testing-maintenance
     testgrid-tab-name: ci-aws-janitor


### PR DESCRIPTION
In an effort to get the periodic job working again, I'm replacing the bootstrap.py functionality that was in the old image with pod utilities (`decorate: true`).

I updated the image to include #15116 which moved the aws-janitor location, since it would update the `command` field as well.

Inspecting the image shows the entrypoint as what I used in the command:

```
            "Entrypoint": [
                "/app/boskos/aws-janitor/app.binary"
            ],
```
ref: #15423