### PR TITLE
update rules_k8s container

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/rules-k8s/gcloud-bazel:v20191007-v0.1-141-gf150cbe
+      - image: gcr.io/rules-k8s/gcloud-bazel:v20200113-v0.3.1-16-g7767a41
         args:
         - bash
         - -c


### PR DESCRIPTION
New container has Bazel 2.0.0 which is required for several dependency updates