### PR TITLE
[Fix]Add sudo on base image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-openssl \
     python-pip \
     rsync \
+    sudo \
     unzip \
     wget \
     xz-utils \


### PR DESCRIPTION
This commit installs sudo on base image. Sudo is used for run docker
command on KFP mkp deployment(https://github.com/kubeflow/pipelines/blob/master/test/deploy-pipeline-mkp-cli.sh#L64). 

Part of https://github.com/kubeflow/pipelines/issues/2950