### PR TITLE
Use ClusterIP instead of NodePort for cluster internal services.

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -94,4 +94,4 @@ spec:
     port: 9090
   selector:
     app: ghproxy
-  type: NodePort # TODO(fejta): remove this?
+  type: ClusterIP

--- a/prow/cluster/tide_service.yaml
+++ b/prow/cluster/tide_service.yaml
@@ -28,4 +28,4 @@ spec:
     targetPort: 8888
   - name: metrics
     port: 9090
-  type: NodePort
+  type: ClusterIP

--- a/prow/cluster/tot_service.yaml
+++ b/prow/cluster/tot_service.yaml
@@ -23,4 +23,4 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: NodePort
+  type: ClusterIP


### PR DESCRIPTION
/assign @fejta @stevekuznetsov 
/kind bug