### PR TITLE
Add ignore to CAPV MD lint pre-submit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -134,6 +134,8 @@ presubmits:
         - /md/lint
         - -i
         - vendor
+        - -i
+        - contrib/haproxy/openapi
         - .
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere


### PR DESCRIPTION
This patch adds an ignore rule to the CAPV MD lint pre-submit.

cc @yastij @codenrhoden @figo