### PR TITLE
Use python2.7 as the python2 interpreter

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,7 +72,7 @@ load("@rules_python//python:pip.bzl", "pip_import")
 
 pip_import(
     name = "py_deps",
-    python_interpreter = "python2",
+    python_interpreter = "python2.7",
     requirements = "//:requirements2.txt",
 )
 


### PR DESCRIPTION
Using `python2` breaks macOS, which has no binary by that name.