### PR TITLE
Kops - update CentOS 7 AMI for newer instance type support

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
@@ -128,7 +128,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-ubuntu-18.04
 
-- interval: 4h
+- interval: 1h
   name: ci-kubernetes-e2e-kops-aws-imagecentos7
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
@@ -148,7 +148,7 @@ periodics:
       - --env=KUBE_SSH_USER=centos
       - --extract=ci/latest
       - --ginkgo-parallel
-      - --kops-args=--image=ami-4bf3d731
+      - --kops-args=--image=ami-02eac2c0129f6376b
       - --kops-ssh-user=centos
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --kops-zones=us-east-1c


### PR DESCRIPTION
Currently this job's master instance isn't even launching because the AMI doesn't support the c5.large instance type we're using for masters. This newer AMI should add support for ENA/NVMe.

I was hoping this AMI would be published in a trusted place such as the [centos wiki](https://wiki.centos.org/Cloud/AWS) but its a little more involved. One needs to use CentOS 7 marketplace product code listed on that page and the aws-cli to find this AMI ID. I was having trouble getting it to show up in search results in the management console.

If this E2E turns green I'll update the kops documentation for centos7.

`aws --region us-east-1 ec2 describe-images --filters "Name=product-code,Values=aw0evgkw8e5c1q413zgy5pjce" --filters "Name=name,Values=CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-05713873c6794f575.4"`
```json
{
    "Images": [
        {
            "Architecture": "x86_64",
            "CreationDate": "2019-01-30T23:40:58.000Z",
            "ImageId": "ami-02eac2c0129f6376b",
            "ImageLocation": "aws-marketplace/CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-05713873c6794f575.4",
            "ImageType": "machine",
            "Public": true,
            "OwnerId": "679593333241",
            "ProductCodes": [
                {
                    "ProductCodeId": "aw0evgkw8e5c1q413zgy5pjce",
                    "ProductCodeType": "marketplace"
                }
            ],
            "State": "available",
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/sda1",
                    "Ebs": {
                        "DeleteOnTermination": false,
                        "SnapshotId": "snap-010d360e3cba720ba",
                        "VolumeSize": 8,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    }
                }
            ],
            "Description": "CentOS Linux 7 x86_64 HVM EBS ENA 1901_01",
            "EnaSupport": true,
            "Hypervisor": "xen",
            "ImageOwnerAlias": "aws-marketplace",
            "Name": "CentOS Linux 7 x86_64 HVM EBS ENA 1901_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-05713873c6794f575.4",
            "RootDeviceName": "/dev/sda1",
            "RootDeviceType": "ebs",
            "SriovNetSupport": "simple",
            "VirtualizationType": "hvm"
        }
    ]
}
```

EDIT: now I think I understand the situation better. The user needs to "subscribe" to the marketplace offering [here](https://aws.amazon.com/marketplace/pp/Centosorg-CentOS-7-x8664-with-Updates-HVM/B00O7WM7QW) before it will show up in their "Private Images" option of the AMI page. I'm not sure if this job will work without an admin of the infra AWS account subscribing to that image, but we can give it a shot.