### PR TITLE
Azure: add MSI role assignment logic after cluster creation

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -37,6 +37,8 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_aws_aws_sdk_go//service/ec2:go_default_library",
+        "@com_github_azure_azure_sdk_for_go//services/authorization/mgmt/2015-07-01/authorization:go_default_library",
+        "@com_github_azure_azure_sdk_for_go//services/preview/msi/mgmt/2015-08-31-preview/msi:go_default_library",
         "@com_github_azure_azure_sdk_for_go//services/resources/mgmt/2018-05-01/resources:go_default_library",
         "@com_github_azure_azure_storage_blob_go//azblob:go_default_library",
         "@com_github_azure_go_autorest//autorest:go_default_library",

--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -163,6 +163,8 @@ type Cluster struct {
 	networkPlugin                    string
 	azureClient                      *AzureClient
 	aksDeploymentMethod              aksDeploymentMethod
+	useManagedIdentity               bool
+	identityName                     string
 }
 
 // IsAzureStackCloud return true if the cloud is AzureStack
@@ -358,13 +360,15 @@ func newAKSEngine() (*Cluster, error) {
 		customKubeBinaryURL:              "",
 		aksEngineBinaryPath:              "aks-engine", // use the one in path by default
 		aksDeploymentMethod:              getAKSDeploymentMethod(*aksOrchestratorRelease),
+		useManagedIdentity:               false,
+		identityName:                     "",
 	}
 	c.getAzCredentials()
 	err = c.SetCustomCloudProfileEnvironment()
 	if err != nil {
 		return nil, fmt.Errorf("failed to create custom cloud profile file: %v", err)
 	}
-	err = c.getARMClient(c.ctx)
+	err = c.getAzureClient(c.ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ARM client: %v", err)
 	}
@@ -487,6 +491,14 @@ func (c *Cluster) populateAPIModelTemplate() error {
 	if !toBool(v.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity) {
 		v.Properties.ServicePrincipalProfile.ClientID = c.credentials.ClientID
 		v.Properties.ServicePrincipalProfile.Secret = c.credentials.ClientSecret
+	} else {
+		c.useManagedIdentity = true
+		if v.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID != "" {
+			c.identityName = v.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID
+		} else {
+			c.identityName = c.resourceGroup + "-id"
+			v.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID = c.identityName
+		}
 	}
 
 	if c.aksCustomWinBinariesURL != "" {
@@ -645,7 +657,7 @@ func (c *Cluster) loadARMTemplates() error {
 	return nil
 }
 
-func (c *Cluster) getARMClient(ctx context.Context) error {
+func (c *Cluster) getAzureClient(ctx context.Context) error {
 	// instantiate Azure Resource Manager Client
 	env, err := azure.EnvironmentFromName(c.azureEnvironment)
 	var client *AzureClient
@@ -683,20 +695,28 @@ func (c *Cluster) createCluster() error {
 	if err != nil {
 		return fmt.Errorf("could not ensure resource group: %v", err)
 	}
+
 	log.Printf("Validating deployment ARM templates.")
 	if _, err := c.azureClient.ValidateDeployment(
 		c.ctx, c.resourceGroup, c.name, &c.templateJSON, &c.parametersJSON,
 	); err != nil {
 		return fmt.Errorf("ARM template invalid: %v", err)
 	}
+
 	log.Printf("Deploying cluster %v in resource group %v.", c.name, c.resourceGroup)
 	if _, err := c.azureClient.DeployTemplate(
 		c.ctx, c.resourceGroup, c.name, &c.templateJSON, &c.parametersJSON,
 	); err != nil {
 		return fmt.Errorf("cannot deploy: %v", err)
 	}
-	return nil
 
+	if c.useManagedIdentity && c.identityName != "" {
+		log.Printf("Assigning 'Owner' role to %s in %s", c.identityName, c.resourceGroup)
+		if err := c.azureClient.AssignOwnerRoleToIdentity(c.ctx, c.resourceGroup, c.identityName); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *Cluster) populateAzureCloudConfig(isVMSS bool) error {

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -23,10 +23,22 @@ import (
 	"os"
 	"time"
 
-	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/preview/msi/mgmt/2015-08-31-preview/msi"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
+	uuid "github.com/satori/go.uuid"
+)
+
+const (
+	// aadOwnerRoleID is the role id that exists in every subscription for 'Owner'
+	aadOwnerRoleID = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+	// aadRoleReferenceTemplate is a template for a roleDefinitionId
+	aadRoleReferenceTemplate = "/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s"
+	// aadRoleResourceGroupScopeTemplate is a template for a roleDefinition scope
+	aadRoleResourceGroupScopeTemplate = "/subscriptions/%s"
 )
 
 type AKSEngineAPIModel struct {
@@ -173,10 +185,12 @@ type AgentPoolProfile struct {
 }
 
 type AzureClient struct {
-	environment       azure.Environment
-	subscriptionID    string
-	deploymentsClient resources.DeploymentsClient
-	groupsClient      resources.GroupsClient
+	environment         azure.Environment
+	subscriptionID      string
+	deploymentsClient   resources.DeploymentsClient
+	groupsClient        resources.GroupsClient
+	msiClient           msi.UserAssignedIdentitiesClient
+	authorizationClient authorization.RoleAssignmentsClient
 }
 
 type FeatureFlags struct {
@@ -282,6 +296,31 @@ func (az *AzureClient) DeleteResourceGroup(ctx context.Context, groupName string
 	return nil
 }
 
+func (az *AzureClient) AssignOwnerRoleToIdentity(ctx context.Context, resourceGroupName, identityName string) error {
+	identity, err := az.msiClient.Get(ctx, resourceGroupName, identityName)
+	if err != nil {
+		return fmt.Errorf("failed to get identity's client ID: %v", err)
+	}
+
+	identityPrincipalID := identity.PrincipalID.String()
+	// Grant the identity 'Owner' access to the subscription
+	// so it can pull images from private registry
+	roleDefinitionID := fmt.Sprintf(aadRoleReferenceTemplate, az.subscriptionID, aadOwnerRoleID)
+	scope := fmt.Sprintf(aadRoleResourceGroupScopeTemplate, az.subscriptionID)
+	roleAssignmentParameters := authorization.RoleAssignmentCreateParameters{
+		Properties: &authorization.RoleAssignmentProperties{
+			RoleDefinitionID: stringPointer(roleDefinitionID),
+			PrincipalID:      stringPointer(identityPrincipalID),
+		},
+	}
+
+	if _, err := az.authorizationClient.Create(ctx, scope, uuid.NewV1().String(), roleAssignmentParameters); err != nil {
+		return fmt.Errorf("failed to assign 'Owner' role to user assigned identity: %v", err)
+	}
+
+	return nil
+}
+
 func getOAuthConfig(env azure.Environment, subscriptionID, tenantID string) (*adal.OAuthConfig, error) {
 
 	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
@@ -308,17 +347,20 @@ func getAzureClient(env azure.Environment, subscriptionID, clientID, tenantID, c
 
 func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *adal.ServicePrincipalToken) *AzureClient {
 	c := &AzureClient{
-		environment:    env,
-		subscriptionID: subscriptionID,
-
-		deploymentsClient: resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		groupsClient:      resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		environment:         env,
+		subscriptionID:      subscriptionID,
+		deploymentsClient:   resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		groupsClient:        resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		msiClient:           msi.NewUserAssignedIdentitiesClient(subscriptionID),
+		authorizationClient: authorization.NewRoleAssignmentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 	}
 
 	authorizer := autorest.NewBearerAuthorizer(armSpt)
 	c.deploymentsClient.Authorizer = authorizer
 	c.deploymentsClient.PollingDuration = 60 * time.Minute
 	c.groupsClient.Authorizer = authorizer
+	c.msiClient.Authorizer = authorizer
+	c.authorizationClient.Authorizer = authorizer
 
 	return c
 }


### PR DESCRIPTION
Follow-up PR for #16129. This PR assigns 'Owner' role to the user identity so that it can pull images from private registry within the subscription.

/assign @feiskyer 
/cc @andyzhangx 