### PR TITLE
Bump pull-kubernetes-e2e-gce mem req to 8Gi

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -58,7 +58,7 @@ presubmits:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200118-eaed6c6-master
         resources:
           requests:
-            memory: "6Gi"
+            memory: "8Gi"
 
   - name: pull-kubernetes-e2e-gce-rbe
     always_run: true


### PR DESCRIPTION
This is an experiment to address https://github.com/kubernetes/kubernetes/issues/87441

My working theory is that bazel's jvm is getting oomkilled. If this reduces Stage flakes on this job, there are others that could benefit from a bump.

OTOH maybe this requires an adjustment to our build cluster and needs discussion first