### PR TITLE
releng: Add ci-release-anago-stage job to test anago stage functionality

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -60,8 +60,39 @@ presubmits:
       testgrid-tab-name: release-test
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
-# package tests
 periodics:
+- interval: 2h
+  name: ci-release-anago-stage
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: release
+    base_ref: master
+    path_alias: k8s.io/release
+  spec:
+    containers:
+    - image: gcr.io/k8s-staging-release-test/k8s-cloud-builder:latest
+      command:
+        - ./gcbmgr
+      args:
+        - stage
+        - master
+        - --attended
+      env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /creds/service-account.json
+      volumeMounts:
+        - name: creds
+          mountPath: /creds
+    volumes:
+      - name: creds
+        secret:
+          secretName: deployer-service-account
+  annotations:
+    testgrid-dashboards: sig-release-releng-informing
+    testgrid-alert-email: release-managers@kubernetes.io
+
+# package tests
 - name: periodic-release-verify-packages-debs
   interval: 6h
   annotations:

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -13,6 +13,7 @@ dashboard_groups:
   - sig-release-1.15-informing
   - sig-release-1.14-blocking
   - sig-release-1.14-informing
+  - sig-release-releng-informing
   - sig-release-image-pushes
   - sig-release-misc
   - sig-release-publishing-bot
@@ -34,6 +35,7 @@ dashboards:
 - name: sig-release-1.15-informing
 - name: sig-release-1.14-blocking
 - name: sig-release-1.14-informing
+- name: sig-release-releng-informing
   dashboard_tab:
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance


### PR DESCRIPTION
(Needs https://github.com/kubernetes/release/pull/1052)

It's overdue that we be able to test anago functionality in CI, instead of relying on Release Managers to test changes against their personal forks/branches.
This PR adds a CI job for anago staging (`./gcbmgr stage master`) and a new dashboard for tracking Release Engineering jobs (`sig-release-releng-informing`).

I'll shuffle some of the existing jobs on `sig-release-misc` to this new dashboard in a follow-up PR.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @tpepper @hoegaarden @saschagrunert @cpanato 
cc: @kubernetes/release-engineering 