### PR TITLE
Fix pull-release-test job for k/release

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -41,16 +41,17 @@ presubmits:
   - name: pull-release-test
     always_run: true
     decorate: true
+    path_alias: k8s.io/release
     extra_refs:
     - org: kubernetes
-      repo: release
+      repo: test-infra
       base_ref: master
-      path_alias: k8s.io/release
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - image: gcr.io/k8s-staging-release-test/releng-ci-bazel:latest
         command:
-        - bazel
+        - ../test-infra/hack/bazel.sh
         args:
         - test
         - //...


### PR DESCRIPTION
I removed the path alias in https://github.com/kubernetes/test-infra/pull/15613/files#r365258628 which may broke our CI completely. I think it's still necessary to have it.

/cc @justaugustus 