### PR TITLE
k8s crier: don't report jobs with no build ID

### DIFF
--- a/prow/crier/reporters/gcs/kubernetes/reporter.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter.go
@@ -153,8 +153,8 @@ func (gr *gcsK8sReporter) GetName() string {
 func (gr *gcsK8sReporter) ShouldReport(pj *prowv1.ProwJob) bool {
 	// This reporting only makes sense for the Kubernetes agent (otherwise we don't
 	// have a pod to look up). It is only particularly useful for us to look at
-	// complete jobs.
-	if pj.Spec.Agent != prowv1.KubernetesAgent || !pj.Complete() {
+	// complete jobs that have a build ID.
+	if pj.Spec.Agent != prowv1.KubernetesAgent || !pj.Complete() || pj.Status.BuildID == "" {
 		return false
 	}
 

--- a/prow/crier/reporters/gcs/kubernetes/reporter_test.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter_test.go
@@ -38,30 +38,42 @@ func TestShouldReport(t *testing.T) {
 		name         string
 		agent        prowv1.ProwJobAgent
 		isComplete   bool
+		hasBuildID   bool
 		shouldReport bool
 	}{
 		{
 			name:         "completed kubernetes tests are reported",
 			agent:        prowv1.KubernetesAgent,
 			isComplete:   true,
+			hasBuildID:   true,
 			shouldReport: true,
 		},
 		{
 			name:         "incomplete kubernetes tests are not reported",
 			agent:        prowv1.KubernetesAgent,
 			isComplete:   false,
+			hasBuildID:   true,
 			shouldReport: false,
 		},
 		{
 			name:         "complete non-kubernetes tests are not reported",
 			agent:        prowv1.JenkinsAgent,
 			isComplete:   true,
+			hasBuildID:   true,
 			shouldReport: false,
 		},
 		{
 			name:         "incomplete non-kubernetes tests are not reported",
 			agent:        prowv1.JenkinsAgent,
 			isComplete:   false,
+			hasBuildID:   true,
+			shouldReport: false,
+		},
+		{
+			name:         "complete kubernetes tests with no build ID are not reported",
+			agent:        prowv1.KubernetesAgent,
+			isComplete:   true,
+			hasBuildID:   false,
 			shouldReport: false,
 		},
 	}
@@ -80,6 +92,9 @@ func TestShouldReport(t *testing.T) {
 			if tc.isComplete {
 				pj.Status.State = prowv1.SuccessState
 				pj.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			}
+			if tc.hasBuildID {
+				pj.Status.BuildID = "123456789"
 			}
 
 			kgr := internalNew(testutil.Fca{}.Config, nil, nil, 1.0, false)


### PR DESCRIPTION
Sometimes completed jobs have no build ID, even if they've been around for a long time.

This seems like a bug in itself, but work around it so we don't repeatedly try to report them and complain about failing.

Fixes #16086 

/cc @cjwagner @chases2 