### PR TITLE
ghproxy: do not record zero-value rate-limits when empty

### DIFF
--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -93,6 +93,9 @@ func init() {
 // `github_token_usage` as well as `github_token_reset` on prometheus.
 func CollectGitHubTokenMetrics(tokenHash, apiVersion string, headers http.Header, reqStartTime, responseTime time.Time) {
 	remaining := headers.Get("X-RateLimit-Remaining")
+	if remaining == "" {
+		return
+	}
 	timeUntilReset := timestampStringToTime(headers.Get("X-RateLimit-Reset"))
 	durationUntilReset := timeUntilReset.Sub(reqStartTime)
 


### PR DESCRIPTION
When a GitHub response does not have any rate limit remaining header, we
cannot update our metric.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```json
{"component":"ghproxy","file":"ghproxy/ghmetrics/ghmetrics.go:107","func":"k8s.io/test-infra/ghproxy/ghmetrics.CollectGitHubTokenMetrics","header":"","level":"debug","msg":"Parsed GitHub header as indicating no remaining rate-limit.","time":"2020-01-24T17:49:49Z","user-agent":""}
```

/assign @cjwagner 