### PR TITLE
Add a pull-kubernetes-e2e-gce-ubuntu job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -107,6 +107,56 @@ presubmits:
           requests:
             memory: "6Gi"
 
+  - name: pull-kubernetes-e2e-gce-ubuntu
+    always_run: false
+    skip_report: false
+    skip_branches:
+      - release-\d+\.\d+ # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=105
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --extract=local
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --runtime-config=batch/v2alpha1=true
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+        - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200203-25ff2bb-master
+        resources:
+          requests:
+            memory: "6Gi"
+
   - name: pull-kubernetes-e2e-gce-rbe
     always_run: true
     skip_report: true

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -463,6 +463,9 @@ dashboards:
   - name: pull-kubernetes-e2e-gce-canary
     test_group_name: pull-kubernetes-e2e-gce-canary
     base_options: width=10
+  - name: pull-kubernetes-e2e-gce-ubuntu
+    test_group_name: pull-kubernetes-e2e-gce-ubuntu
+    base_options: width=10
   - name: pull-kubernetes-e2e-kind-canary
     test_group_name: pull-kubernetes-e2e-kind-canary
     base_options: width=10


### PR DESCRIPTION
Experimental job with ubuntu as master as well as node image. 

This job will help us kick the tires of new versions of docker / containerd / runc etc. Example recent scenario is here: https://github.com/kubernetes/kubernetes/issues/86312

Preliminary work:
- [x] Support py3 needed in ubuntu images - https://github.com/kubernetes/kubernetes/pull/87741
- [x] Tolerate network stuff in ubuntu - https://github.com/kubernetes/kubernetes/pull/87760
- [x] Ensure we find kubectl properly in ubuntu - https://github.com/kubernetes/kubernetes/pull/87772
- [x] Install docker for ubuntu - https://github.com/kubernetes/kubernetes/pull/87761
 
Kicking tires here : https://github.com/kubernetes/kubernetes/pull/87654