### PR TITLE
Azure: Add run_if_changed field in job configuration

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-azure
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.15
     labels:
@@ -49,6 +50,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.15
     labels:
@@ -96,6 +98,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk-vmss
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.15
     labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-azure
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.16
     labels:
@@ -49,6 +50,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.16
     labels:
@@ -96,6 +98,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk-vmss
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.16
     labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-azure
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.17
     labels:
@@ -49,6 +50,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.17
     labels:
@@ -96,6 +98,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk-vmss
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - release-1.17
     labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -3,6 +3,7 @@ presubmits:
   - name: pull-kubernetes-e2e-aks-engine-azure
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - master
     labels:
@@ -54,6 +55,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - master
     labels:
@@ -106,6 +108,7 @@ presubmits:
   - name: pull-kubernetes-e2e-azure-disk-vmss
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     branches:
     - master
     labels:
@@ -159,6 +162,7 @@ presubmits:
     decorate: true
     always_run: false
     optional: true
+    run_if_changed: 'azure.*\.go'
     path_alias: k8s.io/kubernetes
     branches:
     - master


### PR DESCRIPTION
This will automatically run Azure-related presubmit jobs without commenting `/test pull-kubernetes-e2e-...` if any file with a prefix `azure` is modified in the PR.

/assign @feiskyer 