### PR TITLE
Add "google-oss" to dashboard prefix list

### DIFF
--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -44,6 +44,7 @@ var (
 		"cos",
 		"cri-o",
 		"istio",
+		"google-oss",
 		"google",
 		"kopeio",
 		"redhat",


### PR DESCRIPTION
Allows for separate dashboard groups to allow for migration between repositories

/cc @fejta @michelle192837 @cjwagner