### PR TITLE
[capi] presubmit skip branches

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -132,6 +132,9 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
+    skip_branches:
+      - gh-pages
+      - release-0.2
     path_alias: sigs.k8s.io/cluster-api
     optional: true
     always_run: false


### PR DESCRIPTION
We don't want to run this if the base branch is release-0.2

Signed-off-by: Chuck Ha <chuckh@vmware.com>