### PR TITLE
Add windows load test presubmit job for debug

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -354,3 +354,50 @@ presubmits:
     annotations:
       testgrid-dashboards: google-windows
       testgrid-tab-name: pull-windows-gce
+  - name: pull-kubernetes-e2e-windows-node-throughput
+    interval: 2h
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-common-gce-windows: "true"
+      preset-load-gce-windows: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+    annotations:
+      testgrid-dashboards: google-windows
+      testgrid-tab-name: pull-windows-gce-node-throughput
+    decorate: true
+    always_run: false
+    optional: true
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: windows-testing
+      base_ref: master
+      path_alias: k8s.io/windows-testing
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-master
+        args:
+        - --repo=k8s.io/kubernetes=master
+        - --repo=k8s.io/perf-tests=master
+        - --root=/go/src
+        - --timeout=60m
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --cluster=
+        - --extract=ci/k8s-master
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --gcp-nodes=1
+        - --test=false
+        - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/load-test.sh
+        - --test-cmd-args=cluster-loader2
+        - --test-cmd-args=--nodes=1
+        - --test-cmd-args=--provider=gce
+        - --test-cmd-args=--report-dir=/workspace/_artifacts
+        - --test-cmd-args=--testconfig=testing/node-throughput/config.yaml
+        - --test-cmd-args=--testoverrides=./testing/node-throughput/windows_override.yaml
+        - --test-cmd-name=ClusterLoaderV2
+        - --timeout=40m


### PR DESCRIPTION
Add windows load test presubmit job, so we can trigger on demand and get it right. Then change back to periodic job