### PR TITLE
Revert "Merge pull request #15951 from Katharine/janitor-zone-hack"

### DIFF
--- a/boskos/janitor/gcp_janitor.py
+++ b/boskos/janitor/gcp_janitor.py
@@ -14,9 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# I am not dealing with this today.
-# pylint: disable=line-too-long
-
 """Clean up resources from gcp projects. """
 
 import argparse
@@ -169,8 +166,6 @@ def collect(project, age, resource, filt, clear_all):
         '--format=json(name,creationTimestamp.date(tz=UTC),zone,region,isManaged)',
         '--filter=%s' % filt,
         '--project=%s' % project])
-    if resource.condition == 'zone' and resource.name != 'sole-tenancy' and resource.name != 'network-endpoint-groups':
-        cmd.append('--zones=asia-east1-a,asia-east1-b,asia-east1-c,asia-east2-a,asia-east2-b,asia-east2-c,asia-northeast1-a,asia-northeast1-b,asia-northeast1-c,asia-northeast2-a,asia-northeast2-b,asia-northeast2-c,asia-south1-a,asia-south1-b,asia-south1-c,asia-southeast1-a,asia-southeast1-b,asia-southeast1-c,australia-southeast1-a,australia-southeast1-b,australia-southeast1-c,europe-north1-a,europe-north1-b,europe-north1-c,europe-west1-b,europe-west1-c,europe-west1-d,europe-west2-a,europe-west3-a,europe-west4-a,europe-west5-a,europe-west6-a,europe-west2-b,europe-west3-b,europe-west4-b,europe-west5-b,europe-west6-b,europe-west2-c,europe-west3-c,europe-west4-c,europe-west5-c,europe-west6-c,northamerica-northeast1-a,northamerica-northeast1-b,northamerica-northeast1-c,southamerica-east1-a,southamerica-east1-b,southamerica-east1-c,us-central1-a,us-central1-b,us-central1-c,us-central1-f,us-east1-b,us-east1-c,us-east1-d,us-east4-a,us-east4-b,us-east4-c,us-west1-a,us-west1-b,us-west1-c,us-west2-a,us-west2-b,us-west2-c')
     log('%r' % cmd)
 
     # TODO(krzyzacy): work around for alpha API list calls


### PR DESCRIPTION
`gcloud` seems to be behaving better now, so we shouldn't need this any more.

This reverts commit 6384054e3b2688a116dfed806e4584e225bf2b64, reversing
changes made to 3029825d33b1f71a0835170678f7e7ec9d9a8835.