### PR TITLE
Adds a periodic for CAPD e2es in CAPI

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -43,6 +43,35 @@ periodics:
     testgrid-tab-name: unit tests
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
+- name: ci-cluster-api-e2e-test
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api
+      base_ref: master
+      path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
+        args:
+          - runner.sh
+          - "./scripts/ci-capd-e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "4000m"
+            memory: "6Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: e2e tests
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
 - name: ci-cluster-api-build-release-0-2
   interval: 1h
   decorate: true


### PR DESCRIPTION
This requires using `runner.sh` in order to enable DIND. This does not require a service-account as this job is read-only. I tried testing this with pj-on-kind.sh but my environment was messed up in some way and no jobs could pull from docker (including jobs that are known working). So this may require some tweaking but in general should be good and the rest of the commits should happen CAPI side.

/cc @detiber 

related to kubernetes-sigs/cluster-api#1921

Signed-off-by: Chuck Ha <chuckh@vmware.com>