### PR TITLE
Avoid triggering Tide heartbeat alert when prometheus starts.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -9,6 +9,7 @@
             expr: |||
               sum(increase(tidesyncheartbeat{controller="sync"}[15m])) < 1
             |||,
+            'for': '5m',
             labels: {
               severity: 'warning',
             },
@@ -21,6 +22,7 @@
             expr: |||
               sum(increase(tidesyncheartbeat{controller="status-update"}[30m])) < 1
             |||,
+            'for': '5m',
             labels: {
               severity: 'warning',
             },


### PR DESCRIPTION
I think this will address the problem discussed here (assuming that is actually the problem): https://kubernetes.slack.com/archives/CQP3RC68Y/p1575928938003000?thread_ts=1575928468.001100&cid=CQP3RC68Y

/assign @stevekuznetsov @fejta 