### PR TITLE
Support using workload identity to bake cookies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ pod.yaml
 # Terraform files
 **/.terraform/*
 *.tfstate*
+
+# Things running grandmatriarch locally might create
+cookies
+secret.yaml

--- a/prow/cmd/grandmatriarch/bake.sh
+++ b/prow/cmd/grandmatriarch/bake.sh
@@ -19,22 +19,29 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [[ "$#" != 2 ]]; then
-  echo "Usage: $(basename "$0") <json creds> <name>" >&2
+if [[ "$#" == 0 ]]; then
+  echo "Usage: $(basename "$0") [json creds] <name>" >&2
   exit 1
 fi
 
-creds="$1"
-name="$2"
-
-if [[ ! -f "$creds" ]]; then
-  echo "Not found: $creds" >&2
-  exit 1
+if [[ $# == 2 ]]; then
+  creds="$1"
+  shift
+else
+  creds=
 fi
-gcloud auth activate-service-account --key-file="$creds"
-gcloud auth list
+name="$1"
 
-user="$(grep -o -E '[^"]+@[^"]+' "$creds")"
+if [[ -n "$creds" ]]; then
+  echo "Activating $creds..." >&2
+  if [[ ! -f "$creds" ]]; then
+    echo "Not found: $creds" >&2
+    exit 1
+  fi
+  gcloud auth activate-service-account --key-file="$creds"
+  gcloud auth list
+fi
+
 create=yes
 
 print-token() {


### PR DESCRIPTION
ref https://github.com/kubernetes/test-infra/issues/15806

/assign @BenTheElder @clarketm 

https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_workload_identity_on_an_existing_cluster

When workload identity is configured, the pod's service account is automatically bound to a GCP service account. Therefore we do not need to send it a secret.json file (which cannot be stolen since it doesn't exist)