### PR TITLE
Update kubetest2 xml format to generate test run time as a property

### DIFF
--- a/kubetest2/pkg/metadata/junit.go
+++ b/kubetest2/pkg/metadata/junit.go
@@ -83,10 +83,27 @@ func (t *testSuite) AddTestCase(tc testCase) {
 //
 // This will become a row in testgrid.
 type testCase struct {
-	XMLName   xml.Name `xml:"testcase"`
-	Name      string   `xml:"name,attr"`
-	Time      float64  `xml:"time,attr"`
-	Failure   string   `xml:"failure,omitempty"`
-	Skipped   string   `xml:"skipped,omitempty"`
-	SystemOut string   `xml:"system-out,omitempty"`
+	XMLName    xml.Name    `xml:"testcase"`
+	Name       string      `xml:"name,attr"`
+	Time       float64     `xml:"time,attr"`
+	Failure    string      `xml:"failure,omitempty"`
+	Skipped    string      `xml:"skipped,omitempty"`
+	SystemOut  string      `xml:"system-out,omitempty"`
+	Properties *properties `xml:"properties,omitempty"`
+}
+
+// properties holds one or more property of the result of a test/step/command.
+type properties struct {
+	XMLName  xml.Name `xml:"properties"`
+	Property []property
+}
+
+// property holds a specific value of a test/step/command that needs to be
+// highlighted in testgrid.
+//
+// Testgrid will collect this property to use for status purpose if configured.
+type property struct {
+	XMLName xml.Name `xml:"property"`
+	Name    string   `xml:"name,attr"`
+	Value   float64  `xml:"value,attr"`
 }

--- a/kubetest2/pkg/metadata/writer.go
+++ b/kubetest2/pkg/metadata/writer.go
@@ -50,9 +50,18 @@ func (w *Writer) WrapStep(name string, doStep func() error) error {
 	start := w.timeNow()
 	err := doStep()
 	finish := w.timeNow()
+	duration := finish.Sub(start).Seconds()
 	tc := testCase{
 		Name: name,
-		Time: finish.Sub(start).Seconds(),
+		Time: duration,
+		Properties: &properties{
+			Property: []property{
+				{
+					Name:  "runtime",
+					Value: duration,
+				},
+			},
+		},
 	}
 	if err != nil {
 		tc.Failure = err.Error()

--- a/kubetest2/pkg/metadata/writer_test.go
+++ b/kubetest2/pkg/metadata/writer_test.go
@@ -73,7 +73,11 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite failures="0" tests="1" time="3">
-    <testcase name="noop" time="1"></testcase>
+    <testcase name="noop" time="1">
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
+    </testcase>
 </testsuite>`,
 				"\n",
 			),
@@ -92,6 +96,9 @@ func TestWriter(t *testing.T) {
 <?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="1" time="3">
     <testcase name="always fails" time="1">
         <failure>oh noes</failure>
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
     </testcase>
 </testsuite>`,
 				"\n",
@@ -117,6 +124,9 @@ func TestWriter(t *testing.T) {
     <testcase name="always fails (junitError)" time="1">
         <failure>on noes</failure>
         <system-out>uh oh</system-out>
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
     </testcase>
 </testsuite>`,
 				"\n",
@@ -147,11 +157,22 @@ func TestWriter(t *testing.T) {
 			expectedOutput: strings.TrimPrefix(
 				`
 <?xml version="1.0" encoding="UTF-8"?><testsuite failures="1" tests="3" time="7">
-    <testcase name="noop" time="1"></testcase>
-    <testcase name="noop2" time="1"></testcase>
+    <testcase name="noop" time="1">
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
+    </testcase>
+    <testcase name="noop2" time="1">
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
+    </testcase>
     <testcase name="always fails (junitError)" time="1">
         <failure>on noes</failure>
         <system-out>uh oh</system-out>
+        <properties>
+            <property name="runtime" value="1"></property>
+        </properties>
     </testcase>
 </testsuite>`,
 				"\n",


### PR DESCRIPTION
Update kubetest2 xml format to generate test run time as a property element in addition to being an attribute of the testcase element. When configure, this property will be picked up by TestGrid.