### PR TITLE
Azure: make various jobs less flaky

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -368,7 +368,7 @@ periodics:
       - --deployment=aksengine
       - --build=quick
       - --provider=skeleton
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=15
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
@@ -619,7 +619,7 @@ periodics:
       - --deployment=aksengine
       - --build=quick
       - --provider=skeleton
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=15
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
@@ -679,7 +679,7 @@ periodics:
       - --deployment=aksengine
       - --build=quick
       - --provider=skeleton
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=15
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
       - --aksengine-creds=$AZURE_CREDENTIALS
@@ -698,7 +698,7 @@ periodics:
       # 2. PSP related cases, reason: https://github.com/Azure/aks-engine/blob/master/parts/k8s/addons/kubernetesmasteraddons-pod-security-policy.yaml#L41
       # 3. cases in which PV will be created, for these shall be failed since AzureDisk will be disabled when ccm is enabled
       # 4. cases requiring node's public IP
-      - --test_args=--num-nodes=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Mount\spropagation\sshould\spropagate\smounts\sto\sthe\shost|PodSecurityPolicy|PVC\sProtection\sVerify|should\sprovide\sbasic\sidentity|should\sadopt\smatching\sorphans\sand\srelease|should\snot\sdeadlock\swhen\sa\spod's\spredecessor\sfails|should\sperform\srolling\supdates\sand\sroll\sbacks\sof\stemplate\smodifications\swith\sPVCs|should\sperform\srolling\supdates\sand\sroll\sbacks\sof\stemplate\smodifications|Services\sshould\sbe\sable\sto\screate\sa\sfunctioning\sNodePort\sservice$|volumeMode\sshould\snot\smount\s/\smap\sunused\svolumes\sin\sa\spod
+      - --test_args=--num-nodes=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete\sGrace\sPeriod|Should\srecreate\sevicted\sstatefulset|runs\sReplicaSets\sto\sverify\spreemption\srunning\spath|client\-go\sshould\snegotiate|should\scontain\scustom\scolumns\sfor\seach\sresource|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|Mount\spropagation\sshould\spropagate\smounts\sto\sthe\shost|PodSecurityPolicy|PVC\sProtection\sVerify|should\sprovide\sbasic\sidentity|should\sadopt\smatching\sorphans\sand\srelease|should\snot\sdeadlock\swhen\sa\spod's\spredecessor\sfails|should\sperform\srolling\supdates\sand\sroll\sbacks\sof\stemplate\smodifications\swith\sPVCs|should\sperform\srolling\supdates\sand\sroll\sbacks\sof\stemplate\smodifications|Services\sshould\sbe\sable\sto\screate\sa\sfunctioning\sNodePort\sservice$|volumeMode\sshould\snot\smount\s/\smap\sunused\svolumes\sin\sa\spod
       - --timeout=420m
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -442,12 +442,11 @@ periodics:
       - --aksengine-public-key=$KUBE_SSH_PUBLIC_KEY_PATH
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-serial.json
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.45.0/aks-engine-v0.45.0-linux-amd64.tar.gz
-      # Skip four kinds of test cases:
+      # Skip three kinds of test cases:
       # 1. regular resource usage tracking, haven't found the cause of the failures.
       # 2. validates MaxPods limit number of pods that are allowed to run, related to issue kubernetes/kubernetes#80177
       # 3. Checks that the node becomes unreachable, the external IP is unavailable since the corresponding configuration in aks-engine is set to false.
-      # 4. Pod should be scheduled to node that don't match the PodAntiAffinity terms, fixed by https://github.com/kubernetes/kubernetes/pull/80780 and should be re-enabled in 1.17
-      - --test_args=--num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|Checks\sthat\sthe\snode\sbecomes\sunreachable|Pod\sshould\sbe\sscheduled\sto\snode\sthat\sdon.t\smatch\sthe\sPodAntiAffinity\sterms --minStartupPods=8
+      - --test_args=--num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun|Checks\sthat\sthe\snode\sbecomes\sunreachable --minStartupPods=8
       - --timeout=600m
       securityContext:
         privileged: true


### PR DESCRIPTION
Decreasing parallelization to see whether it decreases jobs flakiness. Also re-enabling a test case for ci-cloud-provider-azure-serial.

Skipping the following test cases in ci-cloud-provider-azure-multiple-zones:
- [sig-cli] Kubectl client kubectl get output should contain custom columns for each resource
  - Error message: No test data available for csi.storage.k8s.io/v1alpha1, Resource=csidrivers. No test data available for csi.storage.k8s.io/v1alpha1, Resource=csinodeinfo 
  - Reason to skip: CSINodeInfo / CSIDriver CRDs are installed 
  - Solution: Don't install CSINodeInfo and CSIDriver CRDs since they are not required when using k8s 1.14+
- [sig-scheduling] PreemptionExecutionPath runs ReplicaSets to verify preemption running path
  - Reason to skip: Marked as flaky in https://github.com/kubernetes/kubernetes/issues/86068
- client-go should negotiate watch and report errors with accept
  - Reason to skip: Bad test cases
  - Solution: https://github.com/kubernetes/kubernetes/pull/86354 (only available in master branch)
- [k8s.io] [sig-node] Pods Extended [k8s.io] Delete Grace Period should be submitted and removed [Conformance] 
  - Reason to skip: Marked as flaky in https://github.com/kubernetes/kubernetes/issues/85762 

ref: https://github.com/kubernetes-sigs/cloud-provider-azure/issues/264
/assign @feiskyer 
