### PR TITLE
OWNERS: Add Katharine and justaugustus as approvers for generated tests

### DIFF
--- a/config/jobs/kubernetes/generated/OWNERS
+++ b/config/jobs/kubernetes/generated/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- justaugustus
+- Katharine
 - krzyzacy
 - yguo0905
+
+labels:
+- sig/release
+- area/release-eng

--- a/releng/OWNERS
+++ b/releng/OWNERS
@@ -3,6 +3,7 @@
 approvers:
 - calebamiles
 - justaugustus
+- Katharine
 - tpepper
 
 reviewers:


### PR DESCRIPTION
(cp from https://github.com/kubernetes/test-infra/pull/15875)

- releng/

  Katharine wrote the tools in this directory, so it makes sense that
  she should have ownership here. This was missed when I did the initial
  copy/paste of another releng OWNERS file.

- config/jobs/kubernetes/generated/

  The content of this directory is the output of running the
  generate_tests.py script.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>