### PR TITLE
Fix ci-kubernetes-e2e-gce-node-containerd-throughput job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -272,9 +272,9 @@ presets:
   - name: LOG_DUMP_SYSTEMD_SERVICES
     value: containerd containerd-installation
   - name: KUBE_MASTER_EXTRA_METADATA
-    value: user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/cri-master/env
+    value: user-data=/go/src/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/cri-master/env
   - name: KUBE_NODE_EXTRA_METADATA
-    value: user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/cri-master/env
+    value: user-data=/go/src/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/cri-master/env
   - name: KUBE_CONTAINER_RUNTIME
     value: remote
   - name: KUBE_CONTAINER_RUNTIME_ENDPOINT


### PR DESCRIPTION
node-containerd-throughput job if failing consitently:
https://k8s-testgrid.appspot.com/sig-scalability-node#node-containerd-throughput

`W1218 13:25:39.061] ERROR: (gcloud.compute.instance-templates.create) Unable to read file [/workspace/github.com/containerd/cri/test/e2e/node.yaml]: [Errno 2] No such file or directory: '/workspace/github.com/containerd/cri/test/e2e/node.yaml'`

That repository was checked out to:
```
I1218 13:20:39.655] Checkout: /go/src/github.com/containerd/cri master to /go/src/github.com/containerd/cri
I1218 13:20:39.655] Call:  git init github.com/containerd/cri
I1218 13:20:39.663] Initialized empty Git repository in /go/src/github.com/containerd/cri/.git/
```