### PR TITLE
Fix postsubmit job for cluster-api

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -133,6 +133,9 @@ postsubmits:
           args:
             - runner.sh
             - "./scripts/ci-capd-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
           resources:
             requests:
               cpu: 4


### PR DESCRIPTION
Fixes an issue where the post-submit job does not have access to run kind.

/assign @ncdc 