### PR TITLE
PJUtil: Don't terminate older batches

### DIFF
--- a/prow/pjutil/abort.go
+++ b/prow/pjutil/abort.go
@@ -59,7 +59,7 @@ func TerminateOlderJobs(pjc prowClient, log *logrus.Entry, pjs []prowapi.ProwJob
 	cleanup ProwJobResourcesCleanup) error {
 	dupes := map[string]int{}
 	for i, pj := range pjs {
-		if pj.Complete() || !(pj.Spec.Type == prowapi.PresubmitJob || pj.Spec.Type == prowapi.BatchJob) {
+		if pj.Complete() || pj.Spec.Type != prowapi.PresubmitJob {
 			continue
 		}
 

--- a/prow/pjutil/abort_test.go
+++ b/prow/pjutil/abort_test.go
@@ -120,7 +120,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 			terminateddPJs: sets.NewString("old", "older"),
 		},
 		{
-			name: "terminate all older batch jobs",
+			name: "Don't terminate older batch jobs",
 			pjs: []prowjobv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
@@ -194,7 +194,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old", "older"),
+			terminateddPJs: sets.NewString(),
 		},
 		{
 			name: "terminate older jobs with different orders of refs",
@@ -202,7 +202,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",
@@ -216,7 +216,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",
@@ -236,7 +236,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",
@@ -260,7 +260,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",
@@ -290,7 +290,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						ExtraRefs: []prowjobv1.Refs{
 							{
@@ -306,7 +306,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						ExtraRefs: []prowjobv1.Refs{
 							{
@@ -328,7 +328,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:    "test",
@@ -343,7 +343,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:    "test",
@@ -364,7 +364,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:    "test",
@@ -379,7 +379,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:    "test",
@@ -400,7 +400,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",
@@ -414,7 +414,7 @@ func TestTerminateOlderJobs(t *testing.T) {
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
 					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+						Type: prowjobv1.PresubmitJob,
 						Job:  "j1",
 						Refs: &prowjobv1.Refs{
 							Repo:  "test",


### PR DESCRIPTION
Tide currently re-creates new batch jobs for all required jobs once the
first failure occurred[0]. Combined with the new default of "terminate
older ProwJobs", this results in all running batch jobs of a given batch
getting aborted once one failure occurred due to their re-creation.

This PR changes the abort logic to only abort Presubmit jobs where we
already only create ProwJobs for missing successes and never abort batch
jobs.

[0] https://github.com/kubernetes/test-infra/issues/12216

I noticed this yesterday by coincidence and think we should get this fix ASAP.

/assign @cjwagner @fejta @stevekuznetsov 