### PR TITLE
Allow tide's link to be configured by org/repo level.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,6 +1,10 @@
 # Announcements
 
 New features added to each component:
+ - *January 03, 2020* Added a `pr_status_base_urls` option to the Tide config
+   that allows to specify different tide's URL for each organization or a specific repository.
+   The `pr_status_base_url` will be deprecated on *June 2020* and it will be replaces with the
+   `*` value in `pr_status_base_urls`.
  - *November 05, 2019* The `config-updater` plugin supports update configs on build clusters
     by using [`clusters`](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/updateconfig#usage).
     The fields _namespace_ and _additional_namespaces_ are deprecated.

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1411,6 +1411,25 @@ func parseProwConfig(c *Config) error {
 		return fmt.Errorf("tide has invalid max_goroutines (%d), it needs to be a positive number", c.Tide.MaxGoroutines)
 	}
 
+	if c.Tide.PRStatusBaseURLs == nil {
+		c.Tide.PRStatusBaseURLs = map[string]string{}
+	}
+
+	if len(c.Tide.PRStatusBaseURL) > 0 {
+		if len(c.Tide.PRStatusBaseURLs) > 0 {
+			return fmt.Errorf("both pr_status_base_url and pr_status_base_urls are defined")
+		} else {
+			logrus.Warning("The `pr_status_base_url` setting is deprecated and it has been replaced by `pr_status_base_urls`. It will be removed in June 2020")
+			c.Tide.PRStatusBaseURLs["*"] = c.Tide.PRStatusBaseURL
+		}
+	}
+
+	if len(c.Tide.PRStatusBaseURLs) > 0 {
+		if _, ok := c.Tide.PRStatusBaseURLs["*"]; !ok {
+			return fmt.Errorf("pr_status_base_urls is defined but the default value ('*') is missing")
+		}
+	}
+
 	for name, method := range c.Tide.MergeType {
 		if method != github.MergeMerge &&
 			method != github.MergeRebase &&

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -103,6 +103,10 @@ type Tide struct {
 	// in the tide status context.
 	PRStatusBaseURL string `json:"pr_status_base_url,omitempty"`
 
+	// PRStatusBaseURLs is the base URL for the PR status page
+	// mapped by org or org/repo level.
+	PRStatusBaseURLs map[string]string `json:"pr_status_base_urls,omitempty"`
+
 	// BlockerLabel is an optional label that is used to identify merge blocking
 	// GitHub issues.
 	// Leave this blank to disable this feature and save 1 API token per sync loop.
@@ -180,6 +184,23 @@ func (t *Tide) MergeCommitTemplate(org, repo string) TideMergeCommitTemplate {
 	}
 
 	return v
+}
+
+func (t *Tide) GetPRStatusBaseURL(org, repo string) string {
+	def := t.PRStatusBaseURL
+
+	if len(t.PRStatusBaseURLs) > 0 {
+		def = t.PRStatusBaseURLs["*"]
+	}
+
+	orgRepo := fmt.Sprintf("%s/%s", org, repo)
+	if byOrgRepo, ok := t.PRStatusBaseURLs[orgRepo]; ok {
+		return byOrgRepo
+	} else if byOrg, ok := t.PRStatusBaseURLs[org]; ok {
+		return byOrg
+	}
+
+	return def
 }
 
 // TideQuery is turned into a GitHub search query. See the docs for details:

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -187,20 +187,15 @@ func (t *Tide) MergeCommitTemplate(org, repo string) TideMergeCommitTemplate {
 }
 
 func (t *Tide) GetPRStatusBaseURL(org, repo string) string {
-	def := t.PRStatusBaseURL
-
-	if len(t.PRStatusBaseURLs) > 0 {
-		def = t.PRStatusBaseURLs["*"]
-	}
-
 	orgRepo := fmt.Sprintf("%s/%s", org, repo)
+
 	if byOrgRepo, ok := t.PRStatusBaseURLs[orgRepo]; ok {
 		return byOrgRepo
 	} else if byOrg, ok := t.PRStatusBaseURLs[org]; ok {
 		return byOrg
 	}
 
-	return def
+	return t.PRStatusBaseURLs["*"]
 }
 
 // TideQuery is turned into a GitHub search query. See the docs for details:

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -101,6 +101,7 @@ type Tide struct {
 	// PRStatusBaseURL is the base URL for the PR status page.
 	// This is used to link to a merge requirements overview
 	// in the tide status context.
+	// Will be deprecated on June 2020.
 	PRStatusBaseURL string `json:"pr_status_base_url,omitempty"`
 
 	// PRStatusBaseURLs is the base URL for the PR status page

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -300,7 +300,7 @@ func targetURL(c config.Getter, pr *PullRequest, log *logrus.Entry) string {
 	var link string
 	if tideURL := c().Tide.TargetURL; tideURL != "" {
 		link = tideURL
-	} else if baseURL := c().Tide.PRStatusBaseURL; baseURL != "" {
+	} else if baseURL := c().Tide.GetPRStatusBaseURL(string(pr.Repository.Owner.Login), string(pr.Repository.Name)); baseURL != "" {
 		parseURL, err := url.Parse(baseURL)
 		if err != nil {
 			log.WithError(err).Error("Failed to parse PR status base URL")


### PR DESCRIPTION
This PR adds the `pr_status_base_urls` field that is a mapping of target URLs by defaults ('*'), org or org/repo level.

/cc @stevekuznetsov @petr-muller 