### PR TITLE
Change build directory for ExternalDNS to .

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-external-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-external-dns.yaml
@@ -19,7 +19,7 @@ postsubmits:
               - --project=k8s-staging-external-dns
               - --scratch-bucket=gs://k8s-staging-external-dns-gcb
               - --env-passthrough=PULL_BASE_REF
-              - ci/postsubmit/push-to-staging/
+              - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /creds/service-account.json


### PR DESCRIPTION
The path referenced by us currently doesn't exist. Corresponds to [this argument](https://github.com/kubernetes/test-infra/blob/39bf49d93d43b06130e9862bc96658d66594b170/images/builder/main.go#L301).

Follow up to https://github.com/kubernetes/test-infra/pull/15625

/cc @njuettner 