### PR TITLE
boskos/janitor: fix typo in flag (freqency->frequency)

### DIFF
--- a/boskos/janitor/janitor.go
+++ b/boskos/janitor/janitor.go
@@ -43,7 +43,7 @@ var (
 func init() {
 	flag.Var(&rTypes, "resource-type", "comma-separated list of resources need to be cleaned up")
 	flag.IntVar(&poolSize, "pool-size", 20, "number of concurrent janitor goroutine")
-	flag.DurationVar(&updateFrequency, "update-freqency", 5*time.Minute, "How often to heartbeat owning resources.")
+	flag.DurationVar(&updateFrequency, "update-frequency", 5*time.Minute, "How often to heartbeat owning resources.")
 }
 
 func main() {


### PR DESCRIPTION
Normally I don't like typo fix PRs, but I definitely was confused about why the janitor was failing to start at first.