### PR TITLE
Add missing bazel reference to boskos-http dashboard.

### DIFF
--- a/prow/cluster/monitoring/BUILD.bazel
+++ b/prow/cluster/monitoring/BUILD.bazel
@@ -74,6 +74,7 @@ k8s_objects(
         ":servicemonitor_crd",
         "//prow/cluster/monitoring/mixins/prometheus_out:prow_prometheusrule",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos",
+        "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-boskos-http",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-deck",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-ghproxy",
         "//prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-hook",


### PR DESCRIPTION
The deployment of https://github.com/kubernetes/test-infra/pull/16095 succeeded, but the new dashboard isn't showing up. I think this is the missing piece.

/assign @chases2 @ixdy 