### PR TITLE
Kops - fix staging image push directory

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -19,7 +19,7 @@ postsubmits:
               - --project=k8s-staging-kops
               - --scratch-bucket=gs://k8s-staging-kops-gcb
               - --env-passthrough=PULL_BASE_REF
-              - ci/postsubmit/push-to-staging/
+              - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /creds/service-account.json


### PR DESCRIPTION
I'm hoping to get Kops' image pushing functional since it [has been failing](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-postsubmit-push-to-staging) for as long as this job has existed. This argument needs to be a path in the project rather than the bucket.

For example, [CAPA uses](https://github.com/kubernetes/test-infra/blob/c628c3674eb0c9292812d760232afcdbb7c79c99/config/jobs/image-pushing/k8s-staging-cluster-api.yaml#L58) `.` and the [job](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-cluster-api-provider-aws-push-images/1209125473993363457) uses the cloudbuild.yaml file in the [project root](https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/7c7572e27fc19e7f91253d14b9d5af292f28872c).

Note that the [job will still fail](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/kops-postsubmit-push-to-staging/1208049886021292033) because Kops doesnt have a cloudbuild.yaml file yet, I'll add that after this is merged to more easily test this postsubmit job.