### PR TITLE
Add a timeout option for unscheduled pods.

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -446,6 +446,9 @@ type Plank struct {
 	// PodRunningTimeout is after how long the controller will abort a prowjob pod
 	// stuck in running state. Defaults to two days.
 	PodRunningTimeout *metav1.Duration `json:"pod_running_timeout,omitempty"`
+	// PodUnscheduledTimeout is after how long the controller will abort a prowjob
+	// stuck in an unscheduled state. Defaults to one day.
+	PodUnscheduledTimeout *metav1.Duration `json:"pod_unscheduled_timeout,omitempty"`
 	// DefaultDecorationConfig are defaults for shared fields for ProwJobs
 	// that request to have their PodSpecs decorated.
 	// This will be deprecated on April 2020, and it will be replaces with DefaultDecorationConfigs['*'] instead.
@@ -1332,6 +1335,10 @@ func parseProwConfig(c *Config) error {
 
 	if c.Plank.PodRunningTimeout == nil {
 		c.Plank.PodRunningTimeout = &metav1.Duration{Duration: 48 * time.Hour}
+	}
+
+	if c.Plank.PodUnscheduledTimeout == nil {
+		c.Plank.PodUnscheduledTimeout = &metav1.Duration{Duration: 24 * time.Hour}
 	}
 
 	if c.Plank.AllowCancellations != nil {

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -50,8 +50,9 @@ type fca struct {
 }
 
 const (
-	podPendingTimeout = time.Hour
-	podRunningTimeout = time.Hour * 2
+	podPendingTimeout     = time.Hour
+	podRunningTimeout     = time.Hour * 2
+	podUnscheduledTimeout = time.Minute * 5
 )
 
 func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
@@ -91,8 +92,9 @@ func newFakeConfigAgent(t *testing.T, maxConcurrency int) *fca {
 						MaxConcurrency: maxConcurrency,
 						MaxGoroutines:  20,
 					},
-					PodPendingTimeout: &metav1.Duration{Duration: podPendingTimeout},
-					PodRunningTimeout: &metav1.Duration{Duration: podRunningTimeout},
+					PodPendingTimeout:     &metav1.Duration{Duration: podPendingTimeout},
+					PodRunningTimeout:     &metav1.Duration{Duration: podRunningTimeout},
+					PodUnscheduledTimeout: &metav1.Duration{Duration: podUnscheduledTimeout},
 				},
 			},
 			JobConfig: config.JobConfig{
@@ -1102,8 +1104,9 @@ func TestSyncPendingJob(t *testing.T) {
 			pods: []v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "nightmare",
-						Namespace: "pods",
+						Name:              "nightmare",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-podPendingTimeout)},
 					},
 					Status: v1.PodStatus{
 						Phase:     v1.PodPending,
@@ -1133,8 +1136,9 @@ func TestSyncPendingJob(t *testing.T) {
 			pods: []v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "endless",
-						Namespace: "pods",
+						Name:              "endless",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-podRunningTimeout)},
 					},
 					Status: v1.PodStatus{
 						Phase:     v1.PodRunning,
@@ -1147,6 +1151,66 @@ func TestSyncPendingJob(t *testing.T) {
 			expectedComplete: true,
 			expectedReport:   true,
 			expectedURL:      "endless/aborted",
+		},
+		{
+			name: "stale unschedulable prow job",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "homeless",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "homeless",
+				},
+			},
+			pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "homeless",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-podUnscheduledTimeout - time.Second)},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+					},
+				},
+			},
+			expectedState:    prowapi.ErrorState,
+			expectedNumPods:  1,
+			expectedComplete: true,
+			expectedReport:   true,
+			expectedURL:      "homeless/error",
+		},
+		{
+			name: "scheduled, pending started more than podUnscheduledTimeout ago",
+			pj: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "slowpoke",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "slowpoke",
+				},
+			},
+			pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "slowpoke",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-podUnscheduledTimeout * 2)},
+					},
+					Status: v1.PodStatus{
+						Phase:     v1.PodPending,
+						StartTime: startTime(time.Now().Add(-podUnscheduledTimeout * 2)),
+					},
+				},
+			},
+			expectedState:   prowapi.PendingState,
+			expectedNumPods: 1,
 		},
 	}
 	for _, tc := range testcases {


### PR DESCRIPTION
Add a new option `plank.pod_unscheduled_timeout` that fails prowjobs with associated pods that have been stuck in the `pending` state but have not been give a `status.startTime`, indicating that they are stuck.

Separated from `plank.pod_pending_timeout` to cope with usecases where taking a long time to schedule a pod is expected, and terminating those jobs is undesirable.

Fixes #16034.

/cc @cjwagner 