### PR TITLE
Fix indentation in kubernetes-csi gen-jobs version check

### DIFF
--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -502,7 +502,7 @@ for tests in non-alpha alpha; do
             # Skip generating tests where the k8s version is lower than the deployment version
             # because we do not support running newer deployments and sidecars on older kubernetes releases.
             # The recommended Kubernetes version can be found in each kubernetes-csi sidecar release.
-			if [[ $kubernetes < $deployment ]]; then
+            if [[ $kubernetes < $deployment ]]; then
                 continue
             fi
             actual="$(if [ "$kubernetes" = "master" ]; then echo latest; else echo "release-$kubernetes"; fi)"


### PR DESCRIPTION
Quick fix, I messed up the indentation when updating a comment in my previous PR:
https://github.com/kubernetes/test-infra/pull/15685/files#diff-96340ecad23cb8abd9aa581e9b2864ecR505

Signed-off-by: Grant Griffiths <grant@portworx.com>