### PR TITLE
Kops - Enable milestone applier prow plugin

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -566,6 +566,7 @@ plugins:
 
   kubernetes/kops:
   - milestone
+  - milestoneapplier
 
   kubernetes/kubernetes:
   - blockade


### PR DESCRIPTION
This was meant to be enabled in #15647 but I didn't realize it needed to be added here as well.