### PR TITLE
Add inrepo postsubmits support

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -323,7 +323,7 @@ func TestTrustedJobs(t *testing.T) {
 	}
 
 	// Trusted postsubmits must be defined in trustedPath
-	for _, post := range c.AllPostsubmits(nil) {
+	for _, post := range c.AllStaticPostsubmits(nil) {
 		if post.Cluster != trusted {
 			continue
 		}
@@ -428,7 +428,7 @@ func TestTrustedJobSecretsRestricted(t *testing.T) {
 	// config/jobs/<org>/<project>/<project>-trusted.yaml can and only can use restricted
 	// secrets for <org>/repo>.
 	jobs := []cfg.JobBase{}
-	for _, job := range c.AllPostsubmits(nil) {
+	for _, job := range c.AllStaticPostsubmits(nil) {
 		jobs = append(jobs, job.JobBase)
 	}
 	for _, job := range c.AllPeriodics() {
@@ -470,7 +470,7 @@ func TestConfigSecurityClusterRestricted(t *testing.T) {
 			}
 		}
 	}
-	for repo, jobs := range c.Postsubmits {
+	for repo, jobs := range c.PostsubmitsStatic {
 		if strings.HasPrefix(repo, "kubernetes-security/") {
 			for _, job := range jobs {
 				if job.Agent != "jenkins" && job.Cluster != "security" {
@@ -514,7 +514,7 @@ func TestJobDoesNotHaveDockerSocket(t *testing.T) {
 		}
 	}
 
-	for _, postsubmit := range c.AllPostsubmits(nil) {
+	for _, postsubmit := range c.AllStaticPostsubmits(nil) {
 		if postsubmit.Spec != nil {
 			if err := checkDockerSocketVolumes(postsubmit.Spec.Volumes); err != nil {
 				t.Errorf("Error in postsubmit: %v", err)
@@ -564,7 +564,7 @@ func TestLatestUsesImagePullPolicy(t *testing.T) {
 		}
 	}
 
-	for _, postsubmit := range c.AllPostsubmits(nil) {
+	for _, postsubmit := range c.AllStaticPostsubmits(nil) {
 		if postsubmit.Spec != nil {
 			if err := checkLatestUsesImagePullPolicy(postsubmit.Spec); err != nil {
 				t.Errorf("Error in postsubmit %q: %v", postsubmit.Name, err)
@@ -662,7 +662,7 @@ func TestValidPresets(t *testing.T) {
 		}
 	}
 
-	for _, postsubmit := range c.AllPostsubmits(nil) {
+	for _, postsubmit := range c.AllStaticPostsubmits(nil) {
 		if postsubmit.Spec != nil && !postsubmit.Decorate {
 			if err := checkKubekinsPresets(postsubmit.Name, postsubmit.Spec, postsubmit.Labels, validLabels); err != nil {
 				t.Errorf("Error in postsubmit %q: %v", postsubmit.Name, err)
@@ -889,7 +889,7 @@ func TestValidScenarioArgs(t *testing.T) {
 		}
 	}
 
-	for _, job := range c.AllPostsubmits(nil) {
+	for _, job := range c.AllStaticPostsubmits(nil) {
 		if job.Spec != nil && !job.Decorate {
 			if err := checkScenarioArgs(job.Name, job.Spec.Containers[0].Image, job.Spec.Containers[0].Args); err != nil {
 				t.Errorf("Invalid Scenario Args : %s", err)

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -389,7 +389,7 @@ func TestKubernetesProwInstanceJobsMustHaveMatchingTestgridEntries(t *testing.T)
 		}
 	}
 
-	for _, job := range prowConfig.AllPostsubmits([]string{}) {
+	for _, job := range prowConfig.AllStaticPostsubmits([]string{}) {
 		jobs[job.Name] = false
 	}
 

--- a/experiment/ci-janitor/main.go
+++ b/experiment/ci-janitor/main.go
@@ -149,7 +149,7 @@ func main() {
 	for _, v := range conf.AllStaticPresubmits(nil) {
 		jobs = append(jobs, v.JobBase)
 	}
-	for _, v := range conf.AllPostsubmits(nil) {
+	for _, v := range conf.AllStaticPostsubmits(nil) {
 		jobs = append(jobs, v.JobBase)
 	}
 	for _, v := range conf.AllPeriodics() {

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/errorutil"
@@ -520,7 +520,7 @@ func validateJobRequirements(c config.JobConfig) error {
 			validationErrs = append(validationErrs, validatePresubmitJob(repo, job))
 		}
 	}
-	for repo, jobs := range c.Postsubmits {
+	for repo, jobs := range c.PostsubmitsStatic {
 		for _, job := range jobs {
 			validationErrs = append(validationErrs, validatePostsubmitJob(repo, job))
 		}
@@ -852,7 +852,7 @@ func validateDecoratedJobs(cfg *config.Config) error {
 		}
 	}
 
-	for _, postsubmit := range cfg.AllPostsubmits([]string{}) {
+	for _, postsubmit := range cfg.AllStaticPostsubmits([]string{}) {
 		if postsubmit.Agent == string(v1.KubernetesAgent) && !postsubmit.Decorate {
 			nonDecoratedJobs = append(nonDecoratedJobs, postsubmit.Name)
 		}
@@ -979,7 +979,7 @@ func validateTriggers(cfg *config.Config, pcfg *plugins.Configuration) error {
 	for orgRepo := range cfg.JobConfig.PresubmitsStatic {
 		configuredRepos.Insert(orgRepo)
 	}
-	for orgRepo := range cfg.JobConfig.Postsubmits {
+	for orgRepo := range cfg.JobConfig.PostsubmitsStatic {
 		configuredRepos.Insert(orgRepo)
 	}
 

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1219,9 +1219,14 @@ func TestValidateInRepoConfig(t *testing.T) {
 			prowYAMLData: []byte(`presubmits: [{"name": "hans", "spec": {"containers": [{}]}}]`),
 		},
 		{
-			name:         "Invalid prowYAML, err",
+			name:         "Invalid prowYAML presubmit, err",
 			prowYAMLData: []byte(`presubmits: [{"name": "hans"}]`),
 			expectedErr:  "failed to validate .prow.yaml: invalid presubmit job hans: kubernetes jobs require a spec",
+		},
+		{
+			name:         "Invalid prowYAML postsubmit, err",
+			prowYAMLData: []byte(`postsubmits: [{"name": "hans"}]`),
+			expectedErr:  "failed to validate .prow.yaml: invalid postsubmit job hans: kubernetes jobs require a spec",
 		},
 		{
 			name: "Absent prowYAML, no err",

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -77,7 +77,7 @@ func (o *options) genJobSpec(conf *config.Config, name string) (config.JobBase, 
 			}
 		}
 	}
-	for fullRepoName, ps := range conf.Postsubmits {
+	for fullRepoName, ps := range conf.PostsubmitsStatic {
 		org, repo, err := splitRepoName(fullRepoName)
 		if err != nil {
 			logrus.WithError(err).Warnf("Invalid repo name %s.", fullRepoName)

--- a/prow/cmd/tot/fallbackcheck/main.go
+++ b/prow/cmd/tot/fallbackcheck/main.go
@@ -97,7 +97,7 @@ func main() {
 		}
 		notFound = notFound || nf
 	}
-	for _, post := range cfg.AllPostsubmits(nil) {
+	for _, post := range cfg.AllStaticPostsubmits(nil) {
 		spec := pjutil.PostsubmitToJobSpec(post)
 		nf, err := getJobFallbackNumber(o.bucket, spec)
 		if err != nil {

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -241,7 +241,7 @@ func (f fallbackHandler) getURL(jobName string) string {
 		}
 	}
 	if spec == nil {
-		for _, post := range cfg.AllPostsubmits(nil) {
+		for _, post := range cfg.AllStaticPostsubmits(nil) {
 			if jobName == post.Name {
 				spec = pjutil.PostsubmitToJobSpec(post)
 				break

--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -500,7 +500,7 @@ func (c *JobConfig) SetPostsubmits(jobs map[string][]Postsubmit) error {
 			return err
 		}
 	}
-	c.Postsubmits = nj
+	c.PostsubmitsStatic = nj
 	return nil
 }
 
@@ -530,10 +530,13 @@ func (c *JobConfig) AllStaticPresubmits(repos []string) []Presubmit {
 
 // AllPostsubmits returns all prow postsubmit jobs in repos.
 // if repos is empty, return all postsubmits.
-func (c *JobConfig) AllPostsubmits(repos []string) []Postsubmit {
+// Be aware that this does not return Postsubmits that are versioned inside
+// the repo via the `inrepoconfig` feature and hence this list may be
+// incomplete.
+func (c *JobConfig) AllStaticPostsubmits(repos []string) []Postsubmit {
 	var res []Postsubmit
 
-	for repo, v := range c.Postsubmits {
+	for repo, v := range c.PostsubmitsStatic {
 		if len(repos) == 0 {
 			res = append(res, v...)
 		} else {

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -120,11 +120,11 @@ func TestPresubmits(t *testing.T) {
 
 // TODO(krzyzacy): technically this, and TestPresubmits above should belong to config/ instead of prow/
 func TestPostsubmits(t *testing.T) {
-	if len(c.Postsubmits) == 0 {
+	if len(c.PostsubmitsStatic) == 0 {
 		t.Fatalf("No jobs found in presubmit.yaml.")
 	}
 
-	for _, rootJobs := range c.Postsubmits {
+	for _, rootJobs := range c.PostsubmitsStatic {
 		for i, job := range rootJobs {
 			if job.Name == "" {
 				t.Errorf("Job %v needs a name.", job)
@@ -211,7 +211,7 @@ func TestListPresubmit(t *testing.T) {
 					{JobBase: JobBase{Name: "d"}},
 				},
 			},
-			Postsubmits: map[string][]Postsubmit{
+			PostsubmitsStatic: map[string][]Postsubmit{
 				"r1": {{JobBase: JobBase{Name: "e"}}},
 			},
 			Periodics: []Periodic{
@@ -263,7 +263,7 @@ func TestListPostsubmit(t *testing.T) {
 			PresubmitsStatic: map[string][]Presubmit{
 				"r1": {{JobBase: JobBase{Name: "a"}}},
 			},
-			Postsubmits: map[string][]Postsubmit{
+			PostsubmitsStatic: map[string][]Postsubmit{
 				"r1": {
 					{
 						JobBase: JobBase{
@@ -298,7 +298,7 @@ func TestListPostsubmit(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		actual := c.AllPostsubmits(tc.repos)
+		actual := c.AllStaticPostsubmits(tc.repos)
 		if len(actual) != len(tc.expected) {
 			t.Fatalf("%s - Wrong number of jobs. Got %v, expected %v", tc.name, actual, tc.expected)
 		}
@@ -323,7 +323,7 @@ func TestListPeriodic(t *testing.T) {
 			PresubmitsStatic: map[string][]Presubmit{
 				"r1": {{JobBase: JobBase{Name: "a"}}},
 			},
-			Postsubmits: map[string][]Postsubmit{
+			PostsubmitsStatic: map[string][]Postsubmit{
 				"r1": {{JobBase: JobBase{Name: "b"}}},
 			},
 			Periodics: []Periodic{
@@ -420,7 +420,7 @@ func TestValidPodNames(t *testing.T) {
 			t.Errorf("Job \"%s\" must match regex \"%s\".", j.Name, podRe.String())
 		}
 	}
-	for _, j := range c.AllPostsubmits([]string{}) {
+	for _, j := range c.AllStaticPostsubmits([]string{}) {
 		if !podRe.MatchString(j.Name) {
 			t.Errorf("Job \"%s\" must match regex \"%s\".", j.Name, podRe.String())
 		}
@@ -436,7 +436,7 @@ func TestNoDuplicateJobs(t *testing.T) {
 	// Presubmit test is covered under TestPresubmits() above
 
 	allJobs := make(map[string]bool)
-	for _, j := range c.AllPostsubmits([]string{}) {
+	for _, j := range c.AllStaticPostsubmits([]string{}) {
 		if allJobs[j.Name] {
 			t.Errorf("Found duplicate job in postsubmit: %s.", j.Name)
 		}

--- a/prow/config/jobtests/job_config_test.go
+++ b/prow/config/jobtests/job_config_test.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	cfg "k8s.io/test-infra/prow/config"
@@ -100,7 +100,7 @@ func TestMountsHaveVolumes(t *testing.T) {
 			validateVolumesAndMounts(job.Name, job.Spec, t)
 		}
 	}
-	for _, job := range c.AllPostsubmits(nil) {
+	for _, job := range c.AllStaticPostsubmits(nil) {
 		if job.Spec != nil {
 			validateVolumesAndMounts(job.Name, job.Spec, t)
 		}
@@ -196,7 +196,7 @@ func allJobs() ([]cfg.Presubmit, []cfg.Postsubmit, []cfg.Periodic, error) {
 	{ // Find all postsubmit jobs
 		q := []cfg.Postsubmit{}
 
-		for _, p := range c.Postsubmits {
+		for _, p := range c.PostsubmitsStatic {
 			for _, p2 := range p {
 				q = append(q, p2)
 			}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -504,17 +504,20 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 			name: "jobs from inrepoconfig are considered",
 			config: Config{
 				JobConfig: JobConfig{
-					ProwYAMLGetter: fakeProwYAMLGetterFactory([]Presubmit{
-						{
-							AlwaysRun: true,
-							Reporter:  Reporter{Context: "ir0"},
+					ProwYAMLGetter: fakeProwYAMLGetterFactory(
+						[]Presubmit{
+							{
+								AlwaysRun: true,
+								Reporter:  Reporter{Context: "ir0"},
+							},
+							{
+								AlwaysRun: true,
+								Optional:  true,
+								Reporter:  Reporter{Context: "ir1"},
+							},
 						},
-						{
-							AlwaysRun: true,
-							Optional:  true,
-							Reporter:  Reporter{Context: "ir1"},
-						},
-					}),
+						nil,
+					),
 				},
 				ProwConfig: ProwConfig{
 					InRepoConfig: InRepoConfig{
@@ -549,17 +552,20 @@ func TestConfigGetTideContextPolicy(t *testing.T) {
 							},
 						},
 					},
-					ProwYAMLGetter: fakeProwYAMLGetterFactory([]Presubmit{
-						{
-							AlwaysRun: true,
-							Reporter:  Reporter{Context: "ir0"},
+					ProwYAMLGetter: fakeProwYAMLGetterFactory(
+						[]Presubmit{
+							{
+								AlwaysRun: true,
+								Reporter:  Reporter{Context: "ir0"},
+							},
+							{
+								AlwaysRun: true,
+								Optional:  true,
+								Reporter:  Reporter{Context: "ir1"},
+							},
 						},
-						{
-							AlwaysRun: true,
-							Optional:  true,
-							Reporter:  Reporter{Context: "ir1"},
-						},
-					}),
+						nil,
+					),
 				},
 				ProwConfig: ProwConfig{
 					InRepoConfig: InRepoConfig{
@@ -1034,10 +1040,11 @@ func TestTideContextPolicy_MissingRequiredContexts(t *testing.T) {
 	}
 }
 
-func fakeProwYAMLGetterFactory(presubmits []Presubmit) ProwYAMLGetter {
+func fakeProwYAMLGetterFactory(presubmits []Presubmit, postsubmits []Postsubmit) ProwYAMLGetter {
 	return func(_ *Config, _ git.ClientFactory, _, _ string, _ ...string) (*ProwYAML, error) {
 		return &ProwYAML{
-			Presubmits: presubmits,
+			Presubmits:  presubmits,
+			Postsubmits: postsubmits,
 		}, nil
 	}
 }

--- a/prow/gerrit/adapter/adapter.go
+++ b/prow/gerrit/adapter/adapter.go
@@ -200,8 +200,9 @@ func (c *Controller) ProcessChange(instance string, change client.ChangeInfo) er
 
 	switch change.Status {
 	case client.Merged:
-		postsubmits := c.config().Postsubmits[cloneURI.String()]
-		postsubmits = append(postsubmits, c.config().Postsubmits[cloneURI.Host+"/"+cloneURI.Path]...)
+		// TODO: Do we want to add support for dynamic postsubmits?
+		postsubmits := c.config().PostsubmitsStatic[cloneURI.String()]
+		postsubmits = append(postsubmits, c.config().PostsubmitsStatic[cloneURI.Host+"/"+cloneURI.Path]...)
 		for _, postsubmit := range postsubmits {
 			if shouldRun, err := postsubmit.ShouldRun(change.Branch, changedFiles); err != nil {
 				return fmt.Errorf("failed to determine if postsubmit %q should run: %v", postsubmit.Name, err)

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -691,7 +691,7 @@ func TestProcessChange(t *testing.T) {
 							},
 						},
 					},
-					Postsubmits: map[string][]config.Postsubmit{
+					PostsubmitsStatic: map[string][]config.Postsubmit{
 						"gerrit/postsubmits-project": {
 							{
 								JobBase: config.JobBase{

--- a/prow/inrepoconfig.md
+++ b/prow/inrepoconfig.md
@@ -1,6 +1,6 @@
 # Inrepoconfig
 
-Inrepoconfig is a Prow feature that allows versioning Presubmit jobs in the same repository
+Inrepoconfig is a Prow feature that allows versioning Presubmit and Postsubmit jobs in the same repository
 that also holds the code. If enabled, Prow will use both the centrally-defined jobs and the
 ones defined in the code repository. The latter ones are dynamically loaded on-demand.
 
@@ -58,6 +58,20 @@ named `.prow.yaml` to the root of the repository that holds your code:
 ```yaml
 presubmits:
 - name: pull-test-infra-yamllint
+  always_run: true
+  decorate: true
+  spec:
+    containers:
+    - image: quay.io/kubermatic/yamllint:0.1
+      command:
+      - yamllint
+      - -c
+      - config/jobs/.yamllint.conf
+      - config/jobs
+      - prow/cluster
+
+postsubmits:
+- name: push-test-infra-yamllint
   always_run: true
   decorate: true
   spec:

--- a/prow/plugins/trigger/push_test.go
+++ b/prow/plugins/trigger/push_test.go
@@ -68,9 +68,22 @@ func TestHandlePE(t *testing.T) {
 			pe: github.PushEvent{
 				Ref: "refs/heads/master",
 				Repo: github.Repo{
-					FullName: "org/repo",
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
 				},
 				Deleted: true,
+			},
+			jobsToRun: 0,
+		},
+		{
+			name: "null after sha",
+			pe: github.PushEvent{
+				After: "0000000000000000000000000000000000000000",
+				Ref:   "refs/heads/master",
+				Repo: github.Repo{
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
+				},
 			},
 			jobsToRun: 0,
 		},
@@ -84,7 +97,8 @@ func TestHandlePE(t *testing.T) {
 					},
 				},
 				Repo: github.Repo{
-					FullName: "org/repo",
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
 				},
 			},
 		},
@@ -99,7 +113,8 @@ func TestHandlePE(t *testing.T) {
 					},
 				},
 				Repo: github.Repo{
-					FullName: "org/repo",
+					Owner: github.User{Login: "org"},
+					Name:  "repo",
 				},
 			},
 			jobsToRun: 1,
@@ -114,7 +129,8 @@ func TestHandlePE(t *testing.T) {
 					},
 				},
 				Repo: github.Repo{
-					FullName: "org2/repo2",
+					Owner: github.User{Login: "org2"},
+					Name:  "repo2",
 				},
 			},
 			jobsToRun: 1,
@@ -129,7 +145,8 @@ func TestHandlePE(t *testing.T) {
 					},
 				},
 				Repo: github.Repo{
-					FullName: "org3/repo3",
+					Owner: github.User{Login: "org3"},
+					Name:  "repo3",
 				},
 			},
 			jobsToRun: 1,

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -265,7 +265,6 @@ func skipRequested(c Client, pr *github.PullRequest, skippedJobs []config.Presub
 }
 
 func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter, headSHAGetter config.RefGetter) []config.Presubmit {
-
 	presubmits, err := cfg.GetPresubmits(gc, orgRepo, baseSHAGetter, headSHAGetter)
 	if err != nil {
 		// Fall back to static presubmits to avoid deadlocking when a presubmit is used to verify
@@ -274,4 +273,14 @@ func getPresubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, 
 		presubmits = cfg.PresubmitsStatic[orgRepo]
 	}
 	return presubmits
+}
+
+func getPostsubmits(log *logrus.Entry, gc git.ClientFactory, cfg *config.Config, orgRepo string, baseSHAGetter config.RefGetter) []config.Postsubmit {
+	postsubmits, err := cfg.GetPostsubmits(gc, orgRepo, baseSHAGetter)
+	if err != nil {
+		// Fall back to static postsubmits, loading inrepoconfig returned an error.
+		log.WithError(err).Error("Failed to get postsubmits")
+		postsubmits = cfg.PostsubmitsStatic[orgRepo]
+	}
+	return postsubmits
 }

--- a/releng/config-forker/main.go
+++ b/releng/config-forker/main.go
@@ -46,7 +46,7 @@ const (
 
 func generatePostsubmits(c config.JobConfig, version string) (map[string][]config.Postsubmit, error) {
 	newPostsubmits := map[string][]config.Postsubmit{}
-	for repo, postsubmits := range c.Postsubmits {
+	for repo, postsubmits := range c.PostsubmitsStatic {
 		for _, postsubmit := range postsubmits {
 			if postsubmit.Annotations[forkAnnotation] != "true" {
 				continue

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -758,7 +758,7 @@ func TestGeneratePostsubmits(t *testing.T) {
 		},
 	}
 
-	result, err := generatePostsubmits(config.JobConfig{Postsubmits: postsubmits}, "1.15")
+	result, err := generatePostsubmits(config.JobConfig{PostsubmitsStatic: postsubmits}, "1.15")
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}

--- a/releng/config-rotator/main.go
+++ b/releng/config-rotator/main.go
@@ -23,8 +23,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sigs.k8s.io/yaml"
 	"strings"
+
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/config"
 )
@@ -90,7 +91,7 @@ func updateEverything(c *config.JobConfig, old, new string) {
 			updateJobBase(&presubmits[i].JobBase, old, new)
 		}
 	}
-	for _, postsubmits := range c.Postsubmits {
+	for _, postsubmits := range c.PostsubmitsStatic {
 		for i := range postsubmits {
 			updateJobBase(&postsubmits[i].JobBase, old, new)
 		}
@@ -138,7 +139,7 @@ func main() {
 
 	output, err := yaml.Marshal(map[string]interface{}{
 		"presubmits":  c.PresubmitsStatic,
-		"postsubmits": c.Postsubmits,
+		"postsubmits": c.PostsubmitsStatic,
 		"periodics":   c.Periodics,
 	})
 	if err != nil {

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -185,7 +185,7 @@ func applyProwjobAnnotations(c *configpb.Configuration, reconcile *yamlcfg.Defau
 		}
 	}
 
-	for repo, js := range jobs.Postsubmits {
+	for repo, js := range jobs.PostsubmitsStatic {
 		for _, j := range js {
 			if err := applySingleProwjobAnnotations(c, pc, j.JobBase, prowapi.PostsubmitJob, repo, reconcile); err != nil {
 				return err


### PR DESCRIPTION
### This pull request is a work in progress.

This pull request adds support for in repo postsubmits as discussed here https://github.com/kubernetes/test-infra/issues/15656.

What was done in this pull request :
- added Postsubmits to the `ProwYAML` struct, and added tests
- added `PostsubmitsStatic` in `JobConfig` struct, `GetPostsubmits` function, and added tests
- adapted `GetPresubmits` function to factor out common code with `GetPostsubmits`
- removed `Postsubmits` in `JobConfig` struct, and fixed tests
- adapted `hook/trigger` plugin, and adapted/added tests
- adapted `cmd/checkconfig`, `gerrit` adapter, `testgrid` configurator, `config-rotator`, `config-forker`, `tot`, and `mkpj`
