### PR TITLE
Tide: support query by "author"

### DIFF
--- a/prow/cmd/deck/static/api/tide.ts
+++ b/prow/cmd/deck/static/api/tide.ts
@@ -8,6 +8,7 @@ export interface TideQuery {
   includedBranches?: string[];
   labels?: string[];
   missingLabels?: string[];
+  author?: string;
   milestone?: string;
   reviewApprovedRequired?: boolean;
 }

--- a/prow/cmd/deck/template/pr.html
+++ b/prow/cmd/deck/template/pr.html
@@ -44,6 +44,10 @@
 <dialog id="query-dialog" class="pr-status-dialog mdl-dialog">
   <h4 class="mdl-dialog__title">Query Details</h4>
   <div class="mdl-dialog__content">
+    <div id="query-detail-author" class="hidden">
+      <p class="detail-title">Author</p>
+      <p class="detail-data"></p>
+    </div>
     <div id="query-detail-milestone" class="hidden">
       <p class="detail-title">Milestone</p>
       <p class="detail-data"></p>

--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -49,6 +49,7 @@ It can consist of the following dictionary of fields:
 * `missingLabels`: List of labels any given PR must not posses.
 * `excludedBranches`: List of branches that get excluded when querying the `repos`.
 * `includedBranches`: List of branches that get included when querying the `repos`.
+* `author`: The author of the PR.
 * `reviewApprovedRequired`: If set, each PR in the query must have at
   least one [approved GitHub pull request
   review](https://help.github.com/articles/about-pull-request-reviews/)
@@ -66,6 +67,7 @@ The field to search token correspondence is based on the following mapping:
 * `missingLabels` -> `-label:do-not-merge`
 * `excludedBranches` -> `-branch:dev`
 * `includedBranches` -> `branch:master`
+* `author` -> `author:batman`
 * `reviewApprovedRequired` -> `review:approved`
 
 **Important**: Each query must return a different set of PRs. No two queries are allowed to contain the same PR.

--- a/prow/config/tide.go
+++ b/prow/config/tide.go
@@ -206,6 +206,8 @@ type TideQuery struct {
 	Repos         []string `json:"repos,omitempty"`
 	ExcludedRepos []string `json:"excludedRepos,omitempty"`
 
+	Author string `json:"author,omitempty"`
+
 	ExcludedBranches []string `json:"excludedBranches,omitempty"`
 	IncludedBranches []string `json:"includedBranches,omitempty"`
 
@@ -228,6 +230,9 @@ func (tq *TideQuery) Query() string {
 	}
 	for _, r := range tq.ExcludedRepos {
 		toks = append(toks, fmt.Sprintf("-repo:\"%s\"", r))
+	}
+	if tq.Author != "" {
+		toks = append(toks, fmt.Sprintf("author:\"%s\"", tq.Author))
 	}
 	for _, b := range tq.ExcludedBranches {
 		toks = append(toks, fmt.Sprintf("-base:\"%s\"", b))

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -35,6 +35,7 @@ var testQuery = TideQuery{
 	Repos:                  []string{"k/k", "k/t-i"},
 	Labels:                 []string{labels.LGTM, labels.Approved},
 	MissingLabels:          []string{"foo"},
+	Author:                 "batman",
 	Milestone:              "milestone",
 	ReviewApprovedRequired: true,
 }
@@ -55,6 +56,7 @@ func TestTideQuery(t *testing.T) {
 	checkTok("label:\"lgtm\"")
 	checkTok("label:\"approved\"")
 	checkTok("-label:\"foo\"")
+	checkTok("author:\"batman\"")
 	checkTok("milestone:\"milestone\"")
 	checkTok("review:approved")
 }

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -148,6 +148,18 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 		}
 	}
 
+	qAuthor := github.NormLogin(q.Author)
+	prAuthor := github.NormLogin(string(pr.Author.Login))
+
+	// Weight incorrect author with very high diff so that we select the query
+	// for the correct author.
+	if qAuthor != "" && prAuthor != qAuthor {
+		diff += 1000
+		if desc == "" {
+			desc = fmt.Sprintf(" Must be by author %s.", qAuthor)
+		}
+	}
+
 	// Weight incorrect milestone with relatively high diff so that we select the
 	// query for the correct milestone (but choose favor query for correct branch).
 	if q.Milestone != "" && (pr.Milestone == nil || string(pr.Milestone.Title) != q.Milestone) {


### PR DESCRIPTION
Add support in Tide for query by "author". I am weighting an incorrect author with very high diff (similar to branch) due to the relative importance of the field being accurate (when specified).

This would be a useful, extensible way to expose functionality like requested in https://github.com/istio/test-infra/issues/2304