### PR TITLE
Kops - set PATH for presubmit e2e jobs

### DIFF
--- a/config/jobs/kubernetes/kops/kops-config.yaml
+++ b/config/jobs/kubernetes/kops/kops-config.yaml
@@ -86,6 +86,7 @@ presubmits:
         - --extract=release/latest
         - --ginkgo-parallel
         - --kops-build
+        - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
@@ -130,6 +131,7 @@ presubmits:
         - --extract=release/stable-1.15
         - --ginkgo-parallel
         - --kops-build
+        - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
@@ -174,6 +176,7 @@ presubmits:
         - --extract=release/stable-1.16
         - --ginkgo-parallel
         - --kops-build
+        - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|In-tree.*Volumes.*\[Driver:.*aws\]
         - --timeout=55m
@@ -218,6 +221,7 @@ presubmits:
         - --extract=release/stable-1.17
         - --ginkgo-parallel
         - --kops-build
+        - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m


### PR DESCRIPTION
I'm not a fan of this long brittle path, but this will be temporary as we work to migrate the presubmit jobs off of the [long-deprecated kops-e2e-runner.sh script](https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/kops-e2e-runner.sh#L41), which isn't working correctly in this case anyways:

https://github.com/kubernetes/test-infra/blob/edfbe7c6152d60de3d2376a81b1f2532ad5abfd9/images/kubekins-e2e/kops-e2e-runner.sh#L41

that path is not correct on presubmit e2e jobs because `WORKSPACE=/workspace`, so we continue to fallback to /usr/local/bin/kubectl which causes the issue we're seeing on master presubmit e2e jobs.
