### PR TITLE
sig-node: Clean up some testgrid annotations and config suffixes

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -4,7 +4,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 1h 2h 6h 24h
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-master
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
@@ -60,10 +59,10 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-alpha
+
 - name: ci-kubernetes-node-kubelet-benchmark
   interval: 2h
   labels:
@@ -90,10 +89,10 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-benchmark
+
 - name: ci-kubernetes-node-kubelet-conformance
   interval: 2h
   labels:
@@ -124,10 +123,10 @@ periodics:
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-conformance
+
 - name: ci-kubernetes-node-kubelet-features
   interval: 1h
   labels:
@@ -135,7 +134,6 @@ periodics:
     preset-k8s-ssh: "true"
   annotations:
     fork-per-release: "true"
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-node-kubelet, sig-release-master-informing
     testgrid-tab-name: node-kubelet-features
   spec:
@@ -186,10 +184,10 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-flaky
+
 - name: ci-kubernetes-node-kubelet-orphans
   interval: 12h
   labels:
@@ -216,10 +214,10 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-orphans
+
 - name: ci-kubernetes-node-kubelet-serial
   interval: 4h30m
   labels:
@@ -246,10 +244,10 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-serial
+
 - name: ci-kubernetes-node-kubelet-serial-alpha
   interval: 3h30m
   labels:
@@ -279,6 +277,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-serial-alpha
+
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h
   labels:
@@ -306,6 +305,6 @@ periodics:
       - name: GOPATH
         value: /go
   annotations:
-    testgrid-dashboards: wg-resource-management
+    testgrid-dashboards: wg-resource-management, sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-cpu-manager
     testgrid-alert-email: balaji.warft@gmail.com, connor.p.d@gmail.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -31,8 +31,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-periodic-interval: ""
-    testgrid-dashboards: sig-release-1.14-blocking, sig-node-kubelet,
-      sig-node-cri-1.12
+    testgrid-dashboards: sig-release-1.14-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.14
   interval: 24h
   labels:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -60,7 +60,6 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.15-blocking, sig-node-kubelet
@@ -69,7 +68,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-stable2
+  name: ci-kubernetes-node-kubelet-1-15
   spec:
     containers:
     - args:
@@ -94,13 +93,13 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-node-kubelet, sig-release-1.15-informing
+    testgrid-tab-name: node-kubelet-features-1.15
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-features-stable2
+  name: ci-kubernetes-node-kubelet-features-1-15
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -60,7 +60,6 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-node-kubelet
@@ -69,7 +68,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-stable1
+  name: ci-kubernetes-node-kubelet-1-16
   spec:
     containers:
     - args:
@@ -94,14 +93,13 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-node-kubelet, sig-release-1.16-informing
-    testgrid-tab-name: node-kubelet-features-stable1
+    testgrid-tab-name: node-kubelet-features-1.16
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-features-stable1
+  name: ci-kubernetes-node-kubelet-features-1-16
   spec:
     containers:
     - args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -95,7 +95,6 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-node-kubelet
@@ -104,7 +103,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-beta
+  name: ci-kubernetes-node-kubelet-1-17
   spec:
     containers:
     - args:
@@ -129,14 +128,13 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-node-kubelet, sig-release-1.17-informing
-    testgrid-tab-name: node-kubelet-features-beta
+    testgrid-tab-name: node-kubelet-features-1.17
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-features-beta
+  name: ci-kubernetes-node-kubelet-features-1-17
   spec:
     containers:
     - args:

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -6,48 +6,6 @@
 
 # Start testgroups
 test_groups:
-- name: ci-kubernetes-node-kubelet-benchmark
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-features
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-features
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-orphans
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-orphans
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-serial
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-serial-cpu-manager
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-cpu-manager
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
 - name: ci-cri-containerd-node-e2e
   gcs_prefix: kubernetes-jenkins/logs/ci-cri-containerd-node-e2e
   test_name_config:
@@ -141,62 +99,6 @@ test_groups:
   days_of_results: 60
   num_columns_recent: 3
   num_failures_to_alert: 1
-- name: ci-kubernetes-node-kubelet-flaky
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-flaky
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-conformance
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-alpha
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-alpha
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-beta
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-beta
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-features-beta
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-features-beta
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-stable1
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable1
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-stable2
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable2
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-stable3
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-stable3
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
 
 # Canonical Distribution of Kubernetes (contact: @chuckbutler on github)
 - name: canonical-kubernetes-e2e-gce

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -7,7 +7,6 @@ dashboard_groups:
     - sig-node-ppc64le
     - sig-node-cri-o
     - sig-node-cri
-    - sig-node-cri-1.12
     - sig-node-arm64
     - sig-node-docker
     - sig-node-node-problem-detector
@@ -57,7 +56,6 @@ dashboards:
       base_options: width=10
 
 - name: sig-node-cri
-- name: sig-node-cri-1.12
 - name: sig-node-arm64
   dashboard_tab:
     - name: conformance


### PR DESCRIPTION
(cp from https://github.com/kubernetes/test-infra/pull/15875)

- Remove sig-node-cri-1.12 dashboard
  Dashboard will no longer be in use once we remove the 1.14 release jobs.
- Fix testgrid annotations and suffixes for node-kubelet jobs

/assign @dchen1107 @derekwaynecarr 