### PR TITLE
Add a prowjob-based hint to the spyglass hint message

### DIFF
--- a/prow/spyglass/lenses/metadata/BUILD.bazel
+++ b/prow/spyglass/lenses/metadata/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/spyglass/lenses/metadata",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/crier/reporters/gcs/kubernetes:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "//prow/spyglass/lenses:go_default_library",
@@ -70,6 +71,7 @@ go_test(
     srcs = ["lens_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/crier/reporters/gcs/kubernetes:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 
 	k8sreporter "k8s.io/test-infra/prow/crier/reporters/gcs/kubernetes"
 )
@@ -257,7 +258,7 @@ func TestHintFromPodInfo(t *testing.T) {
 			},
 		},
 		{
-			name:     "pod scheduled to an illegal node is reported",
+			name:     "pod that could not be scheduled is reported",
 			expected: "There are no nodes that your pod can schedule to - check your requests, tolerations, and node selectors (0/3 nodes are available: 3 node(s) didn't match node selector.)",
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
@@ -334,6 +335,88 @@ func TestHintFromPodInfo(t *testing.T) {
 				t.Fatalf("Unexpected failed to marshal pod to JSON (this wasn't even part of the test!): %v", err)
 			}
 			result := hintFromPodInfo(b)
+			if result != tc.expected {
+				t.Errorf("Expected hint %q, but got %q", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestHintFromProwJob(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected string
+		pj       prowv1.ProwJob
+	}{
+		{
+			name:     "errored job has its description reported",
+			expected: "Job execution failed: this is the description",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.ErrorState,
+					Description: "this is the description",
+				},
+			},
+		},
+		{
+			name:     "failed prowjob reports nothing",
+			expected: "",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.FailureState,
+					Description: "this is another description",
+				},
+			},
+		},
+		{
+			name:     "aborted prowjob reports nothing",
+			expected: "",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.AbortedState,
+					Description: "this is another description",
+				},
+			},
+		},
+		{
+			name:     "successful prowjob reports nothing",
+			expected: "",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.SuccessState,
+					Description: "this is another description",
+				},
+			},
+		},
+		{
+			name:     "pending prowjob reports nothing",
+			expected: "",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.PendingState,
+					Description: "this is another description",
+				},
+			},
+		},
+		{
+			name:     "triggered prowjob reports nothing",
+			expected: "",
+			pj: prowv1.ProwJob{
+				Status: prowv1.ProwJobStatus{
+					State:       prowv1.TriggeredState,
+					Description: "this is another description",
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(tc.pj)
+			if err != nil {
+				t.Fatalf("Unexpected failed to marshal prowjob to JSON (this wasn't even part of the test!): %v", err)
+			}
+			result := hintFromProwJob(b)
 			if result != tc.expected {
 				t.Errorf("Expected hint %q, but got %q", tc.expected, result)
 			}


### PR DESCRIPTION
If a prowjob errored and we have nothing from the pod, try including the description of the prowjob status instead.

This, combined with #16154 and a future change to enable having build IDs everywhere, would enable useful error reporting for uncreatable pods.

/cc @cjwagner 