### PR TITLE
Include the error in the prowjob status description when a pod cannot be started

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -374,7 +374,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 			}
 			pj.Status.State = prowapi.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = "Job cannot be processed."
+			pj.Status.Description = fmt.Sprintf("Job cannot be processed: %v", err)
 			c.log.WithFields(pjutil.ProwJobFields(&pj)).WithError(err).Warning("Unprocessable pod.")
 		} else {
 			pj.Status.BuildID = id
@@ -519,7 +519,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]corev1.P
 			}
 			pj.Status.State = prowapi.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = "Job cannot be processed."
+			pj.Status.Description = fmt.Sprintf("Job cannot be processed: %v", err)
 			logrus.WithField("job", pj.Spec.Job).WithError(err).Warning("Unprocessable pod.")
 		}
 	} else {


### PR DESCRIPTION
Sometimes prowjob pod specs are so malformed that they cannot be created at all. In this case you get no hints of any kind, anywhere.

Embed the error message in the prowjob description, as a simple first step towards making these failures discoverable.

(There are a plethora of other issues - for instance, these jobs never get a build ID, which precludes anything about them being stored anywhere, any links to them being generated, any hints being given anywhere useful, etc. But it's a start.)

/cc @cjwagner 