### PR TITLE
Add failure hints to the summary/metadata lens

### DIFF
--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -69,5 +69,10 @@ go_test(
     name = "go_default_test",
     srcs = ["lens_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
+    deps = [
+        "//prow/crier/reporters/gcs/kubernetes:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -8,10 +8,12 @@ go_library(
     importpath = "k8s.io/test-infra/prow/spyglass/lenses/metadata",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/crier/reporters/gcs/kubernetes:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
     ],
 )
 

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -20,6 +20,9 @@ package metadata
 import (
 	"bytes"
 	"encoding/json"
+	"regexp"
+	"sort"
+	"strings"
 	"time"
 
 	"fmt"
@@ -28,6 +31,8 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	k8sreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
 	"k8s.io/test-infra/prow/spyglass/lenses"
 )
@@ -81,6 +86,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		StartTime    time.Time
 		FinishedTime time.Time
 		Elapsed      time.Duration
+		Hint         string
 		Metadata     map[string]interface{}
 	}
 	metadataViewData := MetadataViewData{Status: "Pending"}
@@ -91,12 +97,13 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		if err != nil {
 			logrus.WithError(err).Error("Failed reading from artifact.")
 		}
-		if a.JobPath() == "started.json" {
+		switch a.JobPath() {
+		case "started.json":
 			if err = json.Unmarshal(read, &started); err != nil {
 				logrus.WithError(err).Error("Error unmarshaling started.json")
 			}
 			metadataViewData.StartTime = time.Unix(started.Timestamp, 0)
-		} else if a.JobPath() == "finished.json" {
+		case "finished.json":
 			if err = json.Unmarshal(read, &finished); err != nil {
 				logrus.WithError(err).Error("Error unmarshaling finished.json")
 			}
@@ -104,6 +111,8 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 				metadataViewData.FinishedTime = time.Unix(*finished.Timestamp, 0)
 			}
 			metadataViewData.Status = finished.Result
+		case "podinfo.json":
+			metadataViewData.Hint = hintFromPodInfo(read)
 		}
 	}
 
@@ -135,6 +144,80 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 		logrus.WithError(err).Error("Error executing template.")
 	}
 	return buf.String()
+}
+
+var failedMountRegex = regexp.MustCompile(`MountVolume.SetUp failed for volume "(.+?)" : (.+?)`)
+
+func hintFromPodInfo(buf []byte) string {
+	var report k8sreporter.PodReport
+	if err := json.Unmarshal(buf, &report); err != nil {
+		logrus.WithError(err).Info("Failed to decode podinfo.json")
+		// This error isn't worth highlighting here, and will be reported in the
+		// podinfo lens if that is enabled.
+		return ""
+	}
+
+	// We're more likely to pick a relevant event if we use the last ones first.
+	sort.Slice(report.Events, func(i, j int) bool {
+		a := &report.Events[i]
+		b := &report.Events[j]
+		return b.LastTimestamp.Before(&a.LastTimestamp)
+	})
+
+	// If the pod completed successfully there's probably not much to say.
+	if report.Pod.Status.Phase == v1.PodSucceeded {
+		return ""
+	}
+	// Check if we have any images that didn't pull
+	for _, s := range append(report.Pod.Status.InitContainerStatuses, report.Pod.Status.ContainerStatuses...) {
+		if s.State.Waiting != nil && s.State.Waiting.Reason == "ImagePullBackOff" {
+			return fmt.Sprintf("The %s container could not start because it could not pull %q. Check your images.", s.Name, s.Image)
+		}
+	}
+	// Check if we're trying to mount a volume
+	if report.Pod.Status.Phase == v1.PodPending {
+		failedMount := false
+		for _, e := range report.Events {
+			if e.Reason == "FailedMount" {
+				failedMount = true
+				if strings.HasPrefix(e.Message, "MountVolume.SetUp") {
+					// Annoyingly, parsing this message is the only way to get this information.
+					// If we can't parse it, we'll fall through to a generic bad volume message below.
+					results := failedMountRegex.FindStringSubmatch(e.Message)
+					if results == nil {
+						continue
+					}
+					return fmt.Sprintf("The pod could not start because it could not mount the volume %q: %s", results[1], results[2])
+				}
+			}
+		}
+		if failedMount {
+			return fmt.Sprintf("The job could not start because one or more of the volumes could not be mounted.")
+		}
+	}
+	// Check if we cannot be scheduled
+	// This is unlikely - we only outright fail if a pod is actually scheduled to a node that can't support it.
+	if report.Pod.Status.Phase == v1.PodFailed && report.Pod.Status.Reason == "MatchNodeSelector" {
+		return fmt.Sprintf("The job could not start because it was scheduled to a node that does not satisfy its NodeSelector")
+	}
+	// Usually we would fail to schedule it at all, so it will be pending forever.
+	if report.Pod.Status.Phase == v1.PodPending {
+		for _, e := range report.Events {
+			if e.Reason == "FailedScheduling" {
+				return fmt.Sprintf("There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (%s)", e.Message)
+			}
+		}
+	}
+
+	// There are a bunch of fun ways for the node to fail that we've seen before
+	for _, e := range report.Events {
+		if e.Reason == "FailedCreatePodSandbox" || e.Reason == "FailedSync" || e.Reason == "FailedKillPod" {
+			return "The job may have executed on an unhealthy node. Contact your prow maintainers or check the detailed pod information."
+		}
+	}
+
+	// We've got nothing.
+	return ""
 }
 
 // flattenMetadata flattens the metadata for use by Body.

--- a/prow/spyglass/lenses/metadata/lens.go
+++ b/prow/spyglass/lenses/metadata/lens.go
@@ -146,7 +146,7 @@ func (lens Lens) Body(artifacts []lenses.Artifact, resourceDir string, data stri
 	return buf.String()
 }
 
-var failedMountRegex = regexp.MustCompile(`MountVolume.SetUp failed for volume "(.+?)" : (.+?)`)
+var failedMountRegex = regexp.MustCompile(`MountVolume.SetUp failed for volume "(.+?)" : (.+)`)
 
 func hintFromPodInfo(buf []byte) string {
 	var report k8sreporter.PodReport
@@ -192,7 +192,7 @@ func hintFromPodInfo(buf []byte) string {
 			}
 		}
 		if failedMount {
-			return fmt.Sprintf("The job could not start because one or more of the volumes could not be mounted.")
+			return fmt.Sprintf("The job could not started because one or more of the volumes could not be mounted.")
 		}
 	}
 	// Check if we cannot be scheduled
@@ -212,7 +212,7 @@ func hintFromPodInfo(buf []byte) string {
 	// There are a bunch of fun ways for the node to fail that we've seen before
 	for _, e := range report.Events {
 		if e.Reason == "FailedCreatePodSandbox" || e.Reason == "FailedSync" || e.Reason == "FailedKillPod" {
-			return "The job may have executed on an unhealthy node. Contact your prow maintainers or check the detailed pod information."
+			return "The job may have executed on an unhealthy node. Contact your prow maintainers with a link to this page or check the detailed pod information."
 		}
 	}
 

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -17,10 +17,16 @@ limitations under the License.
 package metadata
 
 import (
+	"encoding/json"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	k8sreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
 )
 
 func TestFlattenMetadata(t *testing.T) {
@@ -93,5 +99,244 @@ func TestFlattenMetadata(t *testing.T) {
 		if !reflect.DeepEqual(flattenedMetadata, test.expectedMap) {
 			t.Errorf("%s: resulting map did not match expected map: %v", test.name, cmp.Diff(flattenedMetadata, test.expectedMap))
 		}
+	}
+}
+
+func TestHintFromPodInfo(t *testing.T) {
+	tests := []struct {
+		name     string
+		info     k8sreporter.PodReport
+		expected string
+	}{
+		{
+			name: "normal failed run has no output",
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodFailed,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Terminated: &v1.ContainerStateTerminated{
+										ExitCode: 1,
+										Reason:   "Completed",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "stuck images are reported by name",
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master". Check your images.`,
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ImagePullBackOff",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "stuck volumes are reported by name",
+			expected: `The pod could not start because it could not mount the volume "some-volume": secrets "no-such-secret" not found`,
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								VolumeMounts: []v1.VolumeMount{
+									{
+										Name:      "some-volume",
+										MountPath: "/mnt/some-volume",
+									},
+								},
+							},
+						},
+						Volumes: []v1.Volume{
+							{
+								Name: "some-volume",
+								VolumeSource: v1.VolumeSource{
+									Secret: &v1.SecretVolumeSource{
+										SecretName: "no-such-secret",
+									},
+								},
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ContainerCreating",
+									},
+								},
+							},
+						},
+					},
+				},
+				Events: []v1.Event{
+					{
+						Type:    "Warning",
+						Reason:  "FailedMount",
+						Message: `MountVolume.SetUp failed for volume "some-volume" : secrets "no-such-secret" not found`,
+					},
+				},
+			},
+		},
+		{
+			name:     "pod scheduled to an illegal node is reported",
+			expected: "The job could not start because it was scheduled to a node that does not satisfy its NodeSelector",
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase:  v1.PodFailed,
+						Reason: "MatchNodeSelector",
+					},
+				},
+			},
+		},
+		{
+			name:     "pod scheduled to an illegal node is reported",
+			expected: "There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (0/3 nodes are available: 3 node(s) didn't match node selector.)",
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+					},
+				},
+				Events: []v1.Event{
+					{
+						Type:    "Warning",
+						Reason:  "FailedScheduling",
+						Message: "0/3 nodes are available: 3 node(s) didn't match node selector.",
+					},
+				},
+			},
+		},
+		{
+			name:     "apparent node failure is reported as such",
+			expected: "The job may have executed on an unhealthy node. Contact your prow maintainers with a link to this page or check the detailed pod information.",
+			info: k8sreporter.PodReport{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "8ef160fc-46b6-11ea-a907-1a9873703b03",
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+							},
+						},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:  "test",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Ready: false,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ContainerCreating",
+									},
+								},
+							},
+						},
+					},
+				},
+				Events: []v1.Event{
+					{
+						Type:   "Warning",
+						Reason: "FailedCreatePodSandbox",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.info)
+			if err != nil {
+				t.Fatalf("Unexpected failed to marshal pod to JSON (this wasn't even part of the test!): %v", err)
+			}
+			result := hintFromPodInfo(b)
+			if result != tc.expected {
+				t.Errorf("Expected hint %q, but got %q", tc.expected, result)
+			}
+		})
 	}
 }

--- a/prow/spyglass/lenses/metadata/style.css
+++ b/prow/spyglass/lenses/metadata/style.css
@@ -6,8 +6,15 @@
 .test-summary {
     color: #e8e8e8;
     padding-left: 17px;
-    padding-bottom: 15px;
     margin: 0;
+}
+
+.failure-hint {
+    font-weight: bold;
+}
+
+#bottom-padding {
+    padding-bottom: 15px;
 }
 
 body {

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -14,6 +14,10 @@
 {{- else -}}
   is still running
 {{- end}} after {{.Elapsed}}. (<a href="#" id="show-table-link">more info</a>)</p>
+{{if .Hint -}}
+<p class="test-summary failure-hint">{{.Hint}}</p>
+{{end -}}
+<div id="bottom-padding"></div>
 <table class="mdl-data-table mdl-js-data-table metadata-table hidden" id="data-table">
   <tbody>
   <tr class="test-row">


### PR DESCRIPTION
Use some heuristics on pod state and events to attempt to provide useful information about job misconfigurations.

Hints include:
- Trying to pull an inaccessible or nonexistent image
- Misconfigured secret/configmap/volume references
- Unsatisfiable taints/tolerances/node selectors or resource requests
- Various types of node failure we've seen before (can't create sandbox, etc.)

If you have more ideas, please suggest them :D

An example:
![image](https://user-images.githubusercontent.com/110792/73688184-63106b00-4680-11ea-8a2a-26feaa5966f9.png)


/cc @BenTheElder @cjwagner 