### PR TITLE
Add periodic e2e for older supported k8s versions

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
@@ -25,6 +25,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.9
@@ -54,6 +55,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.10
@@ -83,6 +85,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.11
@@ -112,6 +115,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.12
@@ -141,6 +145,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.13
@@ -170,6 +175,7 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
           - --timeout=120m
         image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+        imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.14

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.9
+  name: e2e-kops-aws-k8s-1-9
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -30,7 +30,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.9
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.10
+  name: e2e-kops-aws-k8s-1-10
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -60,7 +60,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.10
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.11
+  name: e2e-kops-aws-k8s-1-11
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -90,7 +90,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.11
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.12
+  name: e2e-kops-aws-k8s-1-12
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -120,7 +120,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.12
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.13
+  name: e2e-kops-aws-k8s-1-13
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -150,7 +150,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.13
 - interval: 4h
-  name: e2e-kops-aws-k8s-1.14
+  name: e2e-kops-aws-k8s-1-14
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
@@ -1,0 +1,175 @@
+periodics:
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.9
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.9.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.9
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.9
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.10
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.10.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.10
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.10
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.11
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.11.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.11
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.11
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.12
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.12.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.12
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.12
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.13
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.13.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.13
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.13
+- interval: 4h
+  name: e2e-kops-aws-k8s-1.14
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+      - command:
+          - runner.sh
+          - /workspace/scenarios/kubernetes_e2e.py
+        args:
+          - --cluster=e2e-kops-aws-k8s-1.14.test-cncf-aws.k8s.io
+          - --deployment=kops
+          - --env=KUBE_SSH_USER=admin
+          - --extract=ci/latest
+          - --ginkgo-parallel
+          - --kops-args=---kubernetes-version=1.14
+          - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+          - --provider=aws
+          - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+          - --timeout=120m
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.14


### PR DESCRIPTION
During Office Hours was decided to limit support to Kubernets 1.9+.
To have true support, clusters have to be created and pass e2e using latest Kops.