### PR TITLE
Adds a triggerable job to CAPI for capd e2es

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -104,3 +104,27 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-integration
+  - name: pull-cluster-api-capd-e2e
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    optional: true
+    always_run: false
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-master
+          args:
+            - runner.sh
+            - "./scripts/ci-capd-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: "4000m"
+              memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: pr-e2e


### PR DESCRIPTION
Signed-off-by: Chuck Ha <chuckh@vmware.com>

I'm going to need this to debug the e2es properly. The CAPD e2es are occasionally failing with a timeout that doesn't really make sense. I need pod logs to determine if something is up with the environment or if it's a genuine timeout.

/assign @detiber 