### PR TITLE
Handle multiple /pony requests in a single comment.

### DIFF
--- a/prow/plugins/pony/pony.go
+++ b/prow/plugins/pony/pony.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/github"
@@ -48,6 +49,7 @@ type ponyRepresentations struct {
 const (
 	ponyURL    = realHerd("https://theponyapi.com/api/v1/pony/random")
 	pluginName = "pony"
+	maxPonies  = 5
 )
 
 var (
@@ -124,29 +126,39 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}
-	// Make sure they are requesting a pony
-	mat := match.FindStringSubmatch(e.Body)
+	// Make sure they are requesting a pony and don't allow requesting more than 'maxPonies' defined.
+	mat := match.FindAllStringSubmatch(e.Body, maxPonies)
 	if mat == nil {
 		return nil
 	}
 
-	tag := mat[1]
 	org := e.Repo.Owner.Login
 	repo := e.Repo.Name
 	number := e.Number
 
-	for i := 0; i < 5; i++ {
-		resp, err := p.readPony(tag)
-		if err != nil {
-			log.WithError(err).Println("Failed to get a pony")
-			continue
+	var respBuilder strings.Builder
+	var tagsSpecified bool
+	for _, tag := range mat {
+		for i := 0; i < 5; i++ {
+			if tag[1] != "" {
+				tagsSpecified = true
+			}
+			resp, err := p.readPony(tag[1])
+			if err != nil {
+				log.WithError(err).Println("Failed to get a pony")
+				continue
+			}
+			respBuilder.WriteString(resp + "\n")
+			break
 		}
-		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, resp))
+	}
+	if respBuilder.Len() > 0 {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, respBuilder.String()))
 	}
 
 	var msg string
-	if tag != "" {
-		msg = "Couldn't find a pony matching that query."
+	if tagsSpecified {
+		msg = "Couldn't find a pony matching given tag(s)."
 	} else {
 		msg = "https://theponyapi.com appears to be down"
 	}


### PR DESCRIPTION
With this change, a user can request multiple ponies (/pony) in a single comment. Number of requested ponies is currently capped at 5.

Closes #13938