### PR TITLE
Kops - Enable Milestone Applier plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -304,6 +304,11 @@ milestone_applier:
     master: v1.18
   kubernetes/test-infra:
     master: v1.18
+  kubernetes/kops:
+    master: v1.18
+    release-1.17: v1.17
+    release-1.16: v1.16
+    release-1.15: v1.15
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Now that Kops has 4 active branches and many open cherry-pick PRs, it can be helpful to quickly filter open PRs by milestone. Enabling this plugin will apply milestones to PRs based on their target branch.