### PR TITLE
explicitly search for "repo" in "UpdatePR"

### DIFF
--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -46,7 +46,7 @@ func UpdatePR(org, repo, title, body, matchTitle string, gc updateClient) (*int,
 		return nil, fmt.Errorf("bot name: %v", err)
 	}
 
-	issues, err := gc.FindIssues("is:open is:pr archived:false in:title author:"+me+" "+matchTitle, "updated", false)
+	issues, err := gc.FindIssues("is:open is:pr archived:false in:title repo:"+org+"/"+repo+" author:"+me+" author:"+me+" "+matchTitle, "updated", false)
 	if err != nil {
 		return nil, fmt.Errorf("find issues: %v", err)
 	} else if len(issues) == 0 {


### PR DESCRIPTION
The existing behavior for `UpdatePR` is to perform a search (using `title` and `author`) and simply return the first item. If the title is not unique across GitHub (including forks) for that user, then it could return a false positive with a result from the wrong `org/repo`. Here we want to explicitly qualifying the search with `repo:owner/name` to correctly scope the search results.

**e.g.** 
https://github.com/istio/api/pull/2

> I have since manually reverted the edit of the *description* and *title*, but if you look at the *edit* history one can see this PR was incorrectly mutated because a PR of the same number (i.e. **2**) was matched for a different *org/repo* (https://github.com/clarketm/api/pull/2).