### PR TITLE
Use sinker.terminated_pod_ttl

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -23,7 +23,8 @@ plank:
 sinker:
   resync_period: 1m
   max_prowjob_age: 48h
-  max_pod_age: 30m
+  max_pod_age: 48h
+  terminated_pod_ttl: 30m
 
 deck:
   spyglass:


### PR DESCRIPTION
Use the new `sinker.terminated_pod_ttl` to GC pods 30 minutes after they terminate, instead of 30 minutes after they are created provided they have since terminated. This will be helpful for debugging, and ensure that future tooling that reads pod state after jobs complete isn't racing against sinker.

Leave `sinker.max_pod_age` in place as a fallback.

/cc @michelle192837 @cjwagner @BenTheElder 