### PR TITLE
Kops - Fix double "/" in URL

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -82,7 +82,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
-        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release/
+        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --extract=release/latest
         - --ginkgo-parallel
         - --kops-build
@@ -126,7 +126,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.15.txt
-        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release/
+        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --extract=release/stable-1.15
         - --ginkgo-parallel
         - --kops-build
@@ -170,7 +170,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release/
+        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --extract=release/stable-1.16
         - --ginkgo-parallel
         - --kops-build
@@ -214,7 +214,7 @@ presubmits:
         - --check-leaked-resources=false
         - --cluster=
         - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
-        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release/
+        - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --extract=release/stable-1.17
         - --ginkgo-parallel
         - --kops-build


### PR DESCRIPTION
Still having issues after #16029:
```
error building complete spec: error reading tag file "https://storage.googleapis.com/kubernetes-release/release//v1.18.0-alpha.2/bin/linux/amd64/kube-apiserver.docker_tag": file does not exist
2020/01/27 05:51:47 process.go:155: Step '/workspace/kops create cluster --name e2e-27bacef07b-ff1eb.test-cncf-aws.k8s.io --ssh-public-key /workspace/.ssh/kube_aws_rsa.pub --node-count 4 --node-volume-size 48 --master-volume-size 48 --master-count 1 --zones ap-southeast-2b --master-size c5.large --kubernetes-version https://storage.googleapis.com/kubernetes-release/release//v1.18.0-alpha.2 --admin-access 34.68.196.171/32 --cloud aws --override cluster.spec.nodePortAccess=0.0.0.0/0' finished in 9.937583709s```

/cc @justinsb @rifelpet @johngmyers 