### PR TITLE
Switched aws-encryption-provider test image to golang:1.13

### DIFF
--- a/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
@@ -6,7 +6,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.13-alpine
+      - image: golang:1.13
         args:
         - make
         - lint
@@ -24,7 +24,7 @@ presubmits:
     max_concurrency: 5
     spec:
       containers:
-      - image: golang:1.13-alpine
+      - image: golang:1.13
         args:
         - make
         - test


### PR DESCRIPTION
We need `make` to build kubernetes-sigs/aws-encryption-provider