### PR TITLE
Add job name and started json metadata to the resultstore

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -58,10 +58,16 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["main_test.go"],
+    srcs = [
+        "convert_test.go",
+        "main_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "@com_github_googlecloudplatform_testgrid//resultstore:go_default_library",
         "@com_github_googlecloudplatform_testgrid//util/gcs:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
     ],
 )

--- a/experiment/resultstore/convert.go
+++ b/experiment/resultstore/convert.go
@@ -114,6 +114,8 @@ func convert(project, details string, url gcs.Path, result downloadResult) (resu
 	artifactsPath := basePath + "artifacts/"
 	buildLog := basePath + "build-log.txt"
 	bucket := url.Bucket()
+	jobName := prowJobName(url)
+
 	inv := resultstore.Invocation{
 		Project: project,
 		Details: details,
@@ -124,7 +126,20 @@ func convert(project, details string, url gcs.Path, result downloadResult) (resu
 				URL:         buildLog, // ensure build-log.txt appears as the invocation log
 			},
 		},
+		Properties: []resultstore.Property{
+			{
+				Key:   "Job",
+				Value: jobName,
+			},
+			{
+				Key:   "Pull",
+				Value: started.Pull, // may be empty if pull value is not specified
+			},
+		},
 	}
+
+	startedProperties := startedReposToProperties(started.Repos)
+	inv.Properties = append(inv.Properties, startedProperties...)
 
 	// Files need a unique identifier, trim the common prefix and provide this.
 	uniqPath := func(s string) string { return strings.TrimPrefix(s, basePath) }
@@ -230,4 +245,68 @@ func convert(project, details string, url gcs.Path, result downloadResult) (resu
 	}
 
 	return inv, target, test
+}
+
+func startedReposToProperties(gitRepos map[string]string) []resultstore.Property {
+	var properties []resultstore.Property
+
+	knownOrg := make(map[string]bool)
+	knownBranch := make(map[string]bool)
+	for repo, branch := range gitRepos {
+		orgRepo := strings.SplitN(repo, "/", 2)
+		org := orgRepo[0]
+		repoName := ""
+		if len(orgRepo) == 2 {
+			repoName = orgRepo[1]
+		} else {
+			repoName = org
+		}
+
+		if _, ok := knownOrg[org]; !ok {
+			knownOrg[org] = true
+			orgName := resultstore.Property{
+				Key:   "Org",
+				Value: org,
+			}
+			properties = append(properties, orgName)
+		}
+
+		if _, ok := knownBranch[branch]; !ok {
+			knownBranch[branch] = true
+			branchName := resultstore.Property{
+				Key:   "Branch",
+				Value: branch,
+			}
+			properties = append(properties, branchName)
+		}
+
+		repos := []resultstore.Property{
+			{
+				Key:   "Repo",
+				Value: repoName,
+			},
+			{
+				Key:   "Repo",
+				Value: repo,
+			},
+			{
+				Key:   "Repo",
+				Value: fmt.Sprintf("%s:%s", repo, branch),
+			},
+		}
+		properties = append(properties, repos...)
+	}
+	return properties
+}
+
+// prowJobName returns the prow job name parsed from the GCS bucket.
+// If parsing fails, it returns an empty string.
+// TODO: use prowjob.json when PR 15785 is done.
+func prowJobName(url gcs.Path) string {
+	paths := strings.Split(strings.TrimSuffix(url.Object(), "/"), "/")
+	// Expect the returned split to contain ["logs", <job name>, <uid>]
+	if len(paths) < 3 {
+		return ""
+	}
+	return paths[len(paths)-2]
 }

--- a/experiment/resultstore/convert_test.go
+++ b/experiment/resultstore/convert_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/GoogleCloudPlatform/testgrid/resultstore"
+	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+)
+
+func TestProwJobName(t *testing.T) {
+	cases := []struct {
+		name            string
+		url             string
+		expectedJobName string
+	}{
+		{
+			name:            "wrong url with only bucket name returns empty job name",
+			url:             "gs://bucket",
+			expectedJobName: "",
+		},
+		{
+			name:            "wrong url path with no job name returns empty job name",
+			url:             "gs://bucket/logs",
+			expectedJobName: "",
+		},
+		{
+			name:            "wrong url path with no job name and trailing slash returns empty job name",
+			url:             "gs://bucket/logs/",
+			expectedJobName: "",
+		},
+		{
+			name:            "good job name",
+			url:             "gs://bucket/logs/jobA/1234567890123456789",
+			expectedJobName: "jobA",
+		},
+		{
+			name:            "good job name with trailing slash",
+			url:             "gs://bucket/logs/jobA/1234567890123456789/",
+			expectedJobName: "jobA",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			urlPath, err := gcs.NewPath(tc.url)
+			if err != nil {
+				t.Errorf("incorrect url: %v", err)
+			}
+
+			job := prowJobName(*urlPath)
+			if job != tc.expectedJobName {
+				t.Errorf("incorrect job name: got %q, expected %q", job, tc.expectedJobName)
+			}
+		})
+	}
+}
+
+func TestStartedReposToProperties(t *testing.T) {
+	cases := []struct {
+		name     string
+		repos    map[string]string
+		expected []resultstore.Property
+	}{
+		{
+			name: "empty repos convert to no properties",
+		},
+		{
+			name: "convert repos to properties",
+			repos: map[string]string{
+				"org1/repo1": "master",
+				"org2/repo2": "branch1",
+			},
+			expected: []resultstore.Property{
+				{
+					Key:   "Org",
+					Value: "org1",
+				},
+				{
+					Key:   "Branch",
+					Value: "master",
+				},
+				{
+					Key:   "Repo",
+					Value: "repo1",
+				},
+				{
+					Key:   "Repo",
+					Value: "org1/repo1",
+				},
+				{
+					Key:   "Repo",
+					Value: "org1/repo1:master",
+				},
+				{
+					Key:   "Org",
+					Value: "org2",
+				},
+				{
+					Key:   "Branch",
+					Value: "branch1",
+				},
+				{
+					Key:   "Repo",
+					Value: "repo2",
+				},
+				{
+					Key:   "Repo",
+					Value: "org2/repo2",
+				},
+				{
+					Key:   "Repo",
+					Value: "org2/repo2:branch1",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			properties := startedReposToProperties(tc.repos)
+			if !equality.Semantic.DeepEqual(properties, tc.expected) {
+				t.Errorf(diff.ObjectReflectDiff(properties, tc.expected))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add job name and started json metadata to the resultstore's top level target detail properties to help with result discovery and search