### PR TITLE
Replace Boskos resource usage alerts.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
@@ -1,0 +1,34 @@
+{
+  prometheusAlerts+:: {
+    groups+: [
+      {
+        name: 'Boskos resource usage',
+        rules: [
+          {
+            alert: 'Low resource availability (<10% free)',
+            // This expression calculates the percentage of resources of each type that are free.
+            // If there are multiple instances the most pessimistic value is used.
+            // The threshold for the alert is <10% free.
+            // Resource pools with <= 5 resources are ignored since it is often expected for
+            // small pools to use 100% capacity.
+            expr: |||
+              min(
+                min(boskos_resources{state="free"}) by (type, instance)
+                /
+                (sum(boskos_resources) by (type, instance) > 5)
+              ) by (type) * 100
+              < 10
+            |||,
+            labels: {
+              severity: 'warning',
+              'boskos-type': '{{ $labels.type }}',
+            },
+            annotations: {
+              message: 'The Boskos resource "{{ $labels.type }}" has low availability (currently {{ printf "%0.2f" $value }}% free). See the <https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1|Boskos resource usage dashboard>.',
+            },
+          },
+        ],
+      },
+    ],
+  },
+}

--- a/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
@@ -21,7 +21,7 @@
             |||,
             labels: {
               severity: 'warning',
-              'boskos-type': '{{ $labels.type }}',
+              'boskos_type': '{{ $labels.type }}',
             },
             annotations: {
               message: 'The Boskos resource "{{ $labels.type }}" has low availability (currently {{ printf "%0.2f" $value }}% free). See the <https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1|Boskos resource usage dashboard>.',

--- a/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -6,4 +6,5 @@
 (import 'hook_alert.libsonnet') +
 (import 'sinker_alerts.libsonnet') +
 (import 'tide_alerts.libsonnet') +
-(import 'prober_alerts.libsonnet')
+(import 'prober_alerts.libsonnet') +
+(import 'boskos_alerts.libsonnet')


### PR DESCRIPTION
This reverts https://github.com/kubernetes/test-infra/pull/15537 and includes an additional commit to address:
```
level=error ts=2019-12-09T21:27:06.609348742Z caller=manager.go:754 component="rule manager" msg="loading groups failed" err="group \"Boskos resource usage\", rule 0, \"Low resource availability (<10% free)\": invalid label name: boskos-type"
```
The new label name should be considered valid according to: https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels

/assign @stevekuznetsov @fejta @hongkailiu 