### PR TITLE
Add more buckets to boskos_http_request_duration_seconds histogram

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -60,7 +60,7 @@ var (
 )
 
 var (
-	httpRequestDuration = metrics.HttpRequestDuration("boskos", 0.005, 360)
+	httpRequestDuration = metrics.HttpRequestDuration("boskos", 0.005, 1200)
 	httpResponseSize    = metrics.HttpResponseSize("boskos", 128, 65536)
 	traceHandler        = metrics.TraceHandler(simplifier, httpRequestDuration, httpResponseSize)
 )


### PR DESCRIPTION
We have response time in production over 360.
Adding more buckets here would allow us to have a clearer idea than `+inf`.

/cc @stevekuznetsov 