### PR TITLE
Fix deployment for latest k8s release

### DIFF
--- a/prow/cluster/boskos-metrics.yaml
+++ b/prow/cluster/boskos-metrics.yaml
@@ -28,7 +28,7 @@ spec:
   loadBalancerIP: 104.197.27.114
   type: LoadBalancer
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: boskos-metrics
@@ -36,6 +36,9 @@ metadata:
     app: boskos-metrics
   namespace: test-pods
 spec:
+  selector:
+    matchLabels:
+      app: boskos-metrics
   replicas: 1
   template:
     metadata:

--- a/prow/cluster/boskos-reaper_deployment.yaml
+++ b/prow/cluster/boskos-reaper_deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: boskos-reaper
@@ -6,6 +6,9 @@ metadata:
     app: boskos-reaper
   namespace: test-pods
 spec:
+  selector:
+    matchLabels:
+      app: boskos-reaper
   replicas: 1  # one canonical source of resources
   template:
     metadata:

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
   #    created with: `kubectl create -f prow/cluster/gce-ssd-retain_storageclass.yaml
   storageClassName: gce-ssd-retain
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -42,6 +42,9 @@ metadata:
   labels:
     app: ghproxy
 spec:
+  selector:
+    matchLabels:
+      app: ghproxy
   replicas: 1  # TODO(fejta): this should be HA
   template:
     metadata:

--- a/prow/cluster/monitoring/blackbox_prober.yaml
+++ b/prow/cluster/monitoring/blackbox_prober.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: blackbox-prober
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: blackbox-prober
 spec:
+  selector:
+    matchLabels:
+      app: blackbox-prober
   replicas: 1
   template:
     metadata:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -202,7 +202,7 @@ spec:
   - port: 8888
   type: NodePort
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
@@ -210,6 +210,9 @@ metadata:
   labels:
     app: plank
 spec:
+  selector:
+    matchLabels:
+      app: plank
   replicas: 1 # Do not scale up.
   strategy:
     type: Recreate


### PR DESCRIPTION
To be able to deploy prows plank component we have to switch to
`apps/v1` and add the required selector.
