### PR TITLE
Support a Clone BaseDir of Root

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -96,7 +96,6 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 	} else {
 		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 	}
-
 	return path.Join(baseDir, "src", clonePath)
 }
 

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -95,6 +95,11 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 	} else {
 		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 	}
+
+	// Support a baseDir of root "/"
+	if baseDir == "/" {
+		return fmt.Sprintf("%ssrc/%s", baseDir, clonePath)
+	}
 	return fmt.Sprintf("%s/src/%s", baseDir, clonePath)
 }
 

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -96,11 +97,7 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 	}
 
-	// Support a baseDir of root "/"
-	if baseDir == "/" {
-		return fmt.Sprintf("%ssrc/%s", baseDir, clonePath)
-	}
-	return fmt.Sprintf("%s/src/%s", baseDir, clonePath)
+	return path.Join(baseDir, "src", clonePath)
 }
 
 // gitCtx collects a few common values needed for all git commands.

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -90,6 +90,27 @@ func TestCommandsForRefs(t *testing.T) {
 			},
 		},
 		{
+			name: "simple case, root dir",
+			refs: prowapi.Refs{
+				Org:     "org",
+				Repo:    "repo",
+				BaseRef: "master",
+			},
+			dir: "/",
+			expectedBase: []cloneCommand{
+				{dir: "/", command: "mkdir", args: []string{"-p", "/src/github.com/org/repo"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"init"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "master"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"checkout", "FETCH_HEAD"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"branch", "--force", "master", "FETCH_HEAD"}},
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"checkout", "master"}},
+			},
+			expectedPull: []cloneCommand{
+				{dir: "/src/github.com/org/repo", command: "git", args: []string{"submodule", "update", "--init", "--recursive"}},
+			},
+		},
+		{
 			name: "minimal refs with git user name",
 			refs: prowapi.Refs{
 				Org:     "org",


### PR DESCRIPTION
/kind cleanup

This PR allows clonerefs to have a srcRoot directory of root "/"... without this change you cannot have source checked out to `/src`.