### PR TITLE
kubekins-e2e: Bump K8S_RELEASE version marker for 1.17 to stable-1.17

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -13,7 +13,7 @@ variants:
   '1.17':
     CONFIG: '1.17'
     GO_VERSION: 1.13.4
-    K8S_RELEASE: latest-1.17
+    K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'


### PR DESCRIPTION
Now that [Kubernetes 1.17.0 has been released](https://github.com/kubernetes/sig-release/issues/899), the `stable-1.17` version
marker is available, so we use it here instead of `latest-1.17`.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cpanato @saschagrunert 
