### PR TITLE
Shorten plank timeouts

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -3,7 +3,8 @@ plank:
   report_template: '[Full PR test history](https://prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://gubernator.k8s.io/pr/{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   job_url_prefix_config:
     '*': https://prow.k8s.io/view/gcs/
-  pod_pending_timeout: 60m
+  pod_pending_timeout: 15m
+  pod_unscheduled_timeout: 1m
   default_decoration_configs:
     '*':
       timeout: 2h


### PR DESCRIPTION
Reduce the pod pending timeout to 15 minutes, and the pod unscheduled timeout to 1 minutes.

After observing the cluster for some time:

- I expect the `pod_unscheduled_timeout` change to have no effect: pods are always scheduled in under one second, or never scheduled at all.
- I expect the `pod_pending_timeout` to have a negligible effect: of four thousand pods I have observed, only one ever exceeded fifteen minutes (it was taking a very long time to clone from github). This corresponds to our flake rate increasing by less than 0.03%.

The benefit of these changes is much faster feedback to owners of misconfigured jobs.

/cc @cjwagner @BenTheElder @chases2 @michelle192837 