### PR TITLE
Creates presub job for k8s/kops so we don't regress

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -372,7 +372,7 @@ presubmits:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: verify-packages
   - name: pull-kops-verify-staticcheck
-    always_run: true'
+    always_run: true
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-master

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -371,6 +371,20 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: verify-packages
+  - name: pull-kops-verify-staticcheck
+    always_run: true'
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-master
+        command:
+        - make
+        args:
+        - verify-staticcheck
+    annotations:
+      testgrid-dashboards: presubmits-kops
+      testgrid-tab-name: verify-staticcheck
+      description: Verifies Go sources pass a static source checker
+
 periodics:
 - interval: 30m
   name: ci-kops-build


### PR DESCRIPTION
As per office hours last week, there's been some work to prune down our staticcheck tech debt. 
This PR would add this test as a presumbit on PRs in k8s.io/kops so that we don't accidentally create regressions after all of our hard work. 
On the other note about bringing this into the kops repo- I think this is a great candidate, but I haven't figured out how to activate that functionality yet. Until then, this should help make things a little bit more better.
cc: @hakman  @justinsb @mikesplain @rifelpet  