### PR TITLE
Migrate GKE jobs to us-west1-c

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -1273,7 +1273,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1305,7 +1305,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1338,7 +1338,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1370,7 +1370,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1402,7 +1402,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1435,7 +1435,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1468,7 +1468,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1536,7 +1536,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1568,7 +1568,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1601,7 +1601,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1633,7 +1633,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1665,7 +1665,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1698,7 +1698,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1731,7 +1731,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1799,7 +1799,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1831,7 +1831,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1864,7 +1864,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1896,7 +1896,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1928,7 +1928,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1961,7 +1961,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -1994,7 +1994,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2062,7 +2062,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2094,7 +2094,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2127,7 +2127,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2159,7 +2159,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2191,7 +2191,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2224,7 +2224,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2257,7 +2257,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-1
@@ -2325,7 +2325,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2357,7 +2357,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2390,7 +2390,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2422,7 +2422,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2454,7 +2454,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2487,7 +2487,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2520,7 +2520,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2588,7 +2588,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2620,7 +2620,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2653,7 +2653,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2685,7 +2685,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2717,7 +2717,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2750,7 +2750,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2783,7 +2783,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2851,7 +2851,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2883,7 +2883,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2916,7 +2916,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2948,7 +2948,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -2980,7 +2980,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3013,7 +3013,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3046,7 +3046,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3114,7 +3114,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3146,7 +3146,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3179,7 +3179,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3211,7 +3211,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3243,7 +3243,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3276,7 +3276,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3309,7 +3309,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --image-family=pipeline-2
@@ -3521,7 +3521,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3552,7 +3552,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3582,7 +3582,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3614,7 +3614,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3645,7 +3645,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3850,7 +3850,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3881,7 +3881,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3911,7 +3911,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3942,7 +3942,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -3973,7 +3973,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4177,7 +4177,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4208,7 +4208,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4238,7 +4238,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4269,7 +4269,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4300,7 +4300,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4504,7 +4504,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4535,7 +4535,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4565,7 +4565,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4596,7 +4596,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci
@@ -4627,7 +4627,7 @@ periodics:
       - --check-leaked-resources
       - --provider=gke
       - --deployment=gke
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gke-environment=test
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -19,7 +19,7 @@ periodics:
       - --deployment=gke
       - --extract=gke
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=prod
       - --provider=gke
       - --test=false

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -293,7 +293,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-e2e-gci-gke-autoscaling
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -72,7 +72,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gke.yaml
@@ -28,7 +28,7 @@ presubmits:
         - --extract=local
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
         - --gke-environment=test
@@ -61,7 +61,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
       - --gke-environment=test
@@ -91,7 +91,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --quiet --enable-kubernetes-alpha
       - --gke-environment=test
       - --provider=gke
@@ -120,7 +120,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-create-command=container clusters create --quiet --enable-kubernetes-alpha
       - --gke-environment=test
@@ -150,7 +150,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
@@ -178,7 +178,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --gke-node-locations=us-central1-f,us-central1-a,us-central1-b
@@ -208,7 +208,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
@@ -236,7 +236,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -264,7 +264,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke
@@ -292,7 +292,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke
@@ -404,7 +404,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke
@@ -434,7 +434,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-gke-gci-soak
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --save=gs://kubernetes-e2e-soak-configs/ci-kubernetes-soak-gke-gci
@@ -470,7 +470,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=istio-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-command-group=alpha
       - --gke-create-command=container clusters create --quiet --num-nodes=4 --no-enable-legacy-authorization --addons=Istio --istio-config=auth=NONE
       - --gke-environment=test

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -86,7 +86,7 @@ presubmits:
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
         - --gcp-project=k8s-gke-gpu-pr
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
         - --gke-environment=test

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gke.yaml
@@ -17,7 +17,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke
@@ -47,7 +47,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke
@@ -77,7 +77,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke
@@ -105,7 +105,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-p100,count=2
       - --gke-environment=test
       - --provider=gke
@@ -135,7 +135,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-p100,count=2
       - --gke-environment=test
       - --provider=gke
@@ -165,7 +165,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-p100,count=2
       - --gke-environment=test
       - --provider=gke
@@ -195,7 +195,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-p100,count=2
       - --gke-environment=test
       - --provider=gke
@@ -225,7 +225,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke
@@ -255,7 +255,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke
@@ -286,7 +286,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
       - --gcp-project-type=gpu-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
       - --gke-environment=test
       - --provider=gke

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gke.yaml
@@ -181,7 +181,7 @@ periodics:
       - --extract=ci/k8s-stable2
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
@@ -368,7 +368,7 @@ periodics:
       - --extract=ci/k8s-stable3
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke
@@ -399,7 +399,7 @@ periodics:
       - --extract=ci/k8s-stable3
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke
@@ -431,7 +431,7 @@ periodics:
       - --extract=ci/k8s-stable3
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --ginkgo-parallel
       - --gke-environment=test
       - --provider=gke

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -68,7 +68,7 @@ periodics:
       - --extract=ci/k8s-beta
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -95,7 +95,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -122,7 +122,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -149,7 +149,7 @@ periodics:
       - --extract=ci/k8s-beta
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -176,7 +176,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -203,7 +203,7 @@ periodics:
       - --extract=ci/k8s-stable1
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
@@ -231,7 +231,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project=k8s-jkns-e2e-gke-stackdriver
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -432,7 +432,7 @@ periodics:
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
       - --gcp-project-type=ingress-project
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -461,7 +461,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
+      - --gcp-zone=us-west1-c
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[Feature:NetworkPolicy\] --minStartupPods=8

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -552,7 +552,7 @@ presubmits:
         - --extract=local
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling,KubernetesDashboard
         - --gke-environment=test
@@ -638,7 +638,7 @@ presubmits:
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
         - --gcp-project=k8s-gke-gpu-pr
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
         - --gke-environment=test

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -611,7 +611,7 @@ presubmits:
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
         - --gcp-project=k8s-gke-gpu-pr
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
         - --gke-environment=test
@@ -738,7 +738,7 @@ presubmits:
         - --extract=local
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
         - --gke-environment=test

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -617,7 +617,7 @@ presubmits:
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
         - --gcp-project=k8s-gke-gpu-pr
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
         - --gke-environment=test
@@ -740,7 +740,7 @@ presubmits:
         - --extract=local
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
         - --gke-environment=test

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -713,7 +713,7 @@ presubmits:
         - --extract=local
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --quiet --addons=HttpLoadBalancing,HorizontalPodAutoscaling
         - --gke-environment=test
@@ -799,7 +799,7 @@ presubmits:
         - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
         - --gcp-node-image=gci
         - --gcp-project=k8s-gke-gpu-pr
-        - --gcp-zone=us-west1-b
+        - --gcp-zone=us-west1-c
         - --ginkgo-parallel=30
         - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
         - --gke-environment=test

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -770,7 +770,7 @@ cloudProviders:
     - --check-leaked-resources
     - --provider=gke
     - --deployment=gke
-    - --gcp-zone=us-west1-b
+    - --gcp-zone=us-west1-c
     - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
     - --gke-environment=test
 


### PR DESCRIPTION
They are currently failing to start in us-west1-b.

Non-GKE jobs in us-west1-b are fine, so leave those there.

/cc @michelle192837 