### PR TITLE
Change preset-cloudprovider-azure-cred to preset-azure-cred

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -56,7 +56,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -84,7 +84,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -112,7 +112,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -161,7 +161,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -211,7 +211,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -262,7 +262,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -56,7 +56,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -84,7 +84,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -112,7 +112,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -47,7 +47,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -70,7 +70,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-master
@@ -93,7 +93,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     extra_refs:
     - org: kubernetes

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -1,30 +1,3 @@
-presets:
-- labels:
-    preset-cloudprovider-azure-cred: "true"
-  env:
-  - name: AZURE_CREDENTIALS
-    value: /etc/azure-cred/credentials
-  - name: AZURE_SSH_PUBLIC_KEY_FILE
-    value: /etc/azure-ssh/azure-ssh-pub
-  - name: REGISTRY
-    value: k8sprow.azurecr.io
-  - name: KUBE_VERBOSE
-    value: 0
-  volumes:
-  - name: azure-cred
-    secret:
-      secretName: azure-cred
-  - name: azure-ssh
-    secret:
-      secretName: azure-ssh
-  volumeMounts:
-  - name: azure-cred
-    mountPath: /etc/azure-cred
-    readOnly: true
-  - name: azure-ssh
-    mountPath: /etc/azure-ssh
-    readOnly: true
-
 presubmits:
   kubernetes-sigs/cloud-provider-azure:
   - name: pull-cloud-provider-azure-check
@@ -58,7 +31,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -111,7 +84,7 @@ presubmits:
     - master
     labels:
       preset-service-account: "true"
-      preset-cloudprovider-azure-cred: "true"
+      preset-azure-cred: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
@@ -186,7 +159,7 @@ periodics:
   name: ci-cloud-provider-azure-master
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -246,7 +219,7 @@ periodics:
   name: ci-cloud-provider-azure-autoscaling
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -308,7 +281,7 @@ periodics:
   name: ci-cloud-provider-azure-conformance
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -368,7 +341,7 @@ periodics:
   name: ci-cloud-provider-azure-slow
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -428,7 +401,7 @@ periodics:
   name: ci-cloud-provider-azure-serial
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
     preset-k8s-ssh: "true"
   extra_refs:
@@ -499,7 +472,7 @@ periodics:
   name: ci-cloud-provider-azure-master-vmss
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -559,7 +532,7 @@ periodics:
   name: ci-cloud-provider-azure-conformance-vmss
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -619,7 +592,7 @@ periodics:
   name: ci-cloud-provider-azure-slow-vmss
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes
@@ -679,7 +652,7 @@ periodics:
   name: ci-cloud-provider-azure-multiple-zones
   labels:
     preset-service-account: "true"
-    preset-cloudprovider-azure-cred: "true"
+    preset-azure-cred: "true"
     preset-dind-enabled: "true"
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
[`preset-azure-cred`](https://github.com/kubernetes/test-infra/blob/master/config/prow/config.yaml#L585-L611) should be the single source of truth for Azure-related credentials and environment variables. Azure-related jobs should not create duplicated labels.

Related issue: #15584 #15703
/assign @feiskyer 