### PR TITLE
Add newlines to --inject-bazelrc lines

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -431,6 +431,7 @@ def get_shared_gcs_path(gcs_shared, use_shared_build):
 def inject_bazelrc(lines):
     if not lines:
         return
+    lines = [l + '\n' for l in lines]
     with open('/etc/bazel.bazelrc', 'a') as fp:
         fp.writelines(lines)
     path = os.path.join(os.getenv('HOME'), '.bazelrc')


### PR DESCRIPTION
So that if we pass --inject-bazelrc=foo --inject-bazelrc=bar, it
gets written to bazelrc as
```
foo
bar
```
instead of
```
foobar
```

This is what caused me to open the revert PR #16015