### PR TITLE
Change boskos alert to fire when resource is exhausted instead of predicting exhaustion.

### DIFF
--- a/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
+++ b/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
@@ -5,26 +5,23 @@
         name: 'Boskos resource usage',
         rules: [
           {
-            alert: 'Low resource availability (<10% free)',
-            // This expression calculates the percentage of resources of each type that are free.
-            // If there are multiple instances the most pessimistic value is used.
-            // The threshold for the alert is <10% free.
+            alert: 'Resource exhausted (0% free)',
+            // This expression evaluates to true iff there is resource type with 0 'free' resources.
             // Resource pools with <= 5 resources are ignored since it is often expected for
             // small pools to use 100% capacity.
             expr: |||
-              min(
+              (
                 min(boskos_resources{state="free"}) by (type, instance)
-                /
+                and
                 (sum(boskos_resources) by (type, instance) > 5)
-              ) by (type) * 100
-              < 10
+              ) == 0
             |||,
             labels: {
               severity: 'high',
               'boskos_type': '{{ $labels.type }}',
             },
             annotations: {
-              message: 'The Boskos resource "{{ $labels.type }}" has low availability (currently {{ printf "%0.2f" $value }}% free). See the <https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1|Boskos resource usage dashboard>.',
+              message: 'The Boskos resource "{{ $labels.type }}" has been exhausted (currently 0% free). See the <https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1|Boskos resource usage dashboard>.',
             },
           },
         ],


### PR DESCRIPTION
I validated the query changes against our prometheus instance. With these changes the alert would not have fired today when scalability presubmit projects were nearly exhausted, but would have still fired yesterday when they were completely exhausted.

/assign @chases2 @Katharine 