### PR TITLE
repoowners: use request-local loggers for context

### DIFF
--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/phony:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/repoowners:go_default_library",
     ],
 )
 

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/phony"
 	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/repoowners"
 )
 
 var ice = github.IssueCommentEvent{
@@ -61,6 +62,7 @@ func TestHook(t *testing.T) {
 	ca := &config.Agent{}
 	clientAgent := &plugins.ClientAgent{
 		GitHubClient: github.NewFakeClient(),
+		OwnersClient: repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
 	}
 	metrics := NewMetrics()
 

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -52,6 +52,10 @@ func (f *fakeOwnersClient) LoadRepoOwners(org, repo, base string) (repoowners.Re
 	return &fakeRepoOwners{approvers: f.approvers, reviewers: f.reviewers}, nil
 }
 
+func (f *fakeOwnersClient) WithFields(fields logrus.Fields) repoowners.Interface {
+	return f
+}
+
 type fakeRepoOwners struct {
 	approvers    map[string]sets.String
 	reviewers    map[string]sets.String

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -174,7 +174,7 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 		ProwJobClient:             clientAgent.ProwJobClient,
 		GitClient:                 clientAgent.GitClient,
 		SlackClient:               clientAgent.SlackClient,
-		OwnersClient:              clientAgent.OwnersClient,
+		OwnersClient:              clientAgent.OwnersClient.WithFields(logger.Data),
 		BugzillaClient:            clientAgent.BugzillaClient,
 		Metrics:                   metrics,
 		Config:                    prowConfig,

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -253,23 +253,25 @@ labels:
 		return nil, nil, fmt.Errorf("cannot get commit SHA: %v", err)
 	}
 	return &Client{
-			git:    git,
-			ghc:    ghc,
 			logger: logrus.WithField("client", "repoowners"),
-			cache:  cache,
+			delegate: &delegate{
+				git:   git,
+				ghc:   ghc,
+				cache: cache,
 
-			mdYAMLEnabled: func(org, repo string) bool {
-				return enableMdYaml
-			},
-			skipCollaborators: func(org, repo string) bool {
-				return skipCollab
-			},
-			ownersDirBlacklist: func() prowConf.OwnersDirBlacklist {
-				return prowConf.OwnersDirBlacklist{
-					Repos:                       ownersDirBlacklistByRepo,
-					Default:                     ownersDirBlacklistDefault,
-					IgnorePreconfiguredDefaults: ignorePreconfiguredDefaults,
-				}
+				mdYAMLEnabled: func(org, repo string) bool {
+					return enableMdYaml
+				},
+				skipCollaborators: func(org, repo string) bool {
+					return skipCollab
+				},
+				ownersDirBlacklist: func() prowConf.OwnersDirBlacklist {
+					return prowConf.OwnersDirBlacklist{
+						Repos:                       ownersDirBlacklistByRepo,
+						Default:                     ownersDirBlacklistDefault,
+						IgnorePreconfiguredDefaults: ignorePreconfiguredDefaults,
+					}
+				},
 			},
 		},
 		// Clean up function


### PR DESCRIPTION
When the repo OWNERS client is used to handle requests for a specific
event in hook, it is better to use context-local loggers so that we can
trace the requests to the events that cause them.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner 