### PR TITLE
pull-cip-e2e: use new e2e entrypoint path

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -65,7 +65,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200107-164c5e8-master
         command:
-        - "./test-e2e/e2e-entrypoint-from-container.sh"
+        - "./test-e2e/cip/e2e-entrypoint-from-container.sh"
         env:
         - name: CIP_E2E_KEY_FILE
           value: "/etc/k8s-cip-test-prod-service-account/service-account.json"


### PR DESCRIPTION
This should fix the job for changes to the promoter, taking into account the refactoring in https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/166