### PR TITLE
don't pin ipv6 jobs to snowflake ubuntu cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -107,14 +107,6 @@ presubmits:
       preset-kind-volume-mounts: "true"
     always_run: true
     spec:
-      # run on the ubuntu node pool, which has ipv6 modules
-      tolerations:
-      - key: "dedicated"
-        operator: "Equal"
-        value: "ubuntu"
-        effect: "NoSchedule"
-      nodeSelector:
-        dedicated: "ubuntu"
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
         env:

--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -55,14 +55,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   spec:
-    # run on the ubuntu node pool, which has ipv6 modules
-    tolerations:
-    - key: "dedicated"
-      operator: "Equal"
-      value: "ubuntu"
-      effect: "NoSchedule"
-    nodeSelector:
-      dedicated: "ubuntu"
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
       env:

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -99,14 +99,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   spec:
-    # run on the ubuntu node pool, which has ipv6 modules
-    tolerations:
-    - key: "dedicated"
-      operator: "Equal"
-      value: "ubuntu"
-      effect: "NoSchedule"
-    nodeSelector:
-      dedicated: "ubuntu"
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
       env:
@@ -201,14 +193,6 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   spec:
-    # run on the ubuntu node pool, which has ipv6 modules
-    tolerations:
-    - key: "dedicated"
-      operator: "Equal"
-      value: "ubuntu"
-      effect: "NoSchedule"
-    nodeSelector:
-      dedicated: "ubuntu"
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
       env:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -61,14 +61,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     spec:
-      # run on the ubuntu node pool, which has ipv6 modules
-      tolerations:
-      - key: "dedicated"
-        operator: "Equal"
-        value: "ubuntu"
-        effect: "NoSchedule"
-      nodeSelector:
-        dedicated: "ubuntu"
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20191213-55437e3-master
         env:

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -332,14 +332,6 @@ presubmits:
       timeout: 60m
     path_alias: k8s.io/kubernetes
     spec:
-      # run on the ubuntu node pool, which has ipv6 modules
-      tolerations:
-      - key: "dedicated"
-        operator: "Equal"
-        value: "ubuntu"
-        effect: "NoSchedule"
-      nodeSelector:
-        dedicated: "ubuntu"
       containers:
       - image: gcr.io/k8s-testimages/krte:v20191106-0490589-master
         command:


### PR DESCRIPTION
After discussing with the oncall team I've moved prow.k8s.io's standard build nodes to be ubuntu based.

After this is done we can spin down the snowflake ipv6 pool and bring up more general worker nodes.

Then we can do https://github.com/kubernetes/test-infra/pull/14881