### PR TITLE
fix dashboard typo on kind job

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -43,7 +43,7 @@ periodics:
       securityContext:
         privileged: true
     annotations:
-      testgrid-dashboards: sig-testing-kkind
+      testgrid-dashboards: sig-testing-kind
       testgrid-tab-name: ci unit test
       testgrid-alert-email: bentheelder@google.com
       description: kind CI unit test


### PR DESCRIPTION
it seems that the testgrid dashboad config has a typo
> testgrid-dashboards: sig-testing-kkind