### PR TITLE
Plank: Use ctrlruntimeclient

### DIFF
--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//prow/plank:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],
 )

--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -34,8 +34,10 @@ go_library(
         "@com_github_satori_go_uuid//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 
@@ -63,7 +65,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
@@ -75,6 +76,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/prow/pjutil/abort_test.go
+++ b/prow/pjutil/abort_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package pjutil
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -24,10 +26,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	clienttesting "k8s.io/client-go/testing"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	prowfake "k8s.io/test-infra/prow/client/clientset/versioned/fake"
 )
 
 func TestTerminateOlderJobs(t *testing.T) {
@@ -436,11 +438,10 @@ func TestTerminateOlderJobs(t *testing.T) {
 			for i := range tc.pjs {
 				prowJobs = append(prowJobs, &tc.pjs[i])
 			}
-			fakeProwJobClient := prowfake.NewSimpleClientset(prowJobs...)
-			pjc := fakeProwJobClient.ProwV1().ProwJobs(fakePJNS)
+			fakeProwJobClient := &patchTrackingFakeClient{Client: fakectrlruntimeclient.NewFakeClient(prowJobs...)}
 			log := logrus.NewEntry(logrus.StandardLogger())
 			cleanedupPJs := sets.NewString()
-			err := TerminateOlderJobs(pjc, log, tc.pjs, func(pj prowjobv1.ProwJob) error {
+			err := TerminateOlderJobs(fakeProwJobClient, log, tc.pjs, func(pj prowjobv1.ProwJob) error {
 				cleanedupPJs.Insert(pj.GetName())
 				return nil
 			})
@@ -455,13 +456,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				t.Errorf("%s: found unexpectedly cleaned up jobs: %v", tc.name, extra.List())
 			}
 
-			replacedJobs := sets.NewString()
-			for _, action := range fakeProwJobClient.Fake.Actions() {
-				switch action := action.(type) {
-				case clienttesting.PatchActionImpl:
-					replacedJobs.Insert(action.Name)
-				}
-			}
+			replacedJobs := fakeProwJobClient.patched
 			if missing := tc.terminateddPJs.Difference(replacedJobs); missing.Len() > 0 {
 				t.Errorf("%s: did not replace the expected jobs: %v", tc.name, missing.Len())
 			}
@@ -470,4 +465,21 @@ func TestTerminateOlderJobs(t *testing.T) {
 			}
 		})
 	}
+}
+
+type patchTrackingFakeClient struct {
+	ctrlruntimeclient.Client
+	patched sets.String
+}
+
+func (c *patchTrackingFakeClient) Patch(ctx context.Context, obj runtime.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
+	if c.patched == nil {
+		c.patched = sets.NewString()
+	}
+	metaObject, ok := obj.(metav1.Object)
+	if !ok {
+		return errors.New("Object is no metav1.Object")
+	}
+	c.patched.Insert(metaObject.GetName())
+	return c.Client.Patch(ctx, obj, patch, opts...)
 }

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -12,7 +12,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/reporter:go_default_library",
@@ -24,9 +23,8 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_client_go//kubernetes/fake:go_default_library",
-        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
-        "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )
 
@@ -36,7 +34,6 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plank",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/report:go_default_library",
@@ -50,7 +47,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
-        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plank
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -24,16 +25,13 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	coreapi "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	ktypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	prowv1 "k8s.io/test-infra/prow/client/clientset/versioned/typed/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	reportlib "k8s.io/test-infra/prow/github/report"
@@ -41,20 +39,13 @@ import (
 	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // PodStatus constants
 const (
 	Evicted = "Evicted"
 )
-
-type prowJobClient interface {
-	Create(*prowapi.ProwJob) (*prowapi.ProwJob, error)
-	Update(*prowapi.ProwJob) (*prowapi.ProwJob, error)
-	Get(name string, options metav1.GetOptions) (*prowapi.ProwJob, error)
-	List(opts metav1.ListOptions) (*prowapi.ProwJobList, error)
-	Patch(name string, pt ktypes.PatchType, data []byte, subresources ...string) (result *prowapi.ProwJob, err error)
-}
 
 // GitHubClient contains the methods used by plank on k8s.io/test-infra/prow/github.Client
 // Plank's unit tests implement a fake of this.
@@ -69,12 +60,13 @@ type GitHubClient interface {
 }
 
 // TODO: Dry this out
-type syncFn func(pj prowapi.ProwJob, pm map[string]coreapi.Pod, reports chan<- prowapi.ProwJob) error
+type syncFn func(pj prowapi.ProwJob, pm map[string]corev1.Pod, reports chan<- prowapi.ProwJob) error
 
 // Controller manages ProwJobs.
 type Controller struct {
-	prowJobClient prowJobClient
-	buildClients  map[string]corev1.PodInterface
+	ctx           context.Context
+	prowJobClient ctrlruntimeclient.Client
+	buildClients  map[string]ctrlruntimeclient.Client
 	ghc           GitHubClient
 	log           *logrus.Entry
 	config        config.Getter
@@ -102,12 +94,12 @@ type Controller struct {
 }
 
 // NewController creates a new Controller from the provided clients.
-func NewController(prowJobClient prowv1.ProwJobInterface, buildClients map[string]corev1.PodInterface, ghc GitHubClient, logger *logrus.Entry, cfg config.Getter, totURL, selector string, skipReport bool) (*Controller, error) {
+func NewController(pjClient ctrlruntimeclient.Client, buildClients map[string]ctrlruntimeclient.Client, ghc GitHubClient, logger *logrus.Entry, cfg config.Getter, totURL, selector string, skipReport bool) (*Controller, error) {
 	if logger == nil {
 		logger = logrus.NewEntry(logrus.StandardLogger())
 	}
 	return &Controller{
-		prowJobClient: prowJobClient,
+		prowJobClient: pjClient,
 		buildClients:  buildClients,
 		ghc:           ghc,
 		log:           logger,
@@ -187,7 +179,8 @@ func (c *Controller) incrementNumPendingJobs(job string) {
 // migration to become seamless.
 func (c *Controller) setPreviousReportState(pj prowapi.ProwJob) error {
 	// fetch latest before replace
-	latestPJ, err := c.prowJobClient.Get(pj.ObjectMeta.Name, metav1.GetOptions{})
+	latestPJ := &prowapi.ProwJob{}
+	err := c.prowJobClient.Get(c.ctx, ktypes.NamespacedName{Namespace: c.config().ProwJobNamespace, Name: pj.Name}, latestPJ)
 	c.log.WithFields(pjutil.ProwJobFields(latestPJ)).Debug("Get ProwJob.")
 	if err != nil {
 		return err
@@ -197,7 +190,7 @@ func (c *Controller) setPreviousReportState(pj prowapi.ProwJob) error {
 		latestPJ.Status.PrevReportStates = map[string]prowapi.ProwJobState{}
 	}
 	latestPJ.Status.PrevReportStates[reporter.GitHubReporterName] = latestPJ.Status.State
-	_, err = c.prowJobClient.Update(latestPJ)
+	err = c.prowJobClient.Update(c.ctx, latestPJ)
 	c.log.WithFields(pjutil.ProwJobFields(latestPJ)).Debug("Update ProwJob.")
 	return err
 }
@@ -206,7 +199,12 @@ func (c *Controller) setPreviousReportState(pj prowapi.ProwJob) error {
 func (c *Controller) Sync() error {
 	var syncErrs []error
 
-	pjs, err := c.prowJobClient.List(metav1.ListOptions{LabelSelector: c.selector})
+	pjs := &prowapi.ProwJobList{}
+	listOpts := &ctrlruntimeclient.ListOptions{
+		Namespace: c.config().ProwJobNamespace,
+		Raw:       &metav1.ListOptions{LabelSelector: c.selector},
+	}
+	err := c.prowJobClient.List(c.ctx, pjs, listOpts)
 	c.log.WithField("selector", c.selector).Debug("List ProwJobs.")
 	if err != nil {
 		return fmt.Errorf("error listing prow jobs: %v", err)
@@ -216,9 +214,14 @@ func (c *Controller) Sync() error {
 		selector = strings.Join([]string{c.selector, selector}, ",")
 	}
 
-	pm := map[string]v1.Pod{}
+	pm := map[string]corev1.Pod{}
 	for alias, client := range c.buildClients {
-		pods, err := client.List(metav1.ListOptions{LabelSelector: selector})
+		listOpts := &ctrlruntimeclient.ListOptions{
+			Namespace: c.config().PodNamespace,
+			Raw:       &metav1.ListOptions{LabelSelector: selector},
+		}
+		pods := &corev1.PodList{}
+		err := client.List(c.ctx, pods, listOpts)
 		c.log.WithField("selector", selector).Debug("List Pods.")
 		if err != nil {
 			syncErrs = append(syncErrs, fmt.Errorf("error listing pods in cluster %q: %v", alias, err))
@@ -305,7 +308,7 @@ func (c *Controller) SyncMetrics() {
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs
 // in-place when it aborts.
 // TODO: Dry this out - need to ensure we can abstract children cancellation first.
-func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]coreapi.Pod) error {
+func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]corev1.Pod) error {
 	log := c.log.WithField("aborter", "pod")
 	return pjutil.TerminateOlderJobs(c.prowJobClient, log, pjs, func(toCancel prowapi.ProwJob) error {
 		// Allow aborting presubmit jobs for commits that have been superseded by
@@ -315,7 +318,7 @@ func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]coreapi
 				c.log.WithField("name", pod.ObjectMeta.Name).Debug("Delete Pod.")
 				if client, ok := c.buildClients[toCancel.ClusterAlias()]; !ok {
 					return fmt.Errorf("unknown cluster alias %q", toCancel.ClusterAlias())
-				} else if err := client.Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{}); err != nil {
+				} else if err := client.Delete(c.ctx, &pod); err != nil {
 					return fmt.Errorf("deleting pod: %v", err)
 				}
 			}
@@ -332,7 +335,7 @@ func syncProwJobs(
 	jobs <-chan prowapi.ProwJob,
 	reports chan<- prowapi.ProwJob,
 	syncErrors chan<- error,
-	pm map[string]coreapi.Pod,
+	pm map[string]corev1.Pod,
 ) {
 	goroutines := maxSyncRoutines
 	if goroutines > len(jobs) {
@@ -354,7 +357,7 @@ func syncProwJobs(
 	wg.Wait()
 }
 
-func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Pod, reports chan<- prowapi.ProwJob) error {
+func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod, reports chan<- prowapi.ProwJob) error {
 	// Record last known state so we can log state transitions.
 	prevState := pj.Status.State
 	prevPJ := *pj.DeepCopy()
@@ -381,7 +384,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 	} else {
 
 		switch pod.Status.Phase {
-		case coreapi.PodUnknown:
+		case corev1.PodUnknown:
 			c.incrementNumPendingJobs(pj.Spec.Job)
 			// Pod is in Unknown state. This can happen if there is a problem with
 			// the node. Delete the old pod, we'll start a new one next loop.
@@ -392,15 +395,15 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			}
 
 			c.log.WithField("name", pj.ObjectMeta.Name).Debug("Delete Pod.")
-			return client.Delete(pj.ObjectMeta.Name, &metav1.DeleteOptions{})
+			return client.Delete(c.ctx, &pod)
 
-		case coreapi.PodSucceeded:
+		case corev1.PodSucceeded:
 			// Pod succeeded. Update ProwJob, talk to GitHub, and start next jobs.
 			pj.SetComplete()
 			pj.Status.State = prowapi.SuccessState
 			pj.Status.Description = "Job succeeded."
 
-		case coreapi.PodFailed:
+		case corev1.PodFailed:
 			if pod.Status.Reason == Evicted {
 				// Pod was evicted.
 				if pj.Spec.ErrorOnEviction {
@@ -418,14 +421,14 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 					return fmt.Errorf("evicted pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
 				}
 				c.log.WithField("name", pj.ObjectMeta.Name).Debug("Delete Pod.")
-				return client.Delete(pj.ObjectMeta.Name, &metav1.DeleteOptions{})
+				return client.Delete(c.ctx, &pod)
 			}
 			// Pod failed. Update ProwJob, talk to GitHub.
 			pj.SetComplete()
 			pj.Status.State = prowapi.FailureState
 			pj.Status.Description = "Job failed."
 
-		case coreapi.PodPending:
+		case corev1.PodPending:
 			maxPodPending := c.config().Plank.PodPendingTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodPending {
 				// Pod is running. Do nothing.
@@ -442,12 +445,12 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			if !ok {
 				return fmt.Errorf("pending pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
 			}
-			if err := client.Delete(pj.ObjectMeta.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := client.Delete(c.ctx, &pod); err != nil {
 				return fmt.Errorf("failed to delete pod %s that was in pending timeout: %v", pod.Name, err)
 			}
 			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Deleted stale pending pod.")
 
-		case coreapi.PodRunning:
+		case corev1.PodRunning:
 			maxPodRunning := c.config().Plank.PodRunningTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
 				// Pod is still running. Do nothing.
@@ -464,7 +467,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			if !ok {
 				return fmt.Errorf("running pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
 			}
-			if err := client.Delete(pj.ObjectMeta.Name, &metav1.DeleteOptions{}); err != nil {
+			if err := client.Delete(c.ctx, &pod); err != nil {
 				return fmt.Errorf("failed to delete pod %s that was in running timeout: %v", pod.Name, err)
 			}
 			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Deleted stale running pod.")
@@ -485,11 +488,10 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]coreapi.Po
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
 
-	_, err := pjutil.PatchProwjob(c.prowJobClient, c.log, prevPJ, pj)
-	return err
+	return c.prowJobClient.Patch(c.ctx, pj.DeepCopy(), ctrlruntimeclient.MergeFrom(&prevPJ))
 }
 
-func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]coreapi.Pod, reports chan<- prowapi.ProwJob) error {
+func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]corev1.Pod, reports chan<- prowapi.ProwJob) error {
 	// Record last known state so we can log state transitions.
 	prevState := pj.Status.State
 	prevPJ := pj
@@ -538,8 +540,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]coreapi.
 			WithField("from", prevState).
 			WithField("to", pj.Status.State).Info("Transitioning states.")
 	}
-	_, err := pjutil.PatchProwjob(c.prowJobClient, c.log, prevPJ, pj)
-	return err
+	return c.prowJobClient.Patch(c.ctx, pj.DeepCopy(), ctrlruntimeclient.MergeFrom(&prevPJ))
 }
 
 // TODO: No need to return the pod name since we already have the
@@ -554,24 +555,25 @@ func (c *Controller) startPod(pj prowapi.ProwJob) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
+	pod.Namespace = c.config().PodNamespace
 
 	client, ok := c.buildClients[pj.ClusterAlias()]
 	if !ok {
 		return "", "", fmt.Errorf("unknown cluster alias %q", pj.ClusterAlias())
 	}
-	actual, err := client.Create(pod)
+	err = client.Create(c.ctx, pod)
 	c.log.WithFields(pjutil.ProwJobFields(&pj)).Debug("Create Pod.")
 	if err != nil {
 		return "", "", err
 	}
-	return buildID, actual.ObjectMeta.Name, nil
+	return buildID, pod.ObjectMeta.Name, nil
 }
 
 func (c *Controller) getBuildID(name string) (string, error) {
 	return pjutil.GetBuildID(name, c.totURL)
 }
 
-func getPodBuildID(pod *coreapi.Pod) string {
+func getPodBuildID(pod *corev1.Pod) string {
 	for _, env := range pod.Spec.Containers[0].Env {
 		if env.Name == "BUILD_ID" {
 			return env.Value

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plank
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -28,21 +29,19 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	kapierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/kubernetes/fake"
-	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	clienttesting "k8s.io/client-go/testing"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	prowfake "k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/reporter"
 	"k8s.io/test-infra/prow/pjutil"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 type fca struct {
@@ -288,13 +287,17 @@ func TestTerminateDupes(t *testing.T) {
 		for i := range tc.pjs {
 			prowJobs = append(prowJobs, &tc.pjs[i])
 		}
-		fakeProwJobClient := prowfake.NewSimpleClientset(prowJobs...)
+		fakeProwJobClient := &patchTrackingFakeClient{
+			Client: fakectrlruntimeclient.NewFakeClient(prowJobs...),
+		}
 		var pods []runtime.Object
 		for name := range tc.pm {
 			pod := tc.pm[name]
 			pods = append(pods, &pod)
 		}
-		fakePodClient := fake.NewSimpleClientset(pods...)
+		fakePodClient := &deleteTrackingFakeClient{
+			Client: fakectrlruntimeclient.NewFakeClient(pods...),
+		}
 		fca := &fca{
 			c: &config.Config{
 				ProwConfig: config.ProwConfig{
@@ -310,8 +313,8 @@ func TestTerminateDupes(t *testing.T) {
 		}
 		log := logrus.NewEntry(logrus.StandardLogger())
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
-			buildClients:  map[string]corev1.PodInterface{prowapi.DefaultClusterAlias: fakePodClient.CoreV1().Pods("pods")},
+			prowJobClient: fakeProwJobClient,
+			buildClients:  map[string]ctrlruntimeclient.Client{prowapi.DefaultClusterAlias: fakePodClient},
 			log:           log,
 			config:        fca.Config,
 			clock:         clock.RealClock{},
@@ -321,13 +324,7 @@ func TestTerminateDupes(t *testing.T) {
 			t.Fatalf("Error terminating dupes: %v", err)
 		}
 
-		observedCompletedProwJobs := sets.NewString()
-		for _, action := range fakeProwJobClient.Fake.Actions() {
-			switch action := action.(type) {
-			case clienttesting.PatchActionImpl:
-				observedCompletedProwJobs.Insert(action.Name)
-			}
-		}
+		observedCompletedProwJobs := fakeProwJobClient.patched
 		if missing := tc.terminatedPJs.Difference(observedCompletedProwJobs); missing.Len() > 0 {
 			t.Errorf("%s: did not delete expected prowJobs: %v", tc.name, missing.List())
 		}
@@ -335,13 +332,7 @@ func TestTerminateDupes(t *testing.T) {
 			t.Errorf("%s: found unexpectedly deleted prowJobs: %v", tc.name, extra.List())
 		}
 
-		observedTerminatedPods := sets.NewString()
-		for _, action := range fakePodClient.Fake.Actions() {
-			switch action := action.(type) {
-			case clienttesting.DeleteActionImpl:
-				observedTerminatedPods.Insert(action.Name)
-			}
-		}
+		observedTerminatedPods := fakePodClient.deleted
 		if missing := tc.terminatedPods.Difference(observedTerminatedPods); missing.Len() > 0 {
 			t.Errorf("%s: did not delete expected pods: %v", tc.name, missing.List())
 		}
@@ -704,24 +695,22 @@ func TestSyncTriggeredJobs(t *testing.T) {
 				pm[pods[i].ObjectMeta.Name] = pods[i]
 			}
 		}
-		fakeProwJobClient := prowfake.NewSimpleClientset(&tc.pj)
-		buildClients := map[string]corev1.PodInterface{}
+		fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(&tc.pj)
+		buildClients := map[string]ctrlruntimeclient.Client{}
 		for alias, pods := range tc.pods {
 			var data []runtime.Object
 			for i := range pods {
 				pod := pods[i]
 				data = append(data, &pod)
 			}
-			fakeClient := fake.NewSimpleClientset(data...)
-			if tc.podErr != nil {
-				fakeClient.PrependReactor("create", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-					return true, nil, tc.podErr
-				})
+			fakeClient := &createErroringClient{
+				Client: fakectrlruntimeclient.NewFakeClient(data...),
+				err:    tc.podErr,
 			}
-			buildClients[alias] = fakeClient.CoreV1().Pods("pods")
+			buildClients[alias] = fakeClient
 		}
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: fakeProwJobClient,
 			buildClients:  buildClients,
 			log:           logrus.NewEntry(logrus.StandardLogger()),
 			config:        newFakeConfigAgent(t, tc.maxConcurrency).Config,
@@ -752,8 +741,8 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			}
 		}
 
-		actualProwJobs, err := fakeProwJobClient.ProwV1().ProwJobs("prowjobs").List(metav1.ListOptions{})
-		if err != nil {
+		actualProwJobs := &prowapi.ProwJobList{}
+		if err := fakeProwJobClient.List(context.Background(), actualProwJobs); err != nil {
 			t.Errorf("for case %q could not list prowJobs from the client: %v", tc.name, err)
 		}
 		if len(actualProwJobs.Items) != tc.expectedCreatedPJs+1 {
@@ -770,8 +759,8 @@ func TestSyncTriggeredJobs(t *testing.T) {
 			t.Errorf("for case %q got no pod name, expected one", tc.name)
 		}
 		for alias, expected := range tc.expectedNumPods {
-			actualPods, err := buildClients[alias].List(metav1.ListOptions{})
-			if err != nil {
+			actualPods := &v1.PodList{}
+			if err := buildClients[alias].List(context.Background(), actualPods); err != nil {
 				t.Errorf("for case %q could not list pods from the client: %v", tc.name, err)
 			}
 			if got := len(actualPods.Items); got != expected {
@@ -1168,23 +1157,21 @@ func TestSyncPendingJob(t *testing.T) {
 		for i := range tc.pods {
 			pm[tc.pods[i].ObjectMeta.Name] = tc.pods[i]
 		}
-		fakeProwJobClient := prowfake.NewSimpleClientset(&tc.pj)
+		fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(&tc.pj)
 		var data []runtime.Object
 		for i := range tc.pods {
 			pod := tc.pods[i]
 			data = append(data, &pod)
 		}
-		fakeClient := fake.NewSimpleClientset(data...)
-		if tc.err != nil {
-			fakeClient.PrependReactor("create", "pods", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, nil, tc.err
-			})
+		fakeClient := &createErroringClient{
+			Client: fakectrlruntimeclient.NewFakeClient(data...),
+			err:    tc.err,
 		}
-		buildClients := map[string]corev1.PodInterface{
-			prowapi.DefaultClusterAlias: fakeClient.CoreV1().Pods("pods"),
+		buildClients := map[string]ctrlruntimeclient.Client{
+			prowapi.DefaultClusterAlias: fakeClient,
 		}
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: fakeProwJobClient,
 			buildClients:  buildClients,
 			log:           logrus.NewEntry(logrus.StandardLogger()),
 			config:        newFakeConfigAgent(t, 0).Config,
@@ -1200,8 +1187,8 @@ func TestSyncPendingJob(t *testing.T) {
 		}
 		close(reports)
 
-		actualProwJobs, err := fakeProwJobClient.ProwV1().ProwJobs("prowjobs").List(metav1.ListOptions{})
-		if err != nil {
+		actualProwJobs := &prowapi.ProwJobList{}
+		if err := fakeProwJobClient.List(context.Background(), actualProwJobs); err != nil {
 			t.Errorf("for case %q could not list prowJobs from the client: %v", tc.name, err)
 		}
 		if len(actualProwJobs.Items) != tc.expectedCreatedPJs+1 {
@@ -1211,8 +1198,8 @@ func TestSyncPendingJob(t *testing.T) {
 		if actual.Status.State != tc.expectedState {
 			t.Errorf("for case %q got state %v", tc.name, actual.Status.State)
 		}
-		actualPods, err := buildClients[prowapi.DefaultClusterAlias].List(metav1.ListOptions{})
-		if err != nil {
+		actualPods := &v1.PodList{}
+		if err := buildClients[prowapi.DefaultClusterAlias].List(context.Background(), actualPods); err != nil {
 			t.Errorf("for case %q could not list pods from the client: %v", tc.name, err)
 		}
 		if got := len(actualPods.Items); got != tc.expectedNumPods {
@@ -1253,7 +1240,7 @@ func TestOrderedJobs(t *testing.T) {
 			},
 		}), nil, nil)
 		job.ObjectMeta.CreationTimestamp = metav1.Time{
-			Time: time.Now(),
+			Time: time.Now().Add(time.Duration(i) * time.Hour),
 		}
 		job.Namespace = "prowjobs"
 		pjs = append(pjs, job)
@@ -1269,13 +1256,13 @@ func TestOrderedJobs(t *testing.T) {
 		for i := 0; i < len(pjs); i++ {
 			newPjs[i] = &pjs[orders[i]]
 		}
-		fakeProwJobClient := prowfake.NewSimpleClientset(newPjs...)
-		buildClients := map[string]corev1.PodInterface{
-			"trusted": fake.NewSimpleClientset().CoreV1().Pods("pods"),
+		fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(newPjs...)
+		buildClients := map[string]ctrlruntimeclient.Client{
+			"trusted": fakectrlruntimeclient.NewFakeClient(),
 		}
 		log := logrus.NewEntry(logrus.StandardLogger())
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: fakeProwJobClient,
 			ghc:           &fghc{},
 			buildClients:  buildClients,
 			log:           log,
@@ -1290,7 +1277,7 @@ func TestOrderedJobs(t *testing.T) {
 		}
 		for i, name := range expOut {
 			if c.pjs[i].Spec.Job != name {
-				t.Fatalf("Error in keeping order, want: '%s', got '%s'", name, c.pjs[i].Spec.Job)
+				t.Errorf("Error in keeping order, want: '%s', got '%s'", name, c.pjs[i].Spec.Job)
 			}
 		}
 	}
@@ -1311,14 +1298,14 @@ func TestPeriodic(t *testing.T) {
 	defer totServ.Close()
 	pj := pjutil.NewProwJob(pjutil.PeriodicSpec(per), nil, nil)
 	pj.Namespace = "prowjobs"
-	fakeProwJobClient := prowfake.NewSimpleClientset(&pj)
-	buildClients := map[string]corev1.PodInterface{
-		prowapi.DefaultClusterAlias: fake.NewSimpleClientset().CoreV1().Pods("pods"),
-		"trusted":                   fake.NewSimpleClientset().CoreV1().Pods("pods"),
+	fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(&pj)
+	buildClients := map[string]ctrlruntimeclient.Client{
+		prowapi.DefaultClusterAlias: fakectrlruntimeclient.NewFakeClient(),
+		"trusted":                   fakectrlruntimeclient.NewFakeClient(),
 	}
 	log := logrus.NewEntry(logrus.StandardLogger())
 	c := Controller{
-		prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+		prowJobClient: fakeProwJobClient,
 		ghc:           &fghc{},
 		buildClients:  buildClients,
 		log:           log,
@@ -1331,8 +1318,9 @@ func TestPeriodic(t *testing.T) {
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on first sync: %v", err)
 	}
-	afterFirstSync, err := fakeProwJobClient.ProwV1().ProwJobs("prowjobs").List(metav1.ListOptions{})
-	if err != nil {
+
+	afterFirstSync := &prowapi.ProwJobList{}
+	if err := fakeProwJobClient.List(context.Background(), afterFirstSync); err != nil {
 		t.Fatalf("could not list prowJobs from the client: %v", err)
 	}
 	if len(afterFirstSync.Items) != 1 {
@@ -1341,8 +1329,8 @@ func TestPeriodic(t *testing.T) {
 	if len(afterFirstSync.Items[0].Spec.PodSpec.Containers) != 1 || afterFirstSync.Items[0].Spec.PodSpec.Containers[0].Name != "test-name" {
 		t.Fatalf("Sync step updated the pod spec: %#v", afterFirstSync.Items[0].Spec.PodSpec)
 	}
-	podsAfterSync, err := buildClients["trusted"].List(metav1.ListOptions{})
-	if err != nil {
+	podsAfterSync := &v1.PodList{}
+	if err := buildClients["trusted"].List(context.Background(), podsAfterSync); err != nil {
 		t.Fatalf("could not list pods from the client: %v", err)
 	}
 	if len(podsAfterSync.Items) != 1 {
@@ -1356,8 +1344,8 @@ func TestPeriodic(t *testing.T) {
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on second sync: %v", err)
 	}
-	podsAfterSecondSync, err := buildClients["trusted"].List(metav1.ListOptions{})
-	if err != nil {
+	podsAfterSecondSync := &v1.PodList{}
+	if err := buildClients["trusted"].List(context.Background(), podsAfterSecondSync); err != nil {
 		t.Fatalf("could not list pods from the client: %v", err)
 	}
 	if len(podsAfterSecondSync.Items) != 1 {
@@ -1365,14 +1353,14 @@ func TestPeriodic(t *testing.T) {
 	}
 	update := podsAfterSecondSync.Items[0].DeepCopy()
 	update.Status.Phase = v1.PodSucceeded
-	if _, err := buildClients["trusted"].Update(update); err != nil {
+	if err := buildClients["trusted"].Update(context.Background(), update); err != nil {
 		t.Fatalf("could not update pod to be succeeded: %v", err)
 	}
 	if err := c.Sync(); err != nil {
 		t.Fatalf("Error on third sync: %v", err)
 	}
-	afterThirdSync, err := fakeProwJobClient.ProwV1().ProwJobs("prowjobs").List(metav1.ListOptions{})
-	if err != nil {
+	afterThirdSync := &prowapi.ProwJobList{}
+	if err := fakeProwJobClient.List(context.Background(), afterThirdSync); err != nil {
 		t.Fatalf("could not list prowJobs from the client: %v", err)
 	}
 	if len(afterThirdSync.Items) != 1 {
@@ -1521,12 +1509,12 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 		for i := range test.pjs {
 			prowJobs = append(prowJobs, &test.pjs[i])
 		}
-		fakeProwJobClient := prowfake.NewSimpleClientset(prowJobs...)
-		buildClients := map[string]corev1.PodInterface{
-			prowapi.DefaultClusterAlias: fake.NewSimpleClientset().CoreV1().Pods("pods"),
+		fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(prowJobs...)
+		buildClients := map[string]ctrlruntimeclient.Client{
+			prowapi.DefaultClusterAlias: fakectrlruntimeclient.NewFakeClient(),
 		}
 		c := Controller{
-			prowJobClient: fakeProwJobClient.ProwV1().ProwJobs("prowjobs"),
+			prowJobClient: fakeProwJobClient,
 			buildClients:  buildClients,
 			log:           logrus.NewEntry(logrus.StandardLogger()),
 			config:        newFakeConfigAgent(t, 0).Config,
@@ -1539,8 +1527,8 @@ func TestMaxConcurrencyWithNewlyTriggeredJobs(t *testing.T) {
 		pm := make(map[string]v1.Pod)
 
 		syncProwJobs(c.log, c.syncTriggeredJob, 20, jobs, reports, errors, pm)
-		podsAfterSync, err := buildClients[prowapi.DefaultClusterAlias].List(metav1.ListOptions{})
-		if err != nil {
+		podsAfterSync := &v1.PodList{}
+		if err := buildClients[prowapi.DefaultClusterAlias].List(context.Background(), podsAfterSync); err != nil {
 			t.Fatalf("could not list pods from the client: %v", err)
 		}
 		if len(podsAfterSync.Items) != test.expectedPods {
@@ -1662,7 +1650,7 @@ func TestMaxConcurency(t *testing.T) {
 			for i := range tc.existingProwJobs {
 				prowJobs = append(prowJobs, &tc.existingProwJobs[i])
 			}
-			buildClients := map[string]corev1.PodInterface{}
+			buildClients := map[string]ctrlruntimeclient.Client{}
 			c := Controller{
 				pjs:          tc.existingProwJobs,
 				buildClients: buildClients,
@@ -1681,4 +1669,50 @@ func TestMaxConcurency(t *testing.T) {
 		})
 	}
 
+}
+
+type patchTrackingFakeClient struct {
+	ctrlruntimeclient.Client
+	patched sets.String
+}
+
+func (c *patchTrackingFakeClient) Patch(ctx context.Context, obj runtime.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
+	if c.patched == nil {
+		c.patched = sets.NewString()
+	}
+	metaObject, ok := obj.(metav1.Object)
+	if !ok {
+		return errors.New("Object is no metav1.Object")
+	}
+	c.patched.Insert(metaObject.GetName())
+	return c.Client.Patch(ctx, obj, patch, opts...)
+}
+
+type deleteTrackingFakeClient struct {
+	ctrlruntimeclient.Client
+	deleted sets.String
+}
+
+func (c *deleteTrackingFakeClient) Delete(ctx context.Context, obj runtime.Object, opts ...ctrlruntimeclient.DeleteOption) error {
+	if c.deleted == nil {
+		c.deleted = sets.String{}
+	}
+	metaObject, ok := obj.(metav1.Object)
+	if !ok {
+		return errors.New("object is not a metav1.Object")
+	}
+	c.deleted.Insert(metaObject.GetName())
+	return c.Client.Delete(ctx, obj, opts...)
+}
+
+type createErroringClient struct {
+	ctrlruntimeclient.Client
+	err error
+}
+
+func (c *createErroringClient) Create(ctx context.Context, obj runtime.Object, opts ...ctrlruntimeclient.CreateOption) error {
+	if c.err != nil {
+		return c.err
+	}
+	return c.Client.Create(ctx, obj, opts...)
 }


### PR DESCRIPTION
This PR changes Plank to use an uncached ctrlruntimeclient. No functionality is changed.

This is done as a first step towards https://github.com/kubernetes/test-infra/issues/14236 to allow re-using the tests.