### PR TITLE
boskos: Periodically update dynamic resources

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -44,12 +44,15 @@ import (
 )
 
 const (
-	defaultRequestTTL      = 30 * time.Second
-	defaultRequestGCPeriod = time.Minute
+	defaultDynamicResourceUpdatePeriod = 10 * time.Minute
+	defaultRequestTTL                  = 30 * time.Second
+	defaultRequestGCPeriod             = time.Minute
 )
 
 var (
-	configPath        = flag.String("config", "config.yaml", "Path to init resource file")
+	configPath                  = flag.String("config", "config.yaml", "Path to init resource file")
+	dynamicResourceUpdatePeriod = flag.Duration("dynamic-resource-update-period", defaultDynamicResourceUpdatePeriod,
+		"Period at which to update dynamic resources. Set to 0 to disable.")
 	storagePath       = flag.String("storage", "", "Path to persistent volume to load the state")
 	requestTTL        = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before losing priority in the queue")
 	kubeClientOptions crds.KubernetesClientOptions
@@ -143,6 +146,7 @@ func main() {
 		}
 	})
 
+	r.StartDynamicResourceUpdater(*dynamicResourceUpdatePeriod)
 	r.StartRequestGC(defaultRequestGCPeriod)
 
 	logrus.Info("Start Service")

--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -43,9 +43,12 @@ type DynamicResourceLifeCycle struct {
 	Type string `json:"type"`
 	// Initial state to be created as
 	InitialState string `json:"state"`
-	// Minimum Number of resources to be use a buffer
+	// Minimum number of resources to be use as a buffer.
+	// Resources in the process of being deleted and cleaned up are included in this count.
 	MinCount int `json:"min-count"`
-	// Maximum resources expected
+	// Maximum number of resources expected. This maximum may be temporarily
+	// exceeded while resources are in the process of being deleted, though this
+	// is only expected when MaxCount is lowered.
 	MaxCount int `json:"max-count"`
 	// Lifespan of a resource, time after which the resource should be reset.
 	LifeSpan *time.Duration `json:"lifespan,omitempty"`

--- a/boskos/ranch/storage.go
+++ b/boskos/ranch/storage.go
@@ -199,7 +199,7 @@ func (s *Storage) GetDynamicResourceLifeCycles() ([]common.DynamicResourceLifeCy
 	return resources, nil
 }
 
-// SyncResources will update static and dynamic resources periodically.
+// SyncResources will update static and dynamic resources.
 // It will add new resources to storage and try to remove newly deleted resources
 // from storage.
 // If the newly deleted resource is currently held by a user, the deletion will
@@ -211,7 +211,6 @@ func (s *Storage) SyncResources(config *common.BoskosConfig) error {
 
 	newSRByName := map[string]common.Resource{}
 	existingSRByName := map[string]common.Resource{}
-	existingDRByType := map[string][]common.Resource{}
 	newDRLCByType := map[string]common.DynamicResourceLifeCycle{}
 	existingDRLCByType := map[string]common.DynamicResourceLifeCycle{}
 
@@ -224,6 +223,129 @@ func (s *Storage) SyncResources(config *common.BoskosConfig) error {
 			}
 		}
 	}
+
+	if err := func() error {
+		s.resourcesLock.Lock()
+		defer s.resourcesLock.Unlock()
+
+		resources, err := s.GetResources()
+		if err != nil {
+			logrus.WithError(err).Error("cannot find resources")
+			return err
+		}
+		existingDRLC, err := s.GetDynamicResourceLifeCycles()
+		if err != nil {
+			logrus.WithError(err).Error("cannot find dynamicResourceLifeCycles")
+			return err
+		}
+		for _, dRLC := range existingDRLC {
+			existingDRLCByType[dRLC.Type] = dRLC
+		}
+
+		// Split resources between static and dynamic resources
+		lifeCycleTypes := map[string]bool{}
+
+		for _, lc := range existingDRLC {
+			lifeCycleTypes[lc.Type] = true
+		}
+		// Considering the migration case from mason resources to dynamic resources.
+		// Dynamic resources already exist but they don't have an associated DRLC
+		for _, lc := range newDRLCByType {
+			lifeCycleTypes[lc.Type] = true
+		}
+
+		for _, res := range resources {
+			if !lifeCycleTypes[res.Type] {
+				existingSRByName[res.Name] = res
+			}
+		}
+
+		if err := s.syncStaticResources(newSRByName, existingSRByName); err != nil {
+			return err
+		}
+		if err := s.syncDynamicResourceLifeCycles(newDRLCByType, existingDRLCByType); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return err
+	}
+
+	if err := s.UpdateAllDynamicResources(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// updateDynamicResources updates dynamic resource based on an existing dynamic resource life cycle.
+// It will make sure than MinCount of resource exists, and attempt to delete expired and resources over MaxCount.
+// If resources are held by another user than Boskos, they will be deleted in a following cycle.
+func (s *Storage) updateDynamicResources(lifecycle common.DynamicResourceLifeCycle, resources []common.Resource) (toAdd, toDelete []common.Resource) {
+	var notInUseRes []common.Resource
+	tombStoned := 0
+	toBeDeleted := 0
+	for _, r := range resources {
+		if r.IsInUse() {
+			// We can only delete resources not in use.
+			continue
+		}
+		if r.State == common.Tombstone {
+			// Ready to be fully deleted.
+			toDelete = append(toDelete, r)
+			tombStoned++
+		} else if r.State == common.ToBeDeleted {
+			// Already in the process of cleaning up.
+			// Don't create new resources yet, but also don't delete additional
+			// resources.
+			toBeDeleted++
+		} else {
+			if r.ExpirationDate != nil && s.now().After(*r.ExpirationDate) {
+				// Expired. Don't decrement the active count until it's tombstoned,
+				// however, as it might be depending on other resources that need
+				// to be released first.
+				toDelete = append(toDelete, r)
+				toBeDeleted++
+			} else {
+				notInUseRes = append(notInUseRes, r)
+			}
+		}
+	}
+
+	// Tombstoned resources are ready to be fully deleted, so replace them if necessary.
+	activeCount := len(resources) - tombStoned
+	for i := activeCount; i < lifecycle.MinCount; i++ {
+		res := common.NewResourceFromNewDynamicResourceLifeCycle(s.generateName(), &lifecycle, s.now())
+		toAdd = append(toAdd, res)
+		activeCount++
+	}
+
+	// ToBeDeleted resources may take some time to be fully cleaned up.
+	// We can temporarily exceed MaxCount while these are being cleaned up,
+	// particularly if MaxCount was recently lowered.
+	numberOfResToDelete := activeCount - toBeDeleted - lifecycle.MaxCount
+	// Sorting to get consistent deletion mechanism (ease testing)
+	sort.Stable(sort.Reverse(common.ResourceByName(notInUseRes)))
+	for i := 0; i < len(notInUseRes); i++ {
+		res := notInUseRes[i]
+		if i < numberOfResToDelete {
+			toDelete = append(toDelete, res)
+		}
+	}
+	logrus.Infof("DRLC type %s: adding %+v, deleting %+v", lifecycle.Type, toAdd, toDelete)
+	return
+}
+
+// UpdateAllDynamicResources queries for all existing DynamicResourceLifeCycles
+// and dynamic resources and calls updateDynamicResources for each type.
+// This ensures that the MinCount and MaxCount parameters are honored, that
+// any expired resources are deleted, and that any Tombstoned resources are
+// completely removed.
+func (s *Storage) UpdateAllDynamicResources() error {
+	var resToAdd, resToDelete []common.Resource
+	var dRLCToDelete []common.DynamicResourceLifeCycle
+	existingDRLCByType := map[string]common.DynamicResourceLifeCycle{}
+	existingDRsByType := map[string][]common.Resource{}
+
 	s.resourcesLock.Lock()
 	defer s.resourcesLock.Unlock()
 
@@ -234,109 +356,70 @@ func (s *Storage) SyncResources(config *common.BoskosConfig) error {
 	}
 	existingDRLC, err := s.GetDynamicResourceLifeCycles()
 	if err != nil {
-		logrus.WithError(err).Error("cannot find dynamicResourceLifeCycles")
+		logrus.WithError(err).Error("cannot find DynamicResourceLifeCycles")
 		return err
 	}
 	for _, dRLC := range existingDRLC {
 		existingDRLCByType[dRLC.Type] = dRLC
 	}
 
-	// Split resources between static and dynamic resources
-	lifeCycleTypes := map[string]bool{}
-
-	for _, lc := range existingDRLC {
-		lifeCycleTypes[lc.Type] = true
-	}
-	// Considering the migration case from mason resources to dynamic resources.
-	// Dynamic resources already exist but they don't have an associated DRLC
-	for _, lc := range newDRLCByType {
-		lifeCycleTypes[lc.Type] = true
-	}
-
+	// Filter to only look at dynamic resources
 	for _, res := range resources {
-		if lifeCycleTypes[res.Type] {
-			existingDRByType[res.Type] = append(existingDRByType[res.Type], res)
-		} else {
-			existingSRByName[res.Name] = res
+		if _, ok := existingDRLCByType[res.Type]; ok {
+			existingDRsByType[res.Type] = append(existingDRsByType[res.Type], res)
 		}
 	}
 
-	if err := s.syncStaticResources(newSRByName, existingSRByName); err != nil {
+	for resType, dRLC := range existingDRLCByType {
+		existingDRs := existingDRsByType[resType]
+		toAdd, toDelete := s.updateDynamicResources(dRLC, existingDRs)
+		resToAdd = append(resToAdd, toAdd...)
+		resToDelete = append(resToDelete, toDelete...)
+
+		if dRLC.MinCount == 0 && dRLC.MaxCount == 0 {
+			currentCount := len(existingDRs)
+			addCount := len(resToAdd)
+			delCount := len(resToDelete)
+			if addCount == 0 && (currentCount == 0 || currentCount == delCount) {
+				dRLCToDelete = append(dRLCToDelete, dRLC)
+			}
+		}
+	}
+
+	if err := s.persistResources(resToAdd, resToDelete, true); err != nil {
+		logrus.WithError(err).Error("failed to persist resources")
 		return err
 	}
-	if err := s.syncDynamicResources(newDRLCByType, existingDRLCByType, existingDRByType); err != nil {
-		return err
+
+	if len(dRLCToDelete) > 0 {
+		if err := s.persistDynamicResourceLifeCycles(nil, nil, dRLCToDelete); err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-// updateDynamicResources will update dynamic resource based on existing on a dynamic resource life cycle.
-// It will make sure than MinCount of resource exists, and attempt to delete expired and resources over MaxCount.
-// If resources are held by another user than Boskos, they will be deleted in a following cycle.
-func (s *Storage) updateDynamicResources(lifecycle common.DynamicResourceLifeCycle, resources []common.Resource) (toAdd, toDelete []common.Resource) {
-	var notInUseRes []common.Resource
-	count := 0
-	for _, r := range resources {
-		// We can only delete resources not in use
-		if !r.IsInUse() {
-			// deleting resources already marked for deletion, and not including them in the count.
-			if r.State == common.Tombstone || r.State == common.ToBeDeleted {
-				// those will be deleted, not counting
-				toDelete = append(toDelete, r)
-			} else {
-				// Those resources will be deleted at next iteration counting
-				count++
-				// Expired
-				if r.ExpirationDate != nil && s.now().After(*r.ExpirationDate) {
-					toDelete = append(toDelete, r)
-				} else {
-					notInUseRes = append(notInUseRes, r)
-				}
-			}
-
-		} else {
-			count++
-		}
-	}
-
-	for i := count; i < lifecycle.MinCount; i++ {
-		res := common.NewResourceFromNewDynamicResourceLifeCycle(s.generateName(), &lifecycle, s.now())
-		toAdd = append(toAdd, res)
-		count++
-	}
-
-	numberOfResToDelete := count - lifecycle.MaxCount
-	// Sorting to get consistent deletion mechanism (ease testing)
-	sort.Stable(sort.Reverse(common.ResourceByName(notInUseRes)))
-	for i := 0; i < len(notInUseRes); i++ {
-		res := notInUseRes[i]
-		if i < numberOfResToDelete {
-			toDelete = append(toDelete, res)
-		}
-	}
-	return
-}
-
-func (s *Storage) syncDynamicResources(newDRLCByType, existingDRLCByType map[string]common.DynamicResourceLifeCycle, existingResByType map[string][]common.Resource) error {
+// syncDynamicResourceLifeCycles compares the new DRLC configuration against
+// the current configuration. If a DRLC has been deleted from the new
+// configuration, it is updated to indicate that its dynamic resources should
+// be removed.
+// No dynamic resources are created, deleted, or modified by this function.
+func (s *Storage) syncDynamicResourceLifeCycles(newDRLCByType, existingDRLCByType map[string]common.DynamicResourceLifeCycle) error {
 	var finalError error
-	var resToAdd, resToDelete []common.Resource
-	var dRLCToUpdate, dRLCToAdd, dRLCToDelete []common.DynamicResourceLifeCycle
+	var dRLCToUpdate, dRLCToAdd []common.DynamicResourceLifeCycle
 
 	for _, existingDRLC := range existingDRLCByType {
-		newDRLC, exists := newDRLCByType[existingDRLC.Type]
-		if exists {
+		newDRLC, existsInNew := newDRLCByType[existingDRLC.Type]
+		if existsInNew {
 			if !reflect.DeepEqual(existingDRLC, newDRLC) {
 				dRLCToUpdate = append(dRLCToUpdate, newDRLC)
 			}
-			moreToAdd, moreToDelete := s.updateDynamicResources(newDRLC, existingResByType[newDRLC.Type])
-			resToAdd = append(resToAdd, moreToAdd...)
-			resToDelete = append(resToDelete, moreToDelete...)
 		} else {
-			dRLCToDelete = append(dRLCToDelete, existingDRLC)
-			for _, res := range existingResByType[existingDRLC.Type] {
-				resToDelete = append(resToDelete, res)
-			}
+			// Mark for deletion of all associated dynamic resources.
+			existingDRLC.MinCount = 0
+			existingDRLC.MaxCount = 0
+			dRLCToUpdate = append(dRLCToUpdate, existingDRLC)
 		}
 	}
 
@@ -344,19 +427,12 @@ func (s *Storage) syncDynamicResources(newDRLCByType, existingDRLCByType map[str
 		_, exists := existingDRLCByType[newDRLC.Type]
 		if !exists {
 			dRLCToAdd = append(dRLCToAdd, newDRLC)
-			moreToAdd, moreToDelete := s.updateDynamicResources(newDRLC, existingResByType[newDRLC.Type])
-			resToAdd = append(resToAdd, moreToAdd...)
-			resToDelete = append(resToDelete, moreToDelete...)
 		}
 	}
 
-	if err := s.persistResources(resToAdd, resToDelete, true); err != nil {
+	if err := s.persistDynamicResourceLifeCycles(dRLCToUpdate, dRLCToAdd, nil); err != nil {
 		finalError = multierror.Append(finalError, err)
 	}
-	if err := s.persistDynamicResourceLifeCycles(dRLCToUpdate, dRLCToAdd, dRLCToDelete); err != nil {
-		finalError = multierror.Append(finalError, err)
-	}
-
 	return finalError
 }
 
@@ -425,6 +501,11 @@ func (s *Storage) persistDynamicResourceLifeCycles(dRLCToUpdate, dRLCToAdd, dRLC
 				finalError = multierror.Append(finalError, err)
 				logrus.WithError(err).Errorf("unable to delete resource type life cycle %s", dRLC.Type)
 			}
+		} else {
+			// Mark this DRLC as pending deletion by setting min and max count to zero.
+			dRLC.MinCount = 0
+			dRLC.MaxCount = 0
+			dRLCToUpdate = append(dRLCToUpdate, dRLC)
 		}
 	}
 


### PR DESCRIPTION
Handling of the lifecycles for dynamic resources is moved to a separate
function, `UpdateAllDynamicResources`, which is called periodically
(configurable using `--dynamic-resource-update-period`).

This new function queries for all existing DynamicResourceLifeCycles
and dynamic resources and ensures that the specified number of resources
exist, and that any expired resources are deleted.

When a DynamicResourceLifeCycle is removed from the configuration, the
MinCount and MaxCount for that DRLC in storage are set to 0, which
allows for graceful removal of any associated dynamic resources. Once
all resources have been deleted, the DRLC will be removed.

Fixes #15906 

cc @chemikadze