### PR TITLE
testgrid/openshift: Add bparees to owners

### DIFF
--- a/config/testgrids/openshift/OWNERS
+++ b/config/testgrids/openshift/OWNERS
@@ -4,3 +4,4 @@ approvers:
 - droslean
 - hongkailiu
 - petr-muller
+- bparees


### PR DESCRIPTION
Ben is responsible for a lot of naming moves and will need to be
able to review.