### PR TITLE
Fix setting up prometheus on kubemark cluster by using newer perf-tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -348,7 +348,9 @@ periodics:
     containers:
     - args:
       - --repo=k8s.io/kubernetes=release-1.14
-      - --repo=k8s.io/perf-tests=release-1.14
+      # Use newer perf-tests branch with additional fixes for kubemark
+      # This mismatch is intended only for release branches older than 1.16
+      - --repo=k8s.io/perf-tests=release-1.16
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -221,7 +221,9 @@ periodics:
     containers:
     - args:
       - --repo=k8s.io/kubernetes=release-1.15
-      - --repo=k8s.io/perf-tests=release-1.15
+      # Use newer perf-tests branch with additional fixes for kubemark
+      # This mismatch is intended only for release branches older than 1.16
+      - --repo=k8s.io/perf-tests=release-1.16
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Use 1.16 perf-tests branch in older kubemark tests.

Older perf-tests branches (1.14, 1.15) have some problems with setting up Prometheus stack.
This solution takes less time that debugging all issues on those branches but in the same time it does not invalidate the promise/reason for creation of perf-tests branches - so that changes on perf-tests master would not break presubmits/release breaking tests on old releases.

In general, perf-tests branches should match kubernetes branches, however value of keeping purity of such assignments on old branches is probably not worth time spent on debugging all issues on them.
This assignment should be eventually consistent ;), as new releases would have 1 to 1 mapping to perf-tests, and old branches will be gradually phased out.

Ref: https://github.com/kubernetes/kubernetes/issues/87200

/cc mm4tt