### PR TITLE
Update scheduler benchmark job to select tests to run.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -366,6 +366,8 @@ periodics:
       env:
       - name: KUBE_TIMEOUT
         value: --timeout=1h50m
+      - name: TEST_PREFIX
+        value: BenchmarkScheduling
 
 - name: ci-benchmark-kube-dns-master
   interval: 2h


### PR DESCRIPTION
We are in the progress of changing the way of running scheduler benchmark tests. As part of this, we create a [new set of tests](https://github.com/kubernetes/kubernetes/pull/86160) with different test prefixes. However, we do not want to run the new ones just yet until we have everything working e2e. 
This change makes sure the benchrmark test jobs only run the existing tests.