### PR TITLE
controller-runtime: use go1.13 for release-0.4

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.4.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-release-0.4.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  kubernetes-sigs/controller-runtime:
+  - name: pull-controller-runtime-test-release-0-4
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/controller-runtime
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.4$
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - ./hack/ci-check-everything.sh
+        resources:
+          requests:
+            cpu: 4000m
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kubebuilder
+      testgrid-tab-name: controller-runtime-release-0.4


### PR DESCRIPTION
Following up on #14373, this PR ensures that controller-runtime `release-0.4` builds use `go1.13`