### PR TITLE
Dump contained journal

### DIFF
--- a/kubetest/dump.go
+++ b/kubetest/dump.go
@@ -50,6 +50,7 @@ func newLogDumper(sshClientFactory sshClientFactory, artifactsDir string) (*logD
 	d.services = []string{
 		"node-problem-detector",
 		"kubelet",
+		"containerd",
 		"docker",
 		"kops-configuration",
 		"protokube",


### PR DESCRIPTION
Starting Docker 18.09, `containerd` became a separate package and service.
There is also the possibility running Kubernetes with it as container runtime.

With these in mind, its logs should be also collected.