### PR TITLE
Re-enable non-generated GKE jobs.

### DIFF
--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 10000h # original: 2h
+- interval: 2h
   name: spark-periodic-default-gke
   labels:
     preset-service-account: "true"
@@ -38,7 +38,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic builds and testing of Apache Spark on default version of GKE.
-- interval: 10000h # original: 2h
+- interval: 2h
   name: spark-periodic-latest-gke
   labels:
     preset-service-account: "true"

--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -6,7 +6,7 @@ presets:
     value: "containerd containerd-installation"
 
 periodics:
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-alpha-cluster
   labels:
     preset-service-account: "true"
@@ -37,7 +37,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-alpha-cluster
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster
   labels:
     preset-service-account: "true"
@@ -68,7 +68,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.14-alpha-cluster
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta-alpha-cluster-features
   labels:
     preset-service-account: "true"
@@ -98,7 +98,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.14-alpha-cluster-features
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sbeta
   labels:
     preset-service-account: "true"
@@ -129,7 +129,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.14
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1
   labels:
     preset-service-account: "true"
@@ -160,7 +160,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.13
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster
   labels:
     preset-service-account: "true"
@@ -191,7 +191,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.13-alpha-cluster
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-containerd-gke-k8sstable1-alpha-cluster-features
   labels:
     preset-service-account: "true"
@@ -222,7 +222,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-containerd-gke-1.13-alpha-cluster-features
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster
   labels:
     preset-service-account: "true"
@@ -252,7 +252,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-gke-1.14-alpha-cluster
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sbeta-alpha-cluster-features
   labels:
     preset-service-account: "true"
@@ -281,7 +281,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-gke-1.14-alpha-cluster-features
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster
   labels:
     preset-service-account: "true"
@@ -311,7 +311,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-gke-1.13-alpha-cluster
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-cos-gke-k8sstable1-alpha-cluster-features
   labels:
     preset-service-account: "true"
@@ -341,7 +341,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-gke-1.13-alpha-cluster-features
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-soak-gke-cos-containerd
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kustomize-periodic-default-gke
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 10000h # original: 2h
+- interval: 2h
   name: application-periodic-default-gke
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -274,7 +274,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
     testgrid-tab-name: gci-gce-autoscaling-migs-hpa
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-autoscaling-hpa-cm
   labels:
     preset-gke-alpha-service: "true"

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -54,7 +54,7 @@ periodics:
     testgrid-tab-name: gce
     testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
     description: kubectl gce e2e tests for master branch
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gci-gke-sig-cli
   labels:
     preset-service-account: "true"
@@ -85,7 +85,7 @@ periodics:
     testgrid-tab-name: gke
     testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
     description: kubectl gke e2e tests for master branch
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-serial-sig-cli
   labels:
     preset-service-account: "true"
@@ -476,7 +476,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew-serial
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -507,7 +507,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.14-1.13-gci-kubectl-skew
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -537,7 +537,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.14-1.13-gci-kubectl-skew-serial
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -569,7 +569,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gke
     description: stable1 e2e tests run against a master gke cluster using a stable1 kubectl binary
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-master-new-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -600,7 +600,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gke-serial
     description: stable1 serial tests run against a master gke cluster using a stable1 kubectl binary
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -631,7 +631,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gke
     description: stable1 e2e tests run against a stable1 gke cluster using a master kubectl binary
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-new-master-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -661,7 +661,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gke-serial
     description: stable1 serial tests run against a stable1 gke cluster using a master kubectl binary
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -692,7 +692,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.13-1.14-gci-kubectl-skew
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -722,7 +722,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.13-1.14-gci-kubectl-skew-serial
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -753,7 +753,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.13-1.12-gci-kubectl-skew
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-stable1-stable2-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -783,7 +783,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.13-1.12-gci-kubectl-skew-serial
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -814,7 +814,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gke-1.12-1.13-gci-kubectl-skew
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-stable2-stable1-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
@@ -43,7 +43,7 @@ presubmits:
           requests:
             memory: "6Gi"
 periodics:
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke
   labels:
     preset-service-account: "true"
@@ -73,7 +73,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-features
   labels:
     preset-service-account: "true"
@@ -102,7 +102,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-alpha-features
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-alpha-enabled-default
   labels:
     preset-service-account: "true"
@@ -132,7 +132,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-alpha-enabled-default
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-flaky
   labels:
     preset-service-account: "true"
@@ -160,7 +160,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-flaky
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-multizone
   labels:
     preset-service-account: "true"
@@ -190,7 +190,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-multizone
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-reboot
   labels:
     preset-service-account: "true"
@@ -218,7 +218,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-reboot
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-serial
   labels:
     preset-service-account: "true"
@@ -246,7 +246,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-serial
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-slow
   labels:
     preset-service-account: "true"
@@ -275,7 +275,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-slow
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-updown
   labels:
     preset-service-account: "true"
@@ -303,7 +303,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gci-gke-updown
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-regional
   labels:
     preset-service-account: "true"
@@ -332,7 +332,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-regional
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-regional-serial
   labels:
     preset-service-account: "true"
@@ -359,7 +359,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-regional-serial
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-regional-slow
   labels:
     preset-service-account: "true"
@@ -387,7 +387,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: gke-regional-slow
-- interval: 10000h # original: 1h
+- interval: 1h
   name: ci-kubernetes-e2e-gke-gci-ci-master
   labels:
     preset-service-account: "true"
@@ -415,7 +415,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gci
     testgrid-tab-name: ci-gke-master
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-soak-gke-gci
   labels:
     preset-service-account: "true"
@@ -447,7 +447,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gke-gci
-- interval: 10000h # original: 2h
+- interval: 2h
   name: istio-periodic-e2e-gke-addon
   labels:
     preset-istio-service: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
@@ -1,6 +1,6 @@
 periodics:
 # GKE upgrades
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster
   labels:
     preset-service-account: "true"
@@ -34,7 +34,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-cluster
     description: Upgrade master and node, in gke(gci), from 1.14 to master
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new
   labels:
     preset-service-account: "true"
@@ -66,7 +66,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-cluster-new
     description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping slow tests as we run serially
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-new-parallel
   labels:
     preset-service-account: "true"
@@ -99,7 +99,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-cluster-new-parallel
     description: Upgrade master and node, in gke(gci), from 1.14 to master, and run skewed e2e tests; skipping serial and disruptive tests as we run in parallel
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-cluster-parallel
   labels:
     preset-service-account: "true"
@@ -131,7 +131,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-cluster-parallel
     description: Upgrade master and node, in gke(gci), from 1.14 to master, run parallel tests only
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-new-gci-master-upgrade-master
   labels:
     preset-service-account: "true"
@@ -162,7 +162,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-new-gci-master-upgrade-master
     description: Upgrade master only, in gke(gci), from 1.14 to master
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable-gci-master-upgrade-master
   labels:
     preset-service-account: "true"
@@ -193,7 +193,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-stable-gci-master-upgrade-master
     description: Upgrade master only, in gke, from gci 1.13 to gci master
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster
   labels:
     preset-service-account: "true"
@@ -224,7 +224,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.13-gci-1.12-downgrade-cluster
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable1-gci-stable2-downgrade-cluster-parallel
   labels:
     preset-service-account: "true"
@@ -256,7 +256,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.13-gci-1.12-downgrade-cluster-parallel
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster
   labels:
     preset-service-account: "true"
@@ -287,7 +287,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.12-gci-1.13-upgrade-cluster
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-cluster-new
   labels:
     preset-service-account: "true"
@@ -318,7 +318,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.12-gci-1.13-upgrade-cluster-new
-- interval: 10000h # original: 12h
+- interval: 12h
   name: ci-kubernetes-e2e-gke-gci-stable2-gci-stable1-upgrade-master
   labels:
     preset-service-account: "true"
@@ -349,7 +349,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.12-gci-1.13-upgrade-master
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster
   labels:
     preset-service-account: "true"
@@ -380,7 +380,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.11-gci-1.13-upgrade-cluster
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-cluster-new
   labels:
     preset-service-account: "true"
@@ -412,7 +412,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.11-gci-1.13-upgrade-cluster-new
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-stable3-gci-stable1-upgrade-master
   labels:
     preset-service-account: "true"
@@ -443,7 +443,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-1.11-gci-1.13-upgrade-master
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster
   labels:
     preset-service-account: "true"
@@ -474,7 +474,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-1.13-1.14-upgrade-cluster
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-cluster-new
   labels:
     preset-service-account: "true"
@@ -505,7 +505,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-1.13-1.14-upgrade-cluster-new
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-stable1-beta-upgrade-master
   labels:
     preset-service-account: "true"
@@ -536,7 +536,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-1.13-1.14-upgrade-master
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster
   labels:
     preset-service-account: "true"
@@ -567,7 +567,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-1.14-1.13-downgrade-cluster
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-beta-stable1-downgrade-cluster-parallel
   labels:
     preset-service-account: "true"
@@ -599,7 +599,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-1.14-1.13-downgrade-cluster-parallel
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster
   labels:
     preset-service-account: "true"
@@ -631,7 +631,7 @@ periodics:
     testgrid-dashboards: google-gke-upgrade
     testgrid-tab-name: gke-gci-master-gci-new-downgrade-cluster
     description: Downgrade master and node, in gke(gci), from master to 1.14
-- interval: 10000h # original: 2h
+- interval: 2h
   name: ci-kubernetes-e2e-gke-gci-master-gci-new-downgrade-cluster-parallel
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -51,7 +51,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-sd-logging
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
   labels:
     preset-service-account: "true"
@@ -78,7 +78,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-gci-1.14
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
   labels:
     preset-service-account: "true"
@@ -105,7 +105,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-gci-latest
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
   labels:
     preset-service-account: "true"
@@ -132,7 +132,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-gci-1.13
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
   labels:
     preset-service-account: "true"
@@ -159,7 +159,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-ubuntu-1.14
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
   labels:
     preset-service-account: "true"
@@ -186,7 +186,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-ubuntu-latest
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
   labels:
     preset-service-account: "true"
@@ -213,7 +213,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-ubuntu-1.13
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-stackdriver
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -413,7 +413,7 @@ periodics:
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200110-80c1ae9-master
 
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gke-ingress
   labels:
     preset-service-account: "true"
@@ -443,7 +443,7 @@ periodics:
     testgrid-tab-name: gci-gke-ingress
     testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
     testgrid-alert-stale-results-hours: '24'
-- interval: 10000h # original: 6h
+- interval: 6h
   name: ci-kubernetes-e2e-gci-gke-network-policy
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -168,7 +168,7 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: scalability
 
-- interval: 10000h # original: 30m
+- interval: 30m
   name: ci-kubernetes-e2e-gke-canary
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Separate from the generated jobs (which account for about 50% of them) so they can be turned on with a delay to mitigate the effect of running all of them at once.

/cc @michelle192837 