### PR TITLE
Revert "Use ClusterIP instead of NodePort for cluster internal servic…

### DIFF
--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -94,4 +94,4 @@ spec:
     port: 9090
   selector:
     app: ghproxy
-  type: ClusterIP
+  type: NodePort # TODO(fejta): remove this?

--- a/prow/cluster/tide_service.yaml
+++ b/prow/cluster/tide_service.yaml
@@ -28,4 +28,4 @@ spec:
     targetPort: 8888
   - name: metrics
     port: 9090
-  type: ClusterIP
+  type: NodePort

--- a/prow/cluster/tot_service.yaml
+++ b/prow/cluster/tot_service.yaml
@@ -23,4 +23,4 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
…es."

This reverts commit 7b7cfee38a16c078e11d2d32236b7df21945bb12.

I think we need to manually delete and recreate these services to switch them from NodePort to ClusterIP: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-deploy-prow/1214330981624844289
Reverting until we have time to address this to keep master deployable.
/assign @Katharine 