### PR TITLE
Inrepoconfig: Add config for allowed clusters

### DIFF
--- a/prow/config/inrepoconfig.go
+++ b/prow/config/inrepoconfig.go
@@ -118,6 +118,9 @@ func DefaultAndValidateProwYAML(c *Config, p *ProwYAML, identifier string) error
 		if ps.Branches != nil || ps.SkipBranches != nil {
 			errs = append(errs, fmt.Errorf("job %q contains branchconfig. This is not allowed for jobs in %q", ps.Name, inRepoConfigFileName))
 		}
+		if !c.InRepoConfigAllowsCluster(ps.Cluster, identifier) {
+			errs = append(errs, fmt.Errorf("cluster %q is not allowed for repository %q", ps.Cluster, identifier))
+		}
 	}
 
 	return utilerrors.NewAggregate(errs)

--- a/prow/inrepoconfig.md
+++ b/prow/inrepoconfig.md
@@ -9,9 +9,17 @@ To enable it, add the following to your Prows `config.yaml`:
 ```
 in_repo_config:
   enabled:
-    # The key can be one of "*" for "globally", "org" for the GitHub organization or "org/repo" for
-    # a specific repo. The narrowest match is used.
-    "kubernetes/kubernetes": true
+    # The key can be one of "*" for "globally", "org" or "org/repo".
+    # The narrowest match is used.
+    kubernetes/kubernetes: true
+
+  # Clusters must be allowed before they can be used. Below is the default: Allow the `default` cluster
+  # globally.
+  # This setting also allows using "*" for "globally", "org" or "org/repo" as key.
+	# a given repo. All clusters that are allowed for the specific repo, its org or
+	# globally can be used.
+  allowed_clusters:
+    "*": ["default"]
 ```
 
 Additionally, `Deck` must be configured with an oauth token if that is not already the case. To do


### PR DESCRIPTION
So the thing can also used on Deployments that use clusters as unit for determine privilege, like the prow.k8s.io setup.