### PR TITLE
update cip image

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -10,17 +10,14 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20191026-v2.3.1-36-g0e656d8
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200107-v2.3.1-71-gfd2fae8
         command:
         - cip
         args:
         # Pod Utilities already sets pwd to
         # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
         # suffice, but it's nice to be explicit.
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
-        # Without account keys (-key-files), we should not be trying to activate
-        # any service accounts.
-        - -no-service-account
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     decorate: true

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -784,13 +784,14 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20191026-v2.3.1-36-g0e656d8
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200107-v2.3.1-71-gfd2fae8
         command:
         - cip
         args:
         - -manifest=prow/cip-manifest.yaml
         - -key-files=/etc/service-account/service-account.json
         - -dry-run=false
+        - -use-service-account
         volumeMounts:
         - name: service-account
           mountPath: /etc/service-account
@@ -818,13 +819,14 @@ postsubmits:
     - ^master$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20191026-v2.3.1-36-g0e656d8
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200107-v2.3.1-71-gfd2fae8
         command:
         - cip
         args:
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
         - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
         - -dry-run=false
+        - -use-service-account
         volumeMounts:
         - name: k8s-artifacts-prod-service-account-creds
           mountPath: /etc/k8s-artifacts-prod-service-account
@@ -1213,13 +1215,14 @@ periodics:
     # interactive bash session:
     #
     #   docker run --rm -it gcr.io/cip-demo-staging/cip:<tag> "cd /cip && bash"
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20191026-v2.3.1-36-g0e656d8
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200107-v2.3.1-71-gfd2fae8
       command:
       - cip
       args:
-      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io/manifests
+      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
       - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
       - -dry-run=false
+      - -use-service-account
       volumeMounts:
       - name: k8s-artifacts-prod-service-account-creds
         mountPath: /etc/k8s-artifacts-prod-service-account


### PR DESCRIPTION
This updates the arguments/flags as well in 2 ways:

1. Deprecate '-no-service-account' flag (see
https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/153).
the opposite flag, '-use-service-account' is used whenever we need to
use service accounts.

2. -thin-manifest-dir has changed slightly to point to the toplevel
directory instead of the "manifests" subdir (see
https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/161).