### PR TITLE
Kops - dump kops-controller logs

### DIFF
--- a/kubetest/dump.go
+++ b/kubetest/dump.go
@@ -59,6 +59,7 @@ func newLogDumper(sshClientFactory sshClientFactory, artifactsDir string) (*logD
 		"kube-scheduler",
 		"rescheduler",
 		"kube-controller-manager",
+		"kops-controller",
 		"etcd",
 		"etcd-events",
 		"glbc",


### PR DESCRIPTION
The new kops-controller component in Kops 1.16 will log to `/var/log/kops-controller.log`.

In order to aid in troubleshooting, we should dump its logs as job artifacts in the E2E jobs.