### PR TITLE
Add TerminatedPodTTL option to sinker

### DIFF
--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -374,11 +374,15 @@ func (c *controller) clean() {
 		maxPodAge := c.config().Sinker.MaxPodAge.Duration
 		terminatedPodTTL := c.config().Sinker.TerminatedPodTTL.Duration
 		for _, pod := range pods.Items {
-			reason := reasonPodAged
-			clean := !pod.Status.StartTime.IsZero() && time.Since(pod.Status.StartTime.Time) > maxPodAge
-			if !clean {
-				terminationTime := podTerminationTime(&pod)
-				clean = !terminationTime.IsZero() && time.Since(terminationTime) > terminatedPodTTL
+			reason := ""
+			clean := false
+			terminationTime := podTerminationTime(&pod)
+			switch {
+			case !pod.Status.StartTime.IsZero() && time.Since(pod.Status.StartTime.Time) > maxPodAge:
+				clean = true
+				reason = reasonPodAged
+			case !terminationTime.IsZero() && time.Since(terminationTime) > terminatedPodTTL:
+				clean = true
 				reason = reasonPodTTLed
 			}
 

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -40,8 +40,9 @@ import (
 )
 
 const (
-	maxProwJobAge = 2 * 24 * time.Hour
-	maxPodAge     = 12 * time.Hour
+	maxProwJobAge    = 2 * 24 * time.Hour
+	maxPodAge        = 12 * time.Hour
+	terminatedPodTTL = 30 * time.Minute // must be less than maxPodAge
 )
 
 type fca struct {
@@ -55,8 +56,9 @@ func newFakeConfigAgent() *fca {
 				ProwJobNamespace: "ns",
 				PodNamespace:     "ns",
 				Sinker: config.Sinker{
-					MaxProwJobAge: &metav1.Duration{Duration: maxProwJobAge},
-					MaxPodAge:     &metav1.Duration{Duration: maxPodAge},
+					MaxProwJobAge:    &metav1.Duration{Duration: maxProwJobAge},
+					MaxPodAge:        &metav1.Duration{Duration: maxPodAge},
+					TerminatedPodTTL: &metav1.Duration{Duration: terminatedPodTTL},
 				},
 			},
 			JobConfig: config.JobConfig{
@@ -320,6 +322,57 @@ func TestClean(t *testing.T) {
 				StartTime: startTime(time.Now().Add(-maxPodAge).Add(-time.Second)),
 			},
 		},
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttl-expired",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw: "true",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodFailed,
+				StartTime: startTime(time.Now().Add(-terminatedPodTTL * 2)),
+				ContainerStatuses: []corev1api.ContainerStatus{
+					{
+						State: corev1api.ContainerState{
+							Terminated: &corev1api.ContainerStateTerminated{
+								FinishedAt: metav1.Time{Time: time.Now().Add(-terminatedPodTTL).Add(-time.Second)},
+							},
+						},
+					},
+				},
+			},
+		},
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttl-not-expired",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw: "true",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodFailed,
+				StartTime: startTime(time.Now().Add(-terminatedPodTTL * 2)),
+				ContainerStatuses: []corev1api.ContainerStatus{
+					{
+						State: corev1api.ContainerState{
+							Terminated: &corev1api.ContainerStateTerminated{
+								FinishedAt: metav1.Time{Time: time.Now().Add(-terminatedPodTTL).Add(-time.Second)},
+							},
+						},
+					},
+					{
+						State: corev1api.ContainerState{
+							Terminated: &corev1api.ContainerStateTerminated{
+								FinishedAt: metav1.Time{Time: time.Now().Add(-time.Second)},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	deletedPods := sets.NewString(
 		"job-complete-pod-failed",
@@ -333,6 +386,7 @@ func TestClean(t *testing.T) {
 		"old-succeeded",
 		"old-pending-abort",
 		"old-running",
+		"ttl-expired",
 	)
 	setComplete := func(d time.Duration) *metav1.Time {
 		completed := metav1.NewTime(time.Now().Add(d))
@@ -492,6 +546,26 @@ func TestClean(t *testing.T) {
 			},
 			Status: prowv1.ProwJobStatus{
 				StartTime:      metav1.NewTime(time.Now().Add(-maxProwJobAge).Add(-time.Second)),
+				CompletionTime: setComplete(-time.Second),
+			},
+		},
+		&prowv1.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttl-expired",
+				Namespace: "ns",
+			},
+			Status: prowv1.ProwJobStatus{
+				StartTime:      metav1.NewTime(time.Now().Add(-terminatedPodTTL * 2)),
+				CompletionTime: setComplete(-terminatedPodTTL - time.Second),
+			},
+		},
+		&prowv1.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ttl-not-expired",
+				Namespace: "ns",
+			},
+			Status: prowv1.ProwJobStatus{
+				StartTime:      metav1.NewTime(time.Now().Add(-terminatedPodTTL * 2)),
 				CompletionTime: setComplete(-time.Second),
 			},
 		},

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -499,6 +500,10 @@ type Sinker struct {
 	// MaxPodAge is how old a Pod can be before it is garbage-collected.
 	// Defaults to one day.
 	MaxPodAge *metav1.Duration `json:"max_pod_age,omitempty"`
+	// TerminatedPodTTL is how long a Pod can live after termination before it is
+	// garbage collected.
+	// Defaults to infinite.
+	TerminatedPodTTL *metav1.Duration `json:"terminated_pod_ttl,omitempty"`
 }
 
 // LensConfig names a specific lens, and optionally provides some configuration for it.
@@ -1437,6 +1442,11 @@ func parseProwConfig(c *Config) error {
 
 	if c.Sinker.MaxPodAge == nil {
 		c.Sinker.MaxPodAge = &metav1.Duration{Duration: 24 * time.Hour}
+	}
+
+	if c.Sinker.TerminatedPodTTL == nil {
+		// "Forever"
+		c.Sinker.TerminatedPodTTL = &metav1.Duration{Duration: math.MaxInt64}
 	}
 
 	if c.Tide.SyncPeriod == nil {


### PR DESCRIPTION
This PR adds a new `terminated_pod_ttl` option to sinker, which specifies how long a pod can exist after it has terminated. By default, it is disabled (strictly speaking, it is set to about 200 years).

This is helpful for #15732, and partially fixes #15174 - it adds a post-termination TTL, but doesn't differntiate by status. I think we want to solve pod debugging by uploading more information (as #15732 did and some future PR will do again), so we shouldn't do that here.

Kubernetes pods do not actually have a recorded termination time, so this code defines it as the termination time of the last container in the pod to terminate. We could instead look it up from the associated prowjob - I don't have strong opinions on this, but the current approach is more self-contained.

/cc @cjwagner 