### PR TITLE
Persist state in statusreconciler 

### DIFF
--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//pkg/io:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",

--- a/prow/config/agent.go
+++ b/prow/config/agent.go
@@ -128,6 +128,7 @@ func (ca *Agent) Config() *Config {
 }
 
 // Set sets the config. Useful for testing.
+// Also used by statusreconciler to load last known config
 func (ca *Agent) Set(c *Config) {
 	ca.mut.Lock()
 	defer ca.mut.Unlock()

--- a/prow/config/agent.go
+++ b/prow/config/agent.go
@@ -40,46 +40,54 @@ type Agent struct {
 	subscriptions []DeltaChan
 }
 
+func lastConfigModTime(prowConfig, jobConfig string) (time.Time, error) {
+	// Check if the file changed to see if it needs to be re-read.
+	// os.Stat follows symbolic links, which is how ConfigMaps work.
+	prowStat, err := os.Stat(prowConfig)
+	if err != nil {
+		logrus.WithField("prowConfig", prowConfig).WithError(err).Error("Error loading prow config.")
+		return time.Time{}, err
+	}
+	recentModTime := prowStat.ModTime()
+	// TODO(krzyzacy): allow empty jobConfig till fully migrate config to subdirs
+	if jobConfig != "" {
+		jobConfigStat, err := os.Stat(jobConfig)
+		if err != nil {
+			logrus.WithField("jobConfig", jobConfig).WithError(err).Error("Error loading job configs.")
+			return time.Time{}, err
+		}
+
+		if jobConfigStat.ModTime().After(recentModTime) {
+			recentModTime = jobConfigStat.ModTime()
+		}
+	}
+	return recentModTime, nil
+}
+
 // Start will begin polling the config file at the path. If the first load
 // fails, Start will return the error and abort. Future load failures will log
 // the failure message but continue attempting to load.
 func (ca *Agent) Start(prowConfig, jobConfig string) error {
+	lastModTime, err := lastConfigModTime(prowConfig, jobConfig)
+	if err != nil {
+		lastModTime = time.Time{}
+	}
 	c, err := Load(prowConfig, jobConfig)
 	if err != nil {
 		return err
 	}
 	ca.Set(c)
 	go func() {
-		var lastModTime time.Time
 		// Rarely, if two changes happen in the same second, mtime will
 		// be the same for the second change, and an mtime-based check would
 		// fail. Reload periodically just in case.
 		skips := 0
 		for range time.Tick(1 * time.Second) {
 			if skips < 600 {
-				// Check if the file changed to see if it needs to be re-read.
-				// os.Stat follows symbolic links, which is how ConfigMaps work.
-				prowStat, err := os.Stat(prowConfig)
+				recentModTime, err := lastConfigModTime(prowConfig, jobConfig)
 				if err != nil {
-					logrus.WithField("prowConfig", prowConfig).WithError(err).Error("Error loading prow config.")
 					continue
 				}
-
-				recentModTime := prowStat.ModTime()
-
-				// TODO(krzyzacy): allow empty jobConfig till fully migrate config to subdirs
-				if jobConfig != "" {
-					jobConfigStat, err := os.Stat(jobConfig)
-					if err != nil {
-						logrus.WithField("jobConfig", jobConfig).WithError(err).Error("Error loading job configs.")
-						continue
-					}
-
-					if jobConfigStat.ModTime().After(recentModTime) {
-						recentModTime = jobConfigStat.ModTime()
-					}
-				}
-
 				if !recentModTime.After(lastModTime) {
 					skips++
 					continue // file hasn't been modified

--- a/prow/statusreconciler/BUILD.bazel
+++ b/prow/statusreconciler/BUILD.bazel
@@ -5,11 +5,13 @@ go_library(
     srcs = [
         "controller.go",
         "doc.go",
+        "status.go",
     ],
     importpath = "k8s.io/test-infra/prow/statusreconciler",
     visibility = ["//visibility:public"],
     deps = [
         "//maintenance/migratestatus/migrator:go_default_library",
+        "//pkg/io:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/errorutil:go_default_library",
@@ -19,16 +21,23 @@ go_library(
         "//prow/plugins/trigger:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["controller_test.go"],
+    srcs = [
+        "controller_test.go",
+        "status_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/statusreconciler/status.go
+++ b/prow/statusreconciler/status.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreconciler
+
+import (
+	"context"
+	"io/ioutil"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/pkg/io"
+	"k8s.io/test-infra/prow/config"
+)
+
+type storedState struct {
+	config.Config
+}
+
+type statusClient interface {
+	Load() (chan config.Delta, error)
+	Save() error
+}
+
+type statusController struct {
+	logger        *logrus.Entry
+	opener        io.Opener
+	statusURI     string
+	configPath    string
+	jobConfigPath string
+
+	storedState
+	config.Agent
+}
+
+func (s *statusController) Load() (chan config.Delta, error) {
+	s.Agent = config.Agent{}
+	state, err := s.loadState()
+	if err == nil {
+		s.Agent.Set(&state.Config)
+	}
+	changes := make(chan config.Delta)
+	s.Agent.Subscribe(changes)
+
+	if err := s.Agent.Start(s.configPath, s.jobConfigPath); err != nil {
+		s.logger.WithError(err).Fatal("Error starting config agent.")
+		return nil, err
+	}
+	return changes, nil
+}
+
+func (s *statusController) Save() error {
+	if s.statusURI == "" {
+		return nil
+	}
+	entry := s.logger.WithField("path", s.statusURI)
+	current := s.Agent.Config()
+	buf, err := yaml.Marshal(current)
+	if err != nil {
+		entry.WithError(err).Warn("Cannot marshal state")
+		return err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	writer, err := s.opener.Writer(ctx, s.statusURI)
+	if err != nil {
+		entry.WithError(err).Warn("Cannot open state writer")
+		return err
+	}
+	if _, err = writer.Write(buf); err != nil {
+		entry.WithError(err).Warn("Cannot write state")
+		io.LogClose(writer)
+		return err
+	}
+	if err := writer.Close(); err != nil {
+		entry.WithError(err).Warn("Failed to close written state")
+	}
+	entry.Debug("Saved status state")
+	return nil
+}
+
+func (s *statusController) loadState() (storedState, error) {
+	var state storedState
+	if s.statusURI == "" {
+		s.logger.Debug("No stored state configured")
+		return state, nil
+	}
+	entry := s.logger.WithField("path", s.statusURI)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	reader, err := s.opener.Reader(ctx, s.statusURI)
+	if err != nil {
+		entry.WithError(err).Warn("Cannot open stored state")
+		return state, err
+	}
+	defer io.LogClose(reader)
+
+	buf, err := ioutil.ReadAll(reader)
+	if err != nil {
+		entry.WithError(err).Warn("Cannot read stored state")
+		return state, err
+	}
+
+	if err := yaml.Unmarshal(buf, &state); err != nil {
+		entry.WithError(err).Warn("Cannot unmarshal stored state")
+		return state, err
+	}
+	return state, nil
+}
+
+func (s *statusController) Config() *config.Config {
+	return s.Agent.Config()
+}

--- a/prow/statusreconciler/status_test.go
+++ b/prow/statusreconciler/status_test.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package statusreconciler
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/test-infra/pkg/io"
+	"k8s.io/test-infra/prow/config"
+	"sigs.k8s.io/yaml"
+)
+
+type testOpener struct{}
+
+func (t *testOpener) Reader(ctx context.Context, path string) (io.ReadCloser, error) {
+	return os.Open(path)
+}
+
+func (t *testOpener) Writer(ctx context.Context, path string) (io.WriteCloser, error) {
+	return os.Create(path)
+}
+
+func TestLoadState(t *testing.T) {
+	config := config.Config{
+		ProwConfig: config.ProwConfig{
+			ProwJobNamespace: "default",
+		},
+		JobConfig: config.JobConfig{
+			PresubmitsStatic: map[string][]config.Presubmit{
+				"org/repo": getPresubmits([]string{"foo"}),
+			},
+		},
+	}
+	configFile, cleanup := getConfigFile(t, config)
+	defer cleanup()
+
+	sc := statusController{
+		logger:    logrus.NewEntry(logrus.StandardLogger()),
+		statusURI: configFile,
+		opener:    &testOpener{},
+	}
+
+	got, err := sc.loadState()
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(got.Config, config) {
+		t.Errorf("Expected result %#v', got %#v", config, got)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	presubmitFoo := "presubmit-foo"
+	presubmitBar := "presubmit-bar"
+
+	savedConfig := config.Config{
+		ProwConfig: config.ProwConfig{
+			ProwJobNamespace: "default",
+		},
+		JobConfig: config.JobConfig{
+			PresubmitsStatic: map[string][]config.Presubmit{
+				"org/repo": getPresubmits([]string{presubmitFoo}),
+			},
+		},
+	}
+
+	newProwConfig := config.ProwConfig{
+		ProwJobNamespace: "foo",
+	}
+
+	newJobConfig := config.JobConfig{
+		PresubmitsStatic: map[string][]config.Presubmit{
+			"org/repo": getPresubmits([]string{presubmitFoo, presubmitBar}),
+		},
+	}
+
+	testCases := []struct {
+		name               string
+		existingStatusFile bool
+		savedNamespace     string
+		savedPresubmits    []string
+		newNamespace       string
+		newPresubmits      []string
+	}{
+		{
+			name:          "no status file should not cause any errors",
+			newNamespace:  "foo",
+			newPresubmits: []string{"presubmit-bar", "presubmit-foo"},
+		},
+		{
+			name:               "With an existing status file, configuration changes since last saved should be identified",
+			existingStatusFile: true,
+			savedNamespace:     "default",
+			savedPresubmits:    []string{"presubmit-foo"},
+			newNamespace:       "foo",
+			newPresubmits:      []string{"presubmit-bar", "presubmit-foo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			statusURI := ""
+			if tc.existingStatusFile {
+				statusFile, cleanupStatusFile := getConfigFile(t, savedConfig)
+				defer cleanupStatusFile()
+				statusURI = statusFile
+			}
+
+			configFile, cleanupConfig := getConfigFile(t, config.Config{ProwConfig: newProwConfig})
+			defer cleanupConfig()
+
+			jobConfigFile, cleanupJobConfig := getConfigFile(t, config.Config{JobConfig: newJobConfig})
+			defer cleanupJobConfig()
+
+			sc := statusController{
+				logger:        logrus.NewEntry(logrus.StandardLogger()),
+				statusURI:     statusURI,
+				opener:        &testOpener{},
+				configPath:    configFile,
+				jobConfigPath: jobConfigFile,
+			}
+			changes, err := sc.Load()
+			if err != nil {
+				t.Fatalf("%s: unexpected error %v", tc.name, err)
+			}
+			select {
+			case change := <-changes:
+				verify(t, tc.name+"/before", change.Before, tc.savedNamespace, tc.savedPresubmits)
+				verify(t, tc.name+"/after", change.After, tc.newNamespace, tc.newPresubmits)
+			case <-time.After(3 * time.Second):
+				t.Fatalf("%s: unexpected timeout while waiting for configuration changes", tc.name)
+			}
+		})
+	}
+}
+
+func TestSave(t *testing.T) {
+	presubmitFoo := "presubmit-foo"
+	presubmitBar := "presubmit-bar"
+	prowConfig := config.ProwConfig{
+		ProwJobNamespace: "default",
+	}
+	jobConfig := config.JobConfig{
+		PresubmitsStatic: map[string][]config.Presubmit{
+			"org/repo": getPresubmits([]string{presubmitFoo, presubmitBar}),
+		},
+	}
+
+	configFile, cleanupConfig := getConfigFile(t, config.Config{ProwConfig: prowConfig})
+	defer cleanupConfig()
+
+	jobConfigFile, cleanupJobConfig := getConfigFile(t, config.Config{JobConfig: jobConfig})
+	defer cleanupJobConfig()
+
+	testCases := []struct {
+		name               string
+		specifyStatusFile  bool
+		expectedNamespace  string
+		expectedPresubmits []string
+	}{
+		{
+			name: "not specifying a status file should not cause any errors",
+		},
+		{
+			name:               "save stores the configuration in the specified statusURI",
+			expectedNamespace:  "default",
+			expectedPresubmits: []string{"presubmit-bar", "presubmit-foo"},
+		},
+	}
+
+	for _, tc := range testCases {
+		statusURI := ""
+		if tc.specifyStatusFile {
+			statusFile, cleanupStatusFile := getConfigFile(t, config.Config{})
+			defer cleanupStatusFile()
+			statusURI = statusFile
+		}
+
+		t.Run(tc.name, func(t *testing.T) {
+			sc := statusController{
+				logger:        logrus.NewEntry(logrus.StandardLogger()),
+				statusURI:     statusURI,
+				opener:        &testOpener{},
+				configPath:    configFile,
+				jobConfigPath: jobConfigFile,
+			}
+			if err := sc.Save(); err != nil {
+				t.Fatalf("%s: unexpected error: %v", tc.name, err)
+			}
+
+			if statusURI != "" {
+				buf, err := ioutil.ReadFile(statusURI)
+				if err != nil {
+					t.Fatalf("%s: unexpected error reading status file: %v", tc.name, err)
+				}
+
+				var got config.Config
+				if err := yaml.Unmarshal(buf, &got); err != nil {
+					t.Fatalf("%s: unexpected error unmarshaling status file contents %v", tc.name, err)
+				}
+				verify(t, tc.name, got, tc.expectedNamespace, tc.expectedPresubmits)
+			}
+		})
+	}
+}
+
+func getConfigFile(t *testing.T, config config.Config) (string, func()) {
+	tempFile, err := ioutil.TempFile("/tmp", "prow-test")
+	if err != nil {
+		t.Fatalf("failed to get tempfile: %v", err)
+	}
+	cleanup := func() {
+		if err := tempFile.Close(); err != nil {
+			t.Errorf("failed to close tempFile: %v", err)
+		}
+		if err := os.Remove(tempFile.Name()); err != nil {
+			t.Errorf("failed to remove tempfile: %v", err)
+		}
+	}
+
+	buf, err := yaml.Marshal(config)
+	if err != nil {
+		t.Fatalf("Cannot marshal config: %v", err)
+	}
+
+	if _, err := tempFile.Write(buf); err != nil {
+		t.Fatalf("failed to write to tempfile: %v", err)
+	}
+
+	return tempFile.Name(), cleanup
+}
+
+func getPresubmits(names []string) []config.Presubmit {
+	spec := &v1.PodSpec{
+		Containers: []v1.Container{
+			{
+				Image: "image",
+			},
+		},
+	}
+
+	var presubmits []config.Presubmit
+	for _, name := range names {
+		ps := config.Presubmit{
+			JobBase: config.JobBase{
+				Name: name,
+				Spec: spec,
+			},
+			AlwaysRun: true,
+			Reporter:  config.Reporter{Context: "boo"},
+		}
+		presubmits = append(presubmits, ps)
+	}
+	return presubmits
+}
+
+func verify(t *testing.T, testCase string, config config.Config, Namespace string, presubmits []string) {
+	if config.ProwConfig.ProwJobNamespace != Namespace {
+		t.Errorf("%s: expected namespace %s, got %s", testCase, Namespace, config.ProwConfig.ProwJobNamespace)
+	}
+	var names []string
+	for _, ps := range config.JobConfig.PresubmitsStatic["org/repo"] {
+		names = append(names, ps.JobBase.Name)
+	}
+	sort.Strings(names)
+	sort.Strings(presubmits)
+	if !reflect.DeepEqual(names, presubmits) {
+		t.Errorf("%s: expected presubmit names %v, got %v", testCase, presubmits, names)
+	}
+}


### PR DESCRIPTION
`status-reconciler` now saves the last known configuration at every sync and loads it at startup time. Fixes #13084 