### PR TITLE
Revert "Try capping bazel's memory in some pull-kubernetes-e2e jobs"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -42,8 +42,6 @@ presubmits:
         - --timeout=105
         - --scenario=kubernetes_e2e
         - --
-        # cap bazel's JVM memory usage to resources.requests.memory - 2Gi
-        - --inject-bazelrc=startup --host_jvm_args=-Xmx4g
         - --build=bazel
         - --cluster=
         - --extract=local


### PR DESCRIPTION
We've had enough time to see that this isn't having any effect on
bazel getting killed during the Stage part of kubetest

Reverts #16004
ref: https://github.com/kubernetes/kubernetes/issues/87441