### PR TITLE
Prepare utilities for workload identity

### DIFF
--- a/boskos/push.sh
+++ b/boskos/push.sh
@@ -53,8 +53,9 @@ fi
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-  gcloud auth configure-docker
 fi
+
+gcloud auth configure-docker
 
 # Build and push the current commit, failing on any uncommitted changes.
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -756,7 +756,7 @@ postsubmits:
         command:
         - ./boskos/update_prow_config.sh
         env:
-        - name: PROW_SERVICE_ACCOUNT
+        - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /creds/service-account.json
         volumeMounts:
         - name: creds

--- a/images/builder/ci-runner.sh
+++ b/images/builder/ci-runner.sh
@@ -17,8 +17,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "Activating service account..."
-gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]];then
+  echo "Activating service account..."
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
 
 echo "Executing builder, sending logs to ${ARTIFACTS}..."
 bazel run //images/builder -- --log-dir="${ARTIFACTS}" "$@"

--- a/prow/push.sh
+++ b/prow/push.sh
@@ -52,8 +52,9 @@ fi
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   echo "Detected GOOGLE_APPLICATION_CREDENTIALS, activating..." >&2
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-  gcloud auth configure-docker
 fi
+
+gcloud auth configure-docker
 
 # Build and push the current commit, failing on any uncommitted changes.
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -273,7 +273,11 @@ func main() {
 	var client *storage.Client
 	if strings.HasPrefix(opt.output, "gs://") {
 		var err error
-		client, err = gcs.ClientWithCreds(ctx, opt.creds)
+		var creds []string
+		if opt.creds != "" {
+			creds = append(creds, opt.creds)
+		}
+		client, err = gcs.ClientWithCreds(ctx, creds...)
 		if err != nil {
 			log.Fatalf("failed to create gcs client: %v", err)
 		}


### PR DESCRIPTION
Stop requiring `GOOGLE_APPLICATION_CREDENTIALS` to be set and/or passing in explicit credentials.

ref #15806 