### PR TITLE
Clarify impact of running `/retest` command

### DIFF
--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -287,7 +287,7 @@ func createComment(reportTemplate *template.Template, pj prowapi.ProwJob, entrie
 		}
 	}
 	lines := []string{
-		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun them all:", pj.Spec.Refs.Pulls[0].Author, plural),
+		fmt.Sprintf("@%s: The following test%s **failed**, say `/retest` to rerun all failed tests:", pj.Spec.Refs.Pulls[0].Author, plural),
 		"",
 		"Test name | Commit | Details | Rerun command",
 		"--- | --- | --- | ---",


### PR DESCRIPTION
Currently, on failure, prow reports "The following tests *failed*, say
`/retest` to rerun them all". Updating the text to say "The following tests *failed*, say `/retest` to rerun all failed tests." could more clearly indicate that`/retest` will only rerun the failed tests.