### PR TITLE
Revert "Kops - Migrate all presubmits and postsubmits to pod utils"

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -9,16 +9,16 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_execute_bazel.py
         args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--"
         - "make"
         - "bazel-build"
         resources:
@@ -36,16 +36,16 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_execute_bazel.py
         args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--"
         - "make"
         - "bazel-test"
         resources:
@@ -64,16 +64,18 @@ presubmits:
       preset-aws-credential: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
-    decorate: true
-    decoration_config:
-      timeout: 90m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --root=/go/src
+        - --job=$(JOB_NAME)
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - --
         - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
@@ -103,16 +105,18 @@ presubmits:
       preset-aws-credential: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
-    decorate: true
-    decoration_config:
-      timeout: 90m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --root=/go/src
+        - --job=$(JOB_NAME)
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - --
         - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
@@ -143,16 +147,18 @@ presubmits:
       preset-aws-credential: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
-    decorate: true
-    decoration_config:
-      timeout: 90m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --root=/go/src
+        - --job=$(JOB_NAME)
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - --
         - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
@@ -183,16 +189,18 @@ presubmits:
       preset-aws-credential: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
-    decorate: true
-    decoration_config:
-      timeout: 90m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --root=/go/src
+        - --job=$(JOB_NAME)
+        - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+        - --service-account=/etc/service-account/service-account.json
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=90
+        - --scenario=kubernetes_e2e
+        - --
         - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
@@ -219,16 +227,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_execute_bazel.py
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "verify-bazel"
     annotations:
@@ -240,16 +247,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "verify-generate"
     annotations:
@@ -261,16 +267,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "verify-gomod"
     annotations:
@@ -282,16 +287,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "verify-boilerplate"
     annotations:
@@ -305,16 +309,16 @@ presubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_execute_bazel.py
         args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--"
         - "make"
         - "verify-gofmt"
         resources:
@@ -329,16 +333,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "govet"
     annotations:
@@ -350,16 +353,15 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
         args:
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--root=/go/src"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
         - "make"
         - "verify-packages"
     annotations:
@@ -371,18 +373,17 @@ presubmits:
     always_run: true
     labels:
       preset-service-account: "true"
-    decorate: true
-    decoration_config:
-      timeout: 10m
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/execute.py
-        args:
-        - "make"
-        - "verify-staticcheck"
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20191219-72db7a6-experimental
+          args:
+            - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+            - "--root=/go/src"
+            - "--upload=gs://kubernetes-jenkins/pr-logs"
+            - "--scenario=execute"
+            - "--"
+            - "make"
+            - "verify-staticcheck"
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: verify-staticcheck
@@ -392,16 +393,16 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-dind-enabled: "true"
-  decorate: true
-  decoration_config:
-    timeout: 30m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_execute_bazel.py
       args:
+      - --repo=k8s.io/kops
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=30
+      - --scenario=execute
+      - --
       - make
       - gcs-publish-ci
       - GCS_LOCATION=gs://kops-ci/bin
@@ -421,16 +422,17 @@ postsubmits:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-bazel-remote-cache-enabled: "true"
-    decorate: true
-    decoration_config:
-      timeout: 60m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191221-fe232fc-experimental
-        command:
-        - runner.sh
-        - /workspace/scenarios/kubernetes_execute_bazel.py
         args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/logs"
+        - "--timeout=60"
+        - "--scenario=kubernetes_execute_bazel"
+        - "--"
         - "make"
         - "prow-postsubmit"
         - "UPLOAD_DEST=gs://kubernetes-release-dev/kops/ci"


### PR DESCRIPTION
This reverts commit 03cd4f976bc3507553d190fd4aa1f0f8c0386fa6.

This broke some presubmit jobs for a variety of reasons. I'll do more digging, likely creating additional optional jobs so I can test them without breaking everyone else's PRs.

for posterity:
* [pull-kops-bazel-build](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-bazel-build/1214197989485056006)
* [pull-kops-verify-staticcheck](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-verify-staticcheck/1214197989489250305)
* [pull-kops-bazel-test](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-bazel-test/1214197989480861696)
* [pull-kops-verify-govet](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-verify-govet/1214197989480861697)
* [pull-kops-verify-gofmt](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-verify-gofmt/1214197989480861699)
* [pull-kops-verify-packages](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-verify-packages/1214197989489250304)
* [pull-kops-verify-bazel](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8270/pull-kops-verify-bazel/1214197989485056004)