### PR TITLE
Add NPD e2e tests as presubmit test for NPD repository

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -241,3 +241,35 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
+  - name: ci-npd-e2e-test
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/node-problem-detector
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191211-04e540b-master
+        env:
+        - name: ZONE
+          value: us-central1-a
+        - name: IMAGE_FAMILY
+          value: cos-73-lts
+        - name: IMAGE_PROJECT
+          value: cos-cloud
+        - name: BOSKOS_PROJECT_TYPE
+          value: gce-project
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          ./test/build.sh install-lib &&
+          SSH_USER=${USER} SSH_KEY=${JENKINS_GCE_SSH_PRIVATE_KEY_FILE} make e2e-test
+    annotations:
+      testgrid-dashboards: presubmits-node-problem-detector
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
The [CI job](https://github.com/kubernetes/test-infra/blob/c94bf8ef27667ea000a69b8e5b175e778a3629f3/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml#L251) is ready and running now (except for occasional timeout):
https://k8s-testgrid.appspot.com/sig-node-node-problem-detector#ci-npd-e2e-test

We can add these tests as part of presubmit tests, which will help prevent regression in NPD, and will help us debugging the timeout.

This PR is part of https://github.com/kubernetes/node-problem-detector/issues/296