### PR TITLE
Add support for empty label to ignore voting in gerrit.

### DIFF
--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -176,6 +176,35 @@ func TestReport(t *testing.T) {
 			numExpectedReport: 1,
 		},
 		{
+			name: "1 job, passed, empty label, should report, but not vote",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						client.GerritRevision:    "abc",
+						kube.ProwJobTypeLabel:    "presubmit",
+						client.GerritReportLabel: "",
+					},
+					Annotations: map[string]string{
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			expectReport:      true,
+			reportInclude:     []string{"1 out of 1", "ci-foo", "SUCCESS", "guber/foo"},
+			numExpectedReport: 1,
+		},
+		{
 			name: "1 job, ABORTED, should not report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -430,6 +430,61 @@ func TestReport(t *testing.T) {
 			},
 		},
 		{
+			name: "2 jobs, 1 passed, 1 pending, empty labels, should not wait for aggregation, no vote",
+			pj: &v1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						client.GerritRevision:    "abc",
+						kube.ProwJobTypeLabel:    "presubmit",
+						client.GerritReportLabel: "",
+					},
+					Annotations: map[string]string{
+						client.GerritID:       "123-abc",
+						client.GerritInstance: "gerrit",
+					},
+				},
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
+					URL:   "guber/foo",
+				},
+				Spec: v1.ProwJobSpec{
+					Refs: &v1.Refs{
+						Repo: "foo",
+					},
+					Job: "ci-foo",
+				},
+			},
+			existingPJs: []*v1.ProwJob{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							client.GerritRevision:    "abc",
+							kube.ProwJobTypeLabel:    "presubmit",
+							client.GerritReportLabel: "",
+						},
+						Annotations: map[string]string{
+							client.GerritID:       "123-abc",
+							client.GerritInstance: "gerrit",
+						},
+					},
+					Status: v1.ProwJobStatus{
+						State: v1.PendingState,
+						URL:   "guber/bar",
+					},
+					Spec: v1.ProwJobSpec{
+						Refs: &v1.Refs{
+							Repo: "bar",
+						},
+						Job: "ci-bar",
+					},
+				},
+			},
+			expectReport:      true,
+			reportInclude:     []string{"1 out of 1", "ci-foo", "SUCCESS", "guber/foo"},
+			reportExclude:     []string{"2", "bar"},
+			numExpectedReport: 1,
+		},
+		{
 			name: "2 jobs, one passed, other job failed, should report",
 			pj: &v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -284,7 +284,7 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 		}
 		labels[client.GerritRevision] = change.CurrentRevision
 
-		if gerritLabel, ok := labels[client.GerritReportLabel]; !ok || gerritLabel == "" {
+		if _, ok := labels[client.GerritReportLabel]; !ok {
 			labels[client.GerritReportLabel] = client.CodeReview
 		}
 


### PR DESCRIPTION
It is fairly common for users to use a non-existent label as a way to achieve "informing but not blocking" jobs. Dropping log level down to info to avoid spamming error logs.

/cc @cjwagner 