### PR TITLE
config-bootstrapper: allow for multiple source roots

### DIFF
--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +40,7 @@ import (
 const bootstrapMode = true
 
 type options struct {
-	sourcePath string
+	sourcePaths prowflagutil.Strings
 
 	configPath    string
 	jobConfigPath string
@@ -53,7 +54,7 @@ func gatherOptions() options {
 	o := options{}
 	fs := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	fs.StringVar(&o.sourcePath, "source-path", "", "Path to root of source directory to use for config updates.")
+	fs.Var(&o.sourcePaths, "source-path", "Path to root of source directory to use for config updates. Can be set multiple times.")
 
 	fs.StringVar(&o.configPath, "config-path", "/etc/config/config.yaml", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
@@ -67,8 +68,8 @@ func gatherOptions() options {
 }
 
 func (o *options) Validate() error {
-	if o.sourcePath == "" {
-		return errors.New("--source-path must be provided")
+	if len(o.sourcePaths.Strings()) == 0 {
+		return errors.New("--source-path must be provided at least once")
 	}
 
 	if err := o.kubernetes.Validate(o.dryRun); err != nil {
@@ -78,29 +79,54 @@ func (o *options) Validate() error {
 	return nil
 }
 
-func run(sourcePath, defaultNamespace string, configUpdater plugins.ConfigUpdater, client kubernetes.Interface, buildClusterCoreV1Clients map[string]corev1.CoreV1Interface) int {
+type osFileGetter struct {
+	roots []string
+}
+
+// GetFile returns the content of a file from disk, searching through all known roots.
+// We assume that no two roots will contain the same relative path inside of them, as such
+// a configuration would be racy and unsupported in the updateconfig plugin anyway.
+func (g *osFileGetter) GetFile(filename string) ([]byte, error) {
+	var loadErr error
+	for _, root := range g.roots {
+		candidatePath := filepath.Join(root, filename)
+		if _, err := os.Stat(candidatePath); err == nil {
+			// we found the file under this root
+			return ioutil.ReadFile(candidatePath)
+		} else if !os.IsNotExist(err) {
+			// record this for later in case we can't find the file
+			loadErr = err
+		}
+	}
+	// file was found under no root
+	return nil, loadErr
+}
+
+func run(sourcePaths []string, defaultNamespace string, configUpdater plugins.ConfigUpdater, client kubernetes.Interface, buildClusterCoreV1Clients map[string]corev1.CoreV1Interface) int {
 	var errors int
 	// act like the whole repo just got committed
 	var changes []github.PullRequestChange
-	filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
-		if info.IsDir() {
+	for _, sourcePath := range sourcePaths {
+		filepath.Walk(sourcePath, func(path string, info os.FileInfo, err error) error {
+			if info.IsDir() {
+				return nil
+			}
+			// we know path will be below sourcePaths, but we can't
+			// communicate that to the filepath module. We can ignore
+			// this error as we can be certain it won't occur
+			if relPath, err := filepath.Rel(sourcePath, path); err == nil {
+				changes = append(changes, github.PullRequestChange{
+					Filename: relPath,
+					Status:   github.PullRequestFileAdded,
+				})
+				logrus.Infof("added to mock change: %s", relPath)
+			} else {
+				logrus.WithError(err).Warn("unexpected error determining relative path to file")
+				errors++
+			}
 			return nil
-		}
-		// we know path will be below sourcePath, but we can't
-		// communicate that to the filepath module. We can ignore
-		// this error as we can be certain it won't occur
-		if relPath, err := filepath.Rel(sourcePath, path); err == nil {
-			changes = append(changes, github.PullRequestChange{
-				Filename: relPath,
-				Status:   github.PullRequestFileAdded,
-			})
-			logrus.Infof("added to mock change: %s", relPath)
-		} else {
-			logrus.WithError(err).Warn("unexpected error determining relative path to file")
-			errors++
-		}
-		return nil
-	})
+		})
+	}
 
 	for cm, data := range updateconfig.FilterChanges(configUpdater, changes, defaultNamespace, logrus.NewEntry(logrus.StandardLogger())) {
 		logger := logrus.WithFields(logrus.Fields{"configmap": map[string]string{"name": cm.Name, "namespace": cm.Namespace, "cluster": cm.Cluster}})
@@ -109,7 +135,7 @@ func run(sourcePath, defaultNamespace string, configUpdater plugins.ConfigUpdate
 			logrus.WithError(err).Errorf("Failed to find configMap client")
 			continue
 		}
-		if err := updateconfig.Update(&updateconfig.OSFileGetter{Root: sourcePath}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, nil, logger); err != nil {
+		if err := updateconfig.Update(&osFileGetter{roots: sourcePaths}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, nil, logger); err != nil {
 			logger.WithError(err).Error("failed to update config on cluster")
 			errors++
 		} else {
@@ -147,7 +173,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error getting Kubernetes clients for build cluster.")
 	}
 
-	if errors := run(o.sourcePath, configAgent.Config().ProwJobNamespace, pluginAgent.Config().ConfigUpdater, client, buildClusterCoreV1Clients); errors > 0 {
+	if errors := run(o.sourcePaths.Strings(), configAgent.Config().ProwJobNamespace, pluginAgent.Config().ConfigUpdater, client, buildClusterCoreV1Clients); errors > 0 {
 		logrus.WithField("fail-count", errors).Fatalf("errors occurred during update")
 	}
 }


### PR DESCRIPTION
When the upateconfig plugin runs on content from multiple repositories
on disjoint sets of files, the bootstrap operation can only succeed if
it considers the full content of all repositories. This patch allows for
multiple source roots to be passed to the config-bootstrapper for that
case. We assume that no file exists in the same relative path in
multiple repositories, as that would be invalid not only for the
bootstrapper but also for the plugin in general.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>