### PR TITLE
Azure: Add missing AZ_STORAGE_CONTAINER_NAME in preset-azure-cred label

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -593,6 +593,8 @@ presets:
     value: k8sprow.azurecr.io
   - name: KUBE_VERBOSE
     value: "0"
+  - name: AZ_STORAGE_CONTAINER_NAME
+    value: mystoragecontainer
   volumes:
   - name: azure-cred
     secret:


### PR DESCRIPTION
Addresses https://github.com/kubernetes/kubernetes/pull/86380#issuecomment-567075146. Azure deployer failed to upload a tarball to Azure Storage because it's missing `AZ_STORAGE_CONTAINER_NAME` environment variable (https://github.com/kubernetes/test-infra/blob/master/kubetest/azure.go#L944).

/assign @cblecker 
/cc @andyzhangx 