### PR TITLE
Add dashboard for Boskos HTTP metrics

### DIFF
--- a/prow/cluster/monitoring/grafana_deployment.yaml
+++ b/prow/cluster/monitoring/grafana_deployment.yaml
@@ -69,6 +69,9 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/boskos
           name: grafana-dashboard-boskos
           readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/boskos-http
+          name: grafana-dashboard-boskos-http
+          readOnly: false
         - mountPath: /grafana-dashboard-definitions/0/deck
           name: grafana-dashboard-deck
           readOnly: false
@@ -108,6 +111,9 @@ spec:
       - name: grafana-dashboard-boskos
         configMap:
           name: grafana-dashboard-boskos
+      - name: grafana-dashboard-boskos-http
+        configMap:
+          name: grafana-dashboard-boskos-http
       - name: grafana-dashboard-deck
         configMap:
           name: grafana-dashboard-deck

--- a/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
@@ -16,6 +16,16 @@ k8s_configmap(
 )
 
 k8s_configmap(
+    name = "grafana-dashboard-boskos-http",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    data = {
+        "boskos-http.json": "//prow/cluster/monitoring/mixins/grafana_dashboards:boskos-http",
+    },
+    namespace = "prow-monitoring",
+    visibility = ["//visibility:public"],
+)
+
+k8s_configmap(
     name = "grafana-dashboard-deck",
     cluster = "{STABLE_PROW_CLUSTER}",
     data = {

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
@@ -16,6 +16,21 @@ jsonnet_to_json(
 )
 
 jsonnet_to_json(
+    name = "boskos-http",
+    src = "boskos-http.jsonnet",
+    outs = ["boskos-http.json"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//prow/cluster/monitoring/mixins/lib",
+        "//prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
+)
+
+jsonnet_to_json(
     name = "deck",
     src = "deck.jsonnet",
     outs = ["deck.json"],

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/boskos-http.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/boskos-http.jsonnet
@@ -1,0 +1,82 @@
+local config =  import 'config.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+local template = grafana.template;
+
+local legendConfig = {
+        legend+: {
+            sideWidth: 350
+        },
+    };
+
+local dashboardConfig = {
+        uid: config._config.grafanaDashboardIDs['boskos-http.json'],
+    };
+
+local histogramQuantileDuration(phi, selector='') = prometheus.target(
+        std.format('histogram_quantile(%s, sum(rate(boskos_http_request_duration_seconds_bucket%s[5m])) by (le))', [phi, selector]),
+        legendFormat=std.format('phi=%s', phi),
+    );
+
+local boskosTemplate(name, labelInQuery) = template.new(
+        name,
+        'prometheus',
+        std.format('label_values(boskos_http_request_duration_seconds_bucket, %s)', labelInQuery),
+        label=name,
+        allValues='.*',
+        includeAll=true,
+        refresh='time',
+    );
+
+dashboard.new(
+        'Boskos Server Dashboard',
+        time_from='now-1h',
+        schemaVersion=18,
+      )
+.addTemplate(boskosTemplate('path', 'path'))
+.addTemplate(boskosTemplate('status', 'status'))
+.addPanel(
+    (graphPanel.new(
+        'Latency distribution for path ${path} and status ${status}',
+        description='histogram_quantile(phi, sum(rate(boskos_http_request_duration_seconds_bucket[5m])) by (le))',
+        datasource = 'prometheus',
+        legend_alignAsTable=true,
+        legend_rightSide=true,
+        legend_values=true,
+        legend_current=true,
+        legend_avg=true,
+        legend_sort='avg',
+        legend_sortDesc=true,
+        ) + legendConfig)
+        .addTarget(histogramQuantileDuration('0.99','{path=~"${path}", status=~"${status}"}'))
+        .addTarget(histogramQuantileDuration('0.95','{path=~"${path}", status=~"${status}"}'))
+        .addTarget(histogramQuantileDuration('0.5','{path=~"${path}", status=~"${status}"}')), gridPos={
+        h: 9,
+        w: 24,
+        x: 0,
+        y: 0
+    })
+.addPanel(
+    (graphPanel.new(
+        'Request rate',
+        description='sum(rate(boskos_http_request_duration_seconds_count[5m])) by (path, status)',
+        datasource = 'prometheus',
+        legend_alignAsTable=true,
+        legend_rightSide=true,
+        legend_values=true,
+        legend_current=true,
+        legend_avg=true,
+        legend_sort='avg',
+        legend_sortDesc=true,
+        ) + legendConfig)
+        .addTarget(prometheus.target(
+            'sum(rate(boskos_http_request_duration_seconds_count[5m])) by (path, status)',
+            legendFormat='{{path}} {{status}}'
+        )), gridPos={
+        h: 9,
+        w: 24,
+        x: 0,
+        y: 0
+    })

--- a/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -2,6 +2,7 @@
   _config+:: {
     // Grafana dashboard IDs are necessary for stable links for dashboards
     grafanaDashboardIDs: {
+      'boskos-http.json': 'eec46c579cbf4a518e5bbcbbf4913de9',
       'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
     },
   },


### PR DESCRIPTION
I haven't tested this yet, since I don't know of a good way to test it, but it probably achieves the right result.

I largely generated this by combining the [jsonnet config for deck](https://github.com/kubernetes/test-infra/blob/master/prow/cluster/monitoring/mixins/grafana_dashboards/deck.jsonnet) along with the [config for boskos_http in openshift](https://github.com/openshift/release/blob/a2924bf7f5cde4cfcf012f5d0ad157016a726b6c/cluster/ci/monitoring/mixins/grafana_dashboards/boskos_http.jsonnet).

/area boskos
/assign @cjwagner @stevekuznetsov 