### PR TITLE
Playbooks plural

### DIFF
--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -6,6 +6,14 @@ These are intended to help you diagnose and repair our infrastructure.
 
 <!--TODO: add short entries for each service we host-->
 
+## Prow
+
+[Playbook][prow-playbook]
+
+TDLR: Prow is a set of CI services that we run.
+
+In particular we use this for hosting Kubernetes's CI and GitHub automation.
+
 ## Greenhouse
 
 [Playbook][greenhouse-playbook]
@@ -18,4 +26,5 @@ in presubmit on Prow.
 <!--URLS-->
 [kubernetes-repo]: https://github.com/kubernetes/kubernetes
 [greenhouse-playbook]: ./../greenhouse/playbook.md
+[prow-playbook]: ./../prow/playbook.md
 [remote build cache]: https://docs.bazel.build/versions/master/remote-caching.html

--- a/docs/playbooks.md
+++ b/docs/playbooks.md
@@ -1,6 +1,6 @@
-# Run Book Index
+# Playbook Index
 
-This is an index of the oncall run books for our various services.
+This is an index of the oncall playbooks for our various services.
 
 These are intended to help you diagnose and repair our infrastructure.
 
@@ -8,7 +8,7 @@ These are intended to help you diagnose and repair our infrastructure.
 
 ## Greenhouse
 
-[Run Book][greenhouse-runbook]
+[Playbook][greenhouse-playbook]
 
 TDLR: Greenhouse is a bazel [remote build cache] service.
 
@@ -17,5 +17,5 @@ in presubmit on Prow.
 
 <!--URLS-->
 [kubernetes-repo]: https://github.com/kubernetes/kubernetes
-[greenhouse-runbook]: ./../greenhouse/runbook.md
+[greenhouse-playbook]: ./../greenhouse/playbook.md
 [remote build cache]: https://docs.bazel.build/versions/master/remote-caching.html

--- a/greenhouse/playbook.md
+++ b/greenhouse/playbook.md
@@ -23,7 +23,7 @@ greenhouse. <!--TODO: link to prow info for doing this on our deployment-->
 The greenhouse pods should have the label `app=greenhouse`, you can view
 the logs with `kubectl logs -l=app=greenhouse`.
 
-The logs may also be stored in [StackDriver] / the host cluster's logging
+The logs may also be stored in [Stackdriver] / the host cluster's logging
 integration(s).
 
 ### Monitoring
@@ -130,7 +130,7 @@ issue.
 [remote-build-cache]: https://docs.bazel.build/versions/master/remote-caching.html
 [deployment.yaml]: ./deployment.yaml
 [service.yaml]: ./deployment.yaml
-[prow-k8s-io]: TODO
+[prow-k8s-io]: https://prow.k8s.io
 [bazel#4558]: https://github.com/bazelbuild/bazel/issues/4558
 [velodrome]: http://velodrome.k8s.io/dashboard/db/bazel-cache?refresh=1m&orgId=1
-[StackDriver]: https://cloud.google.com/stackdriver/
+[Stackdriver]: https://cloud.google.com/stackdriver/

--- a/greenhouse/playbook.md
+++ b/greenhouse/playbook.md
@@ -1,6 +1,6 @@
-# Greenhouse Run Book
+# Greenhouse Playbook
 
-This is the run book for GreenHouse. See also [the run book index][runbooks].
+This is the playbook for GreenHouse. See also [the playbook index][playbooks].
 
 TDLR: Greenhouse is a [bazel] [remote build cache][remote-build-cache].
 
@@ -124,7 +124,7 @@ issue.
 <!--URLS-->
 [OWNERS]: ./OWNERS 
 [README]: ./README.md 
-[runbooks]: ./../docs/runbooks.md
+[playbooks]: ./../docs/playbooks.md
 <!--Additional URLS-->
 [bazel]: https://bazel.build/
 [remote-build-cache]: https://docs.bazel.build/versions/master/remote-caching.html

--- a/prow/playbook.md
+++ b/prow/playbook.md
@@ -1,0 +1,61 @@
+# Prow Playbook
+
+This is the playbook for Prow. See also [the playbook index][playbooks].
+
+TDLR: Prow is a set of CI services.
+
+The [OWNERS][OWNERS] are a potential point of contact for more info.
+
+For in depth details about the project see the [README][README].
+
+## General Debugging
+
+Prow runs as a set of Kubernetes deployments.
+
+For the [Kubernetes Project's Prow Deployment][prow-k8s-io] the exact spec is in
+[cluster], and the deployment is in the "prow services cluster".
+
+### Logs
+
+If you are a googler checking prow.k8s.io, you may open `go/prow-debug` in your
+browser. If you are not a googler but have access to this prow, you can
+open [Stackdriver] logs in the `k8s-prow` GCP projects.
+
+Other prow deployments may have their own logging stack.
+
+### Monitoring
+
+TODO ...
+
+## Options
+
+The following well-known options are available for dealing with prow
+service issues.
+
+### Rolling Back
+
+For prow.k8s.io you can simply use `experiment/revert-bump.sh` to roll back
+to the last checked in deployment version.
+
+If prow is at least somewhat healthy, filing and merging PR from this will 
+result in the rolled back version being deployed.
+
+If not, you may need to manually run `bazel run //prow/cluster:production.apply`.
+
+
+## Known Issues
+
+
+### Something TODO
+
+TODO
+
+<!--URLS-->
+[OWNERS]: ./OWNERS
+[README]: ./README.md
+[playbooks]: ./../docs/playbooks.md
+<!--Additional URLS-->
+[cluster]: ./cluster/
+[prow-k8s-io]: https://prow.k8s.io
+[Stackdriver]: https://cloud.google.com/stackdriver/
+


### PR DESCRIPTION
- run book -> playbook. the latter seems to be the most frequently used term..
- stub in a playbook for prow.
- fix a couple minor issues in the greenhouse playbook

The prow playbook is mostly just a stub, but we can iterate from here, this crosses the activation threshold

/cc @Katharine 