### PR TITLE
Make script work on mac

### DIFF
--- a/experiment/workload-identity/bind-service-accounts.sh
+++ b/experiment/workload-identity/bind-service-accounts.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -o errexit
 set -o nounset
@@ -64,6 +64,8 @@ else
       "--member=$want" \
       $gcp_service_account
   ) > /dev/null
+  echo "Sleeping 2m to allow credentials to propagate.." >&2
+  sleep 2m
 fi
 
 pod-identity() {


### PR DESCRIPTION
Allow some time for a newly bound service account to get credentials. Seems to fail for the first minute or two.

ref https://github.com/kubernetes/test-infra/issues/15806