### PR TITLE
Kops - Increase old e2e interval to 12h

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
@@ -1,6 +1,6 @@
 periodics:
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-9
   labels:
     preset-service-account: "true"
@@ -31,7 +31,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.9
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-10
   labels:
     preset-service-account: "true"
@@ -62,7 +62,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.10
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-11
   labels:
     preset-service-account: "true"
@@ -92,7 +92,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.11
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-12
   labels:
     preset-service-account: "true"
@@ -122,7 +122,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.12
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-13
   labels:
     preset-service-account: "true"
@@ -152,7 +152,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.13
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-14
   labels:
     preset-service-account: "true"
@@ -182,7 +182,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.14
 
-- interval: 4h
+- interval: 12h
   name: e2e-kops-aws-k8s-1-15
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Old e2e are now stable, except for some [known issues](https://github.com/kubernetes/kops/pull/8248). There's no reason anymore to run so often.