### PR TITLE
Add GCS reporting to Crier

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -116,6 +116,7 @@ filegroup(
         "//prow/external-plugins/needs-rebase:all-srcs",
         "//prow/external-plugins/refresh:all-srcs",
         "//prow/flagutil:all-srcs",
+        "//prow/gcs/reporter:all-srcs",
         "//prow/gcsupload:all-srcs",
         "//prow/genfiles:all-srcs",
         "//prow/gerrit/adapter:all-srcs",

--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -33,6 +33,20 @@ rules:
     - "watch"
     - "list"
     - "patch"
+# TODO: figure out whether either of these are correct.
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "get"
+- apiGroups:
+    - ""
+  resources:
+    - "events"
+  verbs:
+    - "get"
+    - "list"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/crier:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/gcs/reporter:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/gerrit/reporter:go_default_library",
         "//prow/github/reporter:go_default_library",
@@ -23,6 +24,8 @@ go_library(
         "//prow/pubsub/reporter:go_default_library",
         "//prow/slack/reporter:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
     ],
 )
 

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -23,7 +23,9 @@ import (
 	"os"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/pjutil"
@@ -34,6 +36,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/crier"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	gcsreporter "k8s.io/test-infra/prow/gcs/reporter"
 	gerritclient "k8s.io/test-infra/prow/gerrit/client"
 	gerritreporter "k8s.io/test-infra/prow/gerrit/reporter"
 	githubreporter "k8s.io/test-infra/prow/github/reporter"
@@ -61,8 +64,11 @@ type options struct {
 	pubsubWorkers int
 	githubWorkers int
 	slackWorkers  int
+	gcsWorkers    int
 
 	slackTokenFile string
+
+	gcsCredentialsFile string
 
 	dryrun      bool
 	reportAgent string
@@ -85,7 +91,7 @@ func (o *options) validate() error {
 		o.githubWorkers = 1
 	}
 
-	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers <= 0 {
+	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers <= 0 {
 		return errors.New("crier need to have at least one report worker to start")
 	}
 
@@ -111,6 +117,10 @@ func (o *options) validate() error {
 		}
 	}
 
+	if o.gcsWorkers > 0 && o.gcsCredentialsFile == "" && !o.dryrun {
+		logrus.Warn("Using GCS without a credentials file is unlikely to work.")
+	}
+
 	if err := o.client.Validate(o.dryrun); err != nil {
 		return err
 	}
@@ -128,6 +138,8 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 	fs.IntVar(&o.pubsubWorkers, "pubsub-workers", 0, "Number of pubsub report workers (0 means disabled)")
 	fs.IntVar(&o.githubWorkers, "github-workers", 0, "Number of github report workers (0 means disabled)")
 	fs.IntVar(&o.slackWorkers, "slack-workers", 0, "Number of Slack report workers (0 means disabled)")
+	fs.IntVar(&o.gcsWorkers, "gcs-workers", 0, "Number of GCS report workers (0 means disabled)")
+	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "Location of the GCS credentials file, if gcs-workers is non-zero")
 	fs.StringVar(&o.slackTokenFile, "slack-token-file", "", "Path to a Slack token file")
 	fs.StringVar(&o.reportAgent, "report-agent", "", "Only report specified agent - empty means report to all agents (effective for github and Slack only)")
 
@@ -251,6 +263,33 @@ func main() {
 				prowjobInformerFactory.Prow().V1().ProwJobs(),
 				githubReporter,
 				o.githubWorkers))
+	}
+
+	if o.gcsWorkers > 0 {
+		coreClients, err := o.client.BuildClusterCoreV1Clients(o.dryrun)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error building pod client sets for gcs workers")
+		}
+
+		var c *storage.Client
+		if o.gcsCredentialsFile == "" {
+			c, err = storage.NewClient(context.Background(), option.WithoutAuthentication())
+		} else {
+			c, err = storage.NewClient(context.Background(), option.WithCredentialsFile(o.gcsCredentialsFile))
+		}
+		if err != nil {
+			logrus.WithError(err).Fatal("Error created storage client for gcs workers.")
+		}
+
+		gcsReporter := gcsreporter.New(cfg, coreClients, c, o.dryrun)
+		controllers = append(
+			controllers,
+			crier.NewController(
+				prowjobClientset,
+				kube.RateLimiter(gcsReporter.GetName()),
+				prowjobInformerFactory.Prow().V1().ProwJobs(),
+				gcsReporter,
+				o.gcsWorkers))
 	}
 
 	if len(controllers) == 0 {

--- a/prow/gcs/reporter/BUILD.bazel
+++ b/prow/gcs/reporter/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["reporter.go"],
+    importpath = "k8s.io/test-infra/prow/gcs/reporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/gcsupload:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
+        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/gcs/reporter/reporter.go
+++ b/prow/gcs/reporter/reporter.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+)
+
+const reporterName = "gcsreporter"
+
+type gcsReporter struct {
+	cfg           config.Getter
+	dryRun        bool
+	logger        *logrus.Entry
+	podClientSets map[string]corev1.CoreV1Interface
+	storage       *storage.Client
+}
+
+func (gr *gcsReporter) Report(pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
+	ctx := context.Background() // TODO: get this from somewhere better?
+
+	_, _, err := gr.getJobDestination(pj)
+	if err != nil {
+		return []*prowv1.ProwJob{pj}, nil
+	}
+	// TODO: do something with these errors?
+	// TODO: parallelise?
+	_ = gr.reportPodInfo(pj, ctx)
+	_ = gr.reportFinishedJob(pj, ctx)
+	_ = gr.reportProwjob(pj, ctx)
+	return []*prowv1.ProwJob{pj}, nil
+}
+
+// reportPodInfo reports information about the pod that the job ran in. In particular,
+// it reports the pod status, as well as any events concerning the pod.
+func (gr *gcsReporter) reportPodInfo(pj *prowv1.ProwJob, ctx context.Context) error {
+	// We only report this after a prowjob is complete (and, therefore, pod state is immutable)
+	if !pj.Complete() {
+		return nil
+	}
+
+	pod, err := gr.podClientSets[pj.ClusterName].Pods(gr.cfg().PodNamespace).Get(pj.Name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	var events *v1.EventList
+	if pod != nil {
+		// we don't particularly care if this fails.
+		events, _ = gr.podClientSets[pj.ClusterName].Events(gr.cfg().PodNamespace).Search(scheme.Scheme, pod)
+	}
+
+	outputMap := map[string]interface{}{}
+	if pod != nil {
+		outputMap["pod"] = pod
+	}
+	if events != nil && len(events.Items) > 0 {
+		outputMap["events"] = events.Items
+	}
+
+	output, err := json.Marshal(outputMap)
+	if err != nil {
+		// This should never happen.
+		gr.logger.WithError(err).Warn("Couldn't marshal pod info")
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload pod info to %q/%q", bucketName, dir)
+		return nil
+	}
+
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "pod_info.json")).NewWriter(ctx)
+	_, err = w.Write(output)
+	if err != nil {
+		gr.logger.WithError(err).Warn("Uploading pod info to GCS failed (write)")
+	}
+	err = w.Close()
+	if err != nil {
+		gr.logger.WithError(err).Warn("Uploading pod info to GCS failed (close)")
+	}
+	return err
+}
+
+// reportFinishedJob uploads a finished.json for the job, iff one did not already exist.
+func (gr *gcsReporter) reportFinishedJob(pj *prowv1.ProwJob, ctx context.Context) error {
+	// We don't upload a finished.json until we finish.
+	if !pj.Complete() {
+		return nil
+	}
+
+	// We generate and upload this file unconditionally, using a GCS precondition
+	// to ensure we don't overwrite files that already exist. This saves us from a)
+	// needing to look up the existence of the files and b) any possible races.
+	completion := pj.Status.CompletionTime.Unix()
+	passed := pj.Status.State == prowv1.SuccessState
+	f := metadata.Finished{
+		Timestamp: &completion,
+		Passed:    &passed,
+		Metadata:  metadata.Metadata{"uploader": "crier"},
+		Result:    string(pj.Status.State),
+	}
+	output, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload pod info to %q/%q", bucketName, dir)
+		return nil
+	}
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "finished.json")).If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	return gr.writeContent(w, output)
+}
+
+func (gr *gcsReporter) reportProwjob(pj *prowv1.ProwJob, ctx context.Context) error {
+	// Unconditionally dump the prowjob to GCS, on all job updates.
+	output, err := json.Marshal(pj)
+	if err != nil {
+		return err
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload pod info to %q/%q", bucketName, dir)
+		return nil
+	}
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "prowjob.json")).NewWriter(ctx)
+	return gr.writeContent(w, output)
+}
+
+func (gr *gcsReporter) writeContent(w *storage.Writer, content []byte) error {
+	_, err := w.Write(content)
+	var reportErr error
+	if isErrUnexpected(err) {
+		reportErr = err
+		gr.logger.WithError(err).WithFields(logrus.Fields{"bucket": w.Bucket, "name": w.Name}).Warn("Uploading info to GCS failed (write)")
+	}
+	err = w.Close()
+	if isErrUnexpected(err) {
+		reportErr = err
+		gr.logger.WithError(err).WithFields(logrus.Fields{"bucket": w.Bucket, "name": w.Name}).Warn("Uploading info to GCS failed (close)")
+	}
+	return reportErr
+}
+
+func isErrUnexpected(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Precondition Failed is expected and we can silently ignore it.
+	if e, ok := err.(*googleapi.Error); ok {
+		if e.Code == http.StatusPreconditionFailed {
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+func (gr *gcsReporter) getJobDestination(pj *prowv1.ProwJob) (bucket string, dir string, err error) {
+	// The decoration config is always provided for decorated jobs, but many
+	// jobs are not decorated, so we guess that we should use the default location
+	// for those jobs. This assumption is usually (but not always) correct.
+	// The TestGrid configurator uses the same assumption.
+	ddc := gr.cfg().Plank.GetDefaultDecorationConfigs(pj.Spec.Refs.Repo)
+
+	var gcsConfig *prowv1.GCSConfiguration
+	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil {
+		gcsConfig = pj.Spec.DecorationConfig.GCSConfiguration
+	} else if ddc != nil && ddc.GCSConfiguration != nil {
+		gcsConfig = ddc.GCSConfiguration
+	} else {
+		return "", "", fmt.Errorf("couldn't figure out a GCS config for %q", pj.Spec.Job)
+	}
+
+	_, dir, _ = gcsupload.PathsForJob(gcsConfig, &downwardapi.JobSpec{
+		Type:      pj.Spec.Type,
+		Job:       pj.Spec.Job,
+		BuildID:   pj.Status.BuildID,
+		ProwJobID: pj.Name,
+		Refs:      pj.Spec.Refs,
+		ExtraRefs: pj.Spec.ExtraRefs,
+	}, "")
+
+	return gcsConfig.Bucket, dir, nil
+}
+
+func (gr *gcsReporter) GetName() string {
+	return reporterName
+}
+
+func (gr *gcsReporter) ShouldReport(pj *prowv1.ProwJob) bool {
+	return true
+}
+
+func New(cfg config.Getter, podClientSets map[string]corev1.CoreV1Interface, storage *storage.Client, dryRun bool) *gcsReporter {
+	return &gcsReporter{
+		cfg:           cfg,
+		dryRun:        dryRun,
+		logger:        logrus.WithField("component", reporterName),
+		podClientSets: podClientSets,
+		storage:       storage,
+	}
+}


### PR DESCRIPTION
This PR adds reporting to GCS to crier. In particular, it:

- Uploads `prowjob.json` each time the prowjob changes, containing the entire prowjob.
- Uploads a `finished.json` when the job terminates, if one isn't already there (enforced using a GCS precondition)
- Uploads a `pod_info.json` when the job terminates, containing the pod yaml and the events relating to that pod in keys `pod` and `events`, respectively (which, combined, are approximately what you get out of `kubectl describe pod whatever`)

Obviously it contains a bunch of TODOs and has no unit tests (although much of the unit testing would be quite uninteresting - it's really just moving yamls around). It's also untested (because setting up a useful test cluster is a pain), and I have no idea whether the RBAC is correct.

This would fix #15469, #15154, and enable users to debug why their jobs are not starting. `pod_info.json` would not be consistently present until #15174 is fixed, since it will race with sinker for pods that lasted over 30 minutes before terminating. In the common case, this is a non-issue, since pods with missing images etc. fail much faster. Once #15174 is fixed, pod info should always be available.

This is essentially a draft, but feedback is welcome!

/cc @BenTheElder @krzyzacy @cjwagner @stevekuznetsov 