### PR TITLE
Avoid deadlock from logrus censoring

### DIFF
--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -19,6 +19,7 @@ package logrusutil
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -98,7 +99,6 @@ const censored = "CENSORED"
 
 var (
 	censoredBytes = []byte(censored)
-	standardLog   = logrus.NewEntry(logrus.StandardLogger())
 )
 
 // Censor replaces sensitive parts of the content with a placeholder.
@@ -106,11 +106,11 @@ func (f CensoringFormatter) censor(content []byte) []byte {
 	for _, secret := range f.getSecrets().List() {
 		trimmedSecret := strings.TrimSpace(secret)
 		if trimmedSecret != secret {
-			standardLog.Warning("Secret is not trimmed")
+			fmt.Println("Secret is not trimmed")
 			secret = trimmedSecret
 		}
 		if secret == "" {
-			standardLog.Warning("Secret is an empty string, ignoring")
+			fmt.Println("Secret is an empty string, ignoring")
 			continue
 		}
 		content = bytes.ReplaceAll(content, []byte(secret), censoredBytes)


### PR DESCRIPTION
Hit this issue when using the API in another tool. Isolate the issue:

```
package main

import (
	"fmt"
	"github.com/sirupsen/logrus"
	"k8s.io/apimachinery/pkg/util/sets"
	"k8s.io/test-infra/prow/logrusutil"
	"sync"
)

type secretGetter struct {
	sync.Mutex
	secrets sets.String
}

func (g *secretGetter) addSecrets(newSecrets ...string) {
	g.Lock()
	defer g.Unlock()
	g.secrets.Insert(newSecrets...)
}

func (g *secretGetter) getSecrets() sets.String {
	g.Lock()
	fmt.Println("=========")
	defer func(){
		g.Unlock()
		fmt.Println("++++++++")
	}()
	return g.secrets
}

var (
	secrets *secretGetter
)

func init() {
	secrets = &secretGetter{secrets: sets.NewString()}
	logrus.SetFormatter(logrusutil.NewCensoringFormatter(logrus.StandardLogger().Formatter, secrets.getSecrets))
}

func main() {
	bytes:=[]byte("abc\n")
	fmt.Println("111" + string(bytes))
	secrets.addSecrets(string(bytes))
	fmt.Println("222" + string(bytes))
	logrus.Infof("333" + string(bytes))
	fmt.Println("ok" + string(bytes))
}
```
build and run

```
 ./ttt                  
111abc

222abc

=========
++++++++
fatal error: all goroutines are asleep - deadlock!

goroutine 1 [semacquire]:
sync.runtime_SemacquireMutex(0xc000090034, 0x10eff00, 0x1)
        /usr/local/Cellar/go/1.13.5/libexec/src/runtime/sema.go:71 +0x47
sync.(*Mutex).lockSlow(0xc000090030)
        /usr/local/Cellar/go/1.13.5/libexec/src/sync/mutex.go:138 +0xfc
sync.(*Mutex).Lock(...)
        /usr/local/Cellar/go/1.13.5/libexec/src/sync/mutex.go:81
github.com/sirupsen/logrus.(*MutexWrap).Lock(...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/logger.go:53
github.com/sirupsen/logrus.(*Entry).fireHooks(0xc0000901c0)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:244 +0x173
github.com/sirupsen/logrus.Entry.log(0xc000090000, 0xc000074210, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:224 +0xf4
github.com/sirupsen/logrus.(*Entry).Log(0xc000090070, 0x3, 0xc00009baf8, 0x1, 0x1)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:268 +0xeb
github.com/sirupsen/logrus.(*Entry).Warn(...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:289
github.com/sirupsen/logrus.(*Entry).Warning(...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:293
k8s.io/test-infra/prow/logrusutil.CensoringFormatter.censor(0x110be60, 0xc00008e050, 0xc000010300, 0xc00009e000, 0x42, 0x83, 0x0, 0x10d7460, 0x10668a5)
        /Users/hongkliu/repo/k8s/test-infra/prow/logrusutil/logrusutil.go:109 +0x160
k8s.io/test-infra/prow/logrusutil.CensoringFormatter.Format(0x110be60, 0xc00008e050, 0xc000010300, 0xc000090150, 0x11ab240, 0x1206008, 0x102936a, 0x0, 0x8)
        /Users/hongkliu/repo/k8s/test-infra/prow/logrusutil/logrusutil.go:94 +0xbd
github.com/sirupsen/logrus.(*Entry).write(0xc000090150)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:255 +0xa1
github.com/sirupsen/logrus.Entry.log(0xc000090000, 0xc000074270, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:231 +0x19d
github.com/sirupsen/logrus.(*Entry).Log(0xc0000900e0, 0x4, 0xc00007ce38, 0x1, 0x1)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:268 +0xeb
github.com/sirupsen/logrus.(*Entry).Logf(0xc0000900e0, 0xc000000004, 0xc00007cef0, 0x7, 0x0, 0x0, 0x0)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/entry.go:314 +0xe2
github.com/sirupsen/logrus.(*Logger).Logf(0xc000090000, 0x4, 0xc00007cef0, 0x7, 0x0, 0x0, 0x0)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/logger.go:145 +0x94
github.com/sirupsen/logrus.(*Logger).Infof(...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/logger.go:159
github.com/sirupsen/logrus.Infof(...)
        /Users/hongkliu/go/pkg/mod/github.com/sirupsen/logrus@v1.4.2/exported.go:154
main.main()
        /Users/hongkliu/repo/k8s/test-infra/prow/cmd/ttt/main.go:46 +0x27c

```

it will work if `bytes:=[]byte("abc\n")` -> `bytes:=[]byte("abc")`

/assign @stevekuznetsov 

Will try to get a unit test for this.