### PR TITLE
Switch 1.16 test-integration to podutils, bump to go1.13.4

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -289,23 +289,25 @@ periodics:
     preset-dind-enabled: "true"
     preset-service-account: "true"
   name: ci-kubernetes-integration-stable1
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - args:
-      - --repo=k8s.io/kubernetes=release-1.16
-      - --timeout=100
-      - --scenario=kubernetes_verify
-      - --
-      - --branch=release-1.16
-      - --force
-      - --prow
-      image: gcr.io/k8s-testimages/bootstrap:v20191203-6fb6647
-      name: ""
-      resources:
-        requests:
-          cpu: "4"
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-1.16
+      command:
+      - runner.sh
+      args:
+      - ./hack/jenkins/test-dockerized.sh
+      # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
+      resources:
+        requests:
+          cpu: 4
 - annotations:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -3,8 +3,7 @@ presubmits:
   - name: pull-kubernetes-integration
     always_run: true
     branches:
-    # we migrated to podutils for v1.17+
-    - release-1.16
+    # we migrated to podutils for v1.16+
     - release-1.15
     - release-1.14
     labels:
@@ -69,6 +68,28 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-1.17
+        command:
+        - runner.sh
+        args:
+        - ./hack/jenkins/test-dockerized.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 4
+  - name: pull-kubernetes-integration
+    always_run: true
+    decorate: true
+    branches:
+    - release-1.16 # per-release job
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-1.16
         command:
         - runner.sh
         args:

--- a/images/builder/README.md
+++ b/images/builder/README.md
@@ -15,7 +15,7 @@ and `cloudbuild.yaml`. For example, a subset of the `kubekins-e2e` variants look
 variants:
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -17,7 +17,7 @@ variants:
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.13.4
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':


### PR DESCRIPTION
cc @BenTheElder @tpepper 

Replicates kubernetes/test-infra#15113 and kubernetes/test-infra#15156 for release-1.16

/hold
once this merges, https://github.com/kubernetes/kubernetes/pull/85019 will be required to merge before other 1.16 CI runs will succeed