### PR TITLE
Fix too long prometheus snapshot name in scalability calico job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -196,7 +196,7 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
-      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
+      - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=ci-kubernetes-e2e-gci-gce-scalability-np-${BUILD_ID}
       - --test-cmd-args=--nodes=100
       - --test-cmd-args=--prometheus-scrape-node-exporter
       - --test-cmd-args=--provider=gce


### PR DESCRIPTION
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-scalability-networkpolicies/1215497837878448128
`W0110 05:49:20.888] W0110 05:49:20.887450   12637 experimental.go:117] Incorrect disk name ci-kubernetes-e2e-gci-gce-scalability-networkpolicies-1215497837878448128: disk name doesn't match ^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$. Using default name: e2e-scalability-calico-pvc-8c30863f-313f-4bf5-90df-fc2015345de4`

/cc mm4tt mborsz