### PR TITLE
Increase CAPG k8s CI timeout to 3h

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -146,7 +146,6 @@ periodics:
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
 - name: ci-cluster-api-provider-gcp-make-conformance-stable-k8s-ci-artifacts
-  interval: 3h
   labels:
     preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
@@ -154,6 +153,9 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true
+  decoration_config:
+    timeout: 3h
+  interval: 4h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp


### PR DESCRIPTION
Increase the timeout for
ci-cluster-api-provider-gcp-make-conformance-stable-k8s-ci-artifacts
from 2 to 3 hours, as the tests appear to need slightly more than 2
hours to complete.

Signed-off-by: Andy Goldstein <goldsteina@vmware.com>

/assign @detiber 

xref https://github.com/kubernetes/kubernetes/issues/87816