### PR TITLE
Set a tighter bound for default TerminatedPodTTL

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -534,7 +533,7 @@ type Sinker struct {
 	MaxPodAge *metav1.Duration `json:"max_pod_age,omitempty"`
 	// TerminatedPodTTL is how long a Pod can live after termination before it is
 	// garbage collected.
-	// Defaults to infinite.
+	// Defaults to matching MaxPodAge.
 	TerminatedPodTTL *metav1.Duration `json:"terminated_pod_ttl,omitempty"`
 }
 
@@ -1477,8 +1476,7 @@ func parseProwConfig(c *Config) error {
 	}
 
 	if c.Sinker.TerminatedPodTTL == nil {
-		// "Forever"
-		c.Sinker.TerminatedPodTTL = &metav1.Duration{Duration: math.MaxInt64}
+		c.Sinker.TerminatedPodTTL = &metav1.Duration{Duration: c.Sinker.MaxPodAge.Duration}
 	}
 
 	if c.Tide.SyncPeriod == nil {


### PR DESCRIPTION
Change the default `TerminatedPodTTL` from infinite to the same as `MaxPodAge`.

Most pods will be cleaned up by the time `MaxPodAge` elapses, but some pods won't be caught by that (in particular, pods that never had a `startTime` set because they were never scheduled).

Except in error cases, this should be equivalent to the default of infinity - MaxPodAge usually counts from an earlier time (pod starting) than TerminatedPodTTL (job finishing).

(An almost-identical effect could also be achieved by instead having `MaxPodAge` inspect pod creation time instead of start time.)

/cc @cjwagner @stevekuznetsov 