### PR TITLE
Revert "Switch config_updater configuration to use new format."

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -385,9 +385,7 @@ config_updater:
   maps:
     label_sync/labels.yaml:
       name: label-config
-      clusters:
-        test-infra-trusted:
-          - test-pods
+      namespace: test-pods
     config/prow/config.yaml:
       name: config
     config/prow/plugins.yaml:


### PR DESCRIPTION
This reverts commit 53cf71e378aaa48b174e3239b40f2ffc5c857cf9. (https://github.com/kubernetes/test-infra/pull/15129)

See slack thread for details: https://kubernetes.slack.com/archives/C7J9RP96G/p1576614298013700

/assign @cblecker  @hongkailiu 