### PR TITLE
Try capping bazel's memory in some pull-kubernetes-e2e jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -42,6 +42,8 @@ presubmits:
         - --timeout=105
         - --scenario=kubernetes_e2e
         - --
+        # cap bazel's JVM memory usage to resources.requests.memory - 2Gi
+        - --inject-bazelrc=startup --host_jvm_args=-Xmx4g
         - --build=bazel
         - --cluster=
         - --extract=local
@@ -90,6 +92,8 @@ presubmits:
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
+        # cap bazel's JVM memory usage to resources.requests.memory - 2Gi
+        - --inject-bazelrc=startup --host_jvm_args=-Xmx4g
         - --inject-bazelrc=build --config=ci
         - --build=bazel
         - --cluster=
@@ -102,6 +106,9 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        resources:
+          requests:
+            memory: "6Gi"
 
   - name: pull-kubernetes-e2e-gce-alpha-features
     optional: true

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -58,7 +58,7 @@ presubmits:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200123-f79dd58-master
         resources:
           requests:
-            memory: "8Gi"
+            memory: "6Gi"
 
   - name: pull-kubernetes-e2e-gce-rbe
     always_run: true


### PR DESCRIPTION
My working theory is bazel's jvm is asking for more memory than is 
available, and getting oomkilled. Instead, let's cap its memory so that it
tries to GC instead of grow memory.

The 6Gi number was there for -gce before, capping bazel's jvm to 4Gi is a
total guess to leave some overhead for non-bazel stuff.

Add a 6Gi resource request for -rbe so we can compare apples and oranges to
see how this affects RBE and non-RBE.

This also reverts https://github.com/kubernetes/test-infra/pull/15980

ref: https://github.com/kubernetes/kubernetes/issues/87441