### PR TITLE
Ensure identity bound successfully

### DIFF
--- a/experiment/workload-identity/enable-workload-identity.sh
+++ b/experiment/workload-identity/enable-workload-identity.sh
@@ -81,6 +81,7 @@ case $ans in
   y*|Y*)
     ;;
   *)
+    echo "ABORTING" >&2
     exit 1
     ;;
 esac


### PR DESCRIPTION
Ensures that a pod using this service account authenticates as the expected service account
/assign @michelle192837 @chases2 

ref GoogleCloudPlatform/oss-test-infra#202
ref #15806