### PR TITLE
enable race checks for structured-merge-diff

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -16,6 +16,7 @@ periodics:
       - go
       args:
       - test
+      - -race
       - ./...
   annotations:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -13,6 +13,7 @@ presubmits:
         - go
         args:
         - test
+        - -race
         - ./...
     annotations:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff


### PR DESCRIPTION
We would like to enable go race checks for https://github.com/kubernetes-sigs/structured-merge-diff

I tried running the job locally to see if my change works, but didn't get it to work using phaino :-/