### PR TITLE
Kops - migrate all e2e jobs off of the old kops-e2e-runner.sh

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -77,8 +77,8 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
+        - --deployment=kops
         - --check-leaked-resources=false
         - --cluster=
         - --extract=ci/latest
@@ -119,8 +119,8 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
+        - --deployment=kops
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.15.txt
@@ -162,8 +162,8 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
+        - --deployment=kops
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.16.txt
@@ -205,8 +205,8 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
-        - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
+        - --deployment=kops
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.17.txt

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -15,8 +15,8 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --aws
       - --cluster=e2e-kops-aws.test-cncf-aws.k8s.io
+      - --deployment=kops
       - --env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-green.txt
       - --extract=ci/latest
       - --ginkgo-parallel
@@ -44,8 +44,8 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --aws
       - --cluster=e2e-kops-aws-beta.test-cncf-aws.k8s.io
+      - --deployment=kops
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt
       - --extract=ci/k8s-beta
       - --ginkgo-parallel
@@ -215,36 +215,6 @@ periodics:
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-networking-kopeio-vxlan
-- interval: 1h
-  name: ci-kubernetes-e2e-kops-aws-newrunner
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=ci/latest
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
-
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-newrunner
 - interval: 2h
   name: ci-kubernetes-e2e-kops-aws-stable1
   labels:


### PR DESCRIPTION
Many of the e2e jobs have been using the new runner for months or years.
This migrates the remaining jobs that use the old runner to the new one.
It also deletes the "newrunner" job meant for testing the new runner since it is redundant.

The job was introduced [2 years ago](https://github.com/kubernetes/test-infra/commit/3aca0306e0bd78fb51f9fa38dbacc6bba6bf9379) so I think it has run its course. There are a few k/k presubmits that still use the old runner, so once we confirm this works I can migrate those and remove kops-e2e-runner.sh altogether.