### PR TITLE
use golang:1.13-alpine for running prow job

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.12
+      - image: golang:1.13-alpine
         args:
         - make
         - lint
@@ -24,7 +24,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.12
+      - image: golang:1.13-alpine
         args:
         - make
         - test


### PR DESCRIPTION
We have updated the go version for [kubernetes-sigs/aws-encryption-provider](https://github.com/kubernetes-sigs/aws-encryption-provider). 

This PR updates the image to golang:1.13-alpine which is used in the project's Dockerfile

FYI @micahhausler 