### PR TITLE
sig-release: Update Prow plugin configs

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -152,12 +152,14 @@ blockades:
   blockregexps:
   - ^keps/NEXT_KEP_NUMBER$
   explanation: "KEP numbers are obsolete. Please remove any changes to `NEXT_KEP_NUMBER` from this PR and ensure the KEP filename is the draft date and KEP title e.g., `YYYYMMDD-pony-controller.md`"
-# TODO(justaugustus): Remove this blockade after identifying jobs where release tooling is being leveraged and
-#                     reorganizing k/release to be more restrictive about who can approve changes.
-#                     Deadline: 8/8/19
-#                     ref:
-#                       - https://github.com/kubernetes/test-infra/pull/13328
-#                       - https://github.com/kubernetes/release/issues/816
+### DO NOT REMOVE ###
+# This blockade is intended to restrict the approval of changes to existing release tooling to k/release repo admins.
+# We should only consider removing it after all tools mentioned in the regex have been removed/replaced.
+# ref:
+# - Go refactor umbrella: https://github.com/kubernetes/release/issues/918
+# - deb/rpm refactor umbrella: https://github.com/kubernetes/release/issues/1027
+# - Initial k/release blockade PR: https://github.com/kubernetes/test-infra/pull/13328
+# - Issue on mitigating CI failures caused by k/release changes: https://github.com/kubernetes/release/issues/816
 - repos:
   - kubernetes/release
   blockregexps:
@@ -482,6 +484,30 @@ require_matching_label:
   repo: cloud-provider-aws
   prs: true
   regexp: ^kind/
+- missing_label: needs-kind
+  org: kubernetes
+  repo: release
+  issues: true
+  prs: true
+  regexp: ^kind/
+- missing_label: needs-priority
+  org: kubernetes
+  repo: release
+  issues: true
+  prs: true
+  regexp: ^priority/
+- missing_label: needs-kind
+  org: kubernetes
+  repo: sig-release
+  issues: true
+  prs: true
+  regexp: ^kind/
+- missing_label: needs-priority
+  org: kubernetes
+  repo: sig-release
+  issues: true
+  prs: true
+  regexp: ^priority/
 
 retitle:
   allow_closed_issues: true
@@ -624,14 +650,19 @@ plugins:
 
   kubernetes/release:
   - blockade
+  - mergecommitblocker
   - milestone
   - milestoneapplier
   - override
+  - release-note
+  - require-matching-label
 
   kubernetes/sig-release:
+  - mergecommitblocker
   - milestone
   - milestoneapplier
   - override
+  - require-matching-label
 
   kubernetes/system-validators:
   - milestone


### PR DESCRIPTION
- Update note about temporary blockade in k/rel
  We should continue to consider the blockade on release tooling changes
  permanent until they are completely replaced by [`krel`](https://github.com/kubernetes/release/tree/master/cmd/krel) and [`kubepkg`](https://github.com/kubernetes/release/tree/master/cmd/kubepkg)
- Enable plugins for k/release and k/sig-release:
  - mergecommitblocker
  - release-note (k/rel only)
  - require-matching-label
- Configure k/release and k/sig-release to require kind and priority
  labels for PRs and issues

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Required for https://github.com/kubernetes/release/issues/1065.
/assign @tpepper @hoegaarden @saschagrunert 