### PR TITLE
Make GCE Windows versions explicit, add Windows 1909 job.

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -387,7 +387,7 @@ periodics:
   - 'perfDashPrefix: kubemark-500Nodes-1.14'
   - 'perfDashJobType: performance'
 - annotations:
-    description: Runs tests on a Kubernetes 1.14 cluster with Windows nodes on GCE
+    description: Runs tests on a Kubernetes 1.14 cluster with Windows 2019 nodes on GCE
     testgrid-dashboards: google-windows, sig-release-1.14-informing, sig-windows
     testgrid-tab-name: gce-windows-1.14
   decorate: true
@@ -422,6 +422,9 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-1.14
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -398,7 +398,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    description: Runs tests on a Kubernetes 1.15 cluster with Windows nodes on GCE
+    description: Runs tests on a Kubernetes 1.15 cluster with Windows 2019 nodes on GCE
     testgrid-dashboards: google-windows, sig-release-1.15-informing, sig-windows
     testgrid-tab-name: gce-windows-1.15
   decorate: true
@@ -433,6 +433,9 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-1.15
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -401,7 +401,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    description: Runs tests on a Kubernetes 1.16 cluster with Windows nodes on GCE
+    description: Runs tests on a Kubernetes 1.16 cluster with Windows 2019 nodes on GCE
     testgrid-dashboards: google-windows, sig-release-1.16-informing, sig-windows
     testgrid-tab-name: gce-windows-1.16
   decorate: true
@@ -436,6 +436,9 @@ periodics:
         --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-1.16
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -489,6 +489,9 @@ periodics:
       command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-1.17
       name: ""
       resources: {}

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -88,8 +88,10 @@ periodics:
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
       env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win1909"
       - name: OVERRIDE_NODE_BINARY_TAR_URL
-        value: "https://storage.googleapis.com/kubernetes-release/release/v1.15.3/kubernetes-node-windows-amd64.tar.gz"
+        value: "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/kubernetes-node-windows-amd64.tar.gz"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
       resources:
         requests:
@@ -98,7 +100,7 @@ periodics:
     testgrid-dashboards: google-windows
     testgrid-tab-name: windows-prototype
 
-- name: ci-kubernetes-e2e-windows-gce
+- name: ci-kubernetes-e2e-windows-gce-2019
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
@@ -129,13 +131,58 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing
-    testgrid-tab-name: gce-windows-master
-    description: Runs tests on a Kubernetes cluster with Windows nodes on GCE
+    testgrid-tab-name: gce-windows-2019-master
+    description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
+
+- name: ci-kubernetes-e2e-windows-gce-1909
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: windows-testing
+    base_ref: master
+    path_alias: k8s.io/windows-testing
+  interval: 2h
+  labels:
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-master
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --timeout=120m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win1909"
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200127-8d34d6e-master
+  annotations:
+    fork-per-release: "true"
+    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing
+    testgrid-tab-name: gce-windows-1909-master
+    description: Runs tests on a Kubernetes cluster with Windows 1909 nodes on GCE
 
 - name: ci-kubernetes-e2e-windows-gce-alpha-features
   decorate: true
@@ -169,12 +216,14 @@ periodics:
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=120m
       env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows
-    testgrid-tab-name: gce-windows-master-alpha-features
+    testgrid-tab-name: gce-windows-2019-master-alpha-features
     description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled
 
 - name: ci-kubernetes-e2e-windows-gce-serial
@@ -210,10 +259,13 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]|\[Feature:Windows\]|DaemonRestart --ginkgo.skip=\[Flaky\]|\[LinuxOnly\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=350m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
   annotations:
     testgrid-dashboards: google-windows
-    testgrid-tab-name: windows-gce-serial
+    testgrid-tab-name: gce-windows-2019-serial
 
 - name: ci-kubernetes-e2e-windows-containerd-gce
   decorate: true
@@ -247,12 +299,15 @@ periodics:
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
       - --timeout=150m
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: "win2019"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing, sig-node-containerd
-    testgrid-tab-name: gce-windows-containerd-master
+    testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
 - name: ci-kubernetes-e2e-windows-node-throughput
@@ -264,7 +319,7 @@ periodics:
     preset-load-gce-windows: "true"
   annotations:
     testgrid-dashboards: google-windows
-    testgrid-tab-name: windows-gce-node-throughput
+    testgrid-tab-name: gce-windows-node-throughput
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
@@ -347,6 +402,9 @@ presubmits:
         - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
         - --test-cmd-args=--node-os-distro=windows
         - --timeout=150m
+        env:
+        - name: WINDOWS_NODE_OS_DISTRIBUTION
+          value: "win2019"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
This PR creates a new test job that will run the GCE Windows e2e tests against nodes running Windows Server version 1909, and explicitly annotates existing test jobs as using Windows Server 2019.

The new 1909 job has the same annotations as the current 2019 job, which is intended. Going forward we'll want to test K8s on GCE against both an LTSC version of Windows (2019) and an SAC version (1909 for now, 20-04 for 1.19 or 1.20, ...).