### PR TITLE
Boskos: remove global lock

### DIFF
--- a/boskos/boskos.go
+++ b/boskos/boskos.go
@@ -139,6 +139,8 @@ func main() {
 	v.WatchConfig()
 	v.OnConfigChange(func(in fsnotify.Event) {
 		logrus.Infof("Updating Boskos Config")
+		// TODO: We need retrying here, as we do not delete
+		// resources that currently have an owner
 		if err := r.SyncConfig(*configPath); err != nil {
 			logrus.WithError(err).Errorf("Failed to update config")
 		} else {


### PR DESCRIPTION
Boskos always uses a CRD storage, which means that we get the
built-in optimistic concurrency from Kubernetes. This allows us
to get rid of the lock, as the Update requests we do will fail in
case another request was quicker and updated the object in the meantime.

From a users POV this means that there is a higher chance of
Acquire/AcquireByState requests failing, but a much faster response
time.

As a follow-up, we could make the Acquire/AcquireByState handlers retry
the whole allocation to reduce the likelyhood of transient failures
there.

/assign sebastienvas @stevekuznetsov 