### PR TITLE
Add a lens for viewing job pod information

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -135,6 +135,7 @@ go_library(
         "//prow/spyglass/lenses/coverage:go_default_library",
         "//prow/spyglass/lenses/junit:go_default_library",
         "//prow/spyglass/lenses/metadata:go_default_library",
+        "//prow/spyglass/lenses/podinfo:go_default_library",
         "//prow/spyglass/lenses/restcoverage:go_default_library",
         "//prow/tide:go_default_library",
         "//prow/tide/history:go_default_library",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -81,6 +81,7 @@ import (
 	_ "k8s.io/test-infra/prow/spyglass/lenses/coverage"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/junit"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/metadata"
+	_ "k8s.io/test-infra/prow/spyglass/lenses/podinfo"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/restcoverage"
 )
 

--- a/prow/cmd/deck/static/spyglass/lens.ts
+++ b/prow/cmd/deck/static/spyglass/lens.ts
@@ -202,8 +202,10 @@ class SpyglassImpl implements Spyglass {
   }
 
   private fixAnchorLink(a: HTMLAnchorElement): void {
-    a.href = location.href.split('#')[0] + a.getAttribute('href');
-    a.target = "_self";
+    if (!a.dataset.preserveAnchor) {
+      a.href = location.href.split('#')[0] + a.getAttribute('href');
+      a.target = "_self";
+    }
   }
 }
 

--- a/prow/spyglass/lenses/BUILD.bazel
+++ b/prow/spyglass/lenses/BUILD.bazel
@@ -10,6 +10,7 @@ filegroup(
         "//prow/spyglass/lenses/coverage:template",
         "//prow/spyglass/lenses/junit:template",
         "//prow/spyglass/lenses/metadata:template",
+        "//prow/spyglass/lenses/podinfo:template",
         "//prow/spyglass/lenses/restcoverage:template",
     ],
 )
@@ -21,6 +22,7 @@ filegroup(
         "//prow/spyglass/lenses/coverage:resources",
         "//prow/spyglass/lenses/junit:resources",
         "//prow/spyglass/lenses/metadata:resources",
+        "//prow/spyglass/lenses/podinfo:resources",
         "//prow/spyglass/lenses/restcoverage:resources",
     ],
 )
@@ -53,6 +55,7 @@ filegroup(
         "//prow/spyglass/lenses/coverage:all-srcs",
         "//prow/spyglass/lenses/junit:all-srcs",
         "//prow/spyglass/lenses/metadata:all-srcs",
+        "//prow/spyglass/lenses/podinfo:all-srcs",
         "//prow/spyglass/lenses/restcoverage:all-srcs",
     ],
     tags = ["automanaged"],

--- a/prow/spyglass/lenses/podinfo/BUILD.bazel
+++ b/prow/spyglass/lenses/podinfo/BUILD.bazel
@@ -1,0 +1,64 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@build_bazel_rules_nodejs//:defs.bzl", "rollup_bundle")
+load("@npm_bazel_typescript//:index.bzl", "ts_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["podinfo.go"],
+    importpath = "k8s.io/test-infra/prow/spyglass/lenses/podinfo",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/crier/reporters/gcs/kubernetes:go_default_library",
+        "//prow/entrypoint:go_default_library",
+        "//prow/spyglass/lenses:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+    ],
+)
+
+ts_library(
+    name = "script",
+    srcs = ["podinfo.ts"],
+    deps = [
+        "//prow/spyglass/lenses:lens_api",
+    ],
+)
+
+rollup_bundle(
+    name = "script_bundle",
+    enable_code_splitting = False,
+    entry_point = ":podinfo.ts",
+    deps = [
+        ":script",
+    ],
+)
+
+filegroup(
+    name = "template",
+    srcs = ["template.html"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "resources",
+    srcs = [
+        "style.css",
+        ":script_bundle",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/spyglass/lenses/podinfo/podinfo.go
+++ b/prow/spyglass/lenses/podinfo/podinfo.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package podinfo provides a coverage viewer for Spyglass
+package podinfo
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	k8sreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
+	"k8s.io/test-infra/prow/entrypoint"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/prow/spyglass/lenses"
+)
+
+const (
+	name     = "podinfo"
+	title    = "Job Pod Info"
+	priority = 20
+)
+
+func init() {
+	lenses.RegisterLens(Lens{})
+}
+
+// Lens is the implementation of a coverage-rendering Spyglass lens.
+type Lens struct{}
+
+// Config returns the lens's configuration.
+func (lens Lens) Config() lenses.LensConfig {
+	return lenses.LensConfig{
+		Name:     name,
+		Title:    title,
+		Priority: priority,
+	}
+}
+
+// Header renders the content of <head> from template.html.
+func (lens Lens) Header(artifacts []lenses.Artifact, resourceDir string, config json.RawMessage) string {
+	t, err := loadTemplate(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		return fmt.Sprintf("<!-- FAILED LOADING HEADER: %v -->", err)
+	}
+	var buf bytes.Buffer
+	if err := t.ExecuteTemplate(&buf, "header", nil); err != nil {
+		return fmt.Sprintf("<!-- FAILED EXECUTING HEADER TEMPLATE: %v -->", err)
+	}
+	return buf.String()
+}
+
+// Callback does nothing.
+func (lens Lens) Callback(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
+	return ""
+}
+
+// Body renders the <body>
+func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data string, config json.RawMessage) string {
+	if len(artifacts) == 0 {
+		logrus.Error("podinfo Body() called with no artifacts, which should never happen.")
+		return "Why am I here? There is no podinfo file."
+	}
+
+	artifact := artifacts[0]
+
+	content, err := artifact.ReadAll()
+	if err != nil {
+		logrus.WithError(err).Warn("Couldn't read a podinfo file that should exist.")
+		return fmt.Sprintf("Failed to read the podinfo file: %v", err)
+	}
+
+	infoTemplate, err := loadTemplate(filepath.Join(resourceDir, "template.html"))
+	if err != nil {
+		logrus.WithError(err).Error("Error loading template.")
+		return fmt.Sprintf("Failed to load template file: %v", err)
+	}
+
+	p := k8sreporter.PodReport{}
+	if err := json.Unmarshal(content, &p); err != nil {
+		logrus.WithError(err).Infof("Error unmarshalling PodReport")
+		return fmt.Sprintf("Couldn't unmarshal podinfo.json: %v", err)
+	}
+
+	t := struct {
+		PodReport  k8sreporter.PodReport
+		Containers []containerInfo
+	}{
+		PodReport:  p,
+		Containers: append(assembleContainers(p.Pod.Spec.InitContainers, p.Pod.Status.InitContainerStatuses), assembleContainers(p.Pod.Spec.Containers, p.Pod.Status.ContainerStatuses)...),
+	}
+
+	var buf bytes.Buffer
+	if err := infoTemplate.ExecuteTemplate(&buf, "body", t); err != nil {
+		logrus.WithError(err).Error("Error executing template.")
+	}
+
+	return buf.String()
+}
+
+type containerInfo struct {
+	// Container is a container spec
+	Container *v1.Container
+	// Status is a container status corresponding to the spec
+	Status *v1.ContainerStatus
+	// DecoratedArgs is the arguments the podutils entrypoint is invoking,
+	// which is explicitly extracted because `/tools/entrypoint` is not a very
+	// useful entrypoint to report.
+	DecoratedArgs []string
+}
+
+func assembleContainers(containers []v1.Container, containerStatuses []v1.ContainerStatus) []containerInfo {
+	var assembled []containerInfo
+	for i, c := range containers {
+		ci := containerInfo{
+			Container: &containers[i],
+			Status:    nil,
+		}
+		for _, env := range c.Env {
+			if env.Name == entrypoint.JSONConfigEnvVar && env.Value != "" {
+				entrypointOptions := entrypoint.NewOptions()
+				if err := entrypointOptions.LoadConfig(env.Value); err != nil {
+					logrus.WithError(err).Infof("Couldn't parse JSON config env var")
+					break
+				}
+				ci.DecoratedArgs = entrypointOptions.Args
+				break
+			}
+		}
+		for j, s := range containerStatuses {
+			if s.Name == c.Name {
+				ci.Status = &containerStatuses[j]
+				break
+			}
+		}
+		if ci.Status != nil {
+			assembled = append(assembled, ci)
+		}
+	}
+	return assembled
+}
+
+func loadTemplate(path string) (*template.Template, error) {
+	return template.New("template.html").Funcs(template.FuncMap{
+		"isProw": func(s string) bool {
+			return strings.HasPrefix(s, "prow.k8s.io/") || strings.HasPrefix(s, "testgrid-") || s == "created-by-prow"
+		},
+		"toYaml": func(o interface{}) (string, error) {
+			result, err := yaml.Marshal(o)
+			if err != nil {
+				return "", err
+			}
+			return string(result), nil
+		},
+		"toAge": func(t time.Time) string {
+			d := time.Now().Sub(t)
+			if d < time.Minute {
+				return d.Truncate(time.Second).String()
+			}
+			s := d.Truncate(time.Minute).String()
+			// Chop off the 0s at the end.
+			return s[:len(s)-2]
+		},
+	}).ParseFiles(path)
+}

--- a/prow/spyglass/lenses/podinfo/podinfo.ts
+++ b/prow/spyglass/lenses/podinfo/podinfo.ts
@@ -1,0 +1,15 @@
+window.addEventListener('load', () => {
+  document.querySelectorAll<HTMLAnchorElement>('a.mdl-tabs__tab').forEach((e) => {
+    e.onclick = () => spyglass.contentUpdated();
+  });
+
+  document.querySelectorAll<HTMLAnchorElement>('a.expand-prow').forEach((e) => {
+    e.onclick = () => {
+      if (!e.parentElement || !e.parentElement.parentElement) {
+        return;
+      }
+      e.parentElement.parentElement.classList.add("unhide");
+      spyglass.contentUpdated();
+    };
+  });
+});

--- a/prow/spyglass/lenses/podinfo/style.css
+++ b/prow/spyglass/lenses/podinfo/style.css
@@ -1,0 +1,69 @@
+ul.data {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  line-height: inherit;
+}
+
+.data li {
+  margin-left: 20px;
+  text-indent: -20px;
+  word-break: break-word;
+}
+
+.literal {
+  font-family: monospace;
+  white-space: normal;
+}
+
+.pre {
+  white-space: pre !important;
+  color: #e8e8e8;
+  padding: 20px;
+}
+
+.unhide .hidden {
+  visibility: visible;
+  display: block !important; /* MDL helpfully uses !important here */
+}
+
+.unhide .expand-prow {
+  visibility: collapse;
+  display: none;
+}
+
+#podinfo.mdl-tabs .mdl-tabs__tab-bar {
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: left;
+  border: 0;
+}
+
+#podinfo.mdl-tabs.is-upgraded .mdl-tabs__tab.is-active {
+  color: white;
+}
+
+.mdl-data-table thead th {
+  color: #e8e8e8;
+  text-align: left;
+  font-size: 14px;
+}
+
+code.item {
+  border-width: 1px;
+  border-color: rgba(0,0,0,0.6);
+  display: inline-block;
+  border-style: solid;
+  padding-left: 3px;
+  padding-right: 3px;
+  border-radius: 2px;
+  margin-bottom: 2px;
+}
+
+.mdl-data-table__cell--non-numeric {
+  white-space: normal;
+}
+
+code {
+  white-space: pre-wrap;
+}

--- a/prow/spyglass/lenses/podinfo/template.html
+++ b/prow/spyglass/lenses/podinfo/template.html
@@ -1,0 +1,233 @@
+{{define "header"}}
+<link rel="stylesheet" type="text/css" href="style.css">
+<script type="text/javascript" src="script_bundle.min.js"></script>
+<script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
+{{end}}
+
+{{define "body"}}
+{{$pod:=.PodReport.Pod}}
+<div class="mdl-tabs mdl-js-tabs mdl-js-ripple-effect" id="podinfo">
+  <div class="mdl-tabs__tab-bar">
+    <a href="#pod-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Pod</a>
+    <a href="#volumes-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Volumes</a>
+    <a href="#events-panel" data-preserve-anchor="true" class="mdl-tabs__tab">Events</a>
+    {{range .Containers}}
+    <a href="#{{.Container.Name}}-panel" data-preserve-anchor="true" class="mdl-tabs__tab">{{.Container.Name}}</a>
+    {{end}}
+    <a href="#yaml-panel" data-preserve-anchor="true" class="mdl-tabs__tab">YAML</a>
+  </div>
+
+  <div class="mdl-tabs__panel" id="pod-panel">
+    <table class="mdl-data-table mdl-js-data-table metadata-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod name</td>
+        <td class="mdl-data-table__cell--non-numeric literal">{{$pod.Name}}</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Start time</td>
+        <td class="mdl-data-table__cell--non-numeric">{{$pod.Status.StartTime}}</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Pod status</td>
+        <td class="mdl-data-table__cell--non-numeric literal">{{$pod.Status.Phase}}</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Node</td>
+        <td class="mdl-data-table__cell--non-numeric"><code>{{$pod.Spec.NodeName}}</code> / <code>{{$pod.Status.HostIP}}</code></td>
+      </tr>
+      {{$hasInterestingTolerations := false}}
+      {{range $pod.Spec.Tolerations}}
+        {{if not (eq .Key "node.kubernetes.io/not-ready" "node.kubernetes.io/unreachable")}}
+          {{$hasInterestingTolerations = true}}
+        {{end}}
+      {{end}}
+      {{if $hasInterestingTolerations}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Tolerations</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+          {{range $pod.Spec.Tolerations}}
+          <li><code>{{.Key}}{{if eq .Operator "Equals"}}={{.Value}}{{end}}{{if .Effect}}:{{.Effect}}{{end}}</code>{{if .TolerationSeconds}} for {{.TolerationSeconds}} seconds{{end}}</li>
+          {{end}}
+          </ul>
+        </td>
+      </tr>
+      {{end}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Labels</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            {{$hasProw := false}}
+            {{range $k, $v := $pod.Labels}}
+              {{ if not (isProw $k) }}
+                <li class="literal">{{$k}}={{$v}}</li>
+              {{else}}
+                {{$hasProw = true}}
+              {{end}}
+            {{end}}
+            {{if $hasProw}}
+              <li class="more"><a href="#" class="expand-prow">Show prow labels</a></li>
+              {{range $k, $v := $pod.Labels}}
+                {{ if (isProw $k) }}
+                  <li class="hidden literal">{{$k}}={{$v}}</li>
+                {{end}}
+              {{end}}
+            {{end}}
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Annotations</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+            {{$hasProw := false}}
+            {{range $k, $v := $pod.Annotations}}
+              {{ if not (isProw $k) }}
+                <li class="literal">{{$k}}={{$v}}</li>
+              {{else}}
+                {{$hasProw = true}}
+              {{end}}
+            {{end}}
+            {{if $hasProw}}
+              <li class="more expand-prow"><a href="#" class="expand-prow">Show prow labels</a></li>
+              {{range $k, $v := $pod.Annotations}}
+                {{ if (isProw $k) }}
+                  <li class="hidden literal">{{$k}}={{$v}}</li>
+                {{end}}
+              {{end}}
+            {{end}}
+          </ul>
+        </td>
+      </tr>
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="volumes-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      {{range $pod.Spec.Volumes}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric" style="width: 300px;">{{.Name}}</td>
+        <td class="mdl-data-table__cell--non-numeric literal pre">{{toYaml .}}</td>
+      </tr>
+      {{end}}
+    </table>
+  </div>
+  <div class="mdl-tabs__panel" id="events-panel">
+    <table class="mdl-data-table mdl-js-data-table">
+      <thead>
+      <tr>
+        <th>Type</th>
+        <th>Reason</th>
+        <th>Age</th>
+        <th>Source</th>
+        <th>Message</th>
+      </tr>
+      </thead>
+      {{range .PodReport.Events}}
+        <tr class="event-type-{{.Type}}">
+          <td class="mdl-data-table__cell--non-numeric">{{.Type}}</td>
+          <td class="mdl-data-table__cell--non-numeric">{{.Reason}}</td>
+          <td class="mdl-data-table__cell--non-numeric">{{toAge .LastTimestamp.Time}}{{if lt .Count 1}}({{.Count}} times){{end}}</td>
+          <td class="mdl-data-table__cell--non-numeric literal">{{.Source.Component}}</td>
+          <td class="mdl-data-table__cell--non-numeric">{{.Message}}</td>
+        </tr>
+      {{end}}
+    </table>
+  </div>
+  {{range .Containers}}
+  {{$c := .Container}}
+  {{$status := .Status}}
+  <div class="mdl-tabs__panel" id="{{$c.Name}}-panel">
+    <table class="mdl-data-table mdl-js-data-table metadata-table">
+      <tbody>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Image</td>
+        <td class="mdl-data-table__cell--non-numeric literal">{{$c.Image}}</td>
+      </tr>
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Status</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          {{if $status.State.Terminated}}
+            Terminated ({{$status.State.Terminated.Reason}}{{if $status.State.Terminated.Message}} - {{$status.State.Terminated.Message}}{{end}}) at {{$status.State.Terminated.FinishedAt}} with exit code <code>{{$status.State.Terminated.ExitCode}}</code>
+          {{else if $status.State.Running}}
+            Running since {{$status.State.Terminated.StartedAt}}
+          {{else if $status.State.Waiting}}
+            Waiting ({{$status.State.Waiting.Reason}}{{if $status.State.Waiting.Message}} - {{$status.State.Waiting.Message}}{{end}})
+          {{else}}
+            Unclear.
+          {{end}}
+        </td>
+      </tr>
+      {{if or $c.Command $c.Args}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Command</td>
+        <td class="mdl-data-table__cell--non-numeric literal">
+          {{range $c.Command}}
+            <code class="item command">{{.}}</code>
+          {{end}}
+          {{range $c.Args}}
+            <code class="item">{{.}}</code>
+          {{end}}
+        </td>
+      </tr>
+      {{end}}
+      {{if or .DecoratedArgs}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric"><abbr title="When a job is decorated, the original entrypoint/command/args are overwritten. This is the command invoked by the new entrypoint.">Decorated Command</abbr></td>
+        <td class="mdl-data-table__cell--non-numeric literal">
+          {{range .DecoratedArgs}}
+          <code class="item">{{.}}</code>
+          {{end}}
+        </td>
+      </tr>
+      {{end}}
+      {{if $c.VolumeMounts}}
+      <tr>
+        <td class="mdl-data-table__cell--non-numeric">Volume mounts</td>
+        <td class="mdl-data-table__cell--non-numeric">
+          <ul class="data">
+          {{range $c.VolumeMounts}}
+            <li><code>{{.Name}}{{if or .SubPath .SubPathExpr}}/{{or .SubPath .SubPathExpr}}{{end}}</code> at <code>{{.MountPath}}</code>{{if .ReadOnly}} (read-only){{end}}</li>
+          {{end}}
+          </ul>
+        </td>
+      </tr>
+      {{end}}
+      {{if $c.Env}}
+      <td class="mdl-data-table__cell--non-numeric">Environment variables</td>
+      <td class="mdl-data-table__cell--non-numeric">
+        <ul class="data">
+          {{range $c.Env}}
+            <li>
+              <code>{{.Name}}=</code>
+              {{- if .Value -}}
+                <code>{{- .Value -}}</code>
+              {{- else if .ValueFrom -}}
+                {{- if .ValueFrom.ConfigMapKeyRef -}}
+                  (value of configmap key <code>{{.ValueFrom.ConfigMapKeyRef.Name}}.{{.ValueFrom.ConfigMapKeyRef.Key}}</code>{{if .ValueFrom.ConfigMapKeyRef.Optional}}, if it exists{{end}})
+                {{- else if .ValueFrom.SecretKeyRef -}}
+                  (value of secret key <code>{{.ValueFrom.SecretKeyRef.Name}}.{{.ValueFrom.SecreyKeyRef.Key}}</code>{{if .ValueFrom.SecreyKeyRef.Optional}}, if it exists{{end}})
+                {{- else if .ValueFrom.FieldRef -}}
+                  (value of <code>{{.ValueFrom.FieldRef.APIVersion}}</code> field path <code>{{.ValueFrom.FieldRef.FieldPath}}</code>)
+                {{- else if .ValueFrom.ResourceRef -}}
+                  (container <code>{{.ValueFrom.ResourceFieldRef.ContainerName}}</code>'s <code>{{.ValueFrom.ResourceFieldRef.Resource}}</code> in <code>{{.ValueFrom.ResourceFieldRef.Divisor.String}}</code>)
+                {{- else -}}
+                  (something)
+                {{end}}
+              {{end}}
+            </li>
+          {{end}}
+        </ul>
+      </td>
+      {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{end}}
+  <div class="mdl-tabs__panel" id="yaml-panel">
+    <div class="pre literal">
+      {{- toYaml .PodReport.Pod -}}
+    </div>
+  </div>
+</div>
+{{end}}


### PR DESCRIPTION
This adds a low-priority lens that parses `podinfo.json` and gives you some information about the pod that ran your job. This appears unconditionally (assuming it's configured and that podinfo.json exists) - helpful insights as to why your job misbehaved will come soon to the status lens.

Some screenshots:

![image](https://user-images.githubusercontent.com/110792/73314089-c4988b80-41e1-11ea-9d05-d5c252b59843.png)
![image](https://user-images.githubusercontent.com/110792/73314110-d1b57a80-41e1-11ea-8980-62db5facc552.png)
![image](https://user-images.githubusercontent.com/110792/73314129-e134c380-41e1-11ea-9e60-51e1a594f730.png)
![image](https://user-images.githubusercontent.com/110792/73314188-03c6dc80-41e2-11ea-90ee-28eb510a32a8.png)
![image](https://user-images.githubusercontent.com/110792/73314210-10e3cb80-41e2-11ea-9ac0-54ef1014c74e.png)
