### PR TITLE
peribolos: correctly calculate if org meta has changed

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -810,7 +810,7 @@ func configureOrgMeta(client orgMetadataClient, orgName string, want org.Metadat
 	change = updateString(&cur.Location, want.Location) || change
 	if want.DefaultRepositoryPermission != nil {
 		w := string(*want.DefaultRepositoryPermission)
-		change = updateString(&cur.DefaultRepositoryPermission, &w)
+		change = updateString(&cur.DefaultRepositoryPermission, &w) || change
 	}
 	change = updateBool(&cur.HasOrganizationProjects, want.HasOrganizationProjects) || change
 	change = updateBool(&cur.HasRepositoryProjects, want.HasRepositoryProjects) || change


### PR DESCRIPTION
https://github.com/kubernetes/org/pull/1479 didn't actually update the billing email on GitHub because `changed` was false. 

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-org-peribolos/1204876319272210432 was the postsubmit run after the PR got merged, there is no `EditOrg` call there.

/assign @fejta @cblecker 