### PR TITLE
Sync e2e_node approvers with sig-node approvers

### DIFF
--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -4,3 +4,8 @@ approvers:
 - Random-Liu
 - yguo0905
 - yujuhong
+- tallclair
+- derekwaynecarr
+- ConnorDoyle
+- klueska
+- dchen1107


### PR DESCRIPTION
Synchronizes with approvers in main `kubernetes/kubernetes` repository for `/test/e2e_node`.