### PR TITLE
Move stuck pod deletion from plank to sinker

### DIFF
--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -441,14 +441,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 			pj.SetComplete()
 			pj.Status.State = prowapi.ErrorState
 			pj.Status.Description = "Pod pending timeout."
-			client, ok := c.buildClients[pj.ClusterAlias()]
-			if !ok {
-				return fmt.Errorf("pending pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
-			}
-			if err := client.Delete(c.ctx, &pod); err != nil {
-				return fmt.Errorf("failed to delete pod %s that was in pending timeout: %v", pod.Name, err)
-			}
-			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Deleted stale pending pod.")
+			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Marked job for stale pending pod as errored.")
 
 		case corev1.PodRunning:
 			maxPodRunning := c.config().Plank.PodRunningTimeout.Duration

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1112,7 +1112,7 @@ func TestSyncPendingJob(t *testing.T) {
 				},
 			},
 			expectedState:    prowapi.ErrorState,
-			expectedNumPods:  0,
+			expectedNumPods:  1,
 			expectedComplete: true,
 			expectedReport:   true,
 			expectedURL:      "nightmare/error",


### PR DESCRIPTION
Currently, when plank sees a stuck job, it marks the prowjob as errored and then deletes the pod. This prevents anything from subsequently inspecting the pod to determine why it errored, which is unfortunate.

Instead, have plank _only_ mark the job as errored. Sinker will then remove the pod after the completed job TTL expires.

Since the pod will still be running, this PR changes sinker's definition of termination to be when the job terminated, instead of when the pod terminated, ensuring that running jobs can be cleaned up if the prowjob state indicates they should be.

This is part of [improving prowjob visibility](https://github.com/kubernetes/test-infra/pull/16008).

/cc @cjwagner 