### PR TITLE
Kops - Update presubmits to use k8s release versions

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -81,7 +81,7 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --extract=ci/latest
+        - --extract=release/latest
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws
@@ -124,7 +124,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.15.txt
-        - --extract=ci/latest-1.15
+        - --extract=release/stable-1.15
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws
@@ -167,7 +167,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.16.txt
-        - --extract=ci/latest-1.16
+        - --extract=release/stable-1.16
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws
@@ -210,7 +210,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.17.txt
-        - --extract=ci/latest-1.17
+        - --extract=release/stable-1.17
         - --ginkgo-parallel
         - --kops-build
         - --provider=aws


### PR DESCRIPTION
As discussed during office hours last week.

For the master branch e2e job we use latest-1.18 which currently points to 1.18.0-alpha.2.
For the other release branch e2e jobs we use the latest stable release for each minor version.

See:

* https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
* https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
* https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
* https://storage.googleapis.com/kubernetes-release/release/stable-1.15.txt

[release marker docs](https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md#release-versions), and [example periodic job that uses this same marker](https://github.com/kubernetes/test-infra/blob/0548076d2b56ff19821e4f1ef7b389982dc23f19/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml#L107)