### PR TITLE
Add ci flaky repro job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -239,6 +239,36 @@ periodics:
     description: Uses kubetest to run e2e tests (+Feature:many, -many) against a cluster created with cluster/kube-up.sh
 
 - interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-flaky-repro
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=70
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=ENABLE_POD_SECURITY_POLICY=true
+      - --extract=ci/latest
+      - --gcp-master-image=gci
+      - --gcp-node-image=gci
+      - --gcp-nodes=4
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=30
+      - --provider=gce
+      - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=50m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200127-8d34d6e-master
+  annotations:
+    testgrid-dashboards: google-gce, google-gci
+    testgrid-tab-name: gce-cos-master-flaky-repro
+    description: Same config as ci-kubernetes-e2e-gci-gce but with Flaky tests included, intended to reproduce conditions that cause flakes to appear
+
+- interval: 30m
   name: ci-kubernetes-e2e-gci-gce-flaky
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Currently when a job is tagged as Flaky it is only run in CI in a job
that focuses exclusively on Flaky tests. However, many times flakes do
not end up reproducing in this flakes-only job because there is not
enough test volume to cause them. This means efforts to prove that a
flake is fixed involve opening a PR that removes the [Flake] tag from
a test and repeatedly manually triggering tests.

Let's introduce a gce job named flaky-repro that runs flaky tests in
the conditions that reproduce flakes. Take the "default" gce job, and
subtract its skip of [Flaky]. Since this job is most likely going to
be red or flaky all of the time, keep it off of sig-release boards and
drop alerting.

This should give us more evidence (or at least less manually-generated)
that a given flake has been fixed and no longer reproduces alongside
other tests at high volume