### PR TITLE
Expose and collect Boskos HTTP metrics

### DIFF
--- a/prow/cluster/boskos-metrics.yaml
+++ b/prow/cluster/boskos-metrics.yaml
@@ -21,11 +21,11 @@ spec:
   selector:
     app: boskos-metrics
   ports:
-  - name: default
+  - name: metrics
     protocol: TCP
-    port: 80
+    port: 9090
     targetPort: 9090
-  loadBalancerIP: 104.197.27.114
+  loadBalancerIP: 104.197.27.114  # boskos-metrics
   type: LoadBalancer
 ---
 apiVersion: apps/v1

--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -91,3 +91,19 @@ spec:
     protocol: TCP
     port: 80
     targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: boskos-http-metrics
+  namespace: test-pods
+spec:
+  selector:
+    app: boskos
+  ports:
+  - name: metrics
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  loadBalancerIP: 34.70.169.97  # boskos-http-metrics
+  type: LoadBalancer

--- a/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -9,7 +9,8 @@ stringData:
       metrics_path: /metrics
       static_configs:
         - targets:
-            - "104.197.27.114"
+            - "104.197.27.114:9090"  # boskos resource metrics
+            - "34.70.169.97:9090"  # boskos http metrics
     - job_name: blackbox
       metrics_path: /probe
       params:


### PR DESCRIPTION
The main Boskos service exposes useful Prometheus metrics about its HTTP API:
https://github.com/kubernetes/test-infra/blob/cd538657b7aaacccb650e49ad48de1785d7d3230/boskos/boskos.go#L60-L62

We should collect these.

We'll need to create a new static IP to bind to the load balancer. Assuming we think this is a good idea, I'll do that and then update this PR.

I'm still figuring how to update the various grafana configurations to graph this data, but we may as well start by collecting it.

/area boskos
/area monitoring
/hold

/assign @cjwagner @stevekuznetsov 
cc @Katharine as FYI