### PR TITLE
Config defaulting and validation: Aggregate errors

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"k8s.io/test-infra/prow/git"
 	"sigs.k8s.io/yaml"
@@ -112,11 +113,12 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 		return err
 	}
 
+	var errs []error
 	for _, ps := range p.Presubmits {
 		if ps.Branches != nil || ps.SkipBranches != nil {
-			return fmt.Errorf("job %q contains branchconfig. This is not allowed for jobs in %q", ps.Name, inRepoConfigFileName)
+			errs = append(errs, fmt.Errorf("job %q contains branchconfig. This is not allowed for jobs in %q", ps.Name, inRepoConfigFileName))
 		}
 	}
 
-	return nil
+	return utilerrors.NewAggregate(errs)
 }


### PR DESCRIPTION
Today, when we enounter errors during defaulting or validation, we return with the first error found. This is annoying from a users perspective, because if there are multiple errors, we report them one by one.

This PR changes that to instead aggregate errors.