### PR TITLE
Crier: Report periodics again

### DIFF
--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -136,6 +136,8 @@ func PostsubmitSpec(p config.Postsubmit, refs prowapi.Refs) prowapi.ProwJobSpec 
 // PeriodicSpec initializes a ProwJobSpec for a given periodic job.
 func PeriodicSpec(p config.Periodic) prowapi.ProwJobSpec {
 	pjs := specFromJobBase(p.JobBase)
+	// It is currently not possible to disable reporting for individual periodics.
+	pjs.Report = true
 	pjs.Type = prowapi.PeriodicJob
 
 	return pjs

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -869,3 +869,28 @@ func TestSpecFromJobBase(t *testing.T) {
 		})
 	}
 }
+
+func TestPeriodicSpec(t *testing.T) {
+	testCases := []struct {
+		name   string
+		config config.Periodic
+		verify func(prowapi.ProwJobSpec) error
+	}{
+		{
+			name:   "Report gets set to true",
+			config: config.Periodic{},
+			verify: func(p prowapi.ProwJobSpec) error {
+				if !p.Report {
+					return errors.New("report is not true")
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		if err := tc.verify(PeriodicSpec(tc.config)); err != nil {
+			t.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/15595 we changed
crier to respect the .Spec.Report field rather than handle it within
individual reporters.

This caused periodics to not get reported at all anymore, because their
.Spec.Report field always remains the zero value of a boolean, false.

This PR hardcodes the .Spec.Report field on periodics to true, because
the approach of "negate job.Reporter.SkipReport" used for Presubmits and
Postsubmits does not work for periodics, as they have no Reporter
embedded.

/assign @clarketm 