### PR TITLE
Add tag replacement for periodic jobs in config forker

### DIFF
--- a/experiment/config-forker/README.md
+++ b/experiment/config-forker/README.md
@@ -12,7 +12,7 @@ config-forker forks presubmit, periodic, and postsubmit job configs with the `fo
 ## Supported annotations
 
 - `fork-per-release`: only jobs with this set to `"true"` will be forked.
-- `fork-per-release-replacements`: allows replacing values in container `args` (see [Custom replacements](#custom-replacements)).
+- `fork-per-release-replacements`: allows replacing values in job `tags` (periodics only) and container `args` (see [Custom replacements](#custom-replacements)).
 - `fork-per-release-periodic-interval`: if set, forked jobs will use this value for `interval`. If multiple space-separated values are provided, the first will be used.
 - `fork-per-release-cron`: if set, forked jobs will use this value for `cron`. If multiple values separated with `, ` are provided, the first will be used.
 
@@ -55,8 +55,8 @@ For periodics only:
  
 ## Custom replacements
 
-The `fork-per-release-replacements` annotation can be used for custom replacements in your `args`. It takes the form
-of a comma-separated list of replacements, like this:
+The `fork-per-release-replacements` annotation can be used for custom replacements in your `args` or `tags` (periodic jobs only).
+It takes the form of a comma-separated list of replacements, like this:
 
 ```
 fork-per-release-replacements: "original1 -> replacement1, original2 -> replacement2"

--- a/experiment/config-forker/main_test.go
+++ b/experiment/config-forker/main_test.go
@@ -163,7 +163,7 @@ func TestPerformArgReplacements(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := performArgReplacements(tc.args, "1.15", tc.replacements)
+			result, err := performReplacement(tc.args, "1.15", tc.replacements)
 			if err != nil {
 				if !tc.expectErr {
 					t.Fatalf("Unexpected error: %v", err)
@@ -551,6 +551,7 @@ func TestGeneratePeriodics(t *testing.T) {
 					},
 				},
 			},
+			Tags: []string{"ver: stable"},
 		},
 		{
 			Interval: "2h",
@@ -612,6 +613,7 @@ func TestGeneratePeriodics(t *testing.T) {
 					},
 				},
 			},
+			Tags: []string{"ver: 1.15"},
 		},
 		{
 			Interval: "2h",


### PR DESCRIPTION
Right now, only args are being replaced by config forker. We want to
replace values in tags as well, to be able to add forked per-version
configs to perfrash with different categories (and categories in
perfdash are based on job tags).

Testing:
* ran locally with go run, verified that tags are being replaced
correctly
* unit test