### PR TITLE
Fork kubemark-500 job per release

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -333,6 +333,59 @@ periodics:
   - 'perfDashJobType: performance'
   - "perfDashBuildsCount: 500"
 - annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: kubemark-1.14-500
+  cron: 0 21 * * *
+  labels:
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-kubemark-500-gce-stable3
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.14
+      - --repo=k8s.io/perf-tests=release-1.14
+      - --root=/go/src
+      - --timeout=140
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-500
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-4
+      - --gcp-node-image=gci
+      - --gcp-node-size=n1-standard-8
+      - --gcp-nodes=8
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=500
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=70m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-1.14
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+  tags:
+  - 'perfDashPrefix: kubemark-500Nodes-1.14'
+  - 'perfDashJobType: performance'
+- annotations:
     description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE
     testgrid-dashboards: google-windows, sig-release-1.14-informing, sig-windows
     testgrid-tab-name: gce-windows-1.14

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -205,6 +205,60 @@ periodics:
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
+    fork-per-release-cron: 0 21 * * *
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: kubemark-1.15-500
+  cron: 0 15 * * *
+  labels:
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-kubemark-500-gce-stable2
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.15
+      - --repo=k8s.io/perf-tests=release-1.15
+      - --root=/go/src
+      - --timeout=140
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-500
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-4
+      - --gcp-node-image=gci
+      - --gcp-node-size=n1-standard-8
+      - --gcp-nodes=8
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=500
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=70m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-1.15
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+  tags:
+  - 'perfDashPrefix: kubemark-500Nodes-1.15'
+  - 'perfDashJobType: performance'
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: bazel-build-1.15

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -209,6 +209,60 @@ periodics:
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
+    fork-per-release-cron: 0 15 * * *, 0 21 * * *
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: kubemark-1.16-500
+  cron: 0 9 * * *
+  labels:
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-kubemark-500-gce-stable1
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.16
+      - --repo=k8s.io/perf-tests=release-1.16
+      - --root=/go/src
+      - --timeout=140
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-500
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-4
+      - --gcp-node-image=gci
+      - --gcp-node-size=n1-standard-8
+      - --gcp-nodes=8
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=500
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=70m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-1.16
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+  tags:
+  - 'perfDashPrefix: kubemark-500Nodes-1.16'
+  - 'perfDashJobType: performance'
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: bazel-build-1.16

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -256,6 +256,67 @@ periodics:
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
+    fork-per-release-cron: 0 9 * * *, 0 15 * * *, 0 21 * * *
+    fork-per-release-generic-suffix: "true"
+    testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
+    testgrid-num-failures-to-alert: "1"
+    testgrid-tab-name: kubemark-1.17-500
+  cron: 0 3 * * *
+  labels:
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  name: ci-kubernetes-kubemark-500-gce-beta
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/perf-tests=release-1.17
+      - --root=/go/src
+      - --timeout=140
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-500
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-4
+      - --gcp-node-image=gci
+      - --gcp-node-size=n1-standard-8
+      - --gcp-nodes=8
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=500
+      - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=500
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=70m
+      - --use-logexporter
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-1.17
+      name: ""
+      resources: {}
+      securityContext:
+        privileged: true
+  tags:
+  - 'perfDashPrefix: kubemark-500Nodes-1.17'
+  - 'perfDashJobType: performance'
+- annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: bazel-build-1.17

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -155,8 +155,12 @@ periodics:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
   annotations:
+    fork-per-release: "true"
+    fork-per-release-cron: 0 3 * * *, 0 9 * * *, 0 15 * * *, 0 21 * * *
+    fork-per-release-generic-suffix: "true"
+    fork-per-release-replacements: "kubemark-500Nodes -> kubemark-500Nodes-{{.Version}}, perf-tests=master -> perf-tests=release-{{.Version}}, gcp-project=k8s-jenkins-blocking-kubemark -> gcp-project-type=scalability-project, us-central1-f -> us-east1-b"
     testgrid-dashboards: sig-scalability-kubemark
-    testgrid-tab-name: kubemark-500
+    testgrid-tab-name: kubemark-master-500
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:


### PR DESCRIPTION
That PR adds per release forks of kubemark-500 periodic scalability test.

We already have per release kubemark-500 presubmits (pull-kubernetes-kubemark-e2e-gce-big), which should have corresponding periodics to monitor health of such scenarios.

/cc mm4tt wojtek-t