### PR TITLE
Switch to ubuntu 18.04 image for cpu-manager tests

### DIFF
--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20170420-1 # docker 1.12.6
+    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
     project: ubuntu-os-gke-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4


### PR DESCRIPTION
Use the same image as the other serial tests.

The old one fails during preflight check becuse docker cli
is missing some args.

eg. https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-cpu-manager/1205820052486492165