### PR TITLE
Increases timeout for capa-e2e-jobs on release

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -54,8 +54,8 @@ periodics:
 - name: periodic-cluster-api-provider-aws-e2e-release-0-4
   decorate: true
   decoration_config:
-    timeout: 3h
-  interval: 1h
+    timeout: 4h
+  interval: 5h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -129,7 +129,7 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 3h
+      timeout: 4h
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Adding more test cases forced to increase the timeout
- increases timeout for periodic and presubmit jobs
- applies to release branch jobs only