### PR TITLE
Allow tide merge method labels to be applied with the /label plugin.

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -117,6 +117,9 @@ label:
     - platform/gcp
     - platform/minikube
     - platform/other
+    - tide/merge-method-merge
+    - tide/merge-method-rebase
+    - tide/merge-method-squash
 
 lgtm:
 - repos:


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/16124#issuecomment-582073696
Note that requesting a merge method that is forbidden by the repo's settings will prevent Tide from merging the PR and possibly others in the repo so we may want to address this issue first: https://github.com/kubernetes/test-infra/issues/16159
/hold
/cc @thockin 