### PR TITLE
Revert "Fix severity based alert routing."

### DIFF
--- a/prow/cluster/monitoring/alertmanager-prow_secret.yaml
+++ b/prow/cluster/monitoring/alertmanager-prow_secret.yaml
@@ -13,15 +13,13 @@ stringData:
     route:
       group_by: ['alertname', 'job']
       group_wait: 30s
-      group_interval: 10m
-      repeat_interval: 4h
+      group_interval: 5m
+      repeat_interval: 2h
       receiver: 'slack-warnings'
       routes:
       - receiver: 'slack-alerts'
-        group_interval: 5m
-        repeat_interval: 2h
-        match_re:
-          severity: 'critical|high'
+        match:
+          severity: slack
 
     receivers:
     - name: 'slack-warnings'

--- a/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
@@ -20,7 +20,7 @@
               < 10
             |||,
             labels: {
-              severity: 'high',
+              severity: 'warning',
               'boskos-type': '{{ $labels.type }}',
             },
             annotations: {

--- a/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
@@ -11,7 +11,7 @@
             ||| % name,
             'for': '5m',
             labels: {
-              severity: 'critical',
+              severity: 'slack',
             },
             annotations: {
               message: '@test-infra-oncall The service %s has been down for 5 minutes.' % name,

--- a/prow/cluster/monitoring/mixins/prometheus/configmap_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/configmap_alerts.libsonnet
@@ -9,11 +9,11 @@
             expr: |||
               100 * ((1048576 - prow_configmap_size_bytes) / 1048576) < 15
               and
-              predict_linear(prow_configmap_size_bytes[24h], 7 * 24 * 3600) > 1048576
+              predict_linear(prow_configmap_size_bytes[12h], 7 * 24 * 3600) > 1048576
             |||,
             'for': '5m',
             labels: {
-              severity: 'high',
+              severity: 'critical',
             },
             annotations: {
               message: 'Based on recent sampling, the ConfigMap {{ $labels.name }} in Namespace {{ $labels.namespace }} is expected to fill up within a week. Currently {{ printf "%0.2f" $value }}% is available.',

--- a/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -34,11 +34,11 @@
             expr: |||
               github_token_usage{job="ghproxy"} <  1500
               and
-              predict_linear(github_token_usage{job="ghproxy"}[30m], 1 * 3600) < 0
+              predict_linear(github_token_usage{job="ghproxy"}[1h], 1 * 3600) < 0
             |||,
             'for': '5m',
             labels: {
-              severity: 'high',
+              severity: 'warning',
             },
             annotations: {
               message: 'token {{ $labels.token_hash }} will run out of API quota before the next reset.',

--- a/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -11,12 +11,12 @@
               (sum(increase(prow_webhook_counter[1m])) == 0 or absent(prow_webhook_counter))
               and ((day_of_week() > 0) and (day_of_week() < 6) and (hour() >= 16))
             |||,
-            'for': '10m',
+            'for': '5m',
             labels: {
-              severity: 'high',
+              severity: 'slack',
             },
             annotations: {
-              message: 'There have been no webhook calls on working hours for 10 minutes',
+              message: 'There have been no webhook calls on working hours for 5 minutes',
             },
           },
         ],

--- a/prow/cluster/monitoring/mixins/prometheus/prow_monitoring_absent_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prow_monitoring_absent_alerts.libsonnet
@@ -10,7 +10,7 @@
           |||,
           'for': '5m',
           labels: { 
-            severity: 'critical',
+            severity: 'slack',
           },
           annotations: {
             message: 'The service {{ $labels.job }} has at most 1 instance for 5 minutes.',
@@ -23,7 +23,7 @@
             ||| % name,
             'for': '5m',
             labels: {
-              severity: 'critical',
+              severity: 'slack',
             },
             annotations: {
               message: 'The service %s has been down for 5 minutes.' % name,

--- a/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
@@ -11,7 +11,7 @@
             |||,
             'for': '5m',
             labels: {
-              severity: 'high',
+              severity: 'critical',
             },
             annotations: {
               message: 'Sinker has not removed any Pods in the last hour, likely indicating an outage in the service.',
@@ -24,7 +24,7 @@
             |||,
             'for': '5m',
             labels: {
-              severity: 'high',
+              severity: 'critical',
             },
             annotations: {
               message: 'Sinker has not removed any Prow jobs in the last hour, likely indicating an outage in the service.',

--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -10,7 +10,7 @@
               sum(increase(tidesyncheartbeat{controller="sync"}[15m])) < 1
             |||,
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               message: 'The Tide "sync" controller has not synced in 15 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
@@ -22,7 +22,7 @@
               sum(increase(tidesyncheartbeat{controller="status-update"}[30m])) < 1
             |||,
             labels: {
-              severity: 'critical',
+              severity: 'warning',
             },
             annotations: {
               message: 'The Tide "status-update" controller has not synced in 30 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',


### PR DESCRIPTION
This reverts commit dd6c6d4029f767663a2d2f2a9baf762a245aa340.

/assign @cjwagner @stevekuznetsov 

This should get prometheus back up
/kind oncall-hotlist


Feel free to alternatively address this by:
a) Applying the new config to the cluster
b) Providing me a script which does the same (ideally make it do this automatically on merge)

fixes #15532