### PR TITLE
Tolerate null commit values in job-flakes query 

### DIFF
--- a/metrics/configs/job-flakes-config.yaml
+++ b/metrics/configs/job-flakes-config.yaml
@@ -20,7 +20,7 @@ query: |
       select /* Count the runs and passes for each (job, pr-num, commit) */
         max(stamp) stamp,
         num,
-        if(kind = "pull", commit, version) commit,
+        if(kind = "pull", if(commit is NULL, version, commit), version) commit,
         sum(if(result=='SUCCESS',1,0)) passed,
         count(result) runs
       from (
@@ -51,7 +51,7 @@ query: |
 
 jqfilter: |
   [(.[] | select(.job | contains("pr:")) | {(.job): {
-      flakes: (.flakes|tonumber),
-      runs: (.runs|tonumber),
-      consistency: (.commit_consistency|tonumber)
+      flakes: (.flakes//0|tonumber),
+      runs: (.runs//0|tonumber),
+      consistency: (.commit_consistency//0|tonumber)
   }})] | add


### PR DESCRIPTION
Some release-branch periodics were added but mistakenly dumped their
logs into pr-logs. The job-flakes query is unable to parse the commit
for these ci jobs masquerading as pull jobs, and so null ends up
propogating to commit_consistency. This then causes jq to error out
while attempting to convert null to a number

Add safeguards in the query and in the jq filter to prevent this
from breaking the query

Fixes https://github.com/kubernetes/test-infra/issues/15618

/hold
Want to see if I can get rid of our bad data first, but it may make
sense to have this for defensive measures anyway