### PR TITLE
Azure: Support MSI configuration & revert part of #15981

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -686,7 +686,7 @@ periodics:
       - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-vmss-multi-zones.json
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz
       # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
-      - --test_args=--num-nodes=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete\sGrace\sPeriod|runs\sReplicaSets\sto\sverify\spreemption\srunning\spath|client\-go\sshould\snegotiate|should\scontain\scustom\scolumns\sfor\seach\sresource|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout
+      - --test_args=--num-nodes=2 --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete\sGrace\sPeriod|runs\sReplicaSets\sto\sverify\spreemption\srunning\spath|client\-go\sshould\snegotiate|should\scontain\scustom\scolumns\sfor\seach\sresource|Network\sshould\sset\sTCP\sCLOSE_WAIT\stimeout|PodSecurityPolicy
       - --timeout=420m
       securityContext:
         privileged: true

--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -483,8 +483,11 @@ func (c *Cluster) populateAPIModelTemplate() error {
 	v.Properties.LinuxProfile.SSHKeys.PublicKeys = []PublicKey{{
 		KeyData: c.sshPublicKey,
 	}}
-	v.Properties.ServicePrincipalProfile.ClientID = c.credentials.ClientID
-	v.Properties.ServicePrincipalProfile.Secret = c.credentials.ClientSecret
+
+	if !toBool(v.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity) {
+		v.Properties.ServicePrincipalProfile.ClientID = c.credentials.ClientID
+		v.Properties.ServicePrincipalProfile.Secret = c.credentials.ClientSecret
+	}
 
 	if c.aksCustomWinBinariesURL != "" {
 		v.Properties.OrchestratorProfile.KubernetesConfig.CustomWindowsPackageURL = c.aksCustomWinBinariesURL

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -135,6 +135,7 @@ type KubernetesConfig struct {
 	CustomKubeProxyImage             string            `json:"customKubeProxyImage,omitempty"`
 	CustomKubeSchedulerImage         string            `json:"customKubeSchedulerImage,omitempty"`
 	CustomKubeBinaryURL              string            `json:"customKubeBinaryURL,omitempty"`
+	UseManagedIdentity               *bool             `json:"useManagedIdentity,omitempty"`
 }
 
 type OrchestratorProfile struct {
@@ -327,4 +328,11 @@ func stringPointer(s string) *string {
 
 func boolPointer(b bool) *bool {
 	return &b
+}
+
+func toBool(b *bool) bool {
+	if b == nil {
+		return false
+	}
+	return *b
 }


### PR DESCRIPTION
- MSI-related issue: https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/256
- Used the wrong cluster configuration to test pod security policy-related tests and they passed so I thought it would start working in `cloud-provider-azure-multiple-zones`. Skipping pod security policy-related tests for now and will investigate the failure. 

/assign @feiskyer @andyzhangx 