### PR TITLE
Remove gubernator announcement from spyglass.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -50,7 +50,6 @@ deck:
         - artifacts/filtered.cov
       optional_files:
         - artifacts/filtered.html
-    announcement: "The old job viewer has been deprecated. If you need it, please contact #sig-testing on Slack."
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security


### PR DESCRIPTION
It's been long enough and is sometimes causing confusion.

Fixes #15530.