### PR TITLE
Enable Availability Zones e2e job for Azure Disk CSI driver

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -156,8 +156,7 @@ presubmits:
       description: "Run E2E tests on a single-az cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-multi-az
-    always_run: false
-    optional: true
+    always_run: true
     branches:
     - master
     labels:


### PR DESCRIPTION
With https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/176 and https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/180 merged, we should make e2e job on a multi-az cluster a required CI job.
/assign @andyzhangx 