### PR TITLE
Enable the GCS reporter (again)

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -41,6 +41,8 @@ spec:
         - --github-endpoint=https://api.github.com
         - --slack-workers=1
         - --slack-token-file=/etc/slack/token
+        - --gcs-workers=1
+        - --gcs-credentials-file=/etc/service-account/service-account.json
         volumeMounts:
         - name: config
           mountPath: /etc/config
@@ -53,6 +55,9 @@ spec:
           readOnly: true
         - name: slack
           mountPath: /etc/slack
+          readOnly: true
+        - name: service-account
+          mountPath: /etc/service-account
           readOnly: true
       volumes:
       - name: config
@@ -67,3 +72,6 @@ spec:
       - name: slack
         secret:
           secretName: slack-token
+      - name: service-account
+        secret:
+          secretName: service-account


### PR DESCRIPTION
Turn on the GCS reporter.

I'll monitor this and handle anything that goes wrong, but not until after my next meeting, so holding until then

/hold
/cc @michelle192837 @fejta 