### PR TITLE
Add GCS reporting to Crier

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -116,6 +116,7 @@ filegroup(
         "//prow/external-plugins/needs-rebase:all-srcs",
         "//prow/external-plugins/refresh:all-srcs",
         "//prow/flagutil:all-srcs",
+        "//prow/gcs/reporter:all-srcs",
         "//prow/gcsupload:all-srcs",
         "//prow/genfiles:all-srcs",
         "//prow/gerrit/adapter:all-srcs",

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/crier:go_default_library",
         "//prow/flagutil:go_default_library",
+        "//prow/gcs/reporter:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/gerrit/reporter:go_default_library",
         "//prow/github/reporter:go_default_library",
@@ -23,6 +24,8 @@ go_library(
         "//prow/pubsub/reporter:go_default_library",
         "//prow/slack/reporter:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
     ],
 )
 

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -117,10 +117,6 @@ func (o *options) validate() error {
 		}
 	}
 
-	if o.gcsWorkers > 0 && o.gcsCredentialsFile == "" && !o.dryrun {
-		logrus.Warn("Using GCS without a credentials file is unlikely to work.")
-	}
-
 	if err := o.client.Validate(o.dryrun); err != nil {
 		return err
 	}
@@ -267,11 +263,12 @@ func main() {
 
 	if o.gcsWorkers > 0 {
 		var c *storage.Client
-		if o.gcsCredentialsFile == "" {
-			c, err = storage.NewClient(context.Background(), option.WithoutAuthentication())
-		} else {
-			c, err = storage.NewClient(context.Background(), option.WithCredentialsFile(o.gcsCredentialsFile))
+		var opts []option.ClientOption
+		if o.gcsCredentialsFile != "" {
+			opts = append(opts, option.WithCredentialsFile(o.gcsCredentialsFile))
 		}
+		c, err = storage.NewClient(context.Background(), opts...)
+
 		if err != nil {
 			logrus.WithError(err).Fatal("Error creating storage client for gcs workers.")
 		}

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -23,7 +23,9 @@ import (
 	"os"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/option"
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/pjutil"
@@ -34,6 +36,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/crier"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	gcsreporter "k8s.io/test-infra/prow/gcs/reporter"
 	gerritclient "k8s.io/test-infra/prow/gerrit/client"
 	gerritreporter "k8s.io/test-infra/prow/gerrit/reporter"
 	githubreporter "k8s.io/test-infra/prow/github/reporter"
@@ -61,8 +64,11 @@ type options struct {
 	pubsubWorkers int
 	githubWorkers int
 	slackWorkers  int
+	gcsWorkers    int
 
 	slackTokenFile string
+
+	gcsCredentialsFile string
 
 	dryrun      bool
 	reportAgent string
@@ -85,7 +91,7 @@ func (o *options) validate() error {
 		o.githubWorkers = 1
 	}
 
-	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers <= 0 {
+	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers <= 0 {
 		return errors.New("crier need to have at least one report worker to start")
 	}
 
@@ -111,6 +117,10 @@ func (o *options) validate() error {
 		}
 	}
 
+	if o.gcsWorkers > 0 && o.gcsCredentialsFile == "" && !o.dryrun {
+		logrus.Warn("Using GCS without a credentials file is unlikely to work.")
+	}
+
 	if err := o.client.Validate(o.dryrun); err != nil {
 		return err
 	}
@@ -128,6 +138,8 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 	fs.IntVar(&o.pubsubWorkers, "pubsub-workers", 0, "Number of pubsub report workers (0 means disabled)")
 	fs.IntVar(&o.githubWorkers, "github-workers", 0, "Number of github report workers (0 means disabled)")
 	fs.IntVar(&o.slackWorkers, "slack-workers", 0, "Number of Slack report workers (0 means disabled)")
+	fs.IntVar(&o.gcsWorkers, "gcs-workers", 0, "Number of GCS report workers (0 means disabled)")
+	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "Location of the GCS credentials file, if gcs-workers is non-zero")
 	fs.StringVar(&o.slackTokenFile, "slack-token-file", "", "Path to a Slack token file")
 	fs.StringVar(&o.reportAgent, "report-agent", "", "Only report specified agent - empty means report to all agents (effective for github and Slack only)")
 
@@ -251,6 +263,28 @@ func main() {
 				prowjobInformerFactory.Prow().V1().ProwJobs(),
 				githubReporter,
 				o.githubWorkers))
+	}
+
+	if o.gcsWorkers > 0 {
+		var c *storage.Client
+		if o.gcsCredentialsFile == "" {
+			c, err = storage.NewClient(context.Background(), option.WithoutAuthentication())
+		} else {
+			c, err = storage.NewClient(context.Background(), option.WithCredentialsFile(o.gcsCredentialsFile))
+		}
+		if err != nil {
+			logrus.WithError(err).Fatal("Error creating storage client for gcs workers.")
+		}
+
+		gcsReporter := gcsreporter.New(cfg, c, o.dryrun)
+		controllers = append(
+			controllers,
+			crier.NewController(
+				prowjobClientset,
+				kube.RateLimiter(gcsReporter.GetName()),
+				prowjobInformerFactory.Prow().V1().ProwJobs(),
+				gcsReporter,
+				o.gcsWorkers))
 	}
 
 	if len(controllers) == 0 {

--- a/prow/gcs/reporter/BUILD.bazel
+++ b/prow/gcs/reporter/BUILD.bazel
@@ -39,8 +39,9 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "@com_github_fsouza_fake_gcs_server//fakestorage:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )

--- a/prow/gcs/reporter/BUILD.bazel
+++ b/prow/gcs/reporter/BUILD.bazel
@@ -1,0 +1,46 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["reporter.go"],
+    importpath = "k8s.io/test-infra/prow/gcs/reporter",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/errorutil:go_default_library",
+        "//prow/gcsupload:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
+        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["reporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "@com_github_fsouza_fake_gcs_server//fakestorage:go_default_library",
+        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/prow/gcs/reporter/reporter.go
+++ b/prow/gcs/reporter/reporter.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+
+	"cloud.google.com/go/storage"
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+	"k8s.io/test-infra/prow/errorutil"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+)
+
+const reporterName = "gcsreporter"
+
+type gcsReporter struct {
+	cfg     config.Getter
+	dryRun  bool
+	logger  *logrus.Entry
+	storage *storage.Client
+}
+
+func (gr *gcsReporter) Report(pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
+	ctx := context.Background() // TODO: get this from somewhere better?
+
+	_, _, err := gr.getJobDestination(pj)
+	if err != nil {
+		gr.logger.Infof("Not uploading %q (%s#%s) because we couldn't find a destination.", pj.Name, pj.Spec.Job, pj.Status.BuildID)
+		return []*prowv1.ProwJob{pj}, nil
+	}
+	stateErr := gr.reportJobState(ctx, pj)
+	prowjobErr := gr.reportProwjob(ctx, pj)
+
+	return []*prowv1.ProwJob{pj}, errorutil.NewAggregate(stateErr, prowjobErr)
+}
+
+func (gr *gcsReporter) reportJobState(ctx context.Context, pj *prowv1.ProwJob) error {
+	if pj.Status.State == prowv1.TriggeredState {
+		return gr.reportStartedJob(ctx, pj)
+	}
+	if pj.Complete() {
+		return gr.reportFinishedJob(ctx, pj)
+	}
+	return nil
+}
+
+// reportStartedJob uploads a started.json for the job, iff one did not already exist.
+func (gr *gcsReporter) reportStartedJob(ctx context.Context, pj *prowv1.ProwJob) error {
+	// We only upload started.json when we first start.
+	if pj.Status.State != prowv1.TriggeredState {
+		return nil
+	}
+
+	f := metadata.Started{
+		Timestamp: pj.Status.StartTime.Unix(),
+		Metadata:  metadata.Metadata{"uploader": "crier"},
+	}
+	output, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload started.json to %q/%q", bucketName, dir)
+		return nil
+	}
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "started.json")).If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	return gr.writeContent(w, output)
+}
+
+// reportFinishedJob uploads a finished.json for the job, iff one did not already exist.
+func (gr *gcsReporter) reportFinishedJob(ctx context.Context, pj *prowv1.ProwJob) error {
+	// We don't upload a finished.json until we finish.
+	if !pj.Complete() {
+		return nil
+	}
+
+	completion := pj.Status.CompletionTime.Unix()
+	passed := pj.Status.State == prowv1.SuccessState
+	f := metadata.Finished{
+		Timestamp: &completion,
+		Passed:    &passed,
+		Metadata:  metadata.Metadata{"uploader": "crier"},
+		Result:    string(pj.Status.State),
+	}
+	output, err := json.Marshal(f)
+	if err != nil {
+		return err
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload finished.json info to %q/%q", bucketName, dir)
+		return nil
+	}
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "finished.json")).If(storage.Conditions{DoesNotExist: true}).NewWriter(ctx)
+	return gr.writeContent(w, output)
+}
+
+func (gr *gcsReporter) reportProwjob(ctx context.Context, pj *prowv1.ProwJob) error {
+	// Unconditionally dump the prowjob to GCS, on all job updates.
+	output, err := json.Marshal(pj)
+	if err != nil {
+		return err
+	}
+
+	bucketName, dir, err := gr.getJobDestination(pj)
+	if err != nil {
+		return err
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload pod info to %q/%q", bucketName, dir)
+		return nil
+	}
+	b := gr.storage.Bucket(bucketName)
+	w := b.Object(path.Join(dir, "prowjob.json")).NewWriter(ctx)
+	return gr.writeContent(w, output)
+}
+
+func (gr *gcsReporter) writeContent(w *storage.Writer, content []byte) error {
+	_, err := w.Write(content)
+	var reportErr error
+	if isErrUnexpected(err) {
+		reportErr = err
+		gr.logger.WithError(err).WithFields(logrus.Fields{"bucket": w.Bucket, "name": w.Name}).Warn("Uploading info to GCS failed (write)")
+	}
+	err = w.Close()
+	if isErrUnexpected(err) {
+		reportErr = err
+		gr.logger.WithError(err).WithFields(logrus.Fields{"bucket": w.Bucket, "name": w.Name}).Warn("Uploading info to GCS failed (close)")
+	}
+	return reportErr
+}
+
+func isErrUnexpected(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Precondition Failed is expected and we can silently ignore it.
+	if e, ok := err.(*googleapi.Error); ok {
+		if e.Code == http.StatusPreconditionFailed {
+			return false
+		}
+		return true
+	}
+	return true
+}
+
+func (gr *gcsReporter) getJobDestination(pj *prowv1.ProwJob) (bucket string, dir string, err error) {
+	// The decoration config is always provided for decorated jobs, but many
+	// jobs are not decorated, so we guess that we should use the default location
+	// for those jobs. This assumption is usually (but not always) correct.
+	// The TestGrid configurator uses the same assumption.
+	ddc := gr.cfg().Plank.GetDefaultDecorationConfigs(pj.Spec.Refs.Repo)
+
+	var gcsConfig *prowv1.GCSConfiguration
+	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil {
+		gcsConfig = pj.Spec.DecorationConfig.GCSConfiguration
+	} else if ddc != nil && ddc.GCSConfiguration != nil {
+		gcsConfig = ddc.GCSConfiguration
+	} else {
+		return "", "", fmt.Errorf("couldn't figure out a GCS config for %q", pj.Spec.Job)
+	}
+
+	_, dir, _ = gcsupload.PathsForJob(gcsConfig, &downwardapi.JobSpec{
+		Type:      pj.Spec.Type,
+		Job:       pj.Spec.Job,
+		BuildID:   pj.Status.BuildID,
+		ProwJobID: pj.Name,
+		Refs:      pj.Spec.Refs,
+		ExtraRefs: pj.Spec.ExtraRefs,
+	}, "")
+
+	return gcsConfig.Bucket, dir, nil
+}
+
+func (gr *gcsReporter) GetName() string {
+	return reporterName
+}
+
+func (gr *gcsReporter) ShouldReport(pj *prowv1.ProwJob) bool {
+	return true
+}
+
+func New(cfg config.Getter, storage *storage.Client, dryRun bool) *gcsReporter {
+	return &gcsReporter{
+		cfg:     cfg,
+		dryRun:  dryRun,
+		logger:  logrus.WithField("component", reporterName),
+		storage: storage,
+	}
+}

--- a/prow/gcs/reporter/reporter_test.go
+++ b/prow/gcs/reporter/reporter_test.go
@@ -17,23 +17,23 @@ limitations under the License.
 package reporter
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
-	"os"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
-	"github.com/fsouza/fake-gcs-server/fakestorage"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/api/googleapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
-)
-
-var (
-	fakeGCSServer *fakestorage.Server
 )
 
 type fca struct {
@@ -44,29 +44,333 @@ func (ca fca) Config() *config.Config {
 	return &ca.c
 }
 
-func sampleProwjob() prowv1.ProwJob {
-	return prowv1.ProwJob{
-		Spec: prowv1.ProwJobSpec{
-			Type: prowv1.PresubmitJob,
-			Refs: &prowv1.Refs{
-				Org:   "kubernetes",
-				Repo:  "test-infra",
-				Pulls: []prowv1.Pull{{Number: 12345}},
-			},
-			Agent: prowv1.KubernetesAgent,
-			Job:   "my-little-job",
+func TestIsErrUnexpected(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		unexpected bool
+	}{
+		{
+			name:       "standard errors are unexpected",
+			err:        errors.New("this is just a normal error"),
+			unexpected: true,
 		},
-		Status: prowv1.ProwJobStatus{
-			State:     prowv1.TriggeredState,
-			StartTime: metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
-			PodName:   "some-pod",
-			BuildID:   "123",
+		{
+			name:       "nil errors are expected",
+			err:        nil,
+			unexpected: false,
 		},
+		{
+			name:       "googleapi errors other than Precondition Failed are unexpected",
+			err:        &googleapi.Error{Code: http.StatusNotFound},
+			unexpected: true,
+		},
+		{
+			name:       "Precondition Failed googleapi errors are expected",
+			err:        &googleapi.Error{Code: http.StatusPreconditionFailed},
+			unexpected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isErrUnexpected(tc.err)
+			if result != tc.unexpected {
+				t.Errorf("Expected isErrUnexpected() to return %v, got %v", tc.unexpected, result)
+			}
+		})
 	}
 }
 
-func sampleConfig() config.Getter {
-	return fca{c: config.Config{
+func TestGetJobDestination(t *testing.T) {
+	standardGcsConfig := &prowv1.GCSConfiguration{
+		Bucket:       "kubernetes-jenkins",
+		PathPrefix:   "some-prefix",
+		PathStrategy: prowv1.PathStrategyLegacy,
+		DefaultOrg:   "kubernetes",
+		DefaultRepo:  "kubernetes",
+	}
+	tests := []struct {
+		name              string
+		defaultGcsConfigs map[string]*prowv1.GCSConfiguration
+		prowjobGcsConfig  *prowv1.GCSConfiguration
+		prowjobType       prowv1.ProwJobType
+		expectBucket      string
+		expectDir         string // tip: this will always end in "my-little-job/123"
+		expectErr         bool
+	}{
+		{
+			name:              "decorated prowjob uses inline config when default is empty",
+			defaultGcsConfigs: nil,
+			prowjobGcsConfig:  standardGcsConfig,
+			prowjobType:       prowv1.PeriodicJob,
+			expectBucket:      "kubernetes-jenkins",
+			expectDir:         "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name: "decorated prowjob uses inline config over default config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
+				"*": {
+					Bucket:       "the-wrong-bucket",
+					PathPrefix:   "",
+					PathStrategy: prowv1.PathStrategyLegacy,
+					DefaultOrg:   "kubernetes",
+					DefaultRepo:  "kubernetes",
+				},
+			},
+			prowjobGcsConfig: standardGcsConfig,
+			prowjobType:      prowv1.PeriodicJob,
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:              "undecorated prowjob falls back to default config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{"*": standardGcsConfig},
+			prowjobGcsConfig:  nil,
+			prowjobType:       prowv1.PeriodicJob,
+			expectBucket:      "kubernetes-jenkins",
+			expectDir:         "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:              "undecorated prowjob with no default config is an error",
+			defaultGcsConfigs: nil,
+			prowjobGcsConfig:  nil,
+			prowjobType:       prowv1.PeriodicJob,
+			expectErr:         true,
+		},
+		{
+			name: "undecorated prowjob uses the correct org config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
+				"*": {
+					Bucket:       "the-wrong-bucket",
+					PathPrefix:   "",
+					PathStrategy: prowv1.PathStrategyLegacy,
+					DefaultOrg:   "the-wrong-org",
+					DefaultRepo:  "the-wrong-repo",
+				},
+				"kubernetes": standardGcsConfig,
+			},
+			prowjobGcsConfig: nil,
+			prowjobType:      prowv1.PeriodicJob,
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:             "prowjob type is respected",
+			prowjobGcsConfig: standardGcsConfig,
+			prowjobType:      prowv1.PresubmitJob,
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pj := &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type: tc.prowjobType,
+					Refs: &prowv1.Refs{
+						Org:   "kubernetes",
+						Repo:  "test-infra",
+						Pulls: []prowv1.Pull{{Number: 12345}},
+					},
+					Agent:            prowv1.KubernetesAgent,
+					Job:              "my-little-job",
+					DecorationConfig: &prowv1.DecorationConfig{GCSConfiguration: tc.prowjobGcsConfig},
+				},
+				Status: prowv1.ProwJobStatus{
+					State:     prowv1.TriggeredState,
+					StartTime: metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
+					PodName:   "some-pod",
+					BuildID:   "123",
+				},
+			}
+			decorationConfigs := map[string]*prowv1.DecorationConfig{}
+			for k, v := range tc.defaultGcsConfigs {
+				decorationConfigs[k] = &prowv1.DecorationConfig{GCSConfiguration: v}
+			}
+			cfg := fca{c: config.Config{
+				ProwConfig: config.ProwConfig{
+					Plank: config.Plank{
+						DefaultDecorationConfigs: decorationConfigs,
+					},
+				},
+			}}.Config
+
+			reporter := newWithAuthor(cfg, nil, false)
+			bucket, dir, err := reporter.getJobDestination(pj)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			} else if tc.expectErr {
+				t.Fatalf("Expected an error, but didn't get one; instead got gs://%q/%q", bucket, dir)
+			}
+			if bucket != tc.expectBucket {
+				t.Errorf("Expected bucket %q, but got %q", tc.expectBucket, bucket)
+			}
+			if dir != tc.expectDir {
+				t.Errorf("Expected dir %q, but got %q", tc.expectDir, dir)
+			}
+		})
+	}
+}
+
+type testAuthor struct {
+	alreadyUsed bool
+	bucket      string
+	path        string
+	content     []byte
+	overwrite   bool
+	closed      bool
+}
+
+type testAuthorWriteCloser struct {
+	author *testAuthor
+}
+
+func (wc *testAuthorWriteCloser) Write(p []byte) (int, error) {
+	wc.author.content = append(wc.author.content, p...)
+	return len(p), nil
+}
+
+func (wc *testAuthorWriteCloser) Close() error {
+	wc.author.closed = true
+	return nil
+}
+
+func (ta *testAuthor) NewWriter(ctx context.Context, bucket, path string, overwrite bool) io.WriteCloser {
+	if ta.alreadyUsed {
+		panic(fmt.Sprintf("NewWriter called on testAuthor twice: first for %q/%q, now for %q/%q", ta.bucket, ta.path, bucket, path))
+	}
+	ta.alreadyUsed = true
+	ta.bucket = bucket
+	ta.path = path
+	ta.overwrite = overwrite
+	return &testAuthorWriteCloser{author: ta}
+}
+
+func TestReportJobState(t *testing.T) {
+	completionTime := &metav1.Time{Time: time.Date(2010, 10, 10, 19, 00, 0, 0, time.UTC)}
+	tests := []struct {
+		jobState       prowv1.ProwJobState
+		expectedFile   string
+		completionTime *metav1.Time
+		passed         bool
+	}{
+		{
+			jobState:     prowv1.TriggeredState,
+			expectedFile: "started.json",
+		},
+		{
+			jobState: prowv1.PendingState,
+		},
+		{
+			jobState:       prowv1.SuccessState,
+			expectedFile:   "finished.json",
+			completionTime: completionTime,
+			passed:         true,
+		},
+		{
+			jobState:       prowv1.AbortedState,
+			expectedFile:   "finished.json",
+			completionTime: completionTime,
+		},
+		{
+			jobState:       prowv1.ErrorState,
+			expectedFile:   "finished.json",
+			completionTime: completionTime,
+		},
+		{
+			jobState:       prowv1.FailureState,
+			expectedFile:   "finished.json",
+			completionTime: completionTime,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(fmt.Sprintf("report %s job", tc.jobState), func(t *testing.T) {
+			ctx := context.Background()
+			cfg := fca{c: config.Config{
+				ProwConfig: config.ProwConfig{
+					Plank: config.Plank{
+						DefaultDecorationConfigs: map[string]*prowv1.DecorationConfig{"*": {
+							GCSConfiguration: &prowv1.GCSConfiguration{
+								Bucket:       "kubernetes-jenkins",
+								PathPrefix:   "some-prefix",
+								PathStrategy: prowv1.PathStrategyLegacy,
+								DefaultOrg:   "kubernetes",
+								DefaultRepo:  "kubernetes",
+							},
+						}},
+					},
+				},
+			}}.Config
+			ta := &testAuthor{}
+			reporter := newWithAuthor(cfg, ta, false)
+
+			pj := &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type: prowv1.PresubmitJob,
+					Refs: &prowv1.Refs{
+						Org:   "kubernetes",
+						Repo:  "test-infra",
+						Pulls: []prowv1.Pull{{Number: 12345}},
+					},
+					Agent: prowv1.KubernetesAgent,
+					Job:   "my-little-job",
+				},
+				Status: prowv1.ProwJobStatus{
+					State:          tc.jobState,
+					StartTime:      metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
+					CompletionTime: tc.completionTime,
+					PodName:        "some-pod",
+					BuildID:        "123",
+				},
+			}
+
+			err := reporter.reportJobState(ctx, pj)
+			if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !strings.HasSuffix(ta.path, tc.expectedFile) {
+				t.Errorf("Expected file to be written to %q, but got %q", tc.expectedFile, ta.path)
+			}
+			if ta.overwrite {
+				t.Errorf("Expected file to be written without overwriting, but overwrite was enabled")
+			}
+
+			if tc.expectedFile == "started.json" {
+				var result metadata.Started
+				if err := json.Unmarshal(ta.content, &result); err != nil {
+					t.Errorf("Couldn't decode result as metadata.Started: %v", err)
+				}
+				if result.Timestamp != pj.Status.StartTime.Unix() {
+					t.Errorf("Expected started.json timestamp to be %d, but got %d", pj.Status.StartTime.Unix(), result.Timestamp)
+				}
+			} else if tc.expectedFile == "finished.json" {
+				var result metadata.Finished
+				if err := json.Unmarshal(ta.content, &result); err != nil {
+					t.Errorf("Couldn't decode result as metadata.Finished: %v", err)
+				}
+				if result.Timestamp == nil {
+					t.Errorf("Expected finished.json timestamp to be %d, but it was nil", pj.Status.CompletionTime.Unix())
+				} else if *result.Timestamp != pj.Status.CompletionTime.Unix() {
+					t.Errorf("Expected finished.json timestamp to be %d, but got %d", pj.Status.CompletionTime.Unix(), *result.Timestamp)
+				}
+				if result.Passed == nil {
+					t.Errorf("Expected finished.json passed to be %v, but it was nil", tc.passed)
+				} else if *result.Passed != tc.passed {
+					t.Errorf("Expected finished.json passed to be %v, but got %v", tc.passed, *result.Passed)
+				}
+			}
+		})
+	}
+}
+
+func TestReportProwJob(t *testing.T) {
+	ctx := context.Background()
+	cfg := fca{c: config.Config{
 		ProwConfig: config.ProwConfig{
 			Plank: config.Plank{
 				DefaultDecorationConfigs: map[string]*prowv1.DecorationConfig{"*": {
@@ -81,105 +385,46 @@ func sampleConfig() config.Getter {
 			},
 		},
 	}}.Config
-}
+	ta := &testAuthor{}
+	reporter := newWithAuthor(cfg, ta, false)
 
-func TestMain(m *testing.M) {
-	var longLog string
-	for i := 0; i < 300; i++ {
-		longLog += "here a log\nthere a log\neverywhere a log log\n"
-	}
-	fakeGCSServer = fakestorage.NewServer([]fakestorage.Object{})
-	fakeGCSServer.CreateBucket("kubernetes-jenkins")
-	os.Exit(m.Run())
-}
-
-func TestUploadProwjob(t *testing.T) {
-	cfg := sampleConfig()
-	pj := sampleProwjob()
-
-	s := fakeGCSServer.Client()
-	gr := New(cfg, s, false)
-	ctx := context.Background()
-
-	err := gr.reportProwjob(ctx, &pj)
-
-	if err != nil {
-		t.Fatalf("Unexpected error: %v", err)
+	pj := &prowv1.ProwJob{
+		Spec: prowv1.ProwJobSpec{
+			Type: prowv1.PresubmitJob,
+			Refs: &prowv1.Refs{
+				Org:   "kubernetes",
+				Repo:  "test-infra",
+				Pulls: []prowv1.Pull{{Number: 12345}},
+			},
+			Agent: prowv1.KubernetesAgent,
+			Job:   "my-little-job",
+		},
+		Status: prowv1.ProwJobStatus{
+			State:          prowv1.SuccessState,
+			StartTime:      metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
+			CompletionTime: &metav1.Time{Time: time.Date(2010, 10, 10, 19, 00, 0, 0, time.UTC)},
+			PodName:        "some-pod",
+			BuildID:        "123",
+		},
 	}
 
-	serialised, err := json.Marshal(pj)
-	if err != nil {
-		t.Fatalf("Unexpected error serialising prowjob: %v", err)
+	if err := reporter.reportProwjob(ctx, pj); err != nil {
+		t.Fatalf("Unexpected error calling reportProwjob: %v", err)
 	}
 
-	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/prowjob.json"
-	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
-	if err != nil {
-		t.Fatalf("Couldn't fetch expected file from %s: %v", objPath, err)
+	if !strings.HasSuffix(ta.path, "/prowjob.json") {
+		t.Errorf("Expected prowjob to be written to prowjob.json, got %q", ta.path)
 	}
 
-	if !bytes.Equal(obj.Content, serialised) {
-		t.Fatalf("Serialised content does not match:\n\nExpected:\n%q\n\nActual:\n%q", string(serialised), string(obj.Content))
-	}
-}
-
-func TestUploadStartedJson(t *testing.T) {
-	s := fakeGCSServer.Client()
-	cfg := sampleConfig()
-	pj := sampleProwjob()
-
-	gr := New(cfg, s, false)
-
-	ctx := context.Background()
-	err := gr.reportStartedJob(ctx, &pj)
-	if err != nil {
-		t.Fatalf("Unexpected error reporting job: %v", err)
+	if !ta.overwrite {
+		t.Errorf("Expected prowjob.json to be written with overwrite enabled, but it was not.")
 	}
 
-	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/started.json"
-	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
-	if err != nil {
-		t.Fatalf("Couldn't fetch expected file from %v: %v", objPath, err)
+	var result prowv1.ProwJob
+	if err := json.Unmarshal(ta.content, &result); err != nil {
+		t.Fatalf("Couldn't unmarshal prowjob.json: %v", err)
 	}
-	var result metadata.Started
-	err = json.Unmarshal(obj.Content, &result)
-	if err != nil {
-		t.Fatalf("Couldn't unmarshal started.json: %v. Content: %q", err, string(obj.Content))
-	}
-	if result.Timestamp != pj.Status.StartTime.Unix() {
-		t.Fatalf("started.json does not have the expected timestamp (got %d, expected %d)", result.Timestamp, pj.Status.StartTime.Unix())
-	}
-}
-
-func TestUploadFinishedJson(t *testing.T) {
-	s := fakeGCSServer.Client()
-	cfg := sampleConfig()
-	pj := sampleProwjob()
-	pj.Status.State = prowv1.SuccessState
-	pj.Status.CompletionTime = &metav1.Time{Time: time.Date(2019, 10, 13, 0, 0, 0, 0, time.UTC)}
-
-	gr := New(cfg, s, false)
-
-	ctx := context.Background()
-	err := gr.reportFinishedJob(ctx, &pj)
-	if err != nil {
-		t.Fatalf("Unexpected error reporting job: %v", err)
-	}
-
-	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/finished.json"
-	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
-	if err != nil {
-		t.Fatalf("Couldn't fetch expected file from %v: %v", objPath, err)
-	}
-	var result metadata.Finished
-	err = json.Unmarshal(obj.Content, &result)
-	if err != nil {
-		t.Fatalf("Couldn't unmarshal finished.json: %v. Content: %q", err, string(obj.Content))
-	}
-	if result.Timestamp == nil {
-		t.Fatalf("finished.json does not have a finish timestamp.")
-	}
-	if *result.Timestamp != pj.Status.CompletionTime.Unix() {
-		t.Fatalf("finished.json does not have the expected timestamp (got %d, expected %d)", result.Timestamp, pj.Status.CompletionTime.Unix())
+	if !cmp.Equal(*pj, result) {
+		t.Fatalf("Input prowjob mismatches output prowjob:\n%s", cmp.Diff(*pj, result))
 	}
 }

--- a/prow/gcs/reporter/reporter_test.go
+++ b/prow/gcs/reporter/reporter_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reporter
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/testgrid/metadata"
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+var (
+	fakeGCSServer *fakestorage.Server
+)
+
+type fca struct {
+	c config.Config
+}
+
+func (ca fca) Config() *config.Config {
+	return &ca.c
+}
+
+func sampleProwjob() prowv1.ProwJob {
+	return prowv1.ProwJob{
+		Spec: prowv1.ProwJobSpec{
+			Type: prowv1.PresubmitJob,
+			Refs: &prowv1.Refs{
+				Org:   "kubernetes",
+				Repo:  "test-infra",
+				Pulls: []prowv1.Pull{{Number: 12345}},
+			},
+			Agent: prowv1.KubernetesAgent,
+			Job:   "my-little-job",
+		},
+		Status: prowv1.ProwJobStatus{
+			State:     prowv1.TriggeredState,
+			StartTime: metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
+			PodName:   "some-pod",
+			BuildID:   "123",
+		},
+	}
+}
+
+func sampleConfig() config.Getter {
+	return fca{c: config.Config{
+		ProwConfig: config.ProwConfig{
+			Plank: config.Plank{
+				DefaultDecorationConfigs: map[string]*prowv1.DecorationConfig{"*": {
+					GCSConfiguration: &prowv1.GCSConfiguration{
+						Bucket:       "kubernetes-jenkins",
+						PathPrefix:   "some-prefix",
+						PathStrategy: prowv1.PathStrategyLegacy,
+						DefaultOrg:   "kubernetes",
+						DefaultRepo:  "kubernetes",
+					},
+				}},
+			},
+		},
+	}}.Config
+}
+
+func TestMain(m *testing.M) {
+	var longLog string
+	for i := 0; i < 300; i++ {
+		longLog += "here a log\nthere a log\neverywhere a log log\n"
+	}
+	fakeGCSServer = fakestorage.NewServer([]fakestorage.Object{})
+	fakeGCSServer.CreateBucket("kubernetes-jenkins")
+	os.Exit(m.Run())
+}
+
+func TestUploadProwjob(t *testing.T) {
+	cfg := sampleConfig()
+	pj := sampleProwjob()
+
+	s := fakeGCSServer.Client()
+	gr := New(cfg, s, false)
+	ctx := context.Background()
+
+	err := gr.reportProwjob(ctx, &pj)
+
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	serialised, err := json.Marshal(pj)
+	if err != nil {
+		t.Fatalf("Unexpected error serialising prowjob: %v", err)
+	}
+
+	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/prowjob.json"
+	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
+	if err != nil {
+		t.Fatalf("Couldn't fetch expected file from %s: %v", objPath, err)
+	}
+
+	if !bytes.Equal(obj.Content, serialised) {
+		t.Fatalf("Serialised content does not match:\n\nExpected:\n%q\n\nActual:\n%q", string(serialised), string(obj.Content))
+	}
+}
+
+func TestUploadStartedJson(t *testing.T) {
+	s := fakeGCSServer.Client()
+	cfg := sampleConfig()
+	pj := sampleProwjob()
+
+	gr := New(cfg, s, false)
+
+	ctx := context.Background()
+	err := gr.reportStartedJob(ctx, &pj)
+	if err != nil {
+		t.Fatalf("Unexpected error reporting job: %v", err)
+	}
+
+	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/started.json"
+	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
+	if err != nil {
+		t.Fatalf("Couldn't fetch expected file from %v: %v", objPath, err)
+	}
+	var result metadata.Started
+	err = json.Unmarshal(obj.Content, &result)
+	if err != nil {
+		t.Fatalf("Couldn't unmarshal started.json: %v. Content: %q", err, string(obj.Content))
+	}
+	if result.Timestamp != pj.Status.StartTime.Unix() {
+		t.Fatalf("started.json does not have the expected timestamp (got %d, expected %d)", result.Timestamp, pj.Status.StartTime.Unix())
+	}
+}
+
+func TestUploadFinishedJson(t *testing.T) {
+	s := fakeGCSServer.Client()
+	cfg := sampleConfig()
+	pj := sampleProwjob()
+	pj.Status.State = prowv1.SuccessState
+	pj.Status.CompletionTime = &metav1.Time{Time: time.Date(2019, 10, 13, 0, 0, 0, 0, time.UTC)}
+
+	gr := New(cfg, s, false)
+
+	ctx := context.Background()
+	err := gr.reportFinishedJob(ctx, &pj)
+	if err != nil {
+		t.Fatalf("Unexpected error reporting job: %v", err)
+	}
+
+	objPath := "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123/finished.json"
+	obj, err := fakeGCSServer.GetObject("kubernetes-jenkins", objPath)
+	if err != nil {
+		t.Fatalf("Couldn't fetch expected file from %v: %v", objPath, err)
+	}
+	var result metadata.Finished
+	err = json.Unmarshal(obj.Content, &result)
+	if err != nil {
+		t.Fatalf("Couldn't unmarshal finished.json: %v. Content: %q", err, string(obj.Content))
+	}
+	if result.Timestamp == nil {
+		t.Fatalf("finished.json does not have a finish timestamp.")
+	}
+	if *result.Timestamp != pj.Status.CompletionTime.Unix() {
+		t.Fatalf("finished.json does not have the expected timestamp (got %d, expected %d)", result.Timestamp, pj.Status.CompletionTime.Unix())
+	}
+}


### PR DESCRIPTION
This PR adds GCS reporting of prowjob status to Crier, ensuring that `started.json` and `finished.json` exist regardless of infrastructure or job failures. It also introducing a `prowjob.json`, which contains the complete prowjob object. This new file can be used by other tools to introspect the job after it's gone.

This is like #15732, but does not include reporting pod status (which I will come back to once this is in).

I also wrote up a [quick design doc](https://docs.google.com/document/d/1MYOGrRDg5JG20Qn8zvPRfR6HV41haxTkLEVUbpCb4wk/edit?usp=sharing), for those who would rather read this in English than Go.

/cc @krzyzacy @stevekuznetsov @fejta @cjwagner @BenTheElder 