### PR TITLE
Increase CAPA e2e conformance timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -342,6 +342,8 @@ postsubmits:
   - name: ci-cluster-api-provider-aws-e2e-conformance-release-0-4
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Increase the timeout for
ci-cluster-api-provider-aws-e2e-conformance-release-0-4 to 3 hours (the
default is 2). This job is consistently timing out, and it's unclear if
it needs more time, or if there is some other issue. If it does not
finish in 3 hours, then we know there is some other issue we need to
investigate.

/assign @detiber 