### PR TITLE
Fix a few bugs in the Boskos GCP janitor

### DIFF
--- a/boskos/janitor/BUILD.bazel
+++ b/boskos/janitor/BUILD.bazel
@@ -42,7 +42,7 @@ pkg_tar(
 
 container_image(
     name = "janitor_image",
-    base = "@gcloud-go//image",
+    base = "@cloud-sdk-slim//image",
     tars = [":janitor_tar"],
 )
 

--- a/boskos/janitor/gcp_janitor.py
+++ b/boskos/janitor/gcp_janitor.py
@@ -39,7 +39,6 @@ DEMOLISH_ORDER = [
     Resource('', 'compute', 'disks', None, 'zone', None, False, True),
     Resource('', 'compute', 'disks', None, 'region', None, False, True),
     Resource('', 'compute', 'firewall-rules', None, None, None, False, True),
-    Resource('', 'compute', 'routes', None, None, None, False, True),
     Resource('', 'compute', 'forwarding-rules', None, 'global', None, False, True),
     Resource('', 'compute', 'forwarding-rules', None, 'region', None, False, True),
     Resource('', 'compute', 'target-http-proxies', None, 'global', None, False, True),
@@ -64,10 +63,10 @@ DEMOLISH_ORDER = [
     Resource('', 'compute', 'sole-tenancy', 'node-groups', 'zone', None, False, True),
     Resource('', 'compute', 'sole-tenancy', 'node-templates', 'region', None, False, True),
     Resource('', 'compute', 'network-endpoint-groups', None, 'zone', None, False, False),
-    Resource('', 'compute', 'networks', 'subnets', 'region', None, True, True),
-    Resource('', 'compute', 'networks', None, None, None, False, True),
     Resource('', 'compute', 'routes', None, None, None, False, True),
     Resource('', 'compute', 'routers', None, 'region', None, False, True),
+    Resource('', 'compute', 'networks', 'subnets', 'region', None, True, True),
+    Resource('', 'compute', 'networks', None, None, None, False, True),
 
     # logging resources
     Resource('', 'logging', 'sinks', None, None, None, False, False),

--- a/containers.bzl
+++ b/containers.bzl
@@ -86,3 +86,11 @@ def repositories():
         repository = "cloud-marketplace-containers/google/bazel",
         tag = "1.2.0",
     )
+
+    container_pull(
+        name = "cloud-sdk-slim",
+        digest = "sha256:6dafecdad80abf6470eae9e0b57fc083d1f3413fa15b9fab7c2ad3a102d244c4",  # 2020/01/21
+        registry = "gcr.io",
+        repository = "google.com/cloudsdktool/cloud-sdk",
+        tag = "277.0.0-slim",
+    )


### PR DESCRIPTION
This PR addresses a few issues I discovered in the Boskos GCP janitor.

The main issue is that subcommands fall into a few different categories w.r.t. location flags:
- some operate only at the global level, and thus expect no flags at all
- some operate only at zonal
- some operate only at regional
- some operate at only zonal + regional
- some operate at zonal + global
- some operate at regional + global

The existing logic conflates these categories. I've changed things to make it explicit which flags/options are expected, as well as updating the subcommands to reflect the correct flag values.
I've additionally added support for regional GKE clusters, and fixed the ordering of deletion (networks should be last).

I switched the GCP janitor to use the official cloud SDK image rather than `gcloud-in-go`, since the current version of `gcloud-in-go` used in test-infra is about a year old. I don't feel strongly about this, and would be willing to revert if we update the dependency.