### PR TITLE
Enable privileged mode for blobfuse csi driver

### DIFF
--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -56,6 +56,8 @@ presubmits:
         args:
         - make
         - sanity-test
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-blobfuse-csi-driver-sanity
@@ -77,6 +79,8 @@ presubmits:
         args:
         - make
         - integration-test
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-azure-master, provider-azure-on-call
       testgrid-tab-name: pr-blobfuse-csi-driver-integration

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -100,6 +100,7 @@ presubmits:
       repo: kubernetes
       base_ref: master
       path_alias: k8s.io/kubernetes
+      workdir: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191218-bcc4f6d-master


### PR DESCRIPTION
Sanity and integration tests are failing because privileged mode is disabled.

/assign @andyzhangx 