### PR TITLE
Create managed certs to get them issued

### DIFF
--- a/prow/cluster/BUILD.bazel
+++ b/prow/cluster/BUILD.bazel
@@ -54,6 +54,8 @@ release(
     component("pipeline", "deployment"),
     component("plank", "service", "deployment"),
     component("prow-canary-k8s-io", "managedcertificate"),
+    component("prow-k8s-io", "managedcertificate"),
+    component("prow-kubernetes-io", "managedcertificate"),
     component("prowjob", "customresourcedefinition"),
     component("pushgateway", "deployment"),
     component("sinker", "service", "deployment"),

--- a/prow/cluster/prow-k8s-io_managedcertificate.yaml
+++ b/prow/cluster/prow-k8s-io_managedcertificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: prow-k8s-io
+spec:
+  domains:
+  - prow.k8s.io

--- a/prow/cluster/prow-kubernetes-io_managedcertificate.yaml
+++ b/prow/cluster/prow-kubernetes-io_managedcertificate.yaml
@@ -1,0 +1,7 @@
+apiVersion: networking.gke.io/v1beta1
+kind: ManagedCertificate
+metadata:
+  name: prow-kubernetes-io
+spec:
+  domains:
+  - prow.kubernetes.io

--- a/prow/cluster/tls-ing_ingress.yaml
+++ b/prow/cluster/tls-ing_ingress.yaml
@@ -23,6 +23,7 @@ metadata:
     certmanager.k8s.io/cluster-issuer: letsencrypt-prod
     certmanager.k8s.io/acme-http01-edit-in-place: "true"
     kubernetes.io/ingress.class: "gce"
+    networking.gke.io/managed-certificates: prow-k8s-io, prow-kubernetes-io
 spec:
   tls:
   - secretName: prow-tls


### PR DESCRIPTION
We don't use them for anything yet, but this will cause GKE to get the certs issued for later use.

This is diverting from the original plan - I've verified that by taking this staged approach we can have no downtime for anyone and do not need to do a DNS switch.

/cc @BenTheElder 