### PR TITLE
config/testgrids: Update OpenShift testgrids with more history

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.1-blocking.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.1-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.1
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.1-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.1-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.1
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,26 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.1
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-upgrade-4.1
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.1
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -76,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-nightly
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -97,13 +78,15 @@ dashboards:
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1
   name: redhat-openshift-ocp-release-4.1-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.1
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.1
   name: release-openshift-ocp-installer-e2e-aws-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.1
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.1
   name: release-openshift-ocp-installer-e2e-aws-serial-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1
-  name: release-openshift-origin-installer-e2e-aws-upgrade-4.1
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-nightly
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-nightly
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-nightly
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-blocking.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-console-aws-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -76,7 +76,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -95,7 +95,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-mirrors-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -114,7 +114,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-proxy-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -133,7 +133,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -152,7 +152,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -171,7 +171,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-upi-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -190,7 +190,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -209,7 +209,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -228,7 +228,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -247,7 +247,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -266,7 +266,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -285,7 +285,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -304,7 +304,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -323,7 +323,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -342,7 +342,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -361,7 +361,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -380,7 +380,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -399,7 +399,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -418,7 +418,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -437,7 +437,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -456,7 +456,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -475,26 +475,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-upgrade-4.2
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -513,7 +494,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-nightly
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -532,7 +513,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -551,7 +532,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -570,7 +551,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-upgrade-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -589,7 +570,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -608,7 +589,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -627,7 +608,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -646,7 +627,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -665,7 +646,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-openstack-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -684,7 +665,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-openstack-serial-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -705,77 +686,103 @@ dashboards:
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.2
   name: redhat-openshift-ocp-release-4.2-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.2
   name: release-openshift-ocp-installer-console-aws-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.2
   name: release-openshift-ocp-installer-e2e-aws-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.2
   name: release-openshift-ocp-installer-e2e-aws-fips-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-serial-4.2
   name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.2
   name: release-openshift-ocp-installer-e2e-aws-mirrors-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.2
   name: release-openshift-ocp-installer-e2e-aws-proxy-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
   name: release-openshift-ocp-installer-e2e-aws-rhel7-workers-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.2
   name: release-openshift-ocp-installer-e2e-aws-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.2
   name: release-openshift-ocp-installer-e2e-aws-upi-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.2
   name: release-openshift-ocp-installer-e2e-azure-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-4.2
   name: release-openshift-ocp-installer-e2e-azure-fips-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-serial-4.2
   name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.2
   name: release-openshift-ocp-installer-e2e-azure-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.2
   name: release-openshift-ocp-installer-e2e-gcp-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-4.2
   name: release-openshift-ocp-installer-e2e-gcp-fips-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
   name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.2
   name: release-openshift-ocp-installer-e2e-gcp-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.2
   name: release-openshift-ocp-installer-e2e-metal-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.2
   name: release-openshift-ocp-installer-e2e-metal-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.2
   name: release-openshift-ocp-installer-e2e-openstack-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.2
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.2
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-4.2
+- days_of_results: 17
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-4.2
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.1-to-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2
-  name: release-openshift-origin-installer-e2e-aws-upgrade-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-nightly
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-nightly
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-nightly
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.1-to-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.2
   name: release-openshift-origin-installer-e2e-azure-upgrade-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-4.2
   name: release-openshift-origin-installer-e2e-gcp-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-serial-4.2
   name: release-openshift-origin-installer-e2e-gcp-serial-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade
   name: release-openshift-origin-installer-e2e-gcp-upgrade
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.2
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-4.2
   name: release-openshift-origin-installer-e2e-openstack-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-serial-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-serial-4.2
   name: release-openshift-origin-installer-e2e-openstack-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.2
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.2
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.2

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-blocking.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-console-aws-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -76,7 +76,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -95,7 +95,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -114,7 +114,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-mirrors-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -133,7 +133,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-ovn-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -152,7 +152,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-proxy-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -171,7 +171,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -190,7 +190,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-upi-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -209,7 +209,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -228,7 +228,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -247,7 +247,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -266,7 +266,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-ovn-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -285,7 +285,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -304,7 +304,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -323,7 +323,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -342,7 +342,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -361,7 +361,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-ovn-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -380,7 +380,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -399,7 +399,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -418,7 +418,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -437,7 +437,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -456,7 +456,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -475,7 +475,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -494,7 +494,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -513,7 +513,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -532,7 +532,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-compact-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -551,7 +551,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-disruptive-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -570,7 +570,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -589,7 +589,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -608,7 +608,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -627,7 +627,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-nightly-to-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -646,26 +646,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-upgrade-4.3
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -684,7 +665,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-fips-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -703,7 +684,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2-to-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -722,7 +703,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -741,7 +722,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-compact-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -760,7 +741,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -779,7 +760,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-upgrade-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -798,7 +779,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-compact-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -817,7 +798,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -836,7 +817,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade-4.3
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -857,93 +838,130 @@ dashboards:
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
   name: redhat-openshift-ocp-release-4.3-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.3-cnv
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.3
   name: release-openshift-ocp-installer-console-aws-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.3
   name: release-openshift-ocp-installer-e2e-aws-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.3
+- days_of_results: 8
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.3
   name: release-openshift-ocp-installer-e2e-aws-fips-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-serial-4.3
   name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.3
   name: release-openshift-ocp-installer-e2e-aws-mirrors-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.3
   name: release-openshift-ocp-installer-e2e-aws-ovn-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.3
   name: release-openshift-ocp-installer-e2e-aws-proxy-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.3
   name: release-openshift-ocp-installer-e2e-aws-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.3
   name: release-openshift-ocp-installer-e2e-aws-upi-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.3
   name: release-openshift-ocp-installer-e2e-azure-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-4.3
   name: release-openshift-ocp-installer-e2e-azure-fips-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-serial-4.3
   name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.3
   name: release-openshift-ocp-installer-e2e-azure-ovn-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.3
   name: release-openshift-ocp-installer-e2e-azure-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.3
   name: release-openshift-ocp-installer-e2e-gcp-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-4.3
   name: release-openshift-ocp-installer-e2e-gcp-fips-4.3
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-serial-4.3
   name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.3
   name: release-openshift-ocp-installer-e2e-gcp-ovn-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.3
   name: release-openshift-ocp-installer-e2e-gcp-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.3
   name: release-openshift-ocp-installer-e2e-metal-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.3
   name: release-openshift-ocp-installer-e2e-metal-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.3
   name: release-openshift-ocp-installer-e2e-openstack-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.3
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.3
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.3
   name: release-openshift-origin-installer-e2e-aws-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.3
   name: release-openshift-origin-installer-e2e-aws-compact-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.3
   name: release-openshift-origin-installer-e2e-aws-disruptive-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.3
   name: release-openshift-origin-installer-e2e-aws-serial-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.3
+- days_of_results: 17
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.3
   name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-nightly-to-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-nightly-to-4.3
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-nightly-to-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-4.3
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.2-to-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3
-  name: release-openshift-origin-installer-e2e-aws-upgrade-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-fips-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-fips-4.3
   name: release-openshift-origin-installer-e2e-aws-upgrade-fips-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2-to-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2-to-4.3
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.2-to-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.3
   name: release-openshift-origin-installer-e2e-azure-compact-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.3
+- days_of_results: 17
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.3
   name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.3
   name: release-openshift-origin-installer-e2e-azure-upgrade-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.3
   name: release-openshift-origin-installer-e2e-gcp-compact-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.3
+- days_of_results: 17
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.3
   name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.3
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.3
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.3
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.3

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-blocking.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: canary-release-openshift-origin-installer-e2e-aws-4.4-cnv
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-console-aws-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -76,7 +76,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -95,7 +95,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -114,7 +114,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-mirrors-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -133,7 +133,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-ovn-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -152,7 +152,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-proxy-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -171,7 +171,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -190,7 +190,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-upi-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -209,7 +209,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -228,7 +228,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -247,7 +247,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -266,7 +266,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-ovn-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -285,7 +285,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -304,7 +304,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -323,7 +323,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -342,7 +342,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -361,7 +361,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-ovn-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -380,7 +380,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -399,7 +399,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -418,7 +418,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -437,7 +437,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -456,7 +456,26 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-ocp-installer-e2e-ovirt-4.4
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-ocp-installer-e2e-ovirt-4.4
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -475,7 +494,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -494,7 +513,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -513,7 +532,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -532,7 +551,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-compact-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -551,7 +570,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-disruptive-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -570,7 +589,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-ovn-network-stress-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -589,7 +608,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -608,7 +627,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -627,7 +646,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -646,7 +665,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -665,7 +684,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.3-nightly-to-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -684,26 +703,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-upgrade-4.4
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -722,7 +722,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-fips-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -741,7 +741,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3-to-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -760,7 +760,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -779,7 +779,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-compact-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -798,7 +798,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -817,7 +817,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-upgrade-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -836,7 +836,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-compact-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -855,7 +855,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -874,7 +874,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade-4.4
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -895,97 +895,139 @@ dashboards:
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
   name: redhat-openshift-ocp-release-4.4-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.4-cnv
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.4-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.4-cnv
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.4
   name: release-openshift-ocp-installer-console-aws-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.4
   name: release-openshift-ocp-installer-e2e-aws-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.4
   name: release-openshift-ocp-installer-e2e-aws-fips-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-serial-4.4
   name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.4
   name: release-openshift-ocp-installer-e2e-aws-mirrors-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.4
   name: release-openshift-ocp-installer-e2e-aws-ovn-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.4
   name: release-openshift-ocp-installer-e2e-aws-proxy-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.4
   name: release-openshift-ocp-installer-e2e-aws-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.4
   name: release-openshift-ocp-installer-e2e-aws-upi-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.4
   name: release-openshift-ocp-installer-e2e-azure-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-4.4
   name: release-openshift-ocp-installer-e2e-azure-fips-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-serial-4.4
   name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.4
   name: release-openshift-ocp-installer-e2e-azure-ovn-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.4
   name: release-openshift-ocp-installer-e2e-azure-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.4
   name: release-openshift-ocp-installer-e2e-gcp-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-4.4
   name: release-openshift-ocp-installer-e2e-gcp-fips-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-serial-4.4
   name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.4
   name: release-openshift-ocp-installer-e2e-gcp-ovn-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.4
   name: release-openshift-ocp-installer-e2e-gcp-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.4
   name: release-openshift-ocp-installer-e2e-metal-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.4
   name: release-openshift-ocp-installer-e2e-metal-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4
   name: release-openshift-ocp-installer-e2e-openstack-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-ovirt-4.4
+  name: release-openshift-ocp-installer-e2e-ovirt-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.4
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.4
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.4
   name: release-openshift-origin-installer-e2e-aws-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.4
   name: release-openshift-origin-installer-e2e-aws-compact-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.4
   name: release-openshift-origin-installer-e2e-aws-disruptive-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-ovn-network-stress-4.4
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-ovn-network-stress-4.4
   name: release-openshift-origin-installer-e2e-aws-ovn-network-stress-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.4
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.4
+- days_of_results: 33
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.4
   name: release-openshift-origin-installer-e2e-aws-sdn-network-stress-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.4
   name: release-openshift-origin-installer-e2e-aws-serial-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.4
   name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-nightly-to-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-nightly-to-4.4
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.3-nightly-to-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.3-to-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.4
-  name: release-openshift-origin-installer-e2e-aws-upgrade-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-fips-4.4
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-fips-4.4
   name: release-openshift-origin-installer-e2e-aws-upgrade-fips-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3-to-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3-to-4.4
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.3-to-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.4
   name: release-openshift-origin-installer-e2e-azure-compact-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.4
   name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.4
   name: release-openshift-origin-installer-e2e-azure-upgrade-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.4
   name: release-openshift-origin-installer-e2e-gcp-compact-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.4
   name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.4
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.4
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.4

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-blocking.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-blocking.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -19,7 +19,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -38,7 +38,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-console-aws-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -57,7 +57,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -76,7 +76,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -95,7 +95,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -114,7 +114,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-mirrors-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -133,7 +133,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-ovn-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -152,7 +152,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-proxy-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -171,7 +171,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -190,7 +190,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-aws-upi-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -209,7 +209,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -228,7 +228,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -247,7 +247,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -266,7 +266,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-ovn-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -285,7 +285,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-azure-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -304,7 +304,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -323,7 +323,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -342,7 +342,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -361,7 +361,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-ovn-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -380,7 +380,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -399,7 +399,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -418,7 +418,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-metal-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -437,7 +437,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -456,7 +456,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-openstack-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -475,7 +475,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -494,7 +494,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -513,7 +513,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -532,7 +532,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-compact-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -551,7 +551,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-disruptive-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -570,7 +570,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -589,7 +589,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-serial-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -608,7 +608,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -627,26 +627,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.4-to-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-aws-upgrade-4.5
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -665,7 +646,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4-to-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -684,7 +665,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -703,7 +684,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-compact-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -722,7 +703,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -741,7 +722,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-azure-upgrade-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -760,7 +741,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-compact-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -779,7 +760,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -798,7 +779,7 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade-4.5
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -819,89 +800,124 @@ dashboards:
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.5
   name: redhat-openshift-ocp-release-4.5-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.5
   name: release-openshift-ocp-installer-console-aws-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-4.5
   name: release-openshift-ocp-installer-e2e-aws-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-4.5
   name: release-openshift-ocp-installer-e2e-aws-fips-4.5
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-fips-serial-4.5
   name: release-openshift-ocp-installer-e2e-aws-fips-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-mirrors-4.5
   name: release-openshift-ocp-installer-e2e-aws-mirrors-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-ovn-4.5
   name: release-openshift-ocp-installer-e2e-aws-ovn-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-proxy-4.5
   name: release-openshift-ocp-installer-e2e-aws-proxy-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-serial-4.5
   name: release-openshift-ocp-installer-e2e-aws-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-aws-upi-4.5
   name: release-openshift-ocp-installer-e2e-aws-upi-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-4.5
   name: release-openshift-ocp-installer-e2e-azure-4.5
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-4.5
   name: release-openshift-ocp-installer-e2e-azure-fips-4.5
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-fips-serial-4.5
   name: release-openshift-ocp-installer-e2e-azure-fips-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.5
   name: release-openshift-ocp-installer-e2e-azure-ovn-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-serial-4.5
   name: release-openshift-ocp-installer-e2e-azure-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-4.5
   name: release-openshift-ocp-installer-e2e-gcp-4.5
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-4.5
   name: release-openshift-ocp-installer-e2e-gcp-fips-4.5
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-serial-4.5
   name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.5
   name: release-openshift-ocp-installer-e2e-gcp-ovn-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-serial-4.5
   name: release-openshift-ocp-installer-e2e-gcp-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-4.5
   name: release-openshift-ocp-installer-e2e-metal-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.5
   name: release-openshift-ocp-installer-e2e-metal-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.5
   name: release-openshift-ocp-installer-e2e-openstack-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.5
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-4.5
   name: release-openshift-ocp-installer-e2e-vsphere-upi-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.5
   name: release-openshift-ocp-installer-e2e-vsphere-upi-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-4.5
   name: release-openshift-origin-installer-e2e-aws-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-compact-4.5
   name: release-openshift-origin-installer-e2e-aws-compact-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-disruptive-4.5
   name: release-openshift-origin-installer-e2e-aws-disruptive-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.5
   name: release-openshift-origin-installer-e2e-aws-sdn-multitenant-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-serial-4.5
   name: release-openshift-origin-installer-e2e-aws-serial-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-shared-vpc-4.5
   name: release-openshift-origin-installer-e2e-aws-shared-vpc-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.4-to-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.4-to-4.5
   name: release-openshift-origin-installer-e2e-aws-upgrade-4.4-to-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-4.5
-  name: release-openshift-origin-installer-e2e-aws-upgrade-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4-to-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4-to-4.5
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.4-to-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5
   name: release-openshift-origin-installer-e2e-aws-upgrade-rollback-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-compact-4.5
   name: release-openshift-origin-installer-e2e-azure-compact-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-shared-vpc-4.5
   name: release-openshift-origin-installer-e2e-azure-shared-vpc-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-azure-upgrade-4.5
   name: release-openshift-origin-installer-e2e-azure-upgrade-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-compact-4.5
   name: release-openshift-origin-installer-e2e-gcp-compact-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-shared-vpc-4.5
   name: release-openshift-origin-installer-e2e-gcp-shared-vpc-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.5
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.5
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.5
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.5

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.3-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.3-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -21,5 +21,6 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.3
   name: redhat-openshift-okd-release-4.3-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.3
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.3
   name: release-openshift-okd-installer-e2e-aws-4.3

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.4-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -21,5 +21,6 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.4
   name: redhat-openshift-okd-release-4.4-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.4
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.4
   name: release-openshift-okd-installer-e2e-aws-4.4

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.5-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.5-informing.yaml
@@ -1,6 +1,6 @@
 dashboards:
 - dashboard_tab:
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
       url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
@@ -21,5 +21,6 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.5
   name: redhat-openshift-okd-release-4.5-informing
 test_groups:
-- gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.5
   name: release-openshift-okd-installer-e2e-aws-4.5


### PR DESCRIPTION
A number of periodics have long intervals, so we only collect a small
number of those jobs. Increase the number of those jobs. Also omit
a second test from the global list (from the openshift ci infra) that
isn't relevant for display and helps clarify the flake rate more.

Finally, regen against some updated jobs.

Generated with https://github.com/openshift/ci-tools/pull/365

/assign @stevekuznetsov 