### PR TITLE
Use 100QPS for all kube clients

### DIFF
--- a/prow/kube/config.go
+++ b/prow/kube/config.go
@@ -99,6 +99,10 @@ func buildConfigs(buildCluster string) (map[string]rest.Config, error) {
 		if err != nil {
 			return nil, fmt.Errorf("create %s client: %v", context, err)
 		}
+		// An arbitrary high number we expect to not exceed. There are various components that need more than the default 5 QPS/10 Burst, e.G.
+		// hook for creating ProwJobs and Plank for creating Pods.
+		contextCfg.QPS = 100
+		contextCfg.Burst = 1000
 		configs[context] = *contextCfg
 	}
 	return configs, nil


### PR DESCRIPTION
/assign @stevekuznetsov  @fejta

From the [godocs](https://github.com/kubernetes/client-go/blob/a32a6f7a3052374fff2c57c5b4b52e64dcd55eed/util/flowcontrol/throttle.go#L48) of the ratelimiter:
```
 // The bucket is initially filled with 'burst' tokens, and refills at a rate of 'qps'.
 // The maximum number of tokens in the bucket is capped at 'burst'
```

I would assume that the APIserver breaks before we get above 1k QPS, hence this PR effectively removes clientside ratelimiting.