### PR TITLE
Add exclude regexes to triage

### DIFF
--- a/triage/index.html
+++ b/triage/index.html
@@ -40,11 +40,22 @@ Sort by
 <label><input name="sort" type="radio" value="message">error message</label>
 <br>
 <label style="display:none"><input type="checkbox" id="show-normalize">Display normalized errors</label><br>
-Filter (these are regexes):
 <table>
-<label><tr><td>Failure text<td><input type="text" id="filter-text"></label><br>
-<label><tr><td>Job<td><input type="text" id="filter-job"></label><br>
-<label><tr><td>Test<td><input type="text" id="filter-test"></label><br>
+<tr>
+<td>
+Include Filter (these are regexes):
+<table>
+<label><tr><td>Failure text<td><input type="text" id="filter-include-text"></label><br>
+<label><tr><td>Job<td><input type="text" id="filter-include-job"></label><br>
+<label><tr><td>Test<td><input type="text" id="filter-include-test"></label><br>
+</table>
+<td>
+Exclude Filter (these are regexes):
+<table>
+<label><tr><td>Failure text<td><input type="text" id="filter-exclude-text"></label><br>
+<label><tr><td>Job<td><input type="text" id="filter-exclude-job"></label><br>
+<label><tr><td>Test<td><input type="text" id="filter-exclude-test"></label><br>
+</table>
 </table>
 </span>
 </form>

--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -50,9 +50,12 @@ function readOptions() {
     date: read('date'),
     ci: read('job-ci'),
     pr: read('job-pr'),
-    reText: read('filter-text'),
-    reJob: read('filter-job'),
-    reTest: read('filter-test'),
+    reText: read('filter-include-text'),
+    reJob: read('filter-include-job'),
+    reTest: read('filter-include-test'),
+    reXText: read('filter-exclude-text'),
+    reXJob: read('filter-exclude-job'),
+    reXTest: read('filter-exclude-test'),
     showNormalize: read('show-normalize'),
     sort: read('sort'),
     sig: readSigs(),
@@ -118,9 +121,12 @@ function setOptionsFromURL() {
   write('date', qs.date);
   write('job-ci', qs.ci);
   write('job-pr', qs.pr);
-  write('filter-text', qs.text);
-  write('filter-job', qs.job);
-  write('filter-test', qs.test);
+  write('filter-include-text', qs.text);
+  write('filter-include-job', qs.job);
+  write('filter-include-test', qs.test);
+  write('filter-exclude-text', qs.xtext);
+  write('filter-exclude-job', qs.xjob);
+  write('filter-exclude-test', qs.xtest);
   writeSigs(qs.sig);
 }
 

--- a/triage/model.js
+++ b/triage/model.js
@@ -179,7 +179,8 @@ class Clusters {
   refilter(opts) {
     var out = [];
     for (let cluster of this.data) {
-      if (opts.reText && !opts.reText.test(cluster.text)) {
+      if ((opts.reText && !opts.reText.test(cluster.text)) ||
+          (opts.reXText && opts.reXText.test(cluster.text))) {
         continue;
       }
       if (opts.sig && opts.sig.length && opts.sig.indexOf(cluster.owner) < 0) {
@@ -187,12 +188,14 @@ class Clusters {
       }
       var testsOut = [];
       for (let test of cluster.tests) {
-        if (opts.reTest && !opts.reTest.test(test.name)) {
+        if ((opts.reTest && !opts.reTest.test(test.name)) ||
+            (opts.reXTest && opts.reXTest.test(test.name))) {
           continue;
         }
         var jobsOut = [];
         for (let job of test.jobs) {
-          if (opts.reJob && !opts.reJob.test(job.name)) {
+          if ((opts.reJob && !opts.reJob.test(job.name)) ||
+              (opts.reXJob && opts.reXJob.test(job.name))) {
             continue;
           }
           if (job.name.startsWith("pr:")) {

--- a/triage/script_test.js
+++ b/triage/script_test.js
@@ -37,7 +37,7 @@ describe('Clusters', () => {
             {name: 'volume', jobs: [{name: 'cure', builds: [1, 2]}]},
         ]};
         let spam = {text: 'spam', key: 'spam', id: '5678', owner: 'ui', tests: [
-            {name: 'networking', jobs: [{name: 'g', builds: [2]}]},
+            {name: 'networking', jobs: [{name: 'gcure', builds: [2]}]},
         ]};
         let pr = {text: 'bam', key: 'bam', id: '9abc', tests: [
             {name: 'new', jobs: [{name: 'pr:verify', builds: [3]}]},
@@ -45,9 +45,9 @@ describe('Clusters', () => {
         let first = {text: 'afirst', key: 'afirst', id: 'def0', tests: [
             {name: 'something', jobs: [{name: 'firstjob', builds: [5, 6]}]},
         ]};
-        expect('filters by text', [ham], [ham, spam], {reText: /ham/im, ci: true});
-        expect('filters by test', [ham], [ham, spam], {reTest: /volume/im, ci: true});
-        expect('filters by job', [ham], [ham, spam], {reJob: /cure/im, ci: true});
+        expect('filters by text', [ham, spam], [ham, spam, pr], {reText: /am/im, reXText: /b/im, ci: true});
+        expect('filters by test', [spam], [ham, spam, first], {reTest: /ing/im, reXTest: /some/im, ci: true});
+        expect('filters by job', [ham], [ham, spam], {reJob: /cure/im, reXJob: /g/im, ci: true});
         expect('filters by sig', [ham], [ham, spam], {sig: ['node'], ci: true});
         expect('shows PRs when demanded', [pr], [ham, spam, pr], {pr: true});
         expect('hides PRs otherwise', [ham, spam], [ham, spam, pr], {ci: true});


### PR DESCRIPTION
I wanted to find tests that failed with a specific failure text, but didn't have 'sig-storage' in their name

eg: https://storage.googleapis.com/k8s-gubernator/triage/staging/index.html?text=OCI%20runtime%20start%20failed%3A%20container%20process%20is%20already%20dead%3A%20unknown&job=gce