### PR TITLE
Pod utilities: Default TerminationGracePeriod to decorationConfig.GracePeriod

### DIFF
--- a/prow/pod-utils/decorate/BUILD.bazel
+++ b/prow/pod-utils/decorate/BUILD.bazel
@@ -55,5 +55,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -658,6 +658,11 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 		spec.Volumes = append(spec.Volumes, append(cloneVolumes, codeVolume)...)
 	}
 
+	if spec.TerminationGracePeriodSeconds == nil && pj.Spec.DecorationConfig.GracePeriod != nil {
+		gracePeriodSeconds := int64(pj.Spec.DecorationConfig.GracePeriod.Seconds())
+		spec.TerminationGracePeriodSeconds = &gracePeriodSeconds
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR changes the pod utilities to set
pod.Spec.TerminationGracePeriodSeconds to decorationConfig.GracePeriod,
if the former was unset.

Currently, the Pod utilities never set the TerminationGracePeriodSeconds
on Pods. This means that the only case in which
decorationConfig.GracePeriod has any effect is if the job times out. If
it gets aborted for any other reason (newer version of the job, resource
starvation on the node) the Kubelet will kill it after the pods
TerminationGracePeriodSeconds, which defaults to 30 seconds.

/cc @xmudrii 
/assign @stevekuznetsov 