### PR TITLE
Remove 'ConfigFile' and 'PluginFile' config fields

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -434,18 +434,6 @@ type ConfigUpdater struct {
 	// map[string]ConfigMapSpec{ "/my/path.yaml": {Name: "foo", Namespace: "otherNamespace" }}
 	// will result in replacing the foo configmap whenever path.yaml changes
 	Maps map[string]ConfigMapSpec `json:"maps,omitempty"`
-	// The location of the prow configuration file inside the repository
-	// where the config-updater plugin is enabled. This needs to be relative
-	// to the root of the repository, eg. "config/prow/config.yaml" will match
-	// github.com/kubernetes/test-infra/config/prow/config.yaml assuming the config-updater
-	// plugin is enabled for kubernetes/test-infra. Defaults to "config/prow/config.yaml".
-	ConfigFile string `json:"config_file,omitempty"`
-	// The location of the prow plugin configuration file inside the repository
-	// where the config-updater plugin is enabled. This needs to be relative
-	// to the root of the repository, eg. "config/prow/plugins.yaml" will match
-	// github.com/kubernetes/test-infra/config/prow/plugins.yaml assuming the config-updater
-	// plugin is enabled for kubernetes/test-infra. Defaults to "config/prow/plugins.yaml".
-	PluginFile string `json:"plugin_file,omitempty"`
 	// If GZIP is true then files will be gzipped before insertion into
 	// their corresponding configmap
 	GZIP bool `json:"gzip"`
@@ -838,23 +826,11 @@ func (c *Configuration) EnabledReposForExternalPlugin(plugin string) (orgs, repo
 // SetDefaults sets default options for config updating
 func (c *ConfigUpdater) SetDefaults() {
 	if len(c.Maps) == 0 {
-		cf := c.ConfigFile
-		if cf == "" {
-			cf = "config/prow/config.yaml"
-		} else {
-			logrus.Warnf(`config_file is deprecated, please switch to "maps": {"%s": "config"} before July 2018`, cf)
-		}
-		pf := c.PluginFile
-		if pf == "" {
-			pf = "config/prow/plugins.yaml"
-		} else {
-			logrus.Warnf(`plugin_file is deprecated, please switch to "maps": {"%s": "plugins"} before July 2018`, pf)
-		}
 		c.Maps = map[string]ConfigMapSpec{
-			cf: {
+			"config/prow/config.yaml": {
 				Name: "config",
 			},
-			pf: {
+			"config/prow/plugins.yaml": {
 				Name: "plugins",
 			},
 		}

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -123,37 +123,6 @@ func TestSetDefault_Maps(t *testing.T) {
 			},
 		},
 		{
-			name: "deprecated config",
-			config: ConfigUpdater{
-				ConfigFile: "foo.yaml",
-			},
-			expected: map[string]ConfigMapSpec{
-				"foo.yaml":                 {Name: "config", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-				"config/prow/plugins.yaml": {Name: "plugins", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-			},
-		},
-		{
-			name: "deprecated plugins",
-			config: ConfigUpdater{
-				PluginFile: "bar.yaml",
-			},
-			expected: map[string]ConfigMapSpec{
-				"bar.yaml":                {Name: "plugins", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-				"config/prow/config.yaml": {Name: "config", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-			},
-		},
-		{
-			name: "deprecated both",
-			config: ConfigUpdater{
-				ConfigFile: "foo.yaml",
-				PluginFile: "bar.yaml",
-			},
-			expected: map[string]ConfigMapSpec{
-				"foo.yaml": {Name: "config", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-				"bar.yaml": {Name: "plugins", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},
-			},
-		},
-		{
 			name: "both current and deprecated",
 			config: ConfigUpdater{
 				Maps: map[string]ConfigMapSpec{
@@ -161,8 +130,6 @@ func TestSetDefault_Maps(t *testing.T) {
 					"plugins.yaml":       {Name: "overwrite-plugins"},
 					"unconflicting.yaml": {Name: "ignored"},
 				},
-				ConfigFile: "config.yaml",
-				PluginFile: "plugins.yaml",
 			},
 			expected: map[string]ConfigMapSpec{
 				"config.yaml":        {Name: "overwrite-config", Namespaces: []string{""}, Clusters: map[string][]string{"default": {""}}},

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -52,13 +52,23 @@ func init() {
 func helpProvider(config *plugins.Configuration, enabledRepos []string) (*pluginhelp.PluginHelp, error) {
 	var configInfo map[string]string
 	if len(enabledRepos) == 1 {
-		msg := fmt.Sprintf(
-			"The main configuration is kept in sync with '%s/%s'.\nThe plugin configuration is kept in sync with '%s/%s'.",
-			enabledRepos[0],
-			config.ConfigUpdater.ConfigFile,
-			enabledRepos[0],
-			config.ConfigUpdater.PluginFile,
-		)
+		msg := ""
+		for configFileName, configMapSpec := range config.ConfigUpdater.Maps {
+			msg = msg + fmt.Sprintf(
+				"Files matching %s/%s are used to populate the %s ConfigMap in ",
+				enabledRepos[0],
+				configFileName,
+				configMapSpec.Name,
+			)
+			if len(configMapSpec.AdditionalNamespaces) == 0 {
+				msg = msg + fmt.Sprintf("the %s namespace.\n", configMapSpec.Namespace)
+			} else {
+				for _, nameSpace := range configMapSpec.AdditionalNamespaces {
+					msg = msg + fmt.Sprintf("%s, ", nameSpace)
+				}
+				msg = msg + fmt.Sprintf("and %s namespaces.\n", configMapSpec.Namespace)
+			}
+		}
 		configInfo = map[string]string{"": msg}
 	}
 	return &pluginhelp.PluginHelp{


### PR DESCRIPTION
'ConfigFile' and 'PluginFile' config fields are not used anywhere else so they could be set to anything and not have any effect on behaviour and thus, help text generated by them is not necessarily true. The actual source of help text appears to be the ConfigUpdater.Maps field.
Therefore, removed these fields and modified 'helpProvider' and some tests.

Fix #15128 