### PR TITLE
Increases timeout for CAPA e2e job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -53,6 +53,8 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-release-0-4
   decorate: true
+  decoration_config:
+    timeout: 3h
   interval: 1h
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -128,6 +128,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 3h
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Changes timeout for both ci and presubmit e2e jobs to 3h