### PR TITLE
Fix user and quotes for containerd e2e

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -218,11 +218,11 @@ periodics:
         - --
         - --cluster=e2e-kops-aws-containerd.test-cncf-aws.k8s.io
         - --deployment=kops
-        - --env=KUBE_SSH_USER=admin
+        - --env=KUBE_SSH_USER=ec2-user
         - --extract=ci/latest
         - --ginkgo-parallel
-        - --kops-args="--image=redhat.com/RHEL-8.1.0_HVM-20191029-x86_64-0-Hourly2-GP2 --container-runtime=containerd --networking=calico"
-        - --kops-ssh-user=admin
+        - --kops-args=--image=redhat.com/RHEL-8.1.0_HVM-20191029-x86_64-0-Hourly2-GP2 --container-runtime=containerd --networking=calico
+        - --kops-ssh-user=ec2-user
         - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort


### PR DESCRIPTION
A few more fixes for containerd e2e:
```
I1227 21:45:16.985] Found multiple arguments which look like a cluster name
I1227 21:45:16.986] 	"e2e-kops-aws-containerd.test-cncf-aws.k8s.io" (via flag)
I1227 21:45:16.986] 	"\"--image=redhat.com/RHEL-8.1.0_HVM-20191029-x86_64-0-Hourly2-GP2" (as argument)
```