### PR TITLE
add plugins config arg to deck deployment.

### DIFF
--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -308,6 +308,7 @@ spec:
         - --tide-url=http://tide/
         - --hook-url=http://hook:8888/plugin-help
         - --github-token-path=/etc/github/oauth
+        - --plugin-config=/etc/plugins/plugins.yaml
         ports:
           - name: http
             containerPort: 8080


### PR DESCRIPTION
Fix `"msg":"No plugins configuration was provided to deck.`