### PR TITLE
Add more logging to the GCS reporter

### DIFF
--- a/prow/gcs/reporter/reporter_test.go
+++ b/prow/gcs/reporter/reporter_test.go
@@ -72,9 +72,10 @@ func TestIsErrUnexpected(t *testing.T) {
 		},
 	}
 
+	gr := newWithAuthor(fca{}.Config, nil, false)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			result := isErrUnexpected(tc.err)
+			result := gr.isErrUnexpected(tc.err)
 			if result != tc.unexpected {
 				t.Errorf("Expected isErrUnexpected() to return %v, got %v", tc.unexpected, result)
 			}


### PR DESCRIPTION
It is not uploading `started.json` and not reporting any errors. Add logging so we have some idea what it does think it's doing.