### PR TITLE
Update k8s.io approve settings

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -77,12 +77,13 @@ approve:
   require_self_approval: false
 - repos:
   - bazelbuild
+  - kubernetes-sigs/kind
+  - kubernetes-sigs/slack-infra
   - kubernetes/community
+  - kubernetes/k8s.io
   - kubernetes/org
   - kubernetes/repo-infra
-  - kubernetes-sigs/kind
   - kubernetes/test-infra
-  - kubernetes-sigs/slack-infra
   require_self_approval: false
   ignore_review_state: false
 - repos:


### PR DESCRIPTION
This updates the kubernetes/k8s.io approve settings to match those of k/org and k/community.

It's my intent to make these the defaults org wide, but I want to wait until the survey results come back.

/assign @nikhita 