### PR TITLE
feat: added new labels for community repo

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -199,6 +199,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/cn-summit" href="#area/cn-summit">`area/cn-summit`</a> | Issues or PRs related to the Contributor Summit in China| label | |
 | <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
+| <a id="area/contributor-comms" href="#area/contributor-comms">`area/contributor-comms`</a> | Issues or PRs related to the upstream marketing team| humans | |
 | <a id="area/contributor-guide" href="#area/contributor-guide">`area/contributor-guide`</a> | Issues or PRs related to the contributor guide| label | |
 | <a id="area/contributor-summit" href="#area/contributor-summit">`area/contributor-summit`</a> | Issues or PRs related to all Contributor Summit events| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -780,6 +780,11 @@ repos:
         name: area/slack-management
         target: both
         addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the upstream marketing team
+        name: area/contributor-comms
+        target: both
+        addedBy: humans
   kubernetes/enhancements:
     labels:
       - color: 0052cc


### PR DESCRIPTION
This is PR is to add a **new label** for the *k/community* repo to help the upstream marketing team.

#### Related Issue:
https://github.com/kubernetes/community/issues/4430

#### Label Added:
area/contributor-comms
