### PR TITLE
Kops - Fix e2e tests on release branches

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -116,7 +116,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-experimental
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -160,7 +160,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-experimental
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -204,7 +204,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200130-73a0fc5-experimental
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py


### PR DESCRIPTION
This reverts the last part of #16069 because it causes e2e test failures for release branches.
https://github.com/kubernetes/kops/pull/8447
https://github.com/kubernetes/kops/pull/8448
