### PR TITLE
Updated CAPV Prow job config

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -2,8 +2,7 @@ periodics:
 - name: ci-cluster-api-provider-vsphere-ova-e2e
   labels:
     preset-dind-enabled: "true"
-    preset-service-account: "true"
-    preset-cluster-api-provider-vsphere-e2e-creds: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
     preset-kind-volume-mounts: "true"
   decorate: true
   interval: 24h
@@ -34,3 +33,70 @@ periodics:
     testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@vmware.co
     description: Runs periodic e2e tests
     testgrid-num-columns-recent: '20'
+
+postsubmits:
+  kubernetes-sigs/cluster-api-provider-vsphere:
+
+  # Deploys images and binaries after all merges to master
+  - name: post-cluster-api-provider-vsphere-deploy
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    branches:
+    - ^master$
+    always_run: false
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Dockerfile|Makefile)'
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
+        resources:
+          requests:
+            cpu: "1000m"
+        command:
+        - runner.sh
+        args:
+        - ./hack/release.sh
+        - -l
+        - -p
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: post-deploy
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: Pushes new images and binaries from master
+
+  # Deploys images and binaries for tagged releases
+  - name: post-cluster-api-provider-vsphere-release
+    labels:
+      preset-dind-enabled: "true"
+      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+    branches:
+    - ^v(\d)+\.(\d)+\.(\d)+(-(alpha|beta|rc)\.(\d)+)?$
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
+        resources:
+          requests:
+            cpu: "1000m"
+        command:
+        - runner.sh
+        args:
+        - ./hack/release.sh
+        - -p
+        - -l
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
+      testgrid-tab-name: release
+      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
+      description: releases new tagged images and binaries

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -1,6 +1,6 @@
 presets:
 - labels:
-    preset-cluster-api-provider-vsphere-e2e-creds: "true"
+    preset-cluster-api-provider-vsphere-e2e-config: "true"
   env:
   - name: JUMPHOST
     valueFrom:
@@ -64,7 +64,7 @@ presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
   - name: pull-cluster-api-provider-vsphere-verify-fmt
     always_run: false
-    run_if_changed: '^((api|cmd|controllers|pkg|(vendor/github.com/mbenkmann/goformat/goformat)|(vendor/golang.org/x/tools/cmd/goimports))/)|hack/check-format\.sh'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-format\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -80,7 +80,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-lint
     always_run: false
-    run_if_changed: '^((api|cmd|controllers|pkg|(vendor/golang.org/x/lint/golint))/)|hack/check-lint\.sh'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -96,7 +96,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-vet
     always_run: false
-    run_if_changed: '^((api|cmd|controllers|pkg)/)|hack/check-vet\.sh'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-vet\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -151,7 +151,7 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-verify-crds
     always_run: false
-    run_if_changed: '^((api|config|controllers|pkg|vendor)/)|Makefile|hack/verify-crds\.sh'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/verify-crds\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
@@ -167,11 +167,9 @@ presubmits:
 
   - name: pull-cluster-api-provider-vsphere-test
     always_run: false
-    run_if_changed: '^((api|cmd|config|controllers|hack|pkg|vendor)/)|Makefile|(scripts/(ci-test|fetch_ext_bins)\.sh)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Makefile)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    labels:
-      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
@@ -181,7 +179,7 @@ presubmits:
         command:
         - runner.sh
         args:
-        - ./scripts/ci-test.sh
+        - make test
     annotations:
       testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
       testgrid-tab-name: pr-test
@@ -191,12 +189,10 @@ presubmits:
   - name: pull-cluster-api-provider-vsphere-e2e
     labels:
       preset-dind-enabled: "true"
-      preset-service-account: "true"
-      preset-cluster-api-provider-vsphere-e2e-creds: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
+      preset-cluster-api-provider-vsphere-e2e-config: "true"
       preset-kind-volume-mounts: "true"
     always_run: false
-    run_if_changed: '^((api|cmd|config|controllers|pkg|(scripts/e2e)|vendor)/)|Dockerfile'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Dockerfile|Makefile|hack/e2e\.sh)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 3
@@ -221,70 +217,3 @@ presubmits:
       testgrid-tab-name: pr-e2e
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Runs e2e tests
-
-postsubmits:
-  kubernetes-sigs/cluster-api-provider-vsphere:
-
-  # Deploys images and binaries after all merges to master
-  - name: post-cluster-api-provider-vsphere-deploy
-    labels:
-      preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
-    branches:
-    - ^master$
-    always_run: false
-    run_if_changed: '^(api|cmd|config|controllers|examples|pkg|vendor)/|Dockerfile'
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    max_concurrency: 1
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
-        resources:
-          requests:
-            cpu: "1000m"
-        command:
-        - runner.sh
-        args:
-        - ./hack/release.sh
-        - -l
-        - -p
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: post-deploy
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Pushes new images and binaries from master
-
-  # Deploys images and binaries for tagged releases
-  - name: post-cluster-api-provider-vsphere-release
-    labels:
-      preset-dind-enabled: "true"
-      preset-cluster-api-provider-vsphere-gcs-creds: "true"
-    branches:
-    - ^v(\d)+\.(\d)+\.(\d)+(-(alpha|beta|rc)\.(\d)+)?$
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    max_concurrency: 1
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
-        resources:
-          requests:
-            cpu: "1000m"
-        command:
-        - runner.sh
-        args:
-        - ./hack/release.sh
-        - -p
-        - -l
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: release
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: releases new tagged images and binaries


### PR DESCRIPTION
This patch updates the CAPV Prow config to:

- Not use the service account preset when it's not needed
- Use the correct regex patterns for matching when to run jobs
- Use "make test" instead of "scripts/ci.sh" for running the test job

/assign @yastij 