### PR TITLE
Enable `override` command for kubernetes/dashboard repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -555,6 +555,9 @@ plugins:
   - milestone
   - require-sig
 
+  kubernetes/dashboard:
+  - override
+
   kubernetes/enhancements:
   - blockade
   - milestone


### PR DESCRIPTION
Enable dashboard maintainers to force to pass some check on PR.