### PR TITLE
Kops - enable bazel remote cache on e2e job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -102,6 +102,8 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true


### PR DESCRIPTION
The e2e jobs still build the kops components with bazel, so enabling the remote cache should improve build times.

Starting with the 1.15 e2e job, will test there and expand to remaining e2e jobs (presubmit and periodic) if tests pass.