### PR TITLE
Add a --shutdown-bazel-pre-stage flag to kubetest

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -170,6 +170,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")
 	flag.StringVar(&o.stage.dockerRegistry, "registry", "", "Push images to the specified docker registry (e.g. gcr.io/a-test-project)")
 	flag.StringVar(&o.save, "save", "", "Save credentials to gs:// path on --up if set (or load from there if not --up)")
+	flag.BoolVar(&o.stage.shutdownBazelPreStage, "shutdown-bazel-pre-stage", false, "If true, try to shutdown local bazel server prior to stage")
 	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/hack/e2e.go")
 	flag.BoolVar(&o.soak, "soak", false, "If true, job runs in soak mode")
 	flag.DurationVar(&o.soakDuration, "soak-duration", 7*24*time.Hour, "Maximum age of a soak cluster before it gets recycled")

--- a/kubetest/stage.go
+++ b/kubetest/stage.go
@@ -26,11 +26,12 @@ import (
 )
 
 type stageStrategy struct {
-	bucket         string
-	ci             bool
-	gcsSuffix      string
-	versionSuffix  string
-	dockerRegistry string
+	bucket                string
+	ci                    bool
+	gcsSuffix             string
+	versionSuffix         string
+	dockerRegistry        string
+	shutdownBazelPreStage bool
 }
 
 // Return something like gs://bucket/ci/suffix
@@ -67,6 +68,9 @@ func (s *stageStrategy) Enabled() bool {
 // Stage the release build to GCS.
 // Essentially release/push-build.sh --bucket=B --ci? --gcs-suffix=S --noupdatelatest
 func (s *stageStrategy) Stage(noAllowDup bool) error {
+	if s.shutdownBazelPreStage {
+		util.ShutdownBazel()
+	}
 	name := util.K8s("release", "push-build.sh")
 	b := s.bucket
 	if strings.HasPrefix(b, "gs://") {

--- a/kubetest/util/util.go
+++ b/kubetest/util/util.go
@@ -275,3 +275,12 @@ func FlushMem() {
 		log.Printf("flushMem error (page cache): %v", err)
 	}
 }
+
+// ShutdownBazel will shut down the local bazel server if it is running
+func ShutdownBazel() {
+	log.Println("Shutting down local bazel server.")
+	err := exec.Command("bazel", "shutdown").Run()
+	if err != nil {
+		log.Printf("bazel shutdown error: %v", err)
+	}
+}


### PR DESCRIPTION
kubetest currently calls out to kubernetes/release/push-build.sh for its
stage step, which ends up calling kubernetes/kubernetes'
"bazel run //:push-build" target

Unfortunately, in CI, bazel is occasionally getting abruptly killed
during this step. My working theory is that bazel is getting
oomkilled during this step because of memory it's already consumed during
build beforehand. This is happening even in RBE jobs that should be
offloading this to RBE.

Let's add the option to kill bazel before attempting stage, so that it
has as much room to grow its memory as possible

ref: https://github.com/kubernetes/kubernetes/issues/87441