### PR TITLE
Refactor config updating logic to support config bootstrapping.

### DIFF
--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -34,6 +34,8 @@ import (
 	"k8s.io/test-infra/prow/plugins/updateconfig"
 )
 
+const bootstrapMode = true
+
 type options struct {
 	sourcePath string
 
@@ -135,7 +137,7 @@ func main() {
 			logrus.WithError(err).Errorf("Failed to find configMap client")
 			continue
 		}
-		if err := updateconfig.Update(&updateconfig.OSFileGetter{Root: o.sourcePath}, configMapClient, cm.Name, cm.Namespace, data, nil, logger); err != nil {
+		if err := updateconfig.Update(&updateconfig.OSFileGetter{Root: o.sourcePath}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, nil, logger); err != nil {
 			logger.WithError(err).Error("failed to update config on cluster")
 			errors++
 		} else {

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/prow/plugins/updateconfig/updateconfig_test.go
+++ b/prow/plugins/updateconfig/updateconfig_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/plugins"
 )
 
@@ -1195,6 +1196,169 @@ func TestUpdateConfig(t *testing.T) {
 			} else if !equality.Semantic.DeepEqual(expected, actual) {
 				t.Errorf("%s: incorrect ConfigMap state after update: %v", tc.name, diff.ObjectReflectDiff(expected, actual))
 			}
+		}
+	}
+}
+
+func TestUpdate(t *testing.T) {
+
+	testcases := []struct {
+		name              string
+		updates           []ConfigMapUpdate
+		existConfigMap    runtime.Object
+		expectedConfigMap *coreapi.ConfigMap
+		config            *plugins.ConfigUpdater
+		bootstrap         bool
+	}{
+		{
+			name:      "stale key removed in bootstrap mode",
+			bootstrap: true,
+			updates: []ConfigMapUpdate{
+				{
+					Filename: "config/foo.yaml",
+					Key:      "foo.yaml",
+				},
+			},
+			existConfigMap: runtime.Object(
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multikey-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"foo.yaml": "old-foo-config",
+						"bar.yaml": "old-bar-config",
+					},
+				},
+			),
+			expectedConfigMap: &coreapi.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multikey-config",
+					Namespace: defaultNamespace,
+				},
+				Data: map[string]string{
+					"foo.yaml": "new-foo-config",
+				},
+			},
+		},
+		{
+			name:      "stale key kept when not in bootstrap mode",
+			bootstrap: false,
+			updates: []ConfigMapUpdate{
+				{
+					Filename: "config/foo.yaml",
+					Key:      "foo.yaml",
+				},
+			},
+			existConfigMap: runtime.Object(
+				&coreapi.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "multikey-config",
+						Namespace: defaultNamespace,
+					},
+					Data: map[string]string{
+						"foo.yaml": "old-foo-config",
+						"bar.yaml": "old-bar-config",
+					},
+				},
+			),
+			expectedConfigMap: &coreapi.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "multikey-config",
+					Namespace: defaultNamespace,
+				},
+				Data: map[string]string{
+					"foo.yaml": "new-foo-config",
+					"bar.yaml": "old-bar-config",
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		log := logrus.WithField("plugin", pluginName)
+		fkc := fake.NewSimpleClientset(tc.existConfigMap)
+		configMapClient, err := GetConfigMapClient(fkc.CoreV1(), tc.expectedConfigMap.Namespace, nil, kube.DefaultClusterAlias)
+		if err != nil {
+			log.WithError(err).Errorf("Failed to find configMap client")
+			continue
+		}
+
+		m := tc.config
+		if m == nil {
+			m = &plugins.ConfigUpdater{
+				Maps: map[string]plugins.ConfigMapSpec{
+					"prow/config.yaml": {
+						Name: "config",
+					},
+					"prow/plugins.yaml": {
+						Name: "plugins",
+						Key:  "test-key",
+					},
+					"boskos/resources.yaml": {
+						Name:      "boskos-config",
+						Namespace: "boskos",
+					},
+					"config/foo.yaml": {
+						Name: "multikey-config",
+					},
+					"config/bar.yaml": {
+						Name: "multikey-config",
+					},
+					"dir/subdir/**/*.yaml": {
+						Name: "glob-config",
+					},
+				},
+			}
+		}
+		m.SetDefaults()
+
+		org := "org"
+		repo := "repo"
+		c := setupLocalGitRepo(t, org, repo)
+
+		gitRepo, err := c.Clone(org, repo)
+		if err != nil {
+			t.Fatalf("Failed to clone: %v.", err)
+		}
+		defer func() {
+			if err := c.Clean(); err != nil {
+				t.Errorf("Could not clean up git client cache: %v.", err)
+			}
+		}()
+		if err := gitRepo.Checkout("12345"); err != nil {
+			t.Errorf("Failed to checkout 12345: %v.", err)
+			continue
+		}
+		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, tc.expectedConfigMap.Name, tc.expectedConfigMap.Namespace, tc.updates, tc.bootstrap, nil, log); err != nil {
+			t.Errorf("%s: unexpected error updating: %s", tc.name, err)
+			continue
+		}
+
+		modifiedConfigMaps := sets.NewString()
+		for _, action := range fkc.Fake.Actions() {
+			var obj runtime.Object
+			switch action := action.(type) {
+			case clienttesting.CreateActionImpl:
+				obj = action.Object
+			case clienttesting.UpdateActionImpl:
+				obj = action.Object
+			default:
+				continue
+			}
+			objectMeta, err := meta.Accessor(obj)
+			if err != nil {
+				t.Fatalf("%s: client saw an action for something that wasn't an object: %v", tc.name, err)
+			}
+			modifiedConfigMaps.Insert(objectMeta.GetName())
+		}
+
+		expected := tc.expectedConfigMap
+		actual, err := fkc.CoreV1().ConfigMaps(expected.Namespace).Get(expected.Name, metav1.GetOptions{})
+		if err != nil && errors.IsNotFound(err) {
+			t.Errorf("%s: Should have updated or created configmap for '%s'", tc.name, expected)
+		} else if !equality.Semantic.DeepEqual(expected, actual) {
+			t.Errorf("%s: incorrect ConfigMap state after update: %v", tc.name, diff.ObjectReflectDiff(expected, actual))
 		}
 	}
 }


### PR DESCRIPTION
This addresses the bug where the config-bootstrapper does not delete stale keys from the configmap which results in duplicate ProwJob definitions when files are moved or prevents jobs from being removed when the whole file is deleted.

/kind bug
/assign @Katharine @fejta 