### PR TITLE
Azure: Leverage log dump script from cloud-provider-azure for other jobs

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -864,20 +864,19 @@ func (c *Cluster) uploadToAzureStorage(filePath string) (string, error) {
 	return blobURLString.String(), nil
 }
 
-func getApiModelTemplate(url string, downloadPath string, retry int) (string, error) {
-
-	f, err := os.Create(downloadPath)
+func downloadFromURL(url string, destination string, retry int) (string, error) {
+	f, err := os.Create(destination)
 	if err != nil {
 		return "", err
 	}
 	defer f.Close()
 
 	for i := 0; i < retry; i++ {
-		log.Printf("downloading %v from %v.", downloadPath, url)
+		log.Printf("downloading %v from %v", destination, url)
 		if err := httpRead(url, f); err == nil {
 			break
 		}
-		err = fmt.Errorf("url=%s failed get %v: %v.", url, downloadPath, err)
+		err = fmt.Errorf("url=%s failed get %v: %v", url, destination, err)
 		if i == retry-1 {
 			return "", err
 		}
@@ -885,8 +884,7 @@ func getApiModelTemplate(url string, downloadPath string, retry int) (string, er
 		sleep(time.Duration(i) * time.Second)
 	}
 	f.Chmod(0644)
-	return downloadPath, nil
-
+	return destination, nil
 }
 
 func getZipBuildScript(buildScriptURL string, retry int) (string, error) {
@@ -938,26 +936,26 @@ func (c *Cluster) buildWinZip() error {
 
 func (c *Cluster) Up() error {
 	var err error
-	if *aksCcm == true {
+	if *aksCcm {
 		err = c.buildAzureCloudComponents()
 		if err != nil {
 			return fmt.Errorf("error building Azure cloud components: %v", err)
 		}
 	}
-	if *aksHyperKube == true || c.aksDeploymentMethod == customHyperkube {
+	if *aksHyperKube || c.aksDeploymentMethod == customHyperkube {
 		err = c.buildHyperKube()
 		if err != nil {
 			return fmt.Errorf("error building hyperkube %v", err)
 		}
 	}
-	if *aksWinBinaries == true {
+	if *aksWinBinaries {
 		err = c.buildWinZip()
 		if err != nil {
 			return fmt.Errorf("error building windowsZipFile %v", err)
 		}
 	}
 	if c.apiModelPath != "" {
-		templateFile, err := getApiModelTemplate(c.apiModelPath, path.Join(c.outputDir, "kubernetes.json"), 2)
+		templateFile, err := downloadFromURL(c.apiModelPath, path.Join(c.outputDir, "kubernetes.json"), 2)
 		if err != nil {
 			return fmt.Errorf("error downloading ApiModel template: %v with error %v", c.apiModelPath, err)
 		}
@@ -1051,26 +1049,24 @@ func (c *Cluster) Down() error {
 }
 
 func (c *Cluster) DumpClusterLogs(localPath, gcsPath string) error {
-	if *aksCcm == false {
-		log.Println("Skippng DumpClusterLogs due to CCM not being enabled.")
-		return nil
-	}
 	if err := os.Setenv("ARTIFACTS", localPath); err != nil {
 		return err
 	}
 
-	logDumpDir := util.K8sSigs("cloud-provider-azure", "hack", "log-dump")
-	if _, err := os.Stat(filepath.Join(logDumpDir, "log-dump.sh")); os.IsNotExist(err) {
-		return fmt.Errorf("log-dump.sh not found in cloud-provider-azure repo")
+	// Extract log dump script and manifest from cloud-provider-azure repo
+	const logDumpURLPrefix string = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/"
+	logDumpScript, err := downloadFromURL(logDumpURLPrefix+"log-dump.sh", path.Join(c.outputDir, "log-dump.sh"), 2)
+	if err != nil {
+		return fmt.Errorf("error downloading log dump script: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(logDumpDir, "log-dump-daemonset.yaml")); os.IsNotExist(err) {
-		return fmt.Errorf("log-dump-daemonset.yaml not found in cloud-provider-azure repo")
+	if err := control.FinishRunning(exec.Command("chmod", "+x", logDumpScript)); err != nil {
+		return fmt.Errorf("error changing access premission for %s: %v", logDumpScript, err)
+	}
+	if _, err := downloadFromURL(logDumpURLPrefix+"log-dump-daemonset.yaml", path.Join(c.outputDir, "log-dump-daemonset.yaml"), 2); err != nil {
+		return fmt.Errorf("error downloading log dump manifest: %v", err)
 	}
 
-	cmd := exec.Command("bash", "-c", "./log-dump.sh")
-	cmd.Dir = logDumpDir
-	err := control.FinishRunning(cmd)
-	return err
+	return control.FinishRunning(exec.Command("bash", "-c", logDumpScript))
 }
 
 func (c *Cluster) GetClusterCreated(clusterName string) (time.Time, error) {
@@ -1079,7 +1075,7 @@ func (c *Cluster) GetClusterCreated(clusterName string) (time.Time, error) {
 
 func (c *Cluster) TestSetup() error {
 	// set env vars required by the ccm e2e tests
-	if *testCcm == true {
+	if *testCcm {
 		if err := os.Setenv("K8S_AZURE_TENANTID", c.credentials.TenantID); err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently, we only run log dump script when we are testing out-of-tree cloud controller manager. We should leverage it for other jobs so we could have more information to debug failing jobs.

Log output for non out-of-tree cloud controller manager job:
```
W0116 18:36:52.780] 2020/01/16 18:36:52 azure.go:875: downloading /workspace/aks956443354/log-dump.sh from https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/log-dump.sh
W0116 18:36:52.780] 2020/01/16 18:36:52 util.go:42: curl https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/log-dump.sh
W0116 18:36:52.905] 2020/01/16 18:36:52 process.go:153: Running: chmod +x /workspace/aks956443354/log-dump.sh
W0116 18:36:52.907] 2020/01/16 18:36:52 process.go:155: Step 'chmod +x /workspace/aks956443354/log-dump.sh' finished in 1.792113ms
W0116 18:36:52.907] 2020/01/16 18:36:52 azure.go:875: downloading /workspace/aks956443354/log-dump-daemonset.yaml from https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/log-dump-daemonset.yaml
W0116 18:36:52.908] 2020/01/16 18:36:52 util.go:42: curl https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/log-dump-daemonset.yaml
W0116 18:36:53.049] 2020/01/16 18:36:53 process.go:153: Running: bash -c /workspace/aks956443354/log-dump.sh
I0116 18:36:53.149] Installing log-dump-daemonset.yaml via kubectl
I0116 18:36:53.420] daemonset.apps/log-dump-node created
I0116 18:37:15.332] pod/log-dump-node-6zzz8 condition met
I0116 18:37:15.343] pod/log-dump-node-hrzlp condition met
I0116 18:37:15.356] pod/log-dump-node-lqx9n condition met
I0116 18:37:15.359] pod/log-dump-node-wpmfv condition met
I0116 18:37:15.361] All pods from log-dump-daemonset are ready
I0116 18:37:15.538] NAME                  READY   STATUS    RESTARTS   AGE   IP             NODE                                 NOMINATED NODE   READINESS GATES
I0116 18:37:15.538] log-dump-node-6zzz8   1/1     Running   0          22s   10.240.0.117   k8s-master-24867868-0                <none>           <none>
I0116 18:37:15.538] log-dump-node-hrzlp   1/1     Running   0          22s   10.240.0.60    k8s-agentpool1-24867868-vmss000001   <none>           <none>
I0116 18:37:15.539] log-dump-node-lqx9n   1/1     Running   0          22s   10.240.0.70    k8s-agentpool1-24867868-vmss000002   <none>           <none>
I0116 18:37:15.539] log-dump-node-wpmfv   1/1     Running   0          22s   10.240.0.33    k8s-agentpool1-24867868-vmss000000   <none>           <none>
I0116 18:37:15.984] Creating /workspace/_artifacts/k8s-master-24867868-0 for storing k8s-master-24867868-0's logs
I0116 18:37:15.989] Dumping kube-addon-manager-k8s-master-24867868-0_kube-system_kube-addon-manager-bc11e7203eb537d620c54f8b03e3eb2f5ff2193b2f44b91d45cc98f2815664d5.log
I0116 18:37:16.223] Dumping kube-apiserver-k8s-master-24867868-0_kube-system_kube-apiserver-fb7611d5e44b9503c460466c0f43d52fc88a5f63b9219471351158ab0f125357.log
I0116 18:37:16.483] Dumping kube-controller-manager-k8s-master-24867868-0_kube-system_kube-controller-manager-f180df4390541c029872127635a9ed9908ed90a6b9e4d7759a486e79f0f9384c.log
I0116 18:37:16.719] Dumping kube-proxy-mscfn_kube-system_kube-proxy-dd2c9d434702334d2664b4d7ce2b8ff9ba5994587f629b891beebee4a455405e.log
I0116 18:37:16.955] Dumping kube-scheduler-k8s-master-24867868-0_kube-system_kube-scheduler-d1b605d551d15fc49c50036ac666d7d39fc307cadd8b6d620a2b22b8d61f1c1c.log
I0116 18:37:17.193] Dumping kubelet.log
I0116 18:37:17.533] Dumping docker.log
I0116 18:37:17.778] Dumping etcd.log
I0116 18:37:18.011] Finished dumping logs for k8s-master-24867868-0
I0116 18:37:18.337] Creating /workspace/_artifacts/k8s-agentpool1-24867868-vmss000001 for storing k8s-agentpool1-24867868-vmss000001's logs
I0116 18:37:18.342] Dumping kube-proxy-6rq6s_kube-system_kube-proxy-0112ae8d13b0ac56bf35c15480fc83512710cb85e32067595a827a522dfcdb19.log
I0116 18:37:18.576] Dumping kubelet.log
I0116 18:37:18.924] Dumping docker.log
I0116 18:37:19.168] Dumping etcd.log
I0116 18:37:19.415] Finished dumping logs for k8s-agentpool1-24867868-vmss000001
I0116 18:37:19.759] Creating /workspace/_artifacts/k8s-agentpool1-24867868-vmss000002 for storing k8s-agentpool1-24867868-vmss000002's logs
I0116 18:37:19.764] Dumping kube-proxy-8mdh4_kube-system_kube-proxy-8065b770747566d72dff802c6c71aaca588cfc2e3ba0651505a333e79d526d93.log
I0116 18:37:20.015] Dumping kubelet.log
I0116 18:37:20.355] Dumping docker.log
I0116 18:37:20.623] Dumping etcd.log
I0116 18:37:20.865] Finished dumping logs for k8s-agentpool1-24867868-vmss000002
I0116 18:37:21.196] Creating /workspace/_artifacts/k8s-agentpool1-24867868-vmss000000 for storing k8s-agentpool1-24867868-vmss000000's logs
I0116 18:37:21.202] Dumping kube-proxy-xb5pk_kube-system_kube-proxy-0ad2ff52334cd9f6f51d0c9dbb13259687ada73b500ece9e3324bcdf665d9df0.log
I0116 18:37:21.455] Dumping kubelet.log
I0116 18:37:21.789] Dumping docker.log
I0116 18:37:22.057] Dumping etcd.log
I0116 18:37:22.303] Finished dumping logs for k8s-agentpool1-24867868-vmss000000
I0116 18:37:22.554] Logs successfully dumped to /workspace/_artifacts
I0116 18:37:22.555] Uninstalling log-dump-daemonset.yaml via kubectl
I0116 18:37:22.646] daemonset.apps "log-dump-node" deleted
W0116 18:37:22.747] 2020/01/16 18:37:22 process.go:155: Step 'bash -c /workspace/aks956443354/log-dump.sh' finished in 29.603068817s
```

/assign @feiskyer 