### PR TITLE
Fix "prefix" issue with google-oss

### DIFF
--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -44,7 +44,7 @@ var (
 		"cos",
 		"cri-o",
 		"istio",
-		"google-oss",
+		"googleoss",
 		"google",
 		"kopeio",
 		"redhat",


### PR DESCRIPTION
A dashboard prefixed with "google-oss-..." is also prefixed with
"google-...", meaning everyting in one group would need to be in the
other to pass.

This resolves this issue.

/cc @fejta @michelle192837 