### PR TITLE
Update generated tests to use latest-x.y version markers

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -531,7 +531,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -562,7 +562,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -593,7 +593,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -624,7 +624,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -655,7 +655,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -686,7 +686,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -717,7 +717,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -748,7 +748,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -779,7 +779,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -810,7 +810,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -841,7 +841,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -872,7 +872,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -903,7 +903,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -934,7 +934,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -965,7 +965,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -996,7 +996,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1027,7 +1027,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1058,7 +1058,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1089,7 +1089,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1120,7 +1120,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1151,7 +1151,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1182,7 +1182,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1213,7 +1213,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1244,7 +1244,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1279,7 +1279,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -1311,7 +1311,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1344,7 +1344,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -1376,7 +1376,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -1408,7 +1408,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1441,7 +1441,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1474,7 +1474,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -1506,7 +1506,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1542,7 +1542,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -1574,7 +1574,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1607,7 +1607,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -1639,7 +1639,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -1671,7 +1671,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1704,7 +1704,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1737,7 +1737,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -1769,7 +1769,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -1805,7 +1805,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -1837,7 +1837,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1870,7 +1870,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -1902,7 +1902,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -1934,7 +1934,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1967,7 +1967,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2000,7 +2000,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -2032,7 +2032,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -2068,7 +2068,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -2100,7 +2100,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2133,7 +2133,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -2165,7 +2165,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -2197,7 +2197,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -2230,7 +2230,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2263,7 +2263,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -2295,7 +2295,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -2331,7 +2331,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -2363,7 +2363,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2396,7 +2396,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -2428,7 +2428,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -2460,7 +2460,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -2493,7 +2493,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2526,7 +2526,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -2558,7 +2558,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -2594,7 +2594,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -2626,7 +2626,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2659,7 +2659,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -2691,7 +2691,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -2723,7 +2723,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -2756,7 +2756,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2789,7 +2789,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -2821,7 +2821,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -2857,7 +2857,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -2889,7 +2889,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -2922,7 +2922,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -2954,7 +2954,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -2986,7 +2986,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3019,7 +3019,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3052,7 +3052,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -3084,7 +3084,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -3120,7 +3120,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       env:
@@ -3152,7 +3152,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3185,7 +3185,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=300m
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       env:
@@ -3217,7 +3217,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -3249,7 +3249,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3282,7 +3282,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3315,7 +3315,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=30m
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\] --minStartupPods=8
       - --ginkgo-parallel
@@ -3347,7 +3347,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --gcp-project-type=gpu-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
@@ -3378,7 +3378,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -3405,7 +3405,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -3433,7 +3433,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3464,7 +3464,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3493,7 +3493,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3525,7 +3525,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -3556,7 +3556,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -3586,7 +3586,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3618,7 +3618,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3649,7 +3649,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3677,7 +3677,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.17
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -3709,7 +3709,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -3736,7 +3736,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -3764,7 +3764,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3794,7 +3794,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3823,7 +3823,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3855,7 +3855,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -3886,7 +3886,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -3916,7 +3916,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -3947,7 +3947,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -3978,7 +3978,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4006,7 +4006,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.16
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -4038,7 +4038,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -4065,7 +4065,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -4093,7 +4093,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4122,7 +4122,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -4151,7 +4151,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4183,7 +4183,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -4214,7 +4214,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -4244,7 +4244,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4275,7 +4275,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -4306,7 +4306,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4334,7 +4334,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.15
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -4366,7 +4366,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -4394,7 +4394,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -4421,7 +4421,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4450,7 +4450,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -4479,7 +4479,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4511,7 +4511,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --ginkgo.skip=\[Unreleased\] --minStartupPods=8
@@ -4542,7 +4542,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
@@ -4572,7 +4572,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4603,7 +4603,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -4634,7 +4634,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -4662,7 +4662,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.14
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       - --env=KUBE_PROXY_DAEMONSET=true

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -84,11 +84,16 @@ def update_generated_config(path, latest_version):
     suffixes = ['beta', 'stable1', 'stable2', 'stable3']
     for i, s in enumerate(suffixes):
         vs = "%d.%d" % (v[0], v[1] + 1 - i)
-        config['k8sVersions'][s]['version'] = vs
+        markers = config['k8sVersions'][s]
+        markers['version'] = vs
+        for j, arg in enumerate(markers['args']):
+            markers['args'][j] = re.sub(
+                r'latest(-\d+\.\d+)?', 'latest-%s' % vs, arg)
+
         node = config['nodeK8sVersions'][s]
-        for j, arg in enumerate(node['args']):
-            node['args'][j] = re.sub(
-                r'release-\d+\.\d+', 'release-%s' % vs, arg)
+        for k, arg in enumerate(node['args']):
+            node['args'][k] = re.sub(
+                r'master|release-\d+\.\d+', 'release-%s' % vs, arg)
         node['prowImage'] = node['prowImage'].rpartition('-')[0] + '-' + vs
 
     with open(path, 'w') as f:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -810,19 +810,19 @@ k8sVersions:
     version: master
   beta:
     args:
-    - --extract=ci/k8s-beta
+    - --extract=ci/latest-1.17
     version: '1.17'
   stable1:
     args:
-    - --extract=ci/k8s-stable1
+    - --extract=ci/latest-1.16
     version: '1.16'
   stable2:
     args:
-    - --extract=ci/k8s-stable2
+    - --extract=ci/latest-1.15
     version: '1.15'
   stable3:
     args:
-    - --extract=ci/k8s-stable3
+    - --extract=ci/latest-1.14
     version: '1.14'
 
 testSuites:


### PR DESCRIPTION
- generate_tests: Use "latest" markers instead of "k8s-*" pseudo-versions
  
  The "k8s-beta" version marker leads to confusion as sometimes "beta"
  should refer to the current pre-release branch and sometimes it should
  point to master. There is no consistent guidance or follow-through on
  how or when these markers need to be changed, which can lead to a slew
  of tests that don't test what we think they do.
  
  As a first step, we're setting test_config.yaml to use the "latest**"
  version markers, which are pretty clear at a glance which version of
  Kubernetes will be tested against:
  
  - "dev" --> "latest" --> latest CI build of pre-1.18.0 (master)
  - "beta" --> "latest-1.17" --> latest CI build of release-1.17
  - "stable1" --> "latest-1.16" --> latest CI build of release-1.16
  - "stable2" --> "latest-1.15" --> latest CI build of release-1.15
  - "stable3" --> "latest-1.14" --> latest CI build of release-1.14
  
  "beta" here will shifted back to be even with "dev" once we've deleted
  the 1.14 jobs in a separate PR.

- Update generated tests to remove usage of k8s-* version markers

- prepare_release_branch: Update generated config regex substitutions
  
  prepare_release_branch.py uses a regex to replace the version markers of
  a release branch during the beta.0 branch cut.
  
  As we've moved to using the "latest**" version markers in
  test_config.yaml, we need to update the regexes to properly recognize
  the versions in the "k8sVersions" and "nodeK8sVersions" fields.