### PR TITLE
Increase timeout/interval for Windows containerd job to 4h

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -269,12 +269,14 @@ periodics:
 
 - name: ci-kubernetes-e2e-windows-containerd-gce
   decorate: true
+  decoration_config:
+    timeout: 4h
   extra_refs:
   - org: kubernetes-sigs
     repo: windows-testing
     base_ref: master
     path_alias: k8s.io/windows-testing
-  interval: 2h
+  interval: 4h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -298,7 +300,7 @@ periodics:
       - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/run-e2e.sh
       - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\] --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
       - --test-cmd-args=--node-os-distro=windows
-      - --timeout=150m
+      - --timeout=230m
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"


### PR DESCRIPTION
Test runs for this job are regularly failing at the 2 hour mark: "Test started today at 7:42 AM failed after 2h0m17s. (more info)"
https://testgrid.k8s.io/google-windows#gce-windows-2019-containerd-master&width=20

This PR updates the test timeout and interval to 4 hours instead of 2. containerd is known to be significantly slower than dockershim on Windows for now.