### PR TITLE
releng: Remove bazel version markers

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -290,8 +290,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
+            --version-suffix=-bazel
       command:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.15
@@ -510,7 +509,6 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.15.txt
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.15
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -296,8 +296,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.16.txt
+            --version-suffix=-bazel
       command:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.16
@@ -561,7 +560,6 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.16.txt
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.16
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -350,8 +350,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci-periodic \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-periodic.txt
+            --version-suffix=-bazel
       command:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.17
@@ -613,7 +612,6 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.17.txt
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.17
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -353,8 +353,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci-periodic \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-periodic.txt
+            --version-suffix=-bazel
       command:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.18
@@ -675,7 +674,6 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        - --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-1.18.txt
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-1.18
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -64,7 +64,6 @@ postsubmits:
     - master
     annotations:
       fork-per-release: "true"
-      fork-per-release-replacements: "latest-bazel.txt -> latest-bazel-{{.Version}}.txt"
       testgrid-dashboards: google-unit
       description: "Builds kubernetes using bazel"
     labels:
@@ -86,7 +85,6 @@ postsubmits:
         - "--release=//build/release-tars"
         - "--gcs=gs://kubernetes-release-dev/ci"
         - "--version-suffix=-bazel"
-        - "--publish-version=gs://kubernetes-release-dev/ci/latest-bazel.txt"
         resources:
           requests:
             memory: "6Gi"
@@ -119,8 +117,7 @@ postsubmits:
               "--build=//... -//vendor/..." \
               --release=//build/release-tars \
               --gcs=gs://kubernetes-release-dev/ci-rbe \
-              --version-suffix=-bazel-rbe \
-              --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-rbe.txt
+              --version-suffix=-bazel-rbe
 
     annotations:
       testgrid-dashboards: sig-release-master-informing
@@ -226,8 +223,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci-periodic \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-periodic.txt
+            --version-suffix=-bazel
   rerun_auth_config:
     github_team_ids:
       - 2241179 # release-managers
@@ -266,8 +262,7 @@ periodics:
             "--build=//... -//vendor/..." \
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci-canary \
-            --version-suffix=-bazel \
-            --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-canary.txt
+            --version-suffix=-bazel
   rerun_auth_config:
     github_team_ids:
       - 2241179 # release-managers


### PR DESCRIPTION
~A previous PR changed the names and locations of the bazel version
markers and build artifacts. We fix that here to ensure the job is
properly forked on branch creation and update the 1.14 bazel build job
to adhere to the convention of the newer branches.~

~Figuring out the correct approach for this. I'll update the description once we decide.~

#### Update 3/15/20:
Bazel version markers appear to be unused.
In general, we should opt to use the version markers produced from the
ci-kubernetes-build* jobs instead, so we stop publishing the bazel ones.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/test-infra/pull/15610, https://github.com/kubernetes/kubernetes/issues/88553