### PR TITLE
Debug load test job timeout issue

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -40,6 +40,8 @@ presets:
     value: "Intel Broadwell"
   - name: MAX_PODS_PER_NODE
     value: "128"
+  - name: PREPULL_TIMEOUT
+    value: "10m"
 
 periodics:
 - name: ci-kubernetes-e2e-windows-gce-poc


### PR DESCRIPTION
pods couldn't enter running state until timeout (15m). extends the prepull waiting time to 10m to see if it works