### PR TITLE
Use --max_rows instead of -n for bq calls in triage

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -27,7 +27,7 @@ fi
 
 date
 
-bq --headless --format=json query -n 1000000 \
+bq --headless --format=json query --max_rows 1000000 \
   "select
     path,
     timestamp_to_sec(started) started,
@@ -44,7 +44,7 @@ bq --headless --format=json query -n 1000000 \
     timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))" \
   > triage_builds.json
 
-bq query --allow_large_results --headless -n0 --replace --destination_table k8s-gubernator:temp.triage \
+bq query --allow_large_results --headless --max_rows 0 --replace --destination_table k8s-gubernator:temp.triage \
   "select
     timestamp_to_sec(started) started,
     path build,


### PR DESCRIPTION
This should address #15680 but I'm not using a "fixes" keyword because I'd like to verify before closing the issue