### PR TITLE
Fix github handling of IsNotFound responses

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -564,7 +564,7 @@ func IsNotFound(err error) bool {
 		return false
 	}
 
-	requestErr, ok := err.(*requestError)
+	requestErr, ok := err.(requestError)
 	if !ok {
 		return false
 	}


### PR DESCRIPTION
`requestError` is not a pointer ever for this type assertion and thus this check always fails.
https://github.com/kubernetes/test-infra/blob/5df3c75ff016f89916494d1b2b8589f550af086a/prow/github/client.go#L619-L622
fix https://github.com/istio/test-infra/issues/2294