### PR TITLE
replace size with num-nodes

### DIFF
--- a/experiment/maintenance/shift_nodepool_capacity.py
+++ b/experiment/maintenance/shift_nodepool_capacity.py
@@ -80,7 +80,7 @@ def resize_nodepool(pool, new_size, project, zone, cluster):
     cmd = [
         'gcloud', 'container', 'clusters', 'resize', cluster,
         '--zone', zone, '--project', project, '--node-pool', pool,
-        '--size', str(new_size), '--quiet',
+        '--num-nodes', str(new_size), '--quiet',
     ]
     print(cmd)
     subprocess.call(cmd)


### PR DESCRIPTION
> WARNING: The --size flag is now deprecated. Please use `--num-nodes` instead.