### PR TITLE
Add windows load test job

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -1,17 +1,20 @@
 presets:
 - labels:
-    preset-e2e-gce-windows: "true"
+    preset-common-gce-windows: "true"
   env:
   - name: KUBE_GCE_ENABLE_IP_ALIASES
     value: "true"
-  - name: NUM_WINDOWS_NODES
-    value: "3"
-  - name: NUM_NODES
-    value: "2"
   - name: KUBERNETES_NODE_PLATFORM
     value: "windows"
   - name: KUBELET_TEST_ARGS
     value: "--feature-gates=KubeletPodResources=false"
+- labels:
+    preset-e2e-gce-windows: "true"
+  env:
+  - name: NUM_WINDOWS_NODES
+    value: "3"
+  - name: NUM_NODES
+    value: "2"
 - labels:
     preset-e2e-gce-windows-containerd: "true"
   env:
@@ -22,12 +25,6 @@ presets:
 - labels:
     preset-load-gce-windows: "true"
   env:
-  - name: KUBE_GCE_ENABLE_IP_ALIASES
-    value: "true"
-  - name: KUBERNETES_NODE_PLATFORM
-    value: "windows"
-  - name: KUBELET_TEST_ARGS
-    value: "--feature-gates=KubeletPodResources=false"
   - name: MASTER_SIZE
     value: "n1-standard-4"
   - name: NUM_WINDOWS_NODES
@@ -65,6 +62,7 @@ periodics:
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -111,6 +109,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
   spec:
     containers:
@@ -149,6 +148,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
   spec:
     containers:
@@ -190,6 +190,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
   spec:
     containers:
@@ -225,6 +226,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-e2e-gce-windows-containerd: "true"
   spec:
@@ -258,6 +260,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-common-gce-windows: "true"
     preset-load-gce-windows: "true"
   annotations:
     testgrid-dashboards: google-windows
@@ -314,6 +317,7 @@ presubmits:
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
+      preset-common-gce-windows: "true"
       preset-e2e-gce-windows: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -19,6 +19,32 @@ presets:
     value: "containerd"
   - name: PREPULL_TIMEOUT
     value: "30m"
+- labels:
+    preset-load-gce-windows: "true"
+  env:
+  - name: KUBE_GCE_ENABLE_IP_ALIASES
+    value: "true"
+  - name: KUBERNETES_NODE_PLATFORM
+    value: "windows"
+  - name: KUBELET_TEST_ARGS
+    value: "--feature-gates=KubeletPodResources=false"
+  - name: MASTER_SIZE
+    value: "n1-standard-4"
+  - name: NUM_WINDOWS_NODES
+    value: "1"
+  - name: NUM_NODES
+    value: "1"
+  - name: NODE_SIZE
+    value: "n1-standard-8"
+  - name: NODE_DISK_SIZE
+    value: "100GB"
+  # Ensure good enough architecture for master machines.
+  - name: MASTER_MIN_CPU_ARCHITECTURE
+    value: "Intel Broadwell"
+  # Bump max pods per node in Kubelet, because there are more than 10
+  # system pods in 1-linux-node cluster.
+  - name: MAX_PODS_PER_NODE
+    value: "128"
 
 periodics:
 - name: ci-kubernetes-e2e-windows-gce-poc
@@ -226,6 +252,50 @@ periodics:
     testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing, sig-node-containerd
     testgrid-tab-name: gce-windows-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
+
+- name: ci-kubernetes-e2e-windows-node-throughput
+  interval: 2h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-load-gce-windows: "true"
+  annotations:
+    testgrid-dashboards: google-windows
+    testgrid-tab-name: windows-gce-node-throughput
+  decorate: true
+  decoration_config:
+    timeout: 6h
+  extra_refs:
+  - org: gcpwin
+    repo: gce-k8s-windows-testing
+    base_ref: master
+    path_alias: k8s.io/gce-k8s-windows-testing
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191212-28f7cbc-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
+      - --timeout=60
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-master
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --gcp-nodes=1
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/load-test.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=1
+      - --test-cmd-args=--provider=gce
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/node-throughput/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/node-throughput/windows_override.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=40m
 
 presubmits:
   kubernetes/kubernetes:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -38,8 +38,6 @@ presets:
   # Ensure good enough architecture for master machines.
   - name: MASTER_MIN_CPU_ARCHITECTURE
     value: "Intel Broadwell"
-  # Bump max pods per node in Kubelet, because there are more than 10
-  # system pods in 1-linux-node cluster.
   - name: MAX_PODS_PER_NODE
     value: "128"
 
@@ -267,10 +265,10 @@ periodics:
     testgrid-tab-name: windows-gce-node-throughput
   decorate: true
   extra_refs:
-  - org: gcpwin
-    repo: gce-k8s-windows-testing
+  - org: kubernetes-sigs
+    repo: windows-testing
     base_ref: master
-    path_alias: k8s.io/gce-k8s-windows-testing
+    path_alias: k8s.io/windows-testing
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191212-28f7cbc-master
@@ -288,7 +286,7 @@ periodics:
       - --provider=gce
       - --gcp-nodes=1
       - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/gce-k8s-windows-testing/load-test.sh
+      - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/load-test.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--nodes=1
       - --test-cmd-args=--provider=gce

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -263,8 +263,6 @@ periodics:
     testgrid-dashboards: google-windows
     testgrid-tab-name: windows-gce-node-throughput
   decorate: true
-  decoration_config:
-    timeout: 6h
   extra_refs:
   - org: gcpwin
     repo: gce-k8s-windows-testing
@@ -277,7 +275,7 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
-      - --timeout=60
+      - --timeout=60m
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources


### PR DESCRIPTION
Add gce windows load test job.

Referrences:
1. [linux node throughput periodic job](https://github.com/kubernetes/test-infra/blob/ed38893c63de58511268221cfdf8c11e251224bc/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml#L2)
2. [node throughput preset job](https://github.com/kubernetes/test-infra/blob/9f320127fac5933d68849240028ef80a4dbf9f54/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml#L171)
3. Other e2e windows periodic jobs
4. [Merged PR](https://github.com/kubernetes/perf-tests/pull/930)
5. [Fork of gce-k8s-windows-testing](https://github.com/YangLu1031/gce-k8s-windows-testing.git)