### PR TITLE
Add kubernetes signal on flakes

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind.yaml
@@ -426,3 +426,106 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+
+periodics:
+- name: periodic-kubernetes-e2e-kind-flakes
+  decorate: true
+  interval: 2h
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decoration_config:
+    timeout: 60m
+  path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200123-dd36597-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+      env:
+      - name: FOCUS
+        value: \[Flaky\]
+      # TODO(bentheelder): reduce the skip list further
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+      - name: PARALLEL
+        value: "true"
+      - name: BUILD_TYPE
+        value: bazel
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # TODO(BenTheElder): adjust these everywhere
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-num-failures-to-alert: '10'
+    testgrid-alert-stale-results-hours: '24'
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-flakes, master
+    description: Runs flaky tests against latest kubernetes master with a kubernetes-in-docker cluster
+    testgrid-num-columns-recent: '3'
+
+- name: periodic-kubernetes-e2e-kind-flakes-ipv6
+  decorate: true
+  interval: 2h
+  labels:
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decoration_config:
+    timeout: 60m
+  path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200123-dd36597-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+      env:
+      - name: FOCUS
+        value: \[Flaky\]
+      # TODO(bentheelder): reduce the skip list further
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+      - name: PARALLEL
+        value: "true"
+      - name: BUILD_TYPE
+        value: bazel
+      # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
+      # tell kind CI script to use ipv6
+      - name: "IP_FAMILY"
+        value: "ipv6"
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # TODO(BenTheElder): adjust these everywhere
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-num-failures-to-alert: '10'
+    testgrid-alert-stale-results-hours: '24'
+    testgrid-dashboards: sig-testing-kind
+    testgrid-tab-name: kind-ipv6-flakes, master
+    description: Runs flaky tests against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
+    testgrid-num-columns-recent: '3'


### PR DESCRIPTION
debugging flakes is challenging, mainly because you can't reproduce the error and you don't know in advance what can be causing the flake behavior so you have to experiment and try different hypothesis.
KIND provides you a local environment that allows you to do a more advanced troubleshooting in your local workstation.
Adding a job that gives signal on flakes using KIND can be very useful to try to reproduce it locally.