### PR TITLE
Fix npd-e2e presubmit test naming

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -241,7 +241,7 @@ presubmits:
     annotations:
       testgrid-dashboards: presubmits-node-problem-detector
       testgrid-num-columns-recent: '30'
-  - name: ci-npd-e2e-test
+  - name: pull-npd-e2e-test
     branches:
     - master
     always_run: true


### PR DESCRIPTION
Since this is a presubmit test for pull requests, it should be named as "pull-xxx" instead of "ci-xxx".