### PR TITLE
Add missing common gce windows presets

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -345,6 +345,7 @@ periodics:
     repo: gce-k8s-windows-testing
   interval: 2h
   labels:
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -354,6 +354,7 @@ periodics:
     repo: gce-k8s-windows-testing
   interval: 2h
   labels:
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -360,6 +360,7 @@ periodics:
     repo: gce-k8s-windows-testing
   interval: 2h
   labels:
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -406,6 +406,7 @@ periodics:
     repo: gce-k8s-windows-testing
   interval: 2h
   labels:
+    preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"


### PR DESCRIPTION
We [pulled some common presets](https://github.com/kubernetes/test-infra/pull/15594) out of the `preset-e2e-gce-windows`, named `preset-common-gce-windows` to stop repeating ourself, so should use `preset-e2e-gce-windows` + `preset-common-gce-windows` for equivalent of original `preset-e2e-gce-windows`

Related: https://github.com/kubernetes/test-infra/issues/15738