### PR TITLE
[aws-janitor] Prevent deletions of ELBs still in use

### DIFF
--- a/boskos/aws-janitor/resources/elb.go
+++ b/boskos/aws-janitor/resources/elb.go
@@ -37,7 +37,7 @@ func (LoadBalancers) MarkAndSweep(sess *session.Session, account string, region 
 
 	pageFunc := func(page *elb.DescribeLoadBalancersOutput, _ bool) bool {
 		for _, lb := range page.LoadBalancerDescriptions {
-			a := &loadBalancer{region: region, account: account, name: *lb.LoadBalancerName}
+			a := &loadBalancer{region: region, account: account, name: *lb.LoadBalancerName, dnsName: *lb.DNSName}
 			if set.Mark(a) {
 				klog.Warningf("%s: deleting %T: %s", a.ARN(), a, a.name)
 				toDelete = append(toDelete, a)
@@ -75,6 +75,7 @@ func (LoadBalancers) ListAll(sess *session.Session, acct, region string) (*Set, 
 				region:  region,
 				account: acct,
 				name:    *lb.LoadBalancerName,
+				dnsName: *lb.DNSName,
 			}.ARN()
 			set.firstSeen[arn] = now
 		}
@@ -89,10 +90,11 @@ type loadBalancer struct {
 	region  string
 	account string
 	name    string
+	dnsName string
 }
 
 func (lb loadBalancer) ARN() string {
-	return "fakearn:elb:" + lb.region + ":" + lb.account + ":" + lb.name
+	return "fakearn:elb:" + lb.region + ":" + lb.account + ":" + lb.dnsName
 }
 
 func (lb loadBalancer) ResourceKey() string {


### PR DESCRIPTION
The Kops periodic jobs reuse the same cluster names, and as a result the same ELB names.
aws-janitor currently marks ELBs for deletion based on their LoadBalancerName. This is problematic in the following scenario:

1. Kops job provisions ELB
2. aws-janitor runs and marks the ELB for deletion after the configured TTL
3. Kops job deletes ELB
4. After the TTL has passed, a Kops job provisions a new ELB with the same name
5. aws-janitor sees the new ELB as having existed for longer than the TTL and deletes it
6. Kops job fails

Rather than using a reusable name in the resource key, the DNSName will always be unique even if an ELB was recreated with the same LoadBalancerName.

An example of this occurring is at `W1218 02:09:09` in these two jobs:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-ha-uswest2/1207119506887938048

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1207120262621827075
