### PR TITLE
releng: Enable building kubepkg image and fix commands for deb/rpm jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-release-test.yaml
+++ b/config/jobs/image-pushing/k8s-staging-release-test.yaml
@@ -143,13 +143,12 @@ postsubmits:
           - name: creds
             secret:
               secretName: deployer-service-account
-    - name: post-release-push-image-deb-builder
+    - name: post-release-push-image-kubepkg
       cluster: test-infra-trusted
       annotations:
         testgrid-dashboards: sig-release-image-pushes, sig-release-master-informing
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
-      run_if_changed: '^build\/'
       branches:
         - ^master$
       spec:
@@ -161,38 +160,8 @@ postsubmits:
               - --project=k8s-staging-release-test
               - --scratch-bucket=gs://k8s-staging-release-test-gcb
               - --env-passthrough=PULL_BASE_REF
-              - build/debs
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /creds/service-account.json
-              - name: LOG_TO_STDOUT
-                value: "y"
-            volumeMounts:
-              - name: creds
-                mountPath: /creds
-        volumes:
-          - name: creds
-            secret:
-              secretName: deployer-service-account
-    - name: post-release-push-image-rpm-builder
-      cluster: test-infra-trusted
-      annotations:
-        testgrid-dashboards: sig-release-image-pushes, sig-release-master-informing
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/'
-      branches:
-        - ^master$
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200107-6bdb17e
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-release-test
-              - --scratch-bucket=gs://k8s-staging-release-test-gcb
-              - --env-passthrough=PULL_BASE_REF
-              - build/rpms
+              - --gcb-config=./cloudbuild-kubepkg.yaml
+              - .
             env:
               - name: GOOGLE_APPLICATION_CREDENTIALS
                 value: /creds/service-account.json

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -99,16 +99,12 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-staging-release-test/deb-builder:latest
+    - image: gcr.io/k8s-staging-release-test/kubepkg:latest
       imagePullPolicy: Always
       command:
-      - ./debs
+      - ./kubepkg
       args:
-      # We explicitly don't build the cri-tools package as the tooling will attempt to
-      # fetch a release version of cri-tools from GitHub before it exists.
-      #
-      # ref: https://github.com/kubernetes/kubernetes/issues/84548
-      - -packages=kubelet,kubectl,kubeadm,kubernetes-cni
+      - debs
       resources:
         requests:
           cpu: 4
@@ -123,10 +119,12 @@ periodics:
   decorate: true
   spec:
     containers:
-    - image: gcr.io/k8s-staging-release-test/rpm-builder:latest
+    - image: gcr.io/k8s-staging-release-test/kubepkg-rpm:latest
       imagePullPolicy: Always
       command:
-      - ./build.sh
+      - ./kubepkg
+      args:
+      - rpms
       resources:
         requests:
           cpu: 4


### PR DESCRIPTION
Companion PR to https://github.com/kubernetes/release/pull/1011.
Fixes: https://github.com/kubernetes/kubernetes/issues/86965, https://github.com/kubernetes/kubernetes/issues/87141 (cc: @kubernetes/ci-signal)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hoegaarden @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 