### PR TITLE
Kubetest - Add support for dumping pod logs

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -505,6 +505,8 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 		finished <- k.dumpAllNodes(ctx, logDumper)
 	}()
 
+	logDumper.dumpPods(ctx, "kube-system", []string{"k8s-app=kops-controller"})
+
 	for {
 		select {
 		case <-interrupt.C:


### PR DESCRIPTION
Currently kubetest's logdumper only dumps logs from nodes via SSH. Following the discussion in https://github.com/kubernetes/kops/pull/8454 we decided we should add support in our E2E jobs for downloading pod logs as job artifacts. This allows logs from kube-system to be downloaded via label selector. The logs get saved in the node's directory along side the existing logs ([example directory](https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/kops/8445/pull-kops-e2e-kubernetes-aws/1224369928086228992/artifacts/ip-172-20-32-181.ap-southeast-2.compute.internal/)).

/cc @justinsb
@hakman