### PR TITLE
Kops - only use bazel remote cache on the e2e jobs that are presubmits

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -62,6 +62,8 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true
@@ -145,6 +147,8 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true
@@ -186,6 +190,8 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true

--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -62,8 +62,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true
@@ -147,8 +145,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true
@@ -190,8 +186,6 @@ presubmits:
       preset-service-account: "true"
       preset-aws-ssh: "true"
       preset-aws-credential: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
       preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
     decorate: true

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
@@ -6,8 +6,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -40,8 +38,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -74,8 +70,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -108,8 +102,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -142,8 +134,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -177,8 +167,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -211,8 +199,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -245,8 +231,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -279,8 +263,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -313,8 +295,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-old.yaml
@@ -6,8 +6,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -39,8 +37,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -72,8 +68,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -104,8 +98,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -136,8 +128,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -168,8 +158,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m
@@ -200,8 +188,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 90m

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -5,8 +5,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-e2e-platform-aws: "true"
   decorate: true
   decoration_config:
@@ -36,8 +34,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
     preset-e2e-platform-aws: "true"
   decorate: true
   decoration_config:
@@ -67,8 +63,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -100,8 +94,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -134,8 +126,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -168,8 +158,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -202,8 +190,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -235,8 +221,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -267,8 +251,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -298,8 +280,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -329,8 +309,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -360,8 +338,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 50m
@@ -392,8 +368,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -425,8 +399,6 @@ periodics:
     preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -456,8 +428,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -487,8 +457,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m
@@ -518,8 +486,6 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-    preset-bazel-scratch-dir: "true"
-    preset-bazel-remote-cache-enabled: "true"
   decorate: true
   decoration_config:
     timeout: 140m


### PR DESCRIPTION
The periodic e2e jobs pull down an existing kops binary, so they dont use bazel. only the presubmit e2e jobs use bazel.