### PR TITLE
boskos/metrics: don't completely bail out if one of the resource types errors

### DIFF
--- a/boskos/metrics/metrics.go
+++ b/boskos/metrics/metrics.go
@@ -108,7 +108,8 @@ func update(boskos *client.Client) error {
 	for _, resource := range resources {
 		metric, err := boskos.Metric(resource)
 		if err != nil {
-			return fmt.Errorf("fail to get metric for %s : %v", resource, err)
+			logrus.WithError(err).Errorf("failed to get metric for %s", resource)
+			continue
 		}
 		// Filtering metrics states
 		for state, value := range metric.Current {


### PR DESCRIPTION
If the boskos-metrics component fails to query one of the resource types (e.g. because the type isn't found), it currently errors out, resulting in no metrics being served for any resource type.

Rather than completely bailing out, log an error if there were issues getting metrics for that type, but continue to serve metrics for other types.