### PR TITLE
ExternalDNS: trigger build when tags are pushed

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-external-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-external-dns.yaml
@@ -9,8 +9,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+        - ^v[0-9].*
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200107-6bdb17e

--- a/config/jobs/image-pushing/k8s-staging-external-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-external-dns.yaml
@@ -9,6 +9,8 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200107-6bdb17e


### PR DESCRIPTION
Trigger the pipeline when a git tag is pushed to the repository.

This should allow us to build images like `external-dns:v0.5.18` etc.

(copied from azure provider)