### PR TITLE
prow/config: require-matching-label now replaces require-sig

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -435,6 +435,42 @@ require_matching_label:
     - `/committee <group-name>`
 
     Please see the [group list](https://git.k8s.io/community/sig-list.md) for a listing of the SIGs, working groups, and committees available.
+- missing_label: needs-sig
+  org: kubernetes
+  repo: community
+  issues: true
+  regexp: ^(sig|wg|committee)/
+  missing_comment: |
+    There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+    - `/sig <group-name>`
+    - `/wg <group-name>`
+    - `/committee <group-name>`
+
+    Please see the [group list](https://git.k8s.io/community/sig-list.md) for a listing of the SIGs, working groups, and committees available.
+- missing_label: needs-sig
+  org: kubernetes
+  repo: enhancements
+  issues: true
+  regexp: ^(sig|wg|committee)/
+  missing_comment: |
+    There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+    - `/sig <group-name>`
+    - `/wg <group-name>`
+    - `/committee <group-name>`
+
+    Please see the [group list](https://git.k8s.io/community/sig-list.md) for a listing of the SIGs, working groups, and committees available.
+- missing_label: needs-sig
+  org: kubernetes-sigs
+  repo: contributor-playground
+  issues: true
+  regexp: ^(sig|wg|committee)/
+  missing_comment: |
+    There are no sig labels on this issue. Please add an appropriate label by using one of the following commands:
+    - `/sig <group-name>`
+    - `/wg <group-name>`
+    - `/committee <group-name>`
+
+    Please see the [group list](https://git.k8s.io/community/sig-list.md) for a listing of the SIGs, working groups, and committees available.
 - missing_label: needs-priority
   org: kubernetes
   repo: kubernetes
@@ -552,7 +588,7 @@ plugins:
   kubernetes/community:
   - blockade
   - milestone
-  - require-sig
+  - require-matching-label
 
   kubernetes/dashboard:
   - override
@@ -561,7 +597,7 @@ plugins:
   - blockade
   - milestone
   - milestoneapplier
-  - require-sig
+  - require-matching-label
   - stage
 
   kubernetes/kops:
@@ -759,7 +795,7 @@ plugins:
   - milestone
 
   kubernetes-sigs/contributor-playground:
-  - require-sig
+  - require-matching-label
 
   containerd/cri:
   - assign


### PR DESCRIPTION
The first step to address https://github.com/kubernetes/test-infra/pull/9158#issuecomment-415892529

After this PR merged we can safely delete the old plugin.

An issue might need to be opened to have a field like `repos` 😬

/cc @cjwagner 

ref: https://github.com/kubernetes/test-infra/issues/13587
/cc @nikhita @cblecker 