### PR TITLE
Kops - Lower test concurrency for AWS VPC CNI periodic E2E

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -445,7 +445,7 @@ periodics:
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=ci/latest
-      - --ginkgo-parallel
+      - --ginkgo-parallel=15
       - --kops-args=--networking=amazon-vpc-routed-eni --node-size=m5.large
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws


### PR DESCRIPTION
The [default value is 25](https://github.com/kubernetes/test-infra/blob/55437e354c02c1f1f046e65e3faa184b02632b9c/kubetest/main.go#L48). We're seeing [test failures](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-vpc-cni/1210727216132919302) due to nodes reaching their pod limit due to IP/ENI limits on our instance type. Rather than increasing the instance type even more I'd like to first try decreasing the parallel test count so that less pods are running concurrently.
