### PR TITLE
Kops - Switch from beta/stable version markers and use version-specific markers

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
@@ -1,35 +1,6 @@
 periodics:
-- interval: 1h
-  name: ci-kubernetes-e2e-kops-aws-beta
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-    preset-e2e-platform-aws: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --aws
-      - --cluster=e2e-kops-aws-beta.test-cncf-aws.k8s.io
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-beta.txt
-      - --extract=ci/k8s-beta
-      - --ginkgo-parallel
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-master
-  annotations:
-    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-beta
-
 - interval: 2h
-  name: ci-kubernetes-e2e-kops-aws-stable1
+  name: ci-kubernetes-e2e-kops-aws-1-18
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -43,10 +14,10 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-stable1.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-1-18.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.18
       - --ginkgo-parallel
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
@@ -55,10 +26,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable1
+    testgrid-tab-name: kops-aws-1-18
 
 - interval: 4h
-  name: ci-kubernetes-e2e-kops-aws-stable2
+  name: ci-kubernetes-e2e-kops-aws-1-17
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -72,10 +43,10 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-stable2.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-1-17.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable2
+      - --extract=ci/latest-1.17
       - --ginkgo-parallel
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
@@ -84,10 +55,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable2
+    testgrid-tab-name: kops-aws-1-17
 
-- interval: 6h
-  name: ci-kubernetes-e2e-kops-aws-stable3
+- interval: 4h
+  name: ci-kubernetes-e2e-kops-aws-1-16
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -101,10 +72,10 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-stable3.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-1-16.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/k8s-stable3
+      - --extract=ci/latest-1.16
       - --ginkgo-parallel
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
@@ -113,7 +84,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-stable3
+    testgrid-tab-name: kops-aws-1-16
 
 - interval: 8h
   name: e2e-kops-aws-k8s-1-15
@@ -130,7 +101,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.15.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-15.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=release/stable-1.15
@@ -160,7 +131,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.14.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-14.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=release/stable-1.14
@@ -190,7 +161,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.13.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-13.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=release/stable-1.13
@@ -220,7 +191,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.12.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-12.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=release/stable-1.12
@@ -250,7 +221,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.11.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-11.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=release/stable-1.11
@@ -280,7 +251,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.10.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-10.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_RUN_OBSOLETE_VERSION=true
@@ -311,7 +282,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-k8s-1.9.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-9.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_RUN_OBSOLETE_VERSION=true


### PR DESCRIPTION
As discussed during office hours.

Removing one of the jobs because we already have complete coverage. The `1-18` job tests the latest 1.18 commit and the `kops-aws` job tests the latest master branch (which will diverge when k8s release-1.18 branch is cut)

I also renamed the clusters to not use a period in order to avoid any potential subdomain issues if we choose to test ACM certificates down the road.