### PR TITLE
Increase CAPA periodic e2e conformance timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -85,7 +85,9 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-conformance-release-0-4
   decorate: true
-  interval: 3h
+  decoration_config:
+    timeout: 3h
+  interval: 4h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"


### PR DESCRIPTION
Increase the timeout for periodic-cluster-api-provider-aws-e2e-conformance-release-0-4
to 3h and interval for the same job to 4h. The job is failing due to timeout.