### PR TITLE
Image Promoter: Adds Windows certs for the k/k e2e test images job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -38,7 +38,16 @@ postsubmits:
             volumeMounts:
               - name: creds
                 mountPath: /creds
+              - name: windows-cert
+                mountPath: /root/.docker-1809
+              - name: windows-cert
+                mountPath: /root/.docker-1903
+              - name: windows-cert
+                mountPath: /root/.docker-1909
         volumes:
           - name: creds
             secret:
               secretName: deployer-service-account
+          - name: windows-cert
+            secret:
+              secretName: windows-img-promoter-cert


### PR DESCRIPTION
The plan is to also automatically build and publish Windows E2E test images. This can be achieved by building the Windows container images on remote Windows Server nodes which have Remote Docker configured. In order to connect to them, certificates are used for authentication.

The PR that adds remote docker building and pushing is: https://github.com/kubernetes/kubernetes/pull/76838