### PR TITLE
Revert "Merge pull request #15390 from geojaz/kops/docs-no-retest"

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -565,7 +565,6 @@ plugins:
   - stage
 
   kubernetes/kops:
-  - docs-no-retest
   - milestone
   - milestoneapplier
 


### PR DESCRIPTION
This reverts commit d986bdd8e3d6dd396c99f94c412f5fc79f55786a, reversing
changes made to 0d277f5eb773c3e7114f0c33a1d4f67ba1532f6c.

This plugin doesn't function properly as it's designed for mungegithub, and should not be enabled.

/assign @chases2