### PR TITLE
Run kind ipv6 conformance serial tests on presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -53,6 +53,63 @@ presubmits:
     skip_report: false
     max_concurrency: 8
     optional: true
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      # run on the ubuntu node pool, which has ipv6 modules
+      tolerations:
+      - key: "dedicated"
+        operator: "Equal"
+        value: "ubuntu"
+        effect: "NoSchedule"
+      nodeSelector:
+        dedicated: "ubuntu"
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191218-bcc4f6d-master
+        env:
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
+        # tell kind CI script to use ipv6
+        - name: "IP_FAMILY"
+          value: "ipv6"
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--root=/go/src"
+        - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
+        - "--repo=sigs.k8s.io/kind=master"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
+        - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-testing-kind
+      description: Use kind to run e2e Conformance tests against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
+      testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
+      testgrid-num-failures-to-alert: "15"
+
+  - name: pull-kubernetes-conformance-kind-ipv6-parallel
+    branches:
+    - master
+    always_run: false
+    skip_report: false
+    max_concurrency: 8
+    optional: true
     run_if_changed: '^test/'
     labels:
       preset-service-account: "true"
@@ -78,6 +135,9 @@ presubmits:
         # tell kind CI script to use ipv6
         - name: "IP_FAMILY"
           value: "ipv6"
+        # skip serial tests and run with --ginkgo-parallel
+        - name: "PARALLEL"
+          value: "true"
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"


### PR DESCRIPTION
Running ipv6 conformance serial tests on presubmits implies the job takes more than 1.30 hour.
The signal given by serial tests is not worth the time it takes, however we need signal on serial.
This PR add a new optional job to run conformance ipv6 serial tests as presubmits