### PR TITLE
checkconfig: Use strict Unmarshal for unknown fields

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -24,8 +24,6 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
-	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -425,92 +423,11 @@ func validateURLs(c config.ProwConfig) error {
 }
 
 func validateUnknownFields(cfg interface{}, cfgBytes []byte, filePath string) error {
-	var obj interface{}
-	err := yaml.Unmarshal(cfgBytes, &obj)
+	err := yaml.Unmarshal(cfgBytes, &cfg, yaml.DisallowUnknownFields)
 	if err != nil {
-		return fmt.Errorf("error while unmarshaling yaml: %v", err)
-	}
-	unknownFields := checkUnknownFields("", obj, reflect.ValueOf(cfg))
-	if len(unknownFields) > 0 {
-		sort.Strings(unknownFields)
-		return fmt.Errorf("unknown fields present in %s: %v", filePath, strings.Join(unknownFields, ", "))
+		return fmt.Errorf("unknown fields or bad config in %s: %v", filePath, err)
 	}
 	return nil
-}
-
-func checkUnknownFields(keyPref string, obj interface{}, cfg reflect.Value) []string {
-	var uf []string
-	switch concreteVal := obj.(type) {
-	case map[string]interface{}:
-		// Iterate over map and check every value
-		for key, val := range concreteVal {
-			fullKey := fmt.Sprintf("%s.%s", keyPref, key)
-			subCfg := getSubCfg(key, cfg)
-			if !subCfg.IsValid() {
-				// Append fullKey without leading "."
-				uf = append(uf, fullKey[1:])
-			} else {
-				subUf := checkUnknownFields(fullKey, val, subCfg)
-				uf = append(uf, subUf...)
-			}
-		}
-	case []interface{}:
-		for i, val := range concreteVal {
-			fullKey := fmt.Sprintf("%s[%v]", keyPref, i)
-			var subCfg reflect.Value
-			if cfg.Kind() == reflect.Ptr {
-				subCfg = cfg.Elem().Index(i)
-			} else {
-				subCfg = cfg.Index(i)
-			}
-			uf = append(uf, checkUnknownFields(fullKey, val, subCfg)...)
-		}
-	}
-	return uf
-}
-
-func getSubCfg(key string, cfg reflect.Value) reflect.Value {
-	cfgElem := cfg
-	if cfg.Kind() == reflect.Interface || cfg.Kind() == reflect.Ptr {
-		cfgElem = cfg.Elem()
-	}
-	switch cfgElem.Kind() {
-	case reflect.Map:
-		for _, k := range cfgElem.MapKeys() {
-			strK := fmt.Sprintf("%v", k.Interface())
-			if strK == key {
-				return cfgElem.MapIndex(k)
-			}
-		}
-	case reflect.Struct:
-		for i := 0; i < cfgElem.NumField(); i++ {
-			structField := cfgElem.Type().Field(i)
-			// Check if field is embedded struct
-			if structField.Anonymous {
-				subStruct := getSubCfg(key, cfgElem.Field(i))
-				if subStruct.IsValid() {
-					return subStruct
-				}
-			} else {
-				field := getJSONTagName(structField)
-				if field == key {
-					return cfgElem.Field(i)
-				}
-			}
-		}
-	}
-	return reflect.Value{}
-}
-
-func getJSONTagName(field reflect.StructField) string {
-	jsonTag := field.Tag.Get("json")
-	if jsonTag != "" && jsonTag != "-" {
-		if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
-			return jsonTag[:commaIdx]
-		}
-		return jsonTag
-	}
-	return ""
 }
 
 func validateJobRequirements(c config.JobConfig) error {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
@@ -527,7 +528,8 @@ size:
 			got := validateUnknownFields(tc.cfg, tc.configBytes, tc.filename)
 			if !reflect.DeepEqual(got, tc.expectedErr) {
 				t.Errorf("%s: did not get expected validation error:\n%v", tc.name,
-					diff.ObjectGoPrintDiff(tc.expectedErr, got))
+					cmp.Diff(tc.expectedErr.Error(), got.Error()))
+				// cmp.Diff(tc.expectedErr.Error(), got.Error(), cmp.AllowUnexported()))
 			}
 		})
 	}

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -366,7 +366,7 @@ func TestOrgRepoUnion(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got := tc.a.union(tc.b)
 			if !reflect.DeepEqual(got, tc.expected) {
-				t.Errorf("%s: did not get expected config:\n%v", tc.name, diff.ObjectGoPrintDiff(tc.expected, got))
+				t.Errorf("%s: did not get expected config:\n%v", tc.name, cmp.Diff(tc.expected, got))
 			}
 		})
 	}
@@ -529,7 +529,6 @@ size:
 			if !reflect.DeepEqual(got, tc.expectedErr) {
 				t.Errorf("%s: did not get expected validation error:\n%v", tc.name,
 					cmp.Diff(tc.expectedErr.Error(), got.Error()))
-				// cmp.Diff(tc.expectedErr.Error(), got.Error(), cmp.AllowUnexported()))
 			}
 		})
 	}
@@ -1204,7 +1203,7 @@ func TestValidateJobExtraRefs(t *testing.T) {
 			}
 			if err := validateJobExtraRefs(config); !reflect.DeepEqual(err, errorutil.NewAggregate(tc.expected)) {
 				t.Errorf("%s: did not get expected validation error:\n%v", tc.name,
-					diff.ObjectGoPrintDiff(tc.expected, err))
+					cmp.Diff(tc.expected, err))
 			}
 		})
 	}


### PR DESCRIPTION
- Remove custom reflection-based checks for unknown fields and use strict loading from the upstream library instead.
- Fix panic with error message checking in tests by diffing `foo.Error()` instead of `foo` @ main_test.go:540
- Replace legacyDiff with cmp
- Split a test case which used to check multiple failures to ensure they are all covered

/fixes #15316
/label "tide/merge-squash"