### PR TITLE
e2e-topology-manager: Add CI job for topology manager

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -308,3 +308,34 @@ periodics:
     testgrid-dashboards: wg-resource-management, sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-cpu-manager
     testgrid-alert-email: balaji.warft@gmail.com, connor.p.d@gmail.com
+
+- name: ci-kubernetes-node-kubelet-serial-topology-manager
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200128-8dae294-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project=k8s-jkns-ci-node-e2e
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-topology-manager.yaml
+          - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[Feature:TopologyManager\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: wg-resource-management, sig-node-kubelet
+    testgrid-tab-name: kubelet-serial-gce-e2e-topology-manager
+    testgrid-alert-email: vpickard@redhat.com, klueska@gmail.com

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -150,7 +150,7 @@ presubmits:
   - name: pull-kubernetes-node-kubelet-serial-cpu-manager
     always_run: false
     optional: true
-    skip_report: true
+    skip_report: false
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:
@@ -183,7 +183,7 @@ presubmits:
   - name: pull-kubernetes-node-kubelet-serial-topology-manager
     always_run: false
     optional: true
-    skip_report: true
+    skip_report: false
     skip_branches:
     - release-\d+\.\d+  # per-release image
     annotations:


### PR DESCRIPTION
Add a periodic CI job for topology manager. This job will
run every 4 hours, just like the CPU Manager job.

Also, change the presubmit jobs for both CPUManager
and Topology Manager so that they always report. The
always_run is set to false, so manual trigger is
required.

Signed-off-by: vpickard <vpickard@redhat.com>