### PR TITLE
[capi] remove capi-e2es in favor of capd-e2es

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -43,32 +43,6 @@ periodics:
     testgrid-tab-name: unit tests
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-tests
-  interval: 1h
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: master
-    path_alias: sigs.k8s.io/cluster-api
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-  spec:
-    containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200128-8dae294-master
-        args:
-          - runner.sh
-          - "./scripts/ci-capi-e2e.sh"
-        resources:
-          requests:
-            cpu: 4
-            memory: "6Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi e2e tests
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-capd-e2e-test
   interval: 1h
   decorate: true
@@ -144,10 +118,12 @@ periodics:
     testgrid-num-failures-to-alert: "2"
 postsubmits:
   kubernetes-sigs/cluster-api:
-  - name: ci-cluster-api-e2e-tests-master
+  - name: postsubmit-cluster-api-capd-e2e-tests-master
     interval: 1h
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
+    branches:
+    - master
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -156,13 +132,13 @@ postsubmits:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20200128-8dae294-master
           args:
             - runner.sh
-            - "./scripts/ci-capi-e2e.sh"
+            - "./scripts/ci-capd-e2e.sh"
           resources:
             requests:
               cpu: 4
               memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi e2e tests-master
+      testgrid-tab-name: capd e2e tests-master
       testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
       testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -104,29 +104,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-integration
-  - name: pull-cluster-api-e2e
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api
-    always_run: true
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200128-8dae294-master
-          command:
-            - runner.sh
-            - ./scripts/ci-capi-e2e.sh
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: "4000m"
-              memory: "6Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-cluster-api-e2e
   - name: pull-cluster-api-capd-e2e
     labels:
       preset-dind-enabled: "true"
@@ -137,7 +114,7 @@ presubmits:
       - release-0.2
     path_alias: sigs.k8s.io/cluster-api
     optional: true
-    always_run: false
+    always_run: true
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20200128-8dae294-master


### PR DESCRIPTION
This PR replaces the capi-e2es with capd-e2es. The reason for this is that the functionality found in capi-e2es are a complete subset of capd-e2es. If the capi-e2es would fail then capd-e2es would also fail. However, capd-e2es will give us more signal as more of the code is being exercised. 

To this end, we no longer need the capi-e2es and can replace it entirely with the capd-e2es.

The capd-e2es will now run on every PR but are not blocking yet as they are only 80% reliable. Along with the periodics, this should give us more signal to debug the next bug that is causing this to flake.

/assign @detiber 

Discussed with @wfernandes on slack.

Signed-off-by: Chuck Ha <chuckh@vmware.com>
