### PR TITLE
Remove prometheus-scrape-etcd flag from 1.14 scalability job

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -318,7 +318,6 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--nodes=100
-      - --test-cmd-args=--prometheus-scrape-etcd=false
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml


### PR DESCRIPTION
Remove wrong prometheus-scrape-etcd flag from 1.14 scalability job
Problematic after switch to per-release branches in perf-tests.

/cc mm4tt wojtek-t