### PR TITLE
Enable the new crier GCS reporter

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -41,6 +41,8 @@ spec:
         - --github-endpoint=https://api.github.com
         - --slack-workers=1
         - --slack-token-file=/etc/slack/token
+        - --gcs-workers=1
+        - --gcs-credentials-file=/etc/service-account/service-account.json
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -53,6 +55,9 @@ spec:
           readOnly: true
         - name: slack
           mountPath: /etc/slack
+          readOnly: true
+        - name: service-account
+          mountPath: /etc/service-account
           readOnly: true
       volumes:
       - name: config
@@ -67,3 +72,6 @@ spec:
       - name: slack
         secret:
           secretName: slack-token
+      - name: service-account
+        secret:
+          secretName: service-account


### PR DESCRIPTION
Turn on the new GCS reporter, implemented in #15785 and described [in this design doc](https://docs.google.com/document/d/1MYOGrRDg5JG20Qn8zvPRfR6HV41haxTkLEVUbpCb4wk/edit?usp=sharing).

/cc @michelle192837 