### PR TITLE
Kops - Enable privileged mode for dind

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -422,6 +422,8 @@ presubmits:
         resources:
           requests:
             memory: "2Gi"
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: presubmits-kops
       testgrid-tab-name: verify


### PR DESCRIPTION
The new kops verify job uses docker, so we need not only the preset but privileged mode as well