### PR TITLE
Crier: skip reporting when Spec.Report=false

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -119,7 +119,7 @@ type ProwJobSpec struct {
 	// need to be cloned, determined from config
 	ExtraRefs []Refs `json:"extra_refs,omitempty"`
 	// Report determines if the result of this job should
-	// be posted as a status on GitHub
+	// be reported (e.g. status on GitHub, message in Slack, etc.)
 	Report bool `json:"report,omitempty"`
 	// Context is the name of the status context used to
 	// report back to GitHub

--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -251,7 +251,7 @@ func (c *Controller) processNextItem() bool {
 	}
 
 	// not belong to the current reporter
-	if !c.reporter.ShouldReport(pj) {
+	if !pj.Spec.Report || !c.reporter.ShouldReport(pj) {
 		c.queue.Forget(key)
 		return true
 	}

--- a/prow/crier/controller_test.go
+++ b/prow/crier/controller_test.go
@@ -118,7 +118,8 @@ func TestController_Run(t *testing.T) {
 			knownJobs: map[string]*prowv1.ProwJob{
 				"foo": {
 					Spec: prowv1.ProwJobSpec{
-						Job: "foo",
+						Job:    "foo",
+						Report: true,
 					},
 					Status: prowv1.ProwJobStatus{
 						State: prowv1.TriggeredState,
@@ -135,7 +136,8 @@ func TestController_Run(t *testing.T) {
 			knownJobs: map[string]*prowv1.ProwJob{
 				"foo": {
 					Spec: prowv1.ProwJobSpec{
-						Job: "foo",
+						Job:    "foo",
+						Report: true,
 					},
 					Status: prowv1.ProwJobStatus{
 						State: prowv1.TriggeredState,
@@ -161,6 +163,19 @@ func TestController_Run(t *testing.T) {
 		//	},
 		//},
 		{
+			name:        "doesn't report when SkipReport=true (i.e. Spec.Report=false)",
+			jobsOnQueue: []string{"foo"},
+			knownJobs: map[string]*prowv1.ProwJob{
+				"foo": {
+					Spec: prowv1.ProwJobSpec{
+						Job:    "foo",
+						Report: false,
+					},
+				},
+			},
+			shouldReport: false,
+		},
+		{
 			name:        "doesn't report empty job",
 			jobsOnQueue: []string{"foo"},
 			knownJobs: map[string]*prowv1.ProwJob{
@@ -174,7 +189,8 @@ func TestController_Run(t *testing.T) {
 			knownJobs: map[string]*prowv1.ProwJob{
 				"foo": {
 					Spec: prowv1.ProwJobSpec{
-						Job: "foo",
+						Job:    "foo",
+						Report: true,
 					},
 					Status: prowv1.ProwJobStatus{
 						State: prowv1.TriggeredState,
@@ -191,7 +207,8 @@ func TestController_Run(t *testing.T) {
 			knownJobs: map[string]*prowv1.ProwJob{
 				"foo": {
 					Spec: prowv1.ProwJobSpec{
-						Job: "foo",
+						Job:    "foo",
+						Report: true,
 					},
 					Status: prowv1.ProwJobStatus{
 						State: prowv1.TriggeredState,

--- a/prow/github/reporter/reporter.go
+++ b/prow/github/reporter/reporter.go
@@ -57,8 +57,6 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 	switch {
 	case pj.Labels[client.GerritReportLabel] != "":
 		return false // TODO(fejta): opt-in to github reporting
-	case !pj.Spec.Report:
-		return false // Respect report field
 	case pj.Spec.Type != v1.PresubmitJob && pj.Spec.Type != v1.PostsubmitJob:
 		return false // Report presubmit and postsubmit github jobs for github reporter
 	case c.reportAgent != "" && pj.Spec.Agent != c.reportAgent:

--- a/prow/github/reporter/reporter_test.go
+++ b/prow/github/reporter/reporter_test.go
@@ -33,16 +33,6 @@ func TestShouldReport(t *testing.T) {
 		reportAgent v1.ProwJobAgent
 	}{
 		{
-			name: "should not report skip report job",
-			pj: v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PresubmitJob,
-					Report: false,
-				},
-			},
-			report: false,
-		},
-		{
 			name: "should not report periodic job",
 			pj: v1.ProwJob{
 				Spec: v1.ProwJobSpec{


### PR DESCRIPTION
When `pj.Spec.Report=false` (i.e. `pj.SkipReport=true`), status messages from the SlackReporter should **not** be sent to Slack.