### PR TITLE
prow/spyglass/README: Fix build-log.txt example indent

### DIFF
--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -95,7 +95,7 @@ deck:
           - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
-            - build-log.txt
+      - build-log.txt
     - lens:
         name: junit
       required_files:


### PR DESCRIPTION
Removing the extra indenting that landed with this YAML example in f56bf6d371 (#13478).