### PR TITLE
Add crier reporter that reports pod information to GCS

### DIFF
--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/crier:go_default_library",
         "//prow/crier/reporters/gcs:go_default_library",
+        "//prow/crier/reporters/gcs/kubernetes:go_default_library",
         "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/crier/reporters/github:go_default_library",
         "//prow/crier/reporters/pubsub:go_default_library",

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/crier"
 	gcsreporter "k8s.io/test-infra/prow/crier/reporters/gcs"
+	k8sgcsreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
 	gerritreporter "k8s.io/test-infra/prow/crier/reporters/gerrit"
 	githubreporter "k8s.io/test-infra/prow/crier/reporters/github"
 	pubsubreporter "k8s.io/test-infra/prow/crier/reporters/pubsub"
@@ -65,10 +66,13 @@ type options struct {
 	githubWorkers int
 	slackWorkers  int
 	gcsWorkers    int
+	k8sGcsWorkers int
 
 	slackTokenFile string
 
 	gcsCredentialsFile string
+
+	k8sReportFraction float64
 
 	dryrun      bool
 	reportAgent string
@@ -91,7 +95,7 @@ func (o *options) validate() error {
 		o.githubWorkers = 1
 	}
 
-	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers <= 0 {
+	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers+o.k8sGcsWorkers <= 0 {
 		return errors.New("crier need to have at least one report worker to start")
 	}
 
@@ -135,6 +139,8 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 	fs.IntVar(&o.githubWorkers, "github-workers", 0, "Number of github report workers (0 means disabled)")
 	fs.IntVar(&o.slackWorkers, "slack-workers", 0, "Number of Slack report workers (0 means disabled)")
 	fs.IntVar(&o.gcsWorkers, "gcs-workers", 0, "Number of GCS report workers (0 means disabled)")
+	fs.IntVar(&o.k8sGcsWorkers, "kubernetes-gcs-workers", 0, "Number of Kubernetes-specific GCS report workers (0 means disabled)")
+	fs.Float64Var(&o.k8sReportFraction, "kubernetes-report-fraction", 1.0, "Approximate portion of jobs to report pod information for, if kubernetes-gcs-workers are enabled (0 - > none, 1.0 -> all)")
 	fs.StringVar(&o.gcsCredentialsFile, "gcs-credentials-file", "", "Location of the GCS credentials file, if gcs-workers is non-zero")
 	fs.StringVar(&o.slackTokenFile, "slack-token-file", "", "Path to a Slack token file")
 	fs.StringVar(&o.reportAgent, "report-agent", "", "Only report specified agent - empty means report to all agents (effective for github and Slack only)")
@@ -261,27 +267,46 @@ func main() {
 				o.githubWorkers))
 	}
 
-	if o.gcsWorkers > 0 {
-		var c *storage.Client
+	if o.gcsWorkers > 0 || o.k8sGcsWorkers > 0 {
+		var s *storage.Client
 		var opts []option.ClientOption
 		if o.gcsCredentialsFile != "" {
 			opts = append(opts, option.WithCredentialsFile(o.gcsCredentialsFile))
 		}
-		c, err = storage.NewClient(context.Background(), opts...)
+		s, err = storage.NewClient(context.Background(), opts...)
 
 		if err != nil {
 			logrus.WithError(err).Fatal("Error creating storage client for gcs workers.")
 		}
 
-		gcsReporter := gcsreporter.New(cfg, c, o.dryrun)
-		controllers = append(
-			controllers,
-			crier.NewController(
-				prowjobClientset,
-				kube.RateLimiter(gcsReporter.GetName()),
-				prowjobInformerFactory.Prow().V1().ProwJobs(),
-				gcsReporter,
-				o.gcsWorkers))
+		if o.gcsWorkers > 0 {
+			gcsReporter := gcsreporter.New(cfg, s, o.dryrun)
+			controllers = append(
+				controllers,
+				crier.NewController(
+					prowjobClientset,
+					kube.RateLimiter(gcsReporter.GetName()),
+					prowjobInformerFactory.Prow().V1().ProwJobs(),
+					gcsReporter,
+					o.gcsWorkers))
+		}
+
+		if o.k8sGcsWorkers > 0 {
+			coreClients, err := o.client.BuildClusterCoreV1Clients(o.dryrun)
+			if err != nil {
+				logrus.WithError(err).Fatal("Error building pod client sets for Kubernetes GCS workers")
+			}
+
+			k8sGcsReporter := k8sgcsreporter.New(cfg, s, coreClients, float32(o.k8sReportFraction), o.dryrun)
+			controllers = append(
+				controllers,
+				crier.NewController(
+					prowjobClientset,
+					kube.RateLimiter(k8sGcsReporter.GetName()),
+					prowjobInformerFactory.Prow().V1().ProwJobs(),
+					k8sGcsReporter,
+					o.gcsWorkers))
+		}
 	}
 
 	if len(controllers) == 0 {

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -55,8 +55,9 @@ func TestOptions(t *testing.T) {
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
 				},
-				configPath: "foo",
-				github:     defaultGitHubOptions,
+				configPath:        "foo",
+				github:            defaultGitHubOptions,
+				k8sReportFraction: 1.0,
 			},
 		},
 		{
@@ -71,8 +72,9 @@ func TestOptions(t *testing.T) {
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
 				},
-				configPath: "foo",
-				github:     defaultGitHubOptions,
+				configPath:        "foo",
+				github:            defaultGitHubOptions,
+				k8sReportFraction: 1.0,
 			},
 		},
 		//PubSub Reporter
@@ -80,10 +82,11 @@ func TestOptions(t *testing.T) {
 			name: "pubsub workers, sets workers",
 			args: []string{"--pubsub-workers=7", "--config-path=baz"},
 			expected: &options{
-				pubsubWorkers:  7,
-				configPath:     "baz",
-				github:         defaultGitHubOptions,
-				gerritProjects: defaultGerritProjects,
+				pubsubWorkers:     7,
+				configPath:        "baz",
+				github:            defaultGitHubOptions,
+				gerritProjects:    defaultGerritProjects,
+				k8sReportFraction: 1.0,
 			},
 		},
 		{
@@ -95,11 +98,12 @@ func TestOptions(t *testing.T) {
 			name: "slack workers, sets workers",
 			args: []string{"--slack-workers=13", "--slack-token-file=/bar/baz", "--config-path=foo"},
 			expected: &options{
-				slackWorkers:   13,
-				slackTokenFile: "/bar/baz",
-				configPath:     "foo",
-				github:         defaultGitHubOptions,
-				gerritProjects: defaultGerritProjects,
+				slackWorkers:      13,
+				slackTokenFile:    "/bar/baz",
+				configPath:        "foo",
+				github:            defaultGitHubOptions,
+				gerritProjects:    defaultGerritProjects,
+				k8sReportFraction: 1.0,
 			},
 		},
 		{
@@ -117,8 +121,9 @@ func TestOptions(t *testing.T) {
 				client: prowflagutil.KubernetesOptions{
 					DeckURI: "http://www.example.com",
 				},
-				github:         defaultGitHubOptions,
-				gerritProjects: defaultGerritProjects,
+				github:            defaultGitHubOptions,
+				gerritProjects:    defaultGerritProjects,
+				k8sReportFraction: 1.0,
 			},
 		},
 		{

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -130,6 +130,36 @@ func TestOptions(t *testing.T) {
 			name: "Dry run with no --deck-url, rejects",
 			args: []string{"--slack-workers=13", "--slack-token-file=/bar/baz", "--config-path=foo", "--dry-run"},
 		},
+		{
+			name: "k8s-gcs enables k8s-gcs",
+			args: []string{"--kubernetes-gcs-workers=3", "--config-path=foo"},
+			expected: &options{
+				k8sGCSWorkers:     3,
+				configPath:        "foo",
+				github:            defaultGitHubOptions,
+				gerritProjects:    defaultGerritProjects,
+				k8sReportFraction: 1.0,
+			},
+		},
+		{
+			name: "k8s-gcs with report fraction sets report fraction",
+			args: []string{"--kubernetes-gcs-workers=3", "--config-path=foo", "--kubernetes-report-fraction=0.5"},
+			expected: &options{
+				k8sGCSWorkers:     3,
+				configPath:        "foo",
+				github:            defaultGitHubOptions,
+				gerritProjects:    defaultGerritProjects,
+				k8sReportFraction: 0.5,
+			},
+		},
+		{
+			name: "k8s-gcs with too large report fraction rejects",
+			args: []string{"--kubernetes-gcs-workers=3", "--config-path=foo", "--kubernetes-report-fraction=1.5"},
+		},
+		{
+			name: "k8s-gcs with negative report fraction rejects",
+			args: []string{"--kubernetes-gcs-workers=3", "--config-path=foo", "--kubernetes-report-fraction=-1.2"},
+		},
 	}
 
 	for _, tc := range cases {

--- a/prow/crier/reporters/gcs/BUILD.bazel
+++ b/prow/crier/reporters/gcs/BUILD.bazel
@@ -27,6 +27,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//prow/crier/reporters/gcs/internal/testutil:all-srcs",
         "//prow/crier/reporters/gcs/internal/util:all-srcs",
     ],
     tags = ["automanaged"],

--- a/prow/crier/reporters/gcs/internal/testutil/BUILD.bazel
+++ b/prow/crier/reporters/gcs/internal/testutil/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testutil.go"],
+    importpath = "k8s.io/test-infra/prow/crier/reporters/gcs/internal/testutil",
+    visibility = ["//prow/crier/reporters/gcs:__subpackages__"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/crier/reporters/gcs/internal/testutil/BUILD.bazel
+++ b/prow/crier/reporters/gcs/internal/testutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["testutil.go"],
     importpath = "k8s.io/test-infra/prow/crier/reporters/gcs/internal/testutil",
     visibility = ["//prow/crier/reporters/gcs:__subpackages__"],
+    deps = ["//prow/config:go_default_library"],
 )
 
 filegroup(

--- a/prow/crier/reporters/gcs/internal/testutil/testutil.go
+++ b/prow/crier/reporters/gcs/internal/testutil/testutil.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+type Fca struct {
+	C config.Config
+}
+
+func (ca Fca) Config() *config.Config {
+	return &ca.C
+}
+
+type TestAuthor struct {
+	AlreadyUsed bool
+	Bucket      string
+	Path        string
+	Content     []byte
+	Overwrite   bool
+	Closed      bool
+}
+
+type TestAuthorWriteCloser struct {
+	author *TestAuthor
+}
+
+func (wc *TestAuthorWriteCloser) Write(p []byte) (int, error) {
+	wc.author.Content = append(wc.author.Content, p...)
+	return len(p), nil
+}
+
+func (wc *TestAuthorWriteCloser) Close() error {
+	wc.author.Closed = true
+	return nil
+}
+
+func (ta *TestAuthor) NewWriter(ctx context.Context, bucket, path string, overwrite bool) io.WriteCloser {
+	if ta.AlreadyUsed {
+		panic(fmt.Sprintf("NewWriter called on testAuthor twice: first for %q/%q, now for %q/%q", ta.Bucket, ta.Path, bucket, path))
+	}
+	ta.AlreadyUsed = true
+	ta.Bucket = bucket
+	ta.Path = path
+	ta.Overwrite = overwrite
+	return &TestAuthorWriteCloser{author: ta}
+}

--- a/prow/crier/reporters/gcs/internal/util/BUILD.bazel
+++ b/prow/crier/reporters/gcs/internal/util/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/gcs/internal/testutil:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@org_golang_google_api//googleapi:go_default_library",
     ],

--- a/prow/crier/reporters/gcs/internal/util/BUILD.bazel
+++ b/prow/crier/reporters/gcs/internal/util/BUILD.bazel
@@ -2,17 +2,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["reporter.go"],
-    importpath = "k8s.io/test-infra/prow/crier/reporters/gcs",
+    srcs = ["util.go"],
+    importpath = "k8s.io/test-infra/prow/crier/reporters/gcs/internal/util",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/crier/reporters/gcs/internal/util:go_default_library",
-        "//prow/errorutil:go_default_library",
-        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "//prow/gcsupload:go_default_library",
+        "//prow/pod-utils/downwardapi:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )
 
@@ -25,23 +25,19 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//prow/crier/reporters/gcs/internal/util:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )
 
 go_test(
     name = "go_default_test",
-    srcs = ["reporter_test.go"],
+    srcs = ["util_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )

--- a/prow/crier/reporters/gcs/internal/util/util.go
+++ b/prow/crier/reporters/gcs/internal/util/util.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
+	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/gcsupload"
+	"k8s.io/test-infra/prow/pod-utils/downwardapi"
+)
+
+type Author interface {
+	NewWriter(ctx context.Context, bucket, path string, overwrite bool) io.WriteCloser
+}
+
+type StorageAuthor struct {
+	Client *storage.Client
+}
+
+func (sa StorageAuthor) NewWriter(ctx context.Context, bucket, path string, overwrite bool) io.WriteCloser {
+	obj := sa.Client.Bucket(bucket).Object(path)
+	if !overwrite {
+		obj = obj.If(storage.Conditions{DoesNotExist: true})
+	}
+	return obj.NewWriter(ctx)
+}
+
+func WriteContent(ctx context.Context, logger *logrus.Entry, author Author, bucket, path string, overwrite bool, content []byte) error {
+	logger.WithFields(logrus.Fields{"bucket": bucket, "path": path}).Debugf("Uploading to gs://%s/%s; overwrite: %v", bucket, path, overwrite)
+	w := author.NewWriter(ctx, bucket, path, overwrite)
+	_, err := w.Write(content)
+	var reportErr error
+	if isErrUnexpected(err) {
+		reportErr = err
+		logger.WithError(err).WithFields(logrus.Fields{"bucket": bucket, "path": path}).Warn("Uploading info to GCS failed (write)")
+	}
+	err = w.Close()
+	if isErrUnexpected(err) {
+		reportErr = err
+		logger.WithError(err).WithFields(logrus.Fields{"bucket": bucket, "path": path}).Warn("Uploading info to GCS failed (close)")
+	}
+	return reportErr
+}
+
+func isErrUnexpected(err error) bool {
+	if err == nil {
+		return false
+	}
+	// Precondition Failed is expected and we can silently ignore it.
+	if e, ok := err.(*googleapi.Error); ok {
+		if e.Code == http.StatusPreconditionFailed {
+			return false
+		}
+	}
+	return true
+}
+
+func GetJobDestination(cfg config.Getter, pj *v1.ProwJob) (bucket, dir string, err error) {
+	// We can't divine a destination for jobs that don't have a build ID, so don't try.
+	if pj.Status.BuildID == "" {
+		return "", "", errors.New("cannot get job destination for job with no BuildID")
+	}
+	// The decoration config is always provided for decorated jobs, but many
+	// jobs are not decorated, so we guess that we should use the default location
+	// for those jobs. This assumption is usually (but not always) correct.
+	// The TestGrid configurator uses the same assumption.
+	repo := "*"
+	if pj.Spec.Refs != nil {
+		repo = pj.Spec.Refs.Org + "/" + pj.Spec.Refs.Repo
+	}
+
+	ddc := cfg().Plank.GetDefaultDecorationConfigs(repo)
+
+	var gcsConfig *v1.GCSConfiguration
+	if pj.Spec.DecorationConfig != nil && pj.Spec.DecorationConfig.GCSConfiguration != nil {
+		gcsConfig = pj.Spec.DecorationConfig.GCSConfiguration
+	} else if ddc != nil && ddc.GCSConfiguration != nil {
+		gcsConfig = ddc.GCSConfiguration
+	} else {
+		return "", "", fmt.Errorf("couldn't figure out a GCS config for %q", pj.Spec.Job)
+	}
+
+	ps := downwardapi.NewJobSpec(pj.Spec, pj.Status.BuildID, pj.Name)
+	_, d, _ := gcsupload.PathsForJob(gcsConfig, &ps, "")
+
+	return gcsConfig.Bucket, d, nil
+}

--- a/prow/crier/reporters/gcs/internal/util/util_test.go
+++ b/prow/crier/reporters/gcs/internal/util/util_test.go
@@ -27,15 +27,8 @@ import (
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/crier/reporters/gcs/internal/testutil"
 )
-
-type fca struct {
-	c config.Config
-}
-
-func (ca fca) Config() *config.Config {
-	return &ca.c
-}
 
 func TestIsErrUnexpected(t *testing.T) {
 	tests := []struct {
@@ -200,7 +193,7 @@ func TestGetJobDestination(t *testing.T) {
 			for k, v := range tc.defaultGcsConfigs {
 				decorationConfigs[k] = &prowv1.DecorationConfig{GCSConfiguration: v}
 			}
-			cfg := fca{c: config.Config{
+			cfg := testutil.Fca{C: config.Config{
 				ProwConfig: config.ProwConfig{
 					Plank: config.Plank{
 						DefaultDecorationConfigs: decorationConfigs,

--- a/prow/crier/reporters/gcs/internal/util/util_test.go
+++ b/prow/crier/reporters/gcs/internal/util/util_test.go
@@ -1,0 +1,227 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"google.golang.org/api/googleapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+)
+
+type fca struct {
+	c config.Config
+}
+
+func (ca fca) Config() *config.Config {
+	return &ca.c
+}
+
+func TestIsErrUnexpected(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		unexpected bool
+	}{
+		{
+			name:       "standard errors are unexpected",
+			err:        errors.New("this is just a normal error"),
+			unexpected: true,
+		},
+		{
+			name:       "nil errors are expected",
+			err:        nil,
+			unexpected: false,
+		},
+		{
+			name:       "googleapi errors other than Precondition Failed are unexpected",
+			err:        &googleapi.Error{Code: http.StatusNotFound},
+			unexpected: true,
+		},
+		{
+			name:       "Precondition Failed googleapi errors are expected",
+			err:        &googleapi.Error{Code: http.StatusPreconditionFailed},
+			unexpected: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isErrUnexpected(tc.err)
+			if result != tc.unexpected {
+				t.Errorf("Expected isErrUnexpected() to return %v, got %v", tc.unexpected, result)
+			}
+		})
+	}
+}
+
+func TestGetJobDestination(t *testing.T) {
+	standardGcsConfig := &prowv1.GCSConfiguration{
+		Bucket:       "kubernetes-jenkins",
+		PathPrefix:   "some-prefix",
+		PathStrategy: prowv1.PathStrategyLegacy,
+		DefaultOrg:   "kubernetes",
+		DefaultRepo:  "kubernetes",
+	}
+	standardRefs := &prowv1.Refs{
+		Org:   "kubernetes",
+		Repo:  "test-infra",
+		Pulls: []prowv1.Pull{{Number: 12345}},
+	}
+	tests := []struct {
+		name              string
+		defaultGcsConfigs map[string]*prowv1.GCSConfiguration
+		prowjobGcsConfig  *prowv1.GCSConfiguration
+		prowjobType       prowv1.ProwJobType
+		prowjobRefs       *prowv1.Refs
+		buildID           string
+		expectBucket      string
+		expectDir         string // tip: this will always end in "my-little-job/[buildID]"
+		expectErr         bool
+	}{
+		{
+			name:              "decorated prowjob uses inline config when default is empty",
+			defaultGcsConfigs: nil,
+			prowjobGcsConfig:  standardGcsConfig,
+			prowjobType:       prowv1.PeriodicJob,
+			buildID:           "123",
+			expectBucket:      "kubernetes-jenkins",
+			expectDir:         "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name: "decorated prowjob uses inline config over default config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
+				"*": {
+					Bucket:       "the-wrong-bucket",
+					PathPrefix:   "",
+					PathStrategy: prowv1.PathStrategyLegacy,
+					DefaultOrg:   "kubernetes",
+					DefaultRepo:  "kubernetes",
+				},
+			},
+			prowjobGcsConfig: standardGcsConfig,
+			prowjobType:      prowv1.PeriodicJob,
+			buildID:          "123",
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:              "undecorated prowjob falls back to default config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{"*": standardGcsConfig},
+			prowjobGcsConfig:  nil,
+			prowjobType:       prowv1.PeriodicJob,
+			buildID:           "123",
+			expectBucket:      "kubernetes-jenkins",
+			expectDir:         "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:              "undecorated prowjob with no default config is an error",
+			defaultGcsConfigs: nil,
+			prowjobGcsConfig:  nil,
+			prowjobType:       prowv1.PeriodicJob,
+			buildID:           "123",
+			expectErr:         true,
+		},
+		{
+			name: "undecorated prowjob uses the correct org config",
+			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
+				"*": {
+					Bucket:       "the-wrong-bucket",
+					PathPrefix:   "",
+					PathStrategy: prowv1.PathStrategyLegacy,
+					DefaultOrg:   "the-wrong-org",
+					DefaultRepo:  "the-wrong-repo",
+				},
+				"kubernetes": standardGcsConfig,
+			},
+			prowjobGcsConfig: nil,
+			prowjobType:      prowv1.PeriodicJob,
+			prowjobRefs:      standardRefs,
+			buildID:          "123",
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/logs/my-little-job/123",
+		},
+		{
+			name:             "prowjob type is respected",
+			prowjobGcsConfig: standardGcsConfig,
+			prowjobRefs:      standardRefs,
+			prowjobType:      prowv1.PresubmitJob,
+			buildID:          "123",
+			expectBucket:     "kubernetes-jenkins",
+			expectDir:        "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123",
+		},
+		{
+			name:              "reporting a prowjob with no BuildID is an error",
+			defaultGcsConfigs: nil,
+			prowjobGcsConfig:  standardGcsConfig,
+			prowjobType:       prowv1.PeriodicJob,
+			expectErr:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pj := &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:             tc.prowjobType,
+					Refs:             tc.prowjobRefs,
+					Agent:            prowv1.KubernetesAgent,
+					Job:              "my-little-job",
+					DecorationConfig: &prowv1.DecorationConfig{GCSConfiguration: tc.prowjobGcsConfig},
+				},
+				Status: prowv1.ProwJobStatus{
+					State:     prowv1.TriggeredState,
+					StartTime: metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
+					PodName:   "some-pod",
+					BuildID:   tc.buildID,
+				},
+			}
+			decorationConfigs := map[string]*prowv1.DecorationConfig{}
+			for k, v := range tc.defaultGcsConfigs {
+				decorationConfigs[k] = &prowv1.DecorationConfig{GCSConfiguration: v}
+			}
+			cfg := fca{c: config.Config{
+				ProwConfig: config.ProwConfig{
+					Plank: config.Plank{
+						DefaultDecorationConfigs: decorationConfigs,
+					},
+				},
+			}}.Config
+
+			bucket, dir, err := GetJobDestination(cfg, pj)
+			if err != nil {
+				if !tc.expectErr {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			} else if tc.expectErr {
+				t.Fatalf("Expected an error, but didn't get one; instead got gs://%q/%q", bucket, dir)
+			}
+			if bucket != tc.expectBucket {
+				t.Errorf("Expected bucket %q, but got %q", tc.expectBucket, bucket)
+			}
+			if dir != tc.expectDir {
+				t.Errorf("Expected dir %q, but got %q", tc.expectDir, dir)
+			}
+		})
+	}
+}

--- a/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
+++ b/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
@@ -3,16 +3,32 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = ["reporter.go"],
-    importpath = "k8s.io/test-infra/prow/crier/reporters/gcs",
+    importpath = "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes",
     visibility = ["//visibility:public"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gcs/internal/util:go_default_library",
-        "//prow/errorutil:go_default_library",
-        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/scheme:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["reporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/crier/reporters/gcs/internal/testutil:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )
 
@@ -25,26 +41,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//prow/crier/reporters/gcs/internal/testutil:all-srcs",
-        "//prow/crier/reporters/gcs/internal/util:all-srcs",
-        "//prow/crier/reporters/gcs/kubernetes:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
-)
-
-go_test(
-    name = "go_default_test",
-    srcs = ["reporter_test.go"],
-    embed = [":go_default_library"],
-    deps = [
-        "//prow/apis/prowjobs/v1:go_default_library",
-        "//prow/config:go_default_library",
-        "//prow/crier/reporters/gcs/internal/testutil:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-    ],
 )

--- a/prow/crier/reporters/gcs/kubernetes/reporter.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"math"
+	"path"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+
+	"cloud.google.com/go/storage"
+	"github.com/sirupsen/logrus"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/crier/reporters/gcs/internal/util"
+)
+
+const reporterName = "gcsk8sreporter"
+
+type gcsK8sReporter struct {
+	cfg            config.Getter
+	dryRun         bool
+	logger         *logrus.Entry
+	author         util.Author
+	rg             resourceGetter
+	reportFraction float32
+}
+
+type PodReport struct {
+	Pod    *v1.Pod    `json:"pod,omitempty"`
+	Events []v1.Event `json:"events,omitempty"`
+}
+
+type resourceGetter interface {
+	GetPod(cluster, namespace, name string) (*v1.Pod, error)
+	GetEvents(cluster, namespace string, pod *v1.Pod) ([]v1.Event, error)
+}
+
+type k8sResourceGetter struct {
+	podClientSets map[string]corev1.CoreV1Interface
+}
+
+func (rg k8sResourceGetter) GetPod(cluster, namespace, name string) (*v1.Pod, error) {
+	return rg.podClientSets[cluster].Pods(namespace).Get(name, metav1.GetOptions{})
+}
+
+func (rg k8sResourceGetter) GetEvents(cluster, namespace string, pod *v1.Pod) ([]v1.Event, error) {
+	events, err := rg.podClientSets[cluster].Events(namespace).Search(scheme.Scheme, pod)
+	if err != nil {
+		return nil, err
+	}
+	return events.Items, nil
+}
+
+func (gr *gcsK8sReporter) Report(pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TODO: pass through a global context?
+	defer cancel()
+
+	_, _, err := util.GetJobDestination(gr.cfg, pj)
+	if err != nil {
+		gr.logger.Infof("Not uploading %q (%s#%s) because we couldn't find a destination: %v", pj.Name, pj.Spec.Job, pj.Status.BuildID, err)
+		return []*prowv1.ProwJob{pj}, nil
+	}
+
+	return []*prowv1.ProwJob{pj}, gr.reportPodInfo(ctx, pj)
+}
+
+func (gr *gcsK8sReporter) reportPodInfo(ctx context.Context, pj *prowv1.ProwJob) error {
+	// We only report this after a prowjob is complete (and, therefore, pod state is immutable)
+	if !pj.Complete() {
+		return errors.New("cannot report incomplete jobs")
+	}
+
+	pod, err := gr.rg.GetPod(pj.Spec.Cluster, gr.cfg().PodNamespace, pj.Name)
+	if err != nil {
+		// If we return an error we will be retried ~indefinitely. Given that permanent errors
+		// are expected (pods will be garbage collected), this isn't useful. Instead, just
+		// go along with it.
+		gr.logger.WithError(err).Infof("Couldn't fetch info for pod %s", pj.Name)
+		pod = nil
+	}
+
+	var events []v1.Event
+	if pod != nil {
+		events, err = gr.rg.GetEvents(pj.Spec.Cluster, gr.cfg().PodNamespace, pod)
+		if err != nil {
+			gr.logger.WithError(err).Infof("Couldn't fetch events for pod %s", pj.Name)
+		}
+	}
+
+	if pod == nil && len(events) == 0 {
+		gr.logger.Infof("Not reporting on job %q because we could fetch neither pod nor events", pj.Name)
+		return nil
+	}
+
+	report := PodReport{
+		Pod:    pod,
+		Events: events,
+	}
+
+	output, err := json.Marshal(report)
+	if err != nil {
+		// This should never happen.
+		gr.logger.WithError(err).Warn("Couldn't marshal pod info")
+	}
+
+	bucketName, dir, err := util.GetJobDestination(gr.cfg, pj)
+	if err != nil {
+		return fmt.Errorf("couldn't get job destination: %v", err)
+	}
+
+	if gr.dryRun {
+		gr.logger.Infof("Would upload pod info to %q/%q", bucketName, dir)
+		return nil
+	}
+
+	return util.WriteContent(ctx, gr.logger, gr.author, bucketName, path.Join(dir, "podinfo.json"), true, output)
+}
+
+func (gr *gcsK8sReporter) GetName() string {
+	return reporterName
+}
+
+func (gr *gcsK8sReporter) ShouldReport(pj *prowv1.ProwJob) bool {
+	// This reporting only makes sense for the Kubernetes agent (otherwise we don't
+	// have a pod to look up). It is only particularly useful for us to look at
+	// complete jobs.
+	if pj.Spec.Agent != prowv1.KubernetesAgent || !pj.Complete() {
+		return false
+	}
+
+	// For ramp-up purposes, we can report only on a subset of jobs.
+	if gr.reportFraction < 1.0 {
+		// Assume the names are opaque and take the CRC-32C checksum of it.
+		// (Why CRC-32C? It's sufficiently well distributed and fast)
+		crc := crc32.Checksum([]byte(pj.Name), crc32.MakeTable(crc32.Castagnoli))
+		if crc > uint32(math.MaxUint32*gr.reportFraction) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func New(cfg config.Getter, storage *storage.Client, podClientSets map[string]corev1.CoreV1Interface, reportFraction float32, dryRun bool) *gcsK8sReporter {
+	return internalNew(cfg, util.StorageAuthor{Client: storage}, k8sResourceGetter{podClientSets: podClientSets}, reportFraction, dryRun)
+}
+
+func internalNew(cfg config.Getter, author util.Author, rg resourceGetter, reportFraction float32, dryRun bool) *gcsK8sReporter {
+	return &gcsK8sReporter{
+		cfg:            cfg,
+		dryRun:         dryRun,
+		logger:         logrus.WithField("component", reporterName),
+		author:         author,
+		rg:             rg,
+		reportFraction: reportFraction,
+	}
+}

--- a/prow/crier/reporters/gcs/kubernetes/reporter_test.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/crier/reporters/gcs/internal/testutil"
+
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+)
+
+func TestShouldReport(t *testing.T) {
+	tests := []struct {
+		name         string
+		agent        prowv1.ProwJobAgent
+		isComplete   bool
+		shouldReport bool
+	}{
+		{
+			name:         "completed kubernetes tests are reported",
+			agent:        prowv1.KubernetesAgent,
+			isComplete:   true,
+			shouldReport: true,
+		},
+		{
+			name:         "incomplete kubernetes tests are not reported",
+			agent:        prowv1.KubernetesAgent,
+			isComplete:   false,
+			shouldReport: false,
+		},
+		{
+			name:         "complete non-kubernetes tests are not reported",
+			agent:        prowv1.JenkinsAgent,
+			isComplete:   true,
+			shouldReport: false,
+		},
+		{
+			name:         "incomplete non-kubernetes tests are not reported",
+			agent:        prowv1.JenkinsAgent,
+			isComplete:   false,
+			shouldReport: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pj := &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Agent: tc.agent,
+				},
+				Status: prowv1.ProwJobStatus{
+					State:     prowv1.PendingState,
+					StartTime: metav1.Time{Time: time.Now()},
+				},
+			}
+			if tc.isComplete {
+				pj.Status.State = prowv1.SuccessState
+				pj.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			}
+
+			kgr := internalNew(testutil.Fca{}.Config, nil, nil, 1.0, false)
+			shouldReport := kgr.ShouldReport(pj)
+			if shouldReport != tc.shouldReport {
+				t.Errorf("Expected ShouldReport() to return %v, but got %v", tc.shouldReport, shouldReport)
+			}
+		})
+	}
+}
+
+type testResourceGetter struct {
+	namespace string
+	cluster   string
+	pod       *v1.Pod
+	events    []v1.Event
+}
+
+func (rg testResourceGetter) GetPod(cluster, namespace, name string) (*v1.Pod, error) {
+	if rg.cluster != cluster {
+		return nil, fmt.Errorf("expected cluster %q but got cluster %q", rg.cluster, cluster)
+	}
+	if rg.namespace != namespace {
+		return nil, fmt.Errorf("expected namespace %q but got namespace %q", rg.namespace, namespace)
+	}
+	if rg.pod == nil {
+		return nil, errors.New("no such pod")
+	}
+	if rg.pod.ObjectMeta.Name != name {
+		return nil, fmt.Errorf("expected name %q, but got name %q", rg.pod.ObjectMeta.Name, name)
+	}
+	return rg.pod, nil
+}
+
+func (rg testResourceGetter) GetEvents(cluster, namespace string, pod *v1.Pod) ([]v1.Event, error) {
+	if rg.cluster != cluster {
+		return nil, fmt.Errorf("expected cluster %q but got cluster %q", rg.cluster, cluster)
+	}
+	if rg.namespace != namespace {
+		return nil, fmt.Errorf("expected namespace %q but got namespace %q", rg.namespace, namespace)
+	}
+	if pod == nil {
+		return nil, errors.New("expected non-nil pod")
+	}
+	if pod != rg.pod {
+		return nil, errors.New("got the wrong pod")
+	}
+	return rg.events, nil
+}
+
+func TestReportPodInfo(t *testing.T) {
+	tests := []struct {
+		name         string
+		pjName       string
+		pod          *v1.Pod
+		events       []v1.Event
+		dryRun       bool
+		expectReport bool
+		expectErr    bool
+	}{
+		{
+			name:   "prowjob picks up pod and events",
+			pjName: "ba123965-4fd4-421f-8509-7590c129ab69",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ba123965-4fd4-421f-8509-7590c129ab69",
+					Namespace: "test-pods",
+					Labels:    map[string]string{"created-by-prow": "true"},
+				},
+			},
+			events: []v1.Event{
+				{
+					Type:    "Warning",
+					Message: "Some event",
+				},
+			},
+			expectReport: true,
+		},
+		{
+			name:   "prowjob with no events reports pod",
+			pjName: "ba123965-4fd4-421f-8509-7590c129ab69",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ba123965-4fd4-421f-8509-7590c129ab69",
+					Namespace: "test-pods",
+					Labels:    map[string]string{"created-by-prow": "true"},
+				},
+			},
+			expectReport: true,
+		},
+		{
+			name:         "prowjob with no pod reports nothing but does not error",
+			pjName:       "ba123965-4fd4-421f-8509-7590c129ab69",
+			expectReport: false,
+		},
+		{
+			name:   "nothing is reported in dryrun mode",
+			pjName: "ba123965-4fd4-421f-8509-7590c129ab69",
+			dryRun: true,
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ba123965-4fd4-421f-8509-7590c129ab69",
+					Namespace: "test-pods",
+					Labels:    map[string]string{"created-by-prow": "true"},
+				},
+			},
+			events: []v1.Event{
+				{
+					Type:    "Warning",
+					Message: "Some event",
+				},
+			},
+			expectReport: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			pj := &prowv1.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tc.pjName,
+				},
+				Spec: prowv1.ProwJobSpec{
+					Agent:   prowv1.KubernetesAgent,
+					Cluster: "the-build-cluster",
+					Type:    prowv1.PeriodicJob,
+				},
+				Status: prowv1.ProwJobStatus{
+					State:          prowv1.SuccessState,
+					StartTime:      metav1.Time{Time: time.Now()},
+					CompletionTime: &metav1.Time{Time: time.Now()},
+					BuildID:        "12345",
+				},
+			}
+
+			fca := testutil.Fca{C: config.Config{ProwConfig: config.ProwConfig{
+				PodNamespace: "the-test-namespace",
+				Plank: config.Plank{
+					DefaultDecorationConfigs: map[string]*prowv1.DecorationConfig{"*": {
+						GCSConfiguration: &prowv1.GCSConfiguration{
+							Bucket:       "kubernetes-jenkins",
+							PathPrefix:   "some-prefix",
+							PathStrategy: prowv1.PathStrategyLegacy,
+							DefaultOrg:   "kubernetes",
+							DefaultRepo:  "kubernetes",
+						},
+					}},
+				},
+			}}}
+
+			rg := testResourceGetter{
+				namespace: "the-test-namespace",
+				cluster:   "the-build-cluster",
+				pod:       tc.pod,
+				events:    tc.events,
+			}
+			author := &testutil.TestAuthor{}
+			ctx := context.Background()
+			reporter := internalNew(fca.Config, author, rg, 1.0, tc.dryRun)
+			err := reporter.reportPodInfo(ctx, pj)
+
+			if tc.expectErr {
+				if err == nil {
+					t.Fatal("Expected an error, but didn't get one")
+				}
+				return
+			} else if err != nil {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+
+			if !tc.expectReport {
+				if author.AlreadyUsed {
+					t.Fatalf("Expected nothing to be written, but something was written to %q:\n\n%s", author.Path, string(author.Content))
+				}
+				return
+			}
+
+			var result PodReport
+			err = json.Unmarshal(author.Content, &result)
+			if err != nil {
+				t.Fatalf("Couldn't unmarshal reported JSON: %v", err)
+			}
+
+			if !cmp.Equal(result.Pod, tc.pod) {
+				t.Errorf("Got mismatching pods:\n%s", cmp.Diff(tc.pod, result.Pod))
+			}
+			if !cmp.Equal(result.Events, tc.events) {
+				t.Errorf("Got mismatching events:\n%s", cmp.Diff(tc.events, result.Events))
+			}
+		})
+	}
+}

--- a/prow/crier/reporters/gcs/reporter_test.go
+++ b/prow/crier/reporters/gcs/reporter_test.go
@@ -19,19 +19,15 @@ package gcs
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/google/go-cmp/cmp"
-	"google.golang.org/api/googleapi"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 )
@@ -42,197 +38,6 @@ type fca struct {
 
 func (ca fca) Config() *config.Config {
 	return &ca.c
-}
-
-func TestIsErrUnexpected(t *testing.T) {
-	tests := []struct {
-		name       string
-		err        error
-		unexpected bool
-	}{
-		{
-			name:       "standard errors are unexpected",
-			err:        errors.New("this is just a normal error"),
-			unexpected: true,
-		},
-		{
-			name:       "nil errors are expected",
-			err:        nil,
-			unexpected: false,
-		},
-		{
-			name:       "googleapi errors other than Precondition Failed are unexpected",
-			err:        &googleapi.Error{Code: http.StatusNotFound},
-			unexpected: true,
-		},
-		{
-			name:       "Precondition Failed googleapi errors are expected",
-			err:        &googleapi.Error{Code: http.StatusPreconditionFailed},
-			unexpected: false,
-		},
-	}
-
-	gr := newWithAuthor(fca{}.Config, nil, false)
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			result := gr.isErrUnexpected(tc.err)
-			if result != tc.unexpected {
-				t.Errorf("Expected isErrUnexpected() to return %v, got %v", tc.unexpected, result)
-			}
-		})
-	}
-}
-
-func TestGetJobDestination(t *testing.T) {
-	standardGcsConfig := &prowv1.GCSConfiguration{
-		Bucket:       "kubernetes-jenkins",
-		PathPrefix:   "some-prefix",
-		PathStrategy: prowv1.PathStrategyLegacy,
-		DefaultOrg:   "kubernetes",
-		DefaultRepo:  "kubernetes",
-	}
-	standardRefs := &prowv1.Refs{
-		Org:   "kubernetes",
-		Repo:  "test-infra",
-		Pulls: []prowv1.Pull{{Number: 12345}},
-	}
-	tests := []struct {
-		name              string
-		defaultGcsConfigs map[string]*prowv1.GCSConfiguration
-		prowjobGcsConfig  *prowv1.GCSConfiguration
-		prowjobType       prowv1.ProwJobType
-		prowjobRefs       *prowv1.Refs
-		buildID           string
-		expectBucket      string
-		expectDir         string // tip: this will always end in "my-little-job/[buildID]"
-		expectErr         bool
-	}{
-		{
-			name:              "decorated prowjob uses inline config when default is empty",
-			defaultGcsConfigs: nil,
-			prowjobGcsConfig:  standardGcsConfig,
-			prowjobType:       prowv1.PeriodicJob,
-			buildID:           "123",
-			expectBucket:      "kubernetes-jenkins",
-			expectDir:         "some-prefix/logs/my-little-job/123",
-		},
-		{
-			name: "decorated prowjob uses inline config over default config",
-			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
-				"*": {
-					Bucket:       "the-wrong-bucket",
-					PathPrefix:   "",
-					PathStrategy: prowv1.PathStrategyLegacy,
-					DefaultOrg:   "kubernetes",
-					DefaultRepo:  "kubernetes",
-				},
-			},
-			prowjobGcsConfig: standardGcsConfig,
-			prowjobType:      prowv1.PeriodicJob,
-			buildID:          "123",
-			expectBucket:     "kubernetes-jenkins",
-			expectDir:        "some-prefix/logs/my-little-job/123",
-		},
-		{
-			name:              "undecorated prowjob falls back to default config",
-			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{"*": standardGcsConfig},
-			prowjobGcsConfig:  nil,
-			prowjobType:       prowv1.PeriodicJob,
-			buildID:           "123",
-			expectBucket:      "kubernetes-jenkins",
-			expectDir:         "some-prefix/logs/my-little-job/123",
-		},
-		{
-			name:              "undecorated prowjob with no default config is an error",
-			defaultGcsConfigs: nil,
-			prowjobGcsConfig:  nil,
-			prowjobType:       prowv1.PeriodicJob,
-			buildID:           "123",
-			expectErr:         true,
-		},
-		{
-			name: "undecorated prowjob uses the correct org config",
-			defaultGcsConfigs: map[string]*prowv1.GCSConfiguration{
-				"*": {
-					Bucket:       "the-wrong-bucket",
-					PathPrefix:   "",
-					PathStrategy: prowv1.PathStrategyLegacy,
-					DefaultOrg:   "the-wrong-org",
-					DefaultRepo:  "the-wrong-repo",
-				},
-				"kubernetes": standardGcsConfig,
-			},
-			prowjobGcsConfig: nil,
-			prowjobType:      prowv1.PeriodicJob,
-			prowjobRefs:      standardRefs,
-			buildID:          "123",
-			expectBucket:     "kubernetes-jenkins",
-			expectDir:        "some-prefix/logs/my-little-job/123",
-		},
-		{
-			name:             "prowjob type is respected",
-			prowjobGcsConfig: standardGcsConfig,
-			prowjobRefs:      standardRefs,
-			prowjobType:      prowv1.PresubmitJob,
-			buildID:          "123",
-			expectBucket:     "kubernetes-jenkins",
-			expectDir:        "some-prefix/pr-logs/pull/test-infra/12345/my-little-job/123",
-		},
-		{
-			name:              "reporting a prowjob with no BuildID is an error",
-			defaultGcsConfigs: nil,
-			prowjobGcsConfig:  standardGcsConfig,
-			prowjobType:       prowv1.PeriodicJob,
-			expectErr:         true,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			pj := &prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:             tc.prowjobType,
-					Refs:             tc.prowjobRefs,
-					Agent:            prowv1.KubernetesAgent,
-					Job:              "my-little-job",
-					DecorationConfig: &prowv1.DecorationConfig{GCSConfiguration: tc.prowjobGcsConfig},
-				},
-				Status: prowv1.ProwJobStatus{
-					State:     prowv1.TriggeredState,
-					StartTime: metav1.Time{Time: time.Date(2010, 10, 10, 18, 30, 0, 0, time.UTC)},
-					PodName:   "some-pod",
-					BuildID:   tc.buildID,
-				},
-			}
-			decorationConfigs := map[string]*prowv1.DecorationConfig{}
-			for k, v := range tc.defaultGcsConfigs {
-				decorationConfigs[k] = &prowv1.DecorationConfig{GCSConfiguration: v}
-			}
-			cfg := fca{c: config.Config{
-				ProwConfig: config.ProwConfig{
-					Plank: config.Plank{
-						DefaultDecorationConfigs: decorationConfigs,
-					},
-				},
-			}}.Config
-
-			reporter := newWithAuthor(cfg, nil, false)
-			bucket, dir, err := reporter.getJobDestination(pj)
-			if err != nil {
-				if !tc.expectErr {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-			} else if tc.expectErr {
-				t.Fatalf("Expected an error, but didn't get one; instead got gs://%q/%q", bucket, dir)
-			}
-			if bucket != tc.expectBucket {
-				t.Errorf("Expected bucket %q, but got %q", tc.expectBucket, bucket)
-			}
-			if dir != tc.expectDir {
-				t.Errorf("Expected dir %q, but got %q", tc.expectDir, dir)
-			}
-		})
-	}
 }
 
 type testAuthor struct {


### PR DESCRIPTION
This PR adds a reporter that reports a `podinfo.json` file to completed jobs, containing the pod yaml (as json) and the pod events. This is same information used by `kubectl describe`, and will in future be consumed by a lens to provide information about the pod, which will aid in debugging several classes of failures (bad job config, infra failures, etc.)

This is implemented as a new reporter that shares a substantial amount of code with the gcs reporter. As such, the first commit consists of moving a bunch of the gcs reporter into a shared util package, the second one moves a bunch of unit testing utilities into another shared package, and the third one actually implements the feature. I recommend reviewing by commit.

Since this reporter will add new load to the api server, an option is provided to have it only randomly attach this to a subset of jobs, enabling a more gradual ramp-up.

/cc @cjwagner