### PR TITLE
support multiple comma-delimited dirs in COMPONENT_FILE_DIR

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -66,8 +66,7 @@ main() {
   fi
   echo -e "Bumping: 'gcr.io/k8s-prow/' images to $(color-version ${new_version}) ..." >&2
 
-  bumpfiles=()
-  bumpfiles+=("${COMPONENT_FILE_DIR}"/*.yaml)
+  bumpfiles=($(add_suffix "$(split_on_commas "$COMPONENT_FILE_DIR")"))
   bumpfiles+=("${CONFIG_PATH}")
   if [[ -n "${JOB_CONFIG_PATH}" ]]; then
     bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"))
@@ -175,6 +174,18 @@ list() {
       exit 1
     fi
   fi
+}
+
+split_on_commas() {
+  local IFS=,
+  local array=($1)
+  echo "${array[@]}"
+}
+
+add_suffix() {
+  local array=($1)
+  local suffix="${2:-/*.yaml}"
+  echo "${array[@]/%/$suffix}"
 }
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting

--- a/prow/cmd/autobump/example-periodic.yaml
+++ b/prow/cmd/autobump/example-periodic.yaml
@@ -38,9 +38,10 @@ periodics:
       - name: PLANK_DEPLOYMENT_FILE
         value: prow/cluster/plank_deployment.yaml
     # bump.sh args
-      # Directory containing k8s deployment YAMLs for Prow components.
+      # Directory (or comma-delimited list of directories) containing k8s deployment YAMLs for Prow components.
       - name: COMPONENT_FILE_DIR
         value: prow/cluster
+        # value: prow/cluster,prow/config/jobs
       # Repo relative path of the core Prow config file (config.yaml).
       - name: CONFIG_PATH
         value: config/prow/config.yaml


### PR DESCRIPTION
Simple and backwards-compatible modification to support multiple component directories ([example](https://github.com/istio/test-infra/pull/2253))

/assign @cjwagner 