### PR TITLE
Kops - periodic e2e ordering

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - interval: 8h
-  name: e2e-kops-aws-k8s-1-9
+  name: e2e-kops-aws-k8s-1-15
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15,21 +15,140 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.9.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1.15.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_RUN_OBSOLETE_VERSION=true
-      - --extract=release/stable-1.9
+      - --extract=release/stable-1.15
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.15
+      imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.15
+
+- interval: 8h
+  name: e2e-kops-aws-k8s-1-14
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-1.14.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=release/stable-1.14
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
+      imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.14
+
+- interval: 8h
+  name: e2e-kops-aws-k8s-1-13
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-1.13.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=release/stable-1.13
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
+      imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.13
+
+- interval: 8h
+  name: e2e-kops-aws-k8s-1-12
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-1.12.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=release/stable-1.12
       - --ginkgo-parallel
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.10
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.9
+    testgrid-tab-name: kops-aws-k8s-1.12
+
+- interval: 8h
+  name: e2e-kops-aws-k8s-1-11
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-1.11.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=release/stable-1.11
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.11
+      imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.11
 
 - interval: 8h
   name: e2e-kops-aws-k8s-1-10
@@ -63,7 +182,7 @@ periodics:
     testgrid-tab-name: kops-aws-k8s-1.10
 
 - interval: 8h
-  name: e2e-kops-aws-k8s-1-11
+  name: e2e-kops-aws-k8s-1-9
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -77,137 +196,18 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.11.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1.9.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=release/stable-1.11
+      - --env=KOPS_RUN_OBSOLETE_VERSION=true
+      - --extract=release/stable-1.9
       - --ginkgo-parallel
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.11
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.10
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.11
-
-- interval: 8h
-  name: e2e-kops-aws-k8s-1-12
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-k8s-1.12.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=release/stable-1.12
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
-      - --provider=aws
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.12
-      imagePullPolicy: Always
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.12
-
-- interval: 8h
-  name: e2e-kops-aws-k8s-1-13
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-k8s-1.13.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=release/stable-1.13
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
-      - --provider=aws
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.13
-      imagePullPolicy: Always
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.13
-
-- interval: 8h
-  name: e2e-kops-aws-k8s-1-14
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-k8s-1.14.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=release/stable-1.14
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
-      - --provider=aws
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
-      imagePullPolicy: Always
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.14
-
-- interval: 8h
-  name: e2e-kops-aws-k8s-1-15
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-k8s-1.15.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=release/stable-1.15
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
-      - --provider=aws
-      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.15
-      imagePullPolicy: Always
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-k8s-1.15
+    testgrid-tab-name: kops-aws-k8s-1.9

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
@@ -1,4 +1,119 @@
 periodics:
+- interval: 1h
+  name: ci-kubernetes-e2e-kops-aws-beta
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+    preset-e2e-platform-aws: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --aws
+      - --cluster=e2e-kops-aws-beta.test-cncf-aws.k8s.io
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt
+      - --extract=ci/k8s-beta
+      - --ginkgo-parallel
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-beta
+
+- interval: 2h
+  name: ci-kubernetes-e2e-kops-aws-stable1
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=ci/k8s-stable1
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-stable1
+
+- interval: 4h
+  name: ci-kubernetes-e2e-kops-aws-stable2
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-stable2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=ci/k8s-stable2
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-stable2
+
+- interval: 6h
+  name: ci-kubernetes-e2e-kops-aws-stable3
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-stable3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --extract=ci/k8s-stable3
+      - --ginkgo-parallel
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-stable3
 
 - interval: 8h
   name: e2e-kops-aws-k8s-1-15

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -24,39 +24,10 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws
-- interval: 1h
-  name: ci-kubernetes-e2e-kops-aws-beta
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-    preset-e2e-platform-aws: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --aws
-      - --cluster=e2e-kops-aws-beta.test-cncf-aws.k8s.io
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt
-      - --extract=ci/k8s-beta
-      - --ginkgo-parallel
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
 
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-beta
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
   labels:
@@ -84,10 +55,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-channelalpha
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-ena-nvme
   labels:
@@ -116,10 +87,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-ena-nvme
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-ha-uswest2
   labels:
@@ -148,10 +119,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-ha-uswest2
+
 - interval: 4h
   name: ci-kubernetes-e2e-kops-aws-containerd
   labels:
@@ -180,10 +151,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.17
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-containerd
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-networking-kopeio-vxlan
   labels:
@@ -211,10 +182,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-networking-kopeio-vxlan
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-newrunner
   labels:
@@ -241,97 +212,10 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
       imagePullPolicy: Always
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-newrunner
-- interval: 2h
-  name: ci-kubernetes-e2e-kops-aws-stable1
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable1
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
 
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable1
-- interval: 4h
-  name: ci-kubernetes-e2e-kops-aws-stable2
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-stable2.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable2
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable2
-- interval: 6h
-  name: ci-kubernetes-e2e-kops-aws-stable3
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-aws-stable3.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable3
-      - --ginkgo-parallel
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable3
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-updown
   labels:
@@ -358,10 +242,10 @@ periodics:
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
       - --timeout=30m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-updown
+
 - interval: 24h
   name: ci-kubernetes-e2e-kops-aws-weave
   labels:
@@ -388,7 +272,6 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-weave
@@ -448,10 +331,10 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-gce-channelalpha
   labels:
@@ -477,10 +360,10 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200114-6d2c483-master
-
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-channelalpha
+
 - interval: 30m
   name: ci-kubernetes-e2e-kops-gce-ha
   labels:


### PR DESCRIPTION
split into two commits for easier readability.

The testgrid tabs are ordered based on job yaml filename and then the list of jobs within each file. This reorders our version-specific e2e jobs to be more intuitive.