### PR TITLE
capi/capa/cabpk/capg: build images for semver tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -10,6 +10,8 @@ postsubmits:
       branches:
         - ^master$
         - ^release-0.2$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20191126-282e49f
@@ -41,6 +43,8 @@ postsubmits:
       branches:
         - ^master$
         - ^release-0.4$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20191126-282e49f
@@ -101,6 +105,8 @@ postsubmits:
       branches:
         - ^master$
         - ^release-0.2$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20191126-282e49f
@@ -131,6 +137,8 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20191126-282e49f


### PR DESCRIPTION
Use the regular express for semver from
https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
to match refs for git tags for cluster-api, cluster-api-provider-aws,
and cluster-api-bootstrap-provider-kubeadm. This eliminates one of the
manual steps in the release process for these projects.

If you want me to do this for cluster-api-provider-gcp too, let me know.

I also noticed that cluster-api-provider-openstack is in a different yaml file. I didn't touch that either.

/cc @detiber @vincepri 