### PR TITLE
Azure: Separate presubmit and periodic jobs by dashboard on testgrid

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
+++ b/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
@@ -8,8 +8,8 @@ postsubmits:
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
-        testgrid-dashboards: provider-azure-master
-        testgrid-tab-name: post-provider-azure-push-images
+        testgrid-dashboards: provider-azure-cloud-provider-azure
+        testgrid-tab-name: post-cloud-provider-azure-push-images
       decorate: true
       # this causes the job to only run on the master branch. Remove it if your
       # job makes sense on every branch (unless it's setting a `latest` tag it

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -20,9 +20,8 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-verify
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-unit
@@ -45,9 +44,8 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-unit
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-sanity
@@ -73,9 +71,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-sanity
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-integration
@@ -101,9 +98,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-integration
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-single-az
@@ -150,9 +146,8 @@ presubmits:
           - name: ENABLE_TOPOLOGY
             value: "false"
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-e2e-single-az
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests on a single-az cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-e2e-multi-az
@@ -199,9 +194,8 @@ presubmits:
           - name: ENABLE_TOPOLOGY
             value: "true"
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-e2e-multi-az
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests on a multi-az cluster for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-in-tree-azure-disk-e2e
@@ -250,9 +244,8 @@ presubmits:
           - name: AZURE_STORAGE_DRIVER
             value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-in-tree-azure-disk-e2e
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run Azure Disk e2e test with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
   - name: pull-in-tree-azure-disk-e2e-vmss
@@ -301,9 +294,8 @@ presubmits:
           - name: AZURE_STORAGE_DRIVER
             value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-in-tree-azure-disk-e2e-vmss
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin."
       testgrid-num-columns-recent: '30'
   - name: pull-azuredisk-csi-driver-windows-build
@@ -326,8 +318,7 @@ presubmits:
         - make
         - azuredisk-windows
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-windows-build
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run make azuredisk-windows for Azure Disk CSI driver."
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -20,9 +20,8 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-verify
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run code verification tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-unit
@@ -45,9 +44,8 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-unit
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run unit tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-sanity
@@ -73,9 +71,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-sanity
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run sanity tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-integration
@@ -101,9 +98,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-integration
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run integration tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-e2e
@@ -150,9 +146,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-e2e
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run E2E tests for Azure File CSI driver."
       testgrid-num-columns-recent: '30'
   - name: pull-azurefile-csi-driver-windows-build
@@ -175,8 +170,7 @@ presubmits:
         - make
         - azurefile-windows
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-azurefile-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azurefile-csi-driver-windows-build
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: "Run make azurefile-windows for Azure File CSI driver."
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -17,7 +17,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-blobfuse-csi-driver-verify
       description: "Run code verification tests for Blobfuse CSI driver."
       testgrid-num-columns-recent: '30'
@@ -38,7 +38,7 @@ presubmits:
         - make
         - unit-test
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-blobfuse-csi-driver-unit
       description: "Run unit tests for Blobfuse CSI driver."
       testgrid-num-columns-recent: '30'
@@ -62,7 +62,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-blobfuse-csi-driver-sanity
       description: "Run sanity tests for Blobfuse CSI driver."
       testgrid-num-columns-recent: '30'
@@ -86,7 +86,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-blobfuse-csi-driver-integration
       description: "Run integration tests for Blobfuse CSI driver."
       testgrid-num-columns-recent: '30'
@@ -138,7 +138,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
+      testgrid-dashboards: provider-azure-blobfuse-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-blobfuse-csi-driver-e2e
       description: "Run E2E tests for Blobfuse CSI driver."
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -20,9 +20,8 @@ presubmits:
 
     # pull-cloud-provider-azure-e2e runs kubernetes conformance tests.
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-cloud-provider-check
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-presubmit
+      testgrid-tab-name: pr-cloud-provider-azure-check
       description: "Run lint check tests for cloud-provider-azure."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-e2e
@@ -72,9 +71,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-cloud-provider-e2e
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-presubmit
+      testgrid-tab-name: pr-cloud-provider-azure-e2e
       description: "Run Kubernetes e2e tests for cloud-provider-azure."
       testgrid-num-columns-recent: '30'
   # pull-cloud-provider-azure-e2e-ccm runs Azure specific e2e tests.
@@ -125,9 +123,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-cloud-provider-e2e-ccm
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-presubmit
+      testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-unit
@@ -148,15 +145,14 @@ presubmits:
         - make
         - test-unit
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-cloud-provider-unit
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-presubmit
+      testgrid-tab-name: pr-cloud-provider-azure-unit
       description: "Run unit tests for cloud-provider-azure."
       testgrid-num-columns-recent: '30'
 periodics:
 - interval: 8h
-  # ci-cloud-provider-azure-master runs Azure specific tests periodically.
-  name: ci-cloud-provider-azure-master
+  # cloud-provider-azure-master runs Azure specific tests periodically.
+  name: cloud-provider-azure-master
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -210,13 +206,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 8h
-  # ci-cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
-  name: ci-cloud-provider-azure-autoscaling
+  # cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
+  name: cloud-provider-azure-autoscaling
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -272,13 +268,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-autoscaling
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs node autoscaling tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 8h
-  # ci-cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
-  name: ci-cloud-provider-azure-conformance
+  # cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
+  name: cloud-provider-azure-conformance
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -332,13 +328,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-conformance
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 8h
-  # ci-cloud-provider-azure-slow runs Kubernetes slow tests periodically.
-  name: ci-cloud-provider-azure-slow
+  # cloud-provider-azure-slow runs Kubernetes slow tests periodically.
+  name: cloud-provider-azure-slow
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -392,13 +388,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 12h
-  # ci-cloud-provider-azure-serial runs Kubernetes serial tests periodically.
-  name: ci-cloud-provider-azure-serial
+  # cloud-provider-azure-serial runs Kubernetes serial tests periodically.
+  name: cloud-provider-azure-serial
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -463,13 +459,13 @@ periodics:
       - name: KUBE_SSH_USER
         value: azureuser
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-serial
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes serial tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
 - interval: 8h
-  # ci-cloud-provider-azure-master-vmss runs Azure specific tests periodically on VMSS.
-  name: ci-cloud-provider-azure-master-vmss
+  # cloud-provider-azure-master-vmss runs Azure specific tests periodically on VMSS.
+  name: cloud-provider-azure-master-vmss
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -523,13 +519,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-master-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Azure specific tests periodically with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 8h
-  # ci-cloud-provider-azure-conformance-vmss runs Kubernetes conformance tests periodically on VMSS.
-  name: ci-cloud-provider-azure-conformance-vmss
+  # cloud-provider-azure-conformance-vmss runs Kubernetes conformance tests periodically on VMSS.
+  name: cloud-provider-azure-conformance-vmss
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -583,13 +579,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-conformance-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes conformance tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 8h
-  # ci-cloud-provider-azure-slow-vmss runs Kubernetes slow tests periodically on VMSS.
-  name: ci-cloud-provider-azure-slow-vmss
+  # cloud-provider-azure-slow-vmss runs Kubernetes slow tests periodically on VMSS.
+  name: cloud-provider-azure-slow-vmss
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -643,13 +639,13 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-slow-vmss
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes slow tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 - interval: 8h
-  # ci-cloud-provider-azure-multiple-zones runs Kubernetes multiple availability zones tests periodically.
-  name: ci-cloud-provider-azure-multiple-zones
+  # cloud-provider-azure-multiple-zones runs Kubernetes multiple availability zones tests periodically.
+  name: cloud-provider-azure-multiple-zones
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -708,8 +704,8 @@ periodics:
       - name: REPO_NAME
         value: cloud-provider-azure
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: ci-cloud-provider-azure-multiple-zones
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
+    testgrid-tab-name: cloud-provider-azure-multiple-zones
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs Kubernetes multiple availability zones tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure) on VMSS."
 
@@ -726,10 +722,9 @@ periodics:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
   annotations:
-    testgrid-dashboards: provider-azure-scalability
+    testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-scalability, provider-azure-periodic
     testgrid-tab-name: ci-kubernetes-kubemark-100-azure
     testgrid-num-failures-to-alert: '3'
-    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled."
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -57,9 +57,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-windows, provider-azure-on-call
+      testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-presubmit
       testgrid-tab-name: aks-engine-azure-windows-presubmit
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
       testgrid-num-columns-recent: '30'
 periodics:
@@ -103,7 +102,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -148,7 +147,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-14-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -193,7 +192,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-15-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
@@ -238,7 +237,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing, provider-azure-on-call
+    testgrid-dashboards: sig-windows, sig-release-1.16-informing, sig-release-master-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-16-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -282,7 +281,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.17-informing, sig-release-master-informing, provider-azure-on-call
+    testgrid-dashboards: sig-windows, sig-release-1.17-informing, sig-release-master-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-17-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.17 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -369,7 +368,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-on-call
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-1903-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -184,8 +184,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-1-15
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-15
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
@@ -232,8 +232,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-vmss-1-15
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-vmss-1-15
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -184,8 +184,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-1-16
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-16
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
@@ -232,8 +232,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-vmss-1-16
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-vmss-1-16
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -184,8 +184,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-1-17
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-17
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
@@ -232,8 +232,8 @@ periodics:
       - name: AZURE_STORAGE_DRIVER
         value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
   annotations:
-    testgrid-dashboards: provider-azure-master, provider-azure-on-call
-    testgrid-tab-name: kubernetes-e2e-azure-disk-vmss-1-17
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-vmss-1-17
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -47,9 +47,8 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-k8s-e2e
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-upstream, provider-azure-presubmit
+      testgrid-tab-name: pr-k8s-e2e-master
       description: Run e2e tests
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-azure-disk
@@ -100,9 +99,8 @@ presubmits:
           - name: AZURE_STORAGE_DRIVER
             value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-k8s-e2e-azure-disk
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-upstream, provider-azure-presubmit
+      testgrid-tab-name: pr-k8s-azure-disk-e2e-master
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
       testgrid-num-columns-recent: '30'
   - name: pull-kubernetes-e2e-azure-disk-vmss
@@ -153,8 +151,7 @@ presubmits:
           - name: AZURE_STORAGE_DRIVER
             value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
     annotations:
-      testgrid-dashboards: provider-azure-master, provider-azure-on-call
-      testgrid-tab-name: pr-k8s-e2e-azure-disk-vmss
-      testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+      testgrid-dashboards: provider-azure-upstream, provider-azure-presubmit
+      testgrid-tab-name: pr-k8s-azure-disk-e2e-vmss-master
       description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -41,7 +41,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-on-call
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-periodic
     testgrid-tab-name: dualstack-azure-e2e-1-16
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a 1.16 Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -88,7 +88,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-on-call
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-periodic
     testgrid-tab-name: dualstack-azure-e2e-1-17
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a 1.17 Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
@@ -135,7 +135,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-on-call
+    testgrid-dashboards: sig-network-dualstack-azure-e2e, provider-azure-dualstack, provider-azure-periodic
     testgrid-tab-name: dualstack-azure-e2e-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Dual-stack e2e tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/config.yaml
@@ -1,11 +1,25 @@
 dashboard_groups:
 - name: provider-azure
   dashboard_names:
-    - provider-azure-master
-    - provider-azure-on-call
+    - provider-azure-azuredisk-csi-driver
+    - provider-azure-azurefile-csi-driver
+    - provider-azure-blobfuse-csi-driver
+    - provider-azure-cloud-provider-azure
+    - provider-azure-dualstack
+    - provider-azure-periodic
+    - provider-azure-presubmit
     - provider-azure-scalability
+    - provider-azure-upstream
+    - provider-azure-windows
 
 dashboards:
-- name: provider-azure-master
-- name: provider-azure-on-call
+- name: provider-azure-azuredisk-csi-driver
+- name: provider-azure-azurefile-csi-driver
+- name: provider-azure-blobfuse-csi-driver
+- name: provider-azure-cloud-provider-azure
+- name: provider-azure-dualstack
+- name: provider-azure-periodic
+- name: provider-azure-presubmit
 - name: provider-azure-scalability
+- name: provider-azure-upstream
+- name: provider-azure-windows


### PR DESCRIPTION
Separating each repo by dashboard on testgrid, and in each dashboard, it contains all the related CI jobs as tabs. The purpose of the change is to organize all Azure-related jobs in a more logical way and make jobs more discoverable. Each bullet point is the dashboard name and each sub-bullet point is a job under the dashboard.

- provider-azure-presubmit
  * pr-cloud-provider-azure-verify
  * pr-cloud-provider-azure-unit
  * pr-cloud-provider-azure-e2e
  * pr-cloud-provider-azure-e2e-ccm
  * pr-azuredisk-csi-driver-verify
  * pr-azuredisk-csi-driver-unit
  * pr-azuredisk-csi-driver-sanity
  * pr-azuredisk-csi-driver-integration
  * pr-azuredisk-csi-driver-e2e-single-az
  * pr-azuredisk-csi-driver-e2e-multi-az
  * pr-azurefile-csi-driver-verify
  * pr-azurefile-csi-driver-unit
  * pr-azurefile-csi-driver-sanity
  * pr-azurefile-csi-driver-integration
  * pr-azurefile-csi-driver-e2e
  * pr-blobfuse-csi-driver-verify
  * pr-blobfuse-csi-driver-unit
  * pr-blobfuse-csi-driver-sanity
  * pr-blobfuse-csi-driver-integration
  * pr-blobfuse-csi-driver-e2e
  * pr-k8s-e2e-master
  * pr-k8s-azure-disk-e2e-master
  * pr-k8s-azure-disk-e2e-vmss-master
  * pr-k8s-azure-disk-in-tree-e2e-master (to be setup)
  * pr-k8s-azure-disk-in-tree-e2e-vmss-master (to be setup)
  * pr-k8s-e2e-1-15
  * pr-k8s-azure-disk-e2e-1-15
  * pr-k8s-azure-disk-e2e-vmss-1-15
  * pr-k8s-e2e-1-16
  * pr-k8s-azure-disk-e2e-1-16
  * pr-k8s-azure-disk-e2e-vmss-1-16
  * pr-k8s-e2e-1-17
  * pr-k8s-azure-disk-e2e-1-17
  * pr-k8s-azure-disk-e2e-vmss-1-17

- cloud-provider-azure
  * pr-cloud-provider-azure-verify
  * pr-cloud-provider-azure-unit
  * pr-cloud-provider-azure-e2e
  * pr-cloud-provider-azure-e2e-ccm
  * cloud-provider-azure-master
  * cloud-provider-azure-master-vmss
  * cloud-provider-azure-autoscaling
  * cloud-provider-azure-conformance
  * cloud-provider-azure-conformance-vmss
  * cloud-provider-azure-slow
  * cloud-provider-azure-slow-vmss
  * cloud-provider-azure-serial
  * cloud-provider-azure-multiple-zones
  * post-cloud-provider-azure-push-images

- azuredisk-csi-driver
  * pr-azuredisk-csi-driver-verify
  * pr-azuredisk-csi-driver-unit
  * pr-azuredisk-csi-driver-sanity
  * pr-azuredisk-csi-driver-integration
  * pr-azuredisk-csi-driver-e2e-single-az
  * pr-azuredisk-csi-driver-e2e-multi-az 
  * pr-in-tree-azure-disk-e2e-vmss
  * pr-in-tree-azure-disk-e2e
  * pr-azuredisk-csi-driver-windows-build

- azurefile-csi-driver
   * pr-azurefile-csi-driver-verify
  * pr-azurefile-csi-driver-unit
  * pr-azurefile-csi-driver-sanity
  * pr-azurefile-csi-driver-integration
  * pr-azurefile-csi-driver-e2e

- blobfuse-csi-driver
   * pr-blobfuse-csi-driver-verify
  * pr-blobfuse-csi-driver-unit
  * pr-blobfuse-csi-driver-sanity
  * pr-blobfuse-csi-driver-integration
  * pr-blobfuse-csi-driver-e2e

- provider-azure-upstream
  * pr-k8s-e2e-master
  * pr-k8s-azure-disk-e2e-master
  * pr-k8s-azure-disk-e2e-vmss-master
  * pr-k8s-azure-disk-in-tree-e2e-master (to be setup)
  * pr-k8s-azure-disk-in-tree-e2e-vmss-master (to be setup)
  * pr-k8s-e2e-1-15
  * pr-k8s-azure-disk-e2e-1-15
  * pr-k8s-azure-disk-e2e-vmss-1-15
  * pr-k8s-e2e-1-16
  * pr-k8s-azure-disk-e2e-1-16
  * pr-k8s-azure-disk-e2e-vmss-1-16
  * pr-k8s-e2e-1-17
  * pr-k8s-azure-disk-e2e-1-17
  * pr-k8s-azure-disk-e2e-vmss-1-17
  * k8s-azure-disk-e2e-1-15
  * k8s-azure-disk-e2e-vmss-1-15
  * k8s-azure-disk-e2e-1-16
  * k8s-azure-disk-e2e-vmss-1-16
  * k8s-azure-disk-e2e-1-17
  * k8s-azure-disk-e2e-vmss-1-17
  * k8s-azure-disk-in-tree-e2e-master
  * k8s-azure-disk-in-tree-e2e-vmss-master

- provider-azure-dualstack:
  * dualstack-azure-e2e-1-16
  * dualstack-azure-e2e-1-17
  * dualstack-azure-e2e-master

- provider-azure-windows:
  * aks-engine-azure-windows-master
  * aks-engine-azure-1-14-windows
  * aks-engine-azure-1-15-windows
  * aks-engine-azure-1-16-windows
  * aks-engine-azure-1-17-windows
  * aks-engine-azure-windows-1903-master
  * aks-engine-azure-windows-presubmit

- provider-azure-periodics (monitored by oncall engineer):
  * cloud-provider-azure-master
  * cloud-provider-azure-master-vmss
  * cloud-provider-azure-autoscaling
  * cloud-provider-azure-conformance
  * cloud-provider-azure-conformance-vmss
  * cloud-provider-azure-slow
  * cloud-provider-azure-slow-vmss
  * cloud-provider-azure-serial
  * cloud-provider-azure-multiple-zones
  * k8s-e2e-azure-disk-1-15
  * k8s-e2e-azure-disk-vmss-1-15
  * k8s-e2e-azure-disk-1-16
  * k8s-e2e-azure-disk-vmss-1-16
  * k8s-e2e-azure-disk-1-17
  * k8s-e2e-azure-disk-vmss-1-17
  * k8s-azure-disk-in-tree-e2e-master (to be setup)
  * k8s-azure-disk-in-tree-e2e-vmss-master (to be setup)
  * aks-engine-azure-windows-master
  * aks-engine-azure-1-14-windows
  * aks-engine-azure-1-15-windows
  * aks-engine-azure-1-16-windows
  * aks-engine-azure-1-17-windows
  * aks-engine-azure-windows-1903-master
  * dualstack-azure-e2e-1-16
  * dualstack-azure-e2e-1-17
  * dualstack-azure-e2e-master

- provider-azure-scalability
  * k8s-kubemark-100

