### PR TITLE
Add version to the perfdash category in gce-100 tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -326,8 +326,9 @@ periodics:
       name: ""
       resources: {}
   tags:
-  - 'perfDashPrefix: gce-100Nodes-stable3'
+  - 'perfDashPrefix: gce-100Nodes-1.14'
   - 'perfDashJobType: performance'
+  - "perfDashBuildsCount: 500"
 - annotations:
     description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -201,7 +201,7 @@ periodics:
       name: ""
       resources: {}
   tags:
-  - 'perfDashPrefix: gce-100Nodes'
+  - 'perfDashPrefix: gce-100Nodes-1.15'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -205,7 +205,7 @@ periodics:
       name: ""
       resources: {}
   tags:
-  - 'perfDashPrefix: gce-100Nodes'
+  - 'perfDashPrefix: gce-100Nodes-1.16'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -252,7 +252,7 @@ periodics:
       name: ""
       resources: {}
   tags:
-  - 'perfDashPrefix: gce-100Nodes'
+  - 'perfDashPrefix: gce-100Nodes-1.17'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -107,7 +107,7 @@ periodics:
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-scalability
   tags:
-  - "perfDashPrefix: gce-100Nodes"
+  - "perfDashPrefix: gce-100Nodes-master"
   - "perfDashJobType: performance"
   - "perfDashBuildsCount: 500"
   labels:
@@ -116,8 +116,9 @@ periodics:
     preset-e2e-scalability-common: "true"
   annotations:
     fork-per-release: "true"
-    fork-per-release-generic-suffix: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-replacements: "gce-100Nodes-master -> gce-100Nodes-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com


### PR DESCRIPTION
These are forked by config-forker and used by sig-release to test each
kubernetes release. We want to display these tests on perfdash, so we
need them to be displayed in different categories (to distinguish
between tests for different versions, including master).

Testing:
* ran config forker with go run, checked that perfdash tag is changed to
gce-100Nodes-1.15