### PR TITLE
Add rbac rules so crier can read pods and events

### DIFF
--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -33,6 +33,14 @@ rules:
     - "watch"
     - "list"
     - "patch"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+    - "events"
+  verbs:
+    - "get"
+    - "list"
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
I have only moderate confidence in the correctness of this.

/cc @BenTheElder 