### PR TITLE
boskos: record even longer buckets for response time

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -56,7 +56,7 @@ var (
 )
 
 var (
-	httpRequestDuration = metrics.HttpRequestDuration("boskos", 0.005, 120)
+	httpRequestDuration = metrics.HttpRequestDuration("boskos", 0.005, 360)
 	httpResponseSize    = metrics.HttpResponseSize("boskos", 128, 65536)
 	traceHandler        = metrics.TraceHandler(simplifier, httpRequestDuration, httpResponseSize)
 )


### PR DESCRIPTION
120s was apparently too low to accurately capture tail latencies.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>