### PR TITLE
Grant release-managers rerun privs on kubernetes-build and releng jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-release-test.yaml
+++ b/config/jobs/image-pushing/k8s-staging-release-test.yaml
@@ -33,6 +33,9 @@ periodics:
       - name: creds
         secret:
           secretName: deployer-service-account
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     # TODO(justaugustus): Enable forking for prototype GCB-based build jobs.
     testgrid-dashboards: sig-release-prototype-master-blocking
@@ -73,6 +76,9 @@ periodics:
       - name: creds
         secret:
           secretName: deployer-service-account
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     testgrid-dashboards: sig-release-prototype-master-blocking
     testgrid-tab-name: build-master-fast
@@ -112,6 +118,9 @@ postsubmits:
           - name: creds
             secret:
               secretName: deployer-service-account
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
     - name: post-release-push-image-releng-ci-bazel
       cluster: test-infra-trusted
       annotations:
@@ -143,6 +152,9 @@ postsubmits:
           - name: creds
             secret:
               secretName: deployer-service-account
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
     - name: post-release-push-image-kubepkg
       cluster: test-infra-trusted
       annotations:
@@ -174,3 +186,6 @@ postsubmits:
           - name: creds
             secret:
               secretName: deployer-service-account
+        rerun_auth_config:
+          github_team_ids:
+            - 2241179 # release-managers

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -81,6 +81,9 @@ periodics:
       command:
       - make
       - verify-published-debs
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 - name: periodic-release-verify-packages-rpms
   interval: 6h
   annotations:
@@ -100,3 +103,6 @@ periodics:
       command:
       - make
       - verify-published-rpms
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -56,6 +56,9 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
@@ -88,6 +91,9 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: build-master-fast
@@ -109,6 +115,9 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing
@@ -129,6 +138,9 @@ periodics:
         requests:
           cpu: 4
           memory: "8Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
     testgrid-dashboards: sig-release-master-informing

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -194,6 +194,9 @@ periodics:
       resources:
         requests:
           memory: 6Gi
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 - annotations:
     testgrid-dashboards: sig-release-1.14-blocking, google-unit
     testgrid-tab-name: bazel-test-1.14
@@ -455,6 +458,9 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
+    rerun_auth_config:
+      github_team_ids:
+        - 2241179 # release-managers
   - annotations:
       testgrid-dashboards: sig-release-job-config-errors
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -295,6 +295,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-1.15
       name: ""
       resources: {}
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.15-blocking, google-unit
@@ -466,6 +469,9 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
+    rerun_auth_config:
+      github_team_ids:
+        - 2241179 # release-managers
   - annotations:
       testgrid-dashboards: sig-release-job-config-errors
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -296,6 +296,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-1.16
       name: ""
       resources: {}
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
@@ -469,6 +472,9 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
+    rerun_auth_config:
+      github_team_ids:
+        - 2241179 # release-managers
   - annotations:
       testgrid-dashboards: sig-release-job-config-errors
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -350,6 +350,9 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200117-6384054-1.17
       name: ""
       resources: {}
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
@@ -523,6 +526,9 @@ postsubmits:
         resources:
           requests:
             memory: 6Gi
+    rerun_auth_config:
+      github_team_ids:
+        - 2241179 # release-managers
   - annotations:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-dashboards: sig-release-1.17-informing, google-unit

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -90,6 +90,9 @@ postsubmits:
         resources:
           requests:
             memory: "6Gi"
+    rerun_auth_config:
+      github_team_ids:
+        - 2241179 # release-managers
   - name: post-kubernetes-bazel-build
     branches:
     - master
@@ -225,6 +228,9 @@ periodics:
             --gcs=gs://kubernetes-release-dev/ci-periodic \
             --version-suffix=-bazel \
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-periodic.txt
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 
 - name: periodic-kubernetes-bazel-build-canary
   annotations:
@@ -262,6 +268,9 @@ periodics:
             --gcs=gs://kubernetes-release-dev/ci-canary \
             --version-suffix=-bazel \
             --publish-version=gs://kubernetes-release-dev/ci/latest-bazel-canary.txt
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
 
 # periodic bazel test jobs
 - name: periodic-kubernetes-bazel-test-master

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -57,7 +57,7 @@ deck:
   google_analytics: UA-82843984-5
   rerun_auth_config:
     github_team_ids:
-      - 2009231 #test-infra-admins
+      - 2009231 # test-infra-admins
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
It was suggested on Slack that it might be a good idea for @kubernetes/release-managers to have access to rerun jobs, without having to poke test-infra on-call.

ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1579303883016000

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @Katharine @fejta 
cc: @tpepper @kubernetes/release-engineering 