### PR TITLE
Azure: Change AZ-configured cluster's location from westus2 to eastus2

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -187,7 +187,7 @@ presubmits:
         - "--acsengine-admin-username=azureuser"
         - "--acsengine-creds=$AZURE_CREDENTIALS"
         - "--acsengine-orchestratorRelease=1.16"
-        - "--acsengine-location=westus2"
+        - "--acsengine-location=eastus2"
         - "--acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/multi-az.json"
         - "--acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.43.1/aks-engine-v0.43.1-linux-amd64.tar.gz"

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -718,7 +718,7 @@ periodics:
       - --acsengine-ccm=True
       - --aksengine-cnm=True
       - --acsengine-hyperkube=True
-      - --acsengine-location=westus2
+      - --acsengine-location=eastus2
       - --acsengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --acsengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
       - --acsengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz


### PR DESCRIPTION
https://testgrid.k8s.io/provider-azure-master#ci-cloud-provider-azure-multiple-zones has been failing for the past few days since westus2 is capacity-constrained with AZ-configured clusters.
