### PR TITLE
Add triage exclude regexes to uri

### DIFF
--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -66,8 +66,10 @@ function readOptions() {
   if (!opts.ci) url += '&ci=0';
   if (opts.pr) url += '&pr=1';
   if (opts.sig.length) url += '&sig=' + opts.sig.join(',');
-  for (var name of ["text", "job", "test"]) {
-    var re = opts['re' + name[0].toUpperCase() + name.slice(1)];
+  for (var name of ["text", "job", "test", "xtext", "xjob", "xtest"]) {
+    var re = (name[0] == 'x') ?
+      opts['reX' + name[1].toUpperCase() + name.slice(2)] :
+      opts['re'  + name[0].toUpperCase() + name.slice(1)];
     if (re) {
       var baseRe = re.toString().replace(/im$/, '').replace(/\\\//g, '/').slice(1, -1);
       url += '&' + name + '=' + encodeURIComponent(baseRe);


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/15631 

The exclude regexes weren't being added to the URI, so I couldn't copy-paste a triage link with excludes pre-populated

eg of it working: https://storage.googleapis.com/k8s-gubernator/triage/staging/index.html?job=gce&xtest=sig-storage%7CUp%7CTest

/kind bug