### PR TITLE
Deck: Add nilchecking before attempting to use the github client for inrepoconfig

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -600,6 +600,10 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, o options
 		if err != nil {
 			logrus.WithError(err).Fatal("Error getting Git client.")
 		}
+	} else {
+		if len(cfg().InRepoConfig.Enabled) > 0 {
+			logrus.Fatal("--github-token-path must be configured with a valid token when using the inrepoconfig feature")
+		}
 	}
 
 	if o.spyglass {

--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -206,6 +207,9 @@ func getGCSDirsForPR(c *config.Config, gitHubClient deckGitHubClient, gitClient 
 	toSearch := make(map[string]sets.String)
 	fullRepo := org + "/" + repo
 
+	if c.InRepoConfigEnabled(fullRepo) && gitHubClient == nil {
+		return nil, errors.New("inrepoconfig is enabled but no --github-token-path configured on deck")
+	}
 	prRefGetter := config.NewRefGetterForGitHubPullRequest(gitHubClient, org, repo, prNumber)
 	presubmits, err := c.GetPresubmits(gitClient, org+"/"+repo, prRefGetter.BaseSHA, prRefGetter.HeadSHA)
 	if err != nil {

--- a/prow/inrepconfig.md
+++ b/prow/inrepconfig.md
@@ -14,6 +14,10 @@ in_repo_config:
     "kubernetes/kubernetes": true
 ```
 
+Additionally, `Deck` must be configured with an oauth token if that is not already the case. To do
+so, the `--github-token-path=` flag must be set and point to a valid token file that has permissions
+to read all your repositories.
+
 Afterwards, you need to add a config verification job to make sure people people get told about
 mistakes in their `.prow.yaml` rather than the PR being stuck. It makes sense to define this
 job in the central repository rather than the code repository, so the `checkconfig` version used


### PR DESCRIPTION
This PR adds nilchecking to Deck for the github client in case the inrepocinfig feature is enabled. This is required, because we only create it conditionally when a certain flag is set.

Another probably better approach would be to just require the flag for Deck? The current state of affair is that pretty much everyone who attempts to use the gitHubClient in deck has to nilcheck it first, which seems like a frequent source of bugs.

Fixes #15509