### PR TITLE
Revert "Use newest gcloud build in gce-cos-1.16-scalability-100 job"

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -180,8 +180,6 @@ periodics:
       - --check-leaked-resources
       - --cluster=e2e-big
       - --extract=ci/latest-1.16
-      # TODO(https://github.com/kubernetes/perf-tests/issues/1005): Check whether it helps
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/rc
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project


### PR DESCRIPTION
This reverts commit f00041eda7a5a37e0ae1bfcdce90b580aaf414c3.

It didn't help, see https://github.com/kubernetes/perf-tests/issues/1005