### PR TITLE
provider/azure: set creds for scalability test

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -724,6 +724,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
+    preset-azure-cred: "true"
   annotations:
     testgrid-dashboards: provider-azure-scalability
     testgrid-tab-name: ci-kubernetes-kubemark-100-azure


### PR DESCRIPTION
Scale tests were added as part of https://github.com/kubernetes/test-infra/pull/15067. But the tests have never passed because of

```
W0109 13:38:06.667] 2020/01/09 13:38:06 main.go:316: Something went wrong: error creating deployer: error reading SSH Key $AZURE_SSH_PUBLIC_KEY_FILE open $AZURE_SSH_PUBLIC_KEY_FILE: no such file or directory
```

This PR sets the azure creds in the job to fix the issue. 

/area provider/azure
/assign @feiskyer 