### PR TITLE
Revert "Update SIG Azure jobs to v1.17"

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -62,10 +62,10 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
         args:
         - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/kubernetes=release-1.17"
+        - "--repo=k8s.io/kubernetes=release-1.16"
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
@@ -84,7 +84,7 @@ presubmits:
         - "--aksengine-agentpoolcount=2"
         - "--aksengine-admin-username=azureuser"
         - "--aksengine-creds=$AZURE_CREDENTIALS"
-        - "--aksengine-orchestratorRelease=1.17"
+        - "--aksengine-orchestratorRelease=1.16"
         - "--aksengine-mastervmsize=Standard_DS2_v2"
         - "--aksengine-agentvmsize=Standard_D4s_v3"
         - "--aksengine-ccm=True"
@@ -93,7 +93,7 @@ presubmits:
         - "--aksengine-location=westus2"
         - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json"
-        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz"
+        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz"
         - "--test_args=--num-nodes=2 --ginkgo.focus=\\[Conformance\\] --ginkgo.skip=\\[Serial\\]|\\[sig-node\\]\\sMount\\spropagation|\\[sig-network\\]\\sNetwork\\sshould\\sset\\sTCP\\sCLOSE_WAIT\\stimeout|\\[sig-storage\\]\\sPersistentVolumes-local\\sStress\\swith\\slocal\\svolume\\sprovisioner\\s\\[Serial\\]\\sshould\\suse\\sbe\\sable\\sto\\sprocess\\smany\\spods\\sand\\sreuse\\slocal\\svolumes|should\\sunmount\\sif\\spod\\sis\\sgracefully\\sdeleted\\swhile\\skubelet\\sis\\sdown\\s\\[Disruptive\\]\\[Slow\\]|should\\sunmount\\sif\\spod\\sis\\sforce\\sdeleted\\swhile\\skubelet\\sis\\sdown\\s\\[Disruptive\\]\\[Slow\\]|\\[sig-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\screate\\sa\\sfunctioning\\sNodePort\\sservice|\\[sig-scheduling\\]\\sSchedulerPredicates\\s\\[Serial\\]\\svalidates\\sMaxPods\\slimit\\snumber\\sof\\spods\\sthat\\sare\\sallowed\\sto\\srun\\s\\[Slow\\]|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sDefault\\sshould\\screate\\sand\\sdelete\\sdefault\\spersistent\\svolumes\\s\\[Slow\\]|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sshould\\sprovision\\sstorage\\swith\\sdifferent\\sparameters|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sshould\\stest\\sthat\\sdeleting\\sa\\sclaim\\sbefore\\sthe\\svolume\\sis\\sprovisioned\\sdeletes\\sthe\\svolume.|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sadopt\\smatching\\sorphans\\sand\\srelease\\snon-matching\\spods|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\snot\\sdeadlock\\swhen\\sa\\spod.s\\spredecessor\\sfails|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sperform\\srolling\\supdates\\sand\\sroll\\sbacks\\sof\\stemplate\\smodifications\\swith\\sPVCs|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sprovide\\sbasic\\sidentity|\\[sig-storage\\]\\sPersistentVolumes\\sDefault\\sStorageClass\\spods\\sthat\\suse\\smultiple\\svolumes\\sshould\\sbe\\sreschedulable|\\[sig-storage\\]\\sPVC\\sProtection|\\[sig-storage\\]\\sDynamic\\sProvisioning\\s\\[k8s.io\\]\\sGlusterDynamicProvisioner|\\[sig-storage\\]\\sVolumes\\sAzure\\sDisk\\sshould\\sbe\\smountable\\s\\[Slow\\]|\\[sig-apps\\]\\sNetwork\\sPartition\\s\\[Disruptive\\]\\s\\[Slow\\]|\\[sig-network\\]\\sDNS\\sconfigMap|\\[k8s.io\\]\\s\\[sig-node\\]\\sKubelet\\s\\[Serial\\]\\s\\[Slow\\]\\s\\[k8s.io\\]\\s\\[sig-node\\]\\sregular\\sresource\\susage\\stracking\\sresource\\stracking\\sfor\\s0\\spods\\sper\\snode|\\[k8s.io\\]\\s\\[sig-node\\]\\sKubelet\\s\\[Serial\\]\\s\\[Slow\\]\\s\\[k8s.io\\]\\s\\[sig-node\\]\\sregular\\sresource\\susage\\stracking\\sresource\\stracking\\sfor\\s100\\spods\\sper\\snode|Horizontal\\spod\\sautoscaling\\s\\(scale\\sresource:\\sCPU\\)|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sExternal\\sshould\\slet\\san\\sexternal\\sdynamic\\sprovisioner\\screate\\sand\\sdelete\\spersistent\\svolumes\\s\\[Slow\\]|ESIPP|\\[sig-network\\]\\sServices\\sshould\\spreserve\\ssource\\spod\\sIP\\sfor\\straffic\\sthru\\sservice\\scluster\\sIP|In-tree\\sVolumes|PersistentVolumes-local|CSI\\sVolumes|should\\swrite\\sentries\\sto\\s/etc/hosts|\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[NodeFeature:.+\\]|\\[sig-cli\\]\\sKubectl\\sclient\\s\\[k8s\\.io\\]\\sSimple\\spod\\sshould\\ssupport\\sexec\\susing\\sresource\\/name"
         - "--timeout=420m"
         securityContext:
@@ -115,10 +115,10 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
         args:
         - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/kubernetes=release-1.17"
+        - "--repo=k8s.io/kubernetes=release-1.16"
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
         - "--service-account=/etc/service-account/service-account.json"
@@ -138,7 +138,7 @@ presubmits:
         - "--aksengine-agentpoolcount=2"
         - "--aksengine-admin-username=azureuser"
         - "--aksengine-creds=$AZURE_CREDENTIALS"
-        - "--aksengine-orchestratorRelease=1.17"
+        - "--aksengine-orchestratorRelease=1.16"
         - "--aksengine-mastervmsize=Standard_DS2_v2"
         - "--aksengine-agentvmsize=Standard_D4s_v3"
         - "--aksengine-ccm=True"
@@ -147,7 +147,7 @@ presubmits:
         - "--aksengine-location=westus2"
         - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json"
-        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz"
+        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz"
         - "--timeout=420m"
         securityContext:
           privileged: true
@@ -195,10 +195,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -218,7 +218,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -227,7 +227,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --timeout=420m
       securityContext:
         privileged: true
@@ -255,10 +255,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -278,7 +278,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -287,7 +287,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-autoscaler.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --timeout=420m
       securityContext:
         privileged: true
@@ -317,10 +317,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -339,7 +339,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -348,7 +348,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --test_args=--num-nodes=2 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|\[Slow\]
       - --timeout=420m
       securityContext:
@@ -377,10 +377,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -399,7 +399,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -408,7 +408,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/e2e-slow.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --test_args=--num-nodes=2 --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=420m
       securityContext:
@@ -438,10 +438,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -459,7 +459,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_D4s_v3
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -468,7 +468,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$KUBE_SSH_PUBLIC_KEY_PATH
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-serial.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       # Skip four kinds of test cases:
       # 1. regular resource usage tracking, haven't found the cause of the failures.
       # 2. validates MaxPods limit number of pods that are allowed to run, related to issue kubernetes/kubernetes#80177
@@ -508,10 +508,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -531,7 +531,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -540,7 +540,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --timeout=420m
       securityContext:
         privileged: true
@@ -568,10 +568,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -590,7 +590,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -599,7 +599,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --test_args=--num-nodes=2 --ginkgo.focus=\[Conformance\] --ginkgo.skip=\[Serial\]|\[Slow\]
       - --timeout=420m
       securityContext:
@@ -628,10 +628,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -650,7 +650,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -659,7 +659,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --test_args=--num-nodes=2 --ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=420m
       securityContext:
@@ -688,10 +688,10 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -710,7 +710,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -719,7 +719,7 @@ periodics:
       - --aksengine-location=eastus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       # Four kinds of cases should be skipped:
       # 1. ssh related cases
       # 2. PSP related cases, reason: https://github.com/Azure/aks-engine/blob/master/parts/k8s/addons/kubernetesmasteraddons-pod-security-policy.yaml#L41
@@ -760,10 +760,10 @@ periodics:
     description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled."
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-1.16
       args:
       - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.16
       - --repo=sigs.k8s.io/$(REPO_NAME)=master
       - --root=/go/src
       - --service-account=/etc/service-account/service-account.json
@@ -780,7 +780,7 @@ periodics:
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
-      - --aksengine-orchestratorRelease=1.17
+      - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
       - --aksengine-ccm=True
@@ -789,7 +789,7 @@ periodics:
       - --aksengine-location=westus2
       - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
+      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.44.0/aks-engine-v0.44.0-linux-amd64.tar.gz
       - --kubemark
       - --kubemark-nodes=100
       - --test=false

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -34,14 +34,14 @@ presubmits:
         - "--aksengine-agentpoolcount=3"
         - "--aksengine-admin-username=azureuser"
         - "--aksengine-creds=$AZURE_CREDENTIALS"
-        - "--aksengine-orchestratorRelease=1.17" # needed for now until aks-engine supports `custom`
+        - "--aksengine-orchestratorRelease=1.16" # needed for now until aks-engine supports `custom`
         - "--aksengine-mastervmsize=Standard_DS2_v2"
         - "--aksengine-agentvmsize=Standard_DS2_v2"
         - "--aksengine-hyperkube=True" # build hyperkube image
         - "--aksengine-location=westus2"
         - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json"
-        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz"
+        - "--aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz"
         - "--test_args=--ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\] --ginkgo.skip=\\[sig-node\\]\\sMount\\spropagation|\\[sig-network\\]\\sNetwork\\sshould\\sset\\sTCP\\sCLOSE_WAIT\\stimeout|\\[sig-storage\\]\\sPersistentVolumes-local\\sStress\\swith\\slocal\\svolume\\sprovisioner\\s\\[Serial\\]\\sshould\\suse\\sbe\\sable\\sto\\sprocess\\smany\\spods\\sand\\sreuse\\slocal\\svolumes|should\\sunmount\\sif\\spod\\sis\\sgracefully\\sdeleted\\swhile\\skubelet\\sis\\sdown\\s\\[Disruptive\\]\\[Slow\\]|should\\sunmount\\sif\\spod\\sis\\sforce\\sdeleted\\swhile\\skubelet\\sis\\sdown\\s\\[Disruptive\\]\\[Slow\\]|\\[sig-network\\]\\sServices\\sshould\\sbe\\sable\\sto\\screate\\sa\\sfunctioning\\sNodePort\\sservice|\\[sig-scheduling\\]\\sSchedulerPredicates\\s\\[Serial\\]\\svalidates\\sMaxPods\\slimit\\snumber\\sof\\spods\\sthat\\sare\\sallowed\\sto\\srun\\s\\[Slow\\]|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sDefault\\sshould\\screate\\sand\\sdelete\\sdefault\\spersistent\\svolumes\\s\\[Slow\\]|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sshould\\sprovision\\sstorage\\swith\\sdifferent\\sparameters|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sshould\\stest\\sthat\\sdeleting\\sa\\sclaim\\sbefore\\sthe\\svolume\\sis\\sprovisioned\\sdeletes\\sthe\\svolume.|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sadopt\\smatching\\sorphans\\sand\\srelease\\snon-matching\\spods|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\snot\\sdeadlock\\swhen\\sa\\spod.s\\spredecessor\\sfails|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sperform\\srolling\\supdates\\sand\\sroll\\sbacks\\sof\\stemplate\\smodifications\\swith\\sPVCs|\\[sig-apps\\]\\sStatefulSet\\s\\[k8s.io\\]\\sBasic\\sStatefulSet\\sfunctionality\\s\\[StatefulSetBasic\\]\\sshould\\sprovide\\sbasic\\sidentity|\\[sig-storage\\]\\sPersistentVolumes\\sDefault\\sStorageClass\\spods\\sthat\\suse\\smultiple\\svolumes\\sshould\\sbe\\sreschedulable|\\[sig-storage\\]\\sPVC\\sProtection|\\[sig-storage\\]\\sDynamic\\sProvisioning\\s\\[k8s.io\\]\\sGlusterDynamicProvisioner|\\[sig-storage\\]\\sVolumes\\sAzure\\sDisk\\sshould\\sbe\\smountable\\s\\[Slow\\]|\\[sig-apps\\]\\sNetwork\\sPartition\\s\\[Disruptive\\]\\s\\[Slow\\]|\\[sig-network\\]\\sDNS\\sconfigMap|\\[k8s.io\\]\\s\\[sig-node\\]\\sKubelet\\s\\[Serial\\]\\s\\[Slow\\]\\s\\[k8s.io\\]\\s\\[sig-node\\]\\sregular\\sresource\\susage\\stracking\\sresource\\stracking\\sfor\\s0\\spods\\sper\\snode|\\[k8s.io\\]\\s\\[sig-node\\]\\sKubelet\\s\\[Serial\\]\\s\\[Slow\\]\\s\\[k8s.io\\]\\s\\[sig-node\\]\\sregular\\sresource\\susage\\stracking\\sresource\\stracking\\sfor\\s100\\spods\\sper\\snode|Horizontal\\spod\\sautoscaling\\s\\(scale\\sresource:\\sCPU\\)|\\[sig-storage\\]\\sDynamic\\sProvisioning\\sDynamicProvisioner\\sExternal\\sshould\\slet\\san\\sexternal\\sdynamic\\sprovisioner\\screate\\sand\\sdelete\\spersistent\\svolumes\\s\\[Slow\\]|ESIPP|\\[sig-network\\]\\sServices\\sshould\\spreserve\\ssource\\spod\\sIP\\sfor\\straffic\\sthru\\sservice\\scluster\\sIP|In-tree\\sVolumes|PersistentVolumes-local|CSI\\sVolumes|should\\swrite\\sentries\\sto\\s/etc/hosts|\\[Slow\\]|\\[Serial\\]|\\[Disruptive\\]|\\[Flaky\\]|\\[Feature:.+\\]|\\[NodeFeature:.+\\]"
         - "--timeout=420m"
         securityContext:
@@ -86,12 +86,12 @@ presubmits:
         - "--ginkgo-parallel=1"
         - "--aksengine-admin-username=azureuser"
         - "--aksengine-creds=$AZURE_CREDENTIALS"
-        - "--aksengine-orchestratorRelease=1.17"
+        - "--aksengine-orchestratorRelease=1.16"
         - "--aksengine-hyperkube=True"
         - "--aksengine-location=westus2"
         - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json"
-        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz"
+        - "--aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz"
         - "--test-azure-disk-csi-driver=True"
         - "--timeout=420m"
         securityContext:
@@ -139,12 +139,12 @@ presubmits:
         - "--ginkgo-parallel=1"
         - "--aksengine-admin-username=azureuser"
         - "--aksengine-creds=$AZURE_CREDENTIALS"
-        - "--aksengine-orchestratorRelease=1.17"
+        - "--aksengine-orchestratorRelease=1.16"
         - "--aksengine-hyperkube=True"
         - "--aksengine-location=westus2"
         - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
         - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json"
-        - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz"
+        - "--aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz"
         - "--test-azure-disk-csi-driver=True"
         - "--timeout=420m"
         securityContext:


### PR DESCRIPTION
This reverts commit ef0928e7fc102453ca180f47c2606a15e8aaa1aa.

With v1.17.0, AKS engine would fail with the following error:

```
Error: validating API model after populating values: customHyperkubeImage has no effect in Kubernetes version 1.17.0 or above
```

/area provider/azure
/assign @justaugustus @andyzhangx 
/cc @ritazh @chewong 