### PR TITLE
Move gce-cos-master-default back to release-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -169,7 +169,7 @@ periodics:
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20191231-77c7890-master
   annotations:
-    testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-default
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-email: kubernetes-release-team@googlegroups.com


### PR DESCRIPTION
I'd like to see this back in release-blocking. It's the CI equivalent
to the merge-blocking pull-kubernetes-e2e-gce job that all code has to
go through.

http://velodrome.k8s.io/dashboard/db/job-health-release-informing?orgId=1&var-rjob=ci-kubernetes-e2e-gci-gce&from=now-6M&to=now

Its metrics are back in line with the criteria for release-blocking jobs

/sig release
/sig testing
FYI @kubernetes/ci-signal