### PR TITLE
Kops - Upgrade some less used periodic jobs to use pod utilites

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -148,13 +148,15 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
   spec:
     containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --cluster=e2e-kops-aws-imagecentos7.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=centos
@@ -296,13 +298,15 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
   spec:
     containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
       - --cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin


### PR DESCRIPTION
These two jobs are already [continuously failing](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#Summary) so if they break it wont have much impact. Using the instructions [here](https://github.com/kubernetes/test-infra/blob/cab76bdbd3760143a7b45dc35cf0b4d8d43b6c77/prow/pod-utilities.md) and following an example "kubernetes_e2e" scenario job that uses pod utilites [here](https://github.com/kubernetes/test-infra/blob/c9b56298df0116d7b35c02dbd901a5f7299c15b1/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml#L398-L434)

If these continue to work I will upgrade the remaining periodic e2e jobs as well as the presubmit e2e jobs, followed by the presubmit bazel jobs.

I'm hoping that upgrading our jobs to pod utils will either prevent the stuck jobs (such as [this one](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8247/pull-kops-e2e-kubernetes-aws/1213068623300530176/) and all the "R" [jobs here](https://testgrid.k8s.io/presubmits-kops#e2e)) from occurring or give us more information to troubleshoot them.