### PR TITLE
Kops - Fix image used by some presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -229,7 +229,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -269,7 +269,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -289,7 +289,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -335,7 +335,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -355,7 +355,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -375,7 +375,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
           args:
             - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
             - "--root=/go/src"


### PR DESCRIPTION
The old image has not been updated in [almost a year](https://console.cloud.google.com/gcr/images/k8s-testimages/GLOBAL/gcloud-in-go?gcrImageListsize=30) and is still running Go 1.11:

```
docker run --entrypoint=/usr/local/go/bin/go gcr.io/k8s-testimages/gcloud-in-go:v20190125-cc5d6ecff3 version
go version go1.11.5 linux/amd64
```

We have [open PRs](https://github.com/kubernetes/kops/pull/8203) which are not compatible with go 1.11 which is causing their presubmits to fail.
This switches those jobs to use the same kubekins image as the E2E jobs.
I see [other projects](https://github.com/kubernetes/test-infra/blob/c628c3674eb0c9292812d760232afcdbb7c79c99/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml#L23) using the same kubekins-e2e image for non-e2e jobs as well.

The new image has Go 1.13 as [we expect](https://github.com/kubernetes/kops/blob/master/go.mod#L3):

```
docker run --entrypoint=/usr/local/go/bin/go gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental version
go version go1.13.4 linux/amd64
```