### PR TITLE
Expand load test run time

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -313,7 +313,7 @@ periodics:
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
 - name: ci-kubernetes-e2e-windows-node-throughput
-  interval: 4h
+  interval: 6h
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -323,6 +323,8 @@ periodics:
     testgrid-dashboards: google-windows
     testgrid-tab-name: gce-windows-node-throughput
   decorate: true
+  decoration_config:
+    timeout: 4h
   extra_refs:
   - org: kubernetes-sigs
     repo: windows-testing
@@ -354,7 +356,7 @@ periodics:
       - --test-cmd-args=--testconfig=testing/node-throughput/config.yaml
       - --test-cmd-args=--testoverrides=./testing/node-throughput/windows_override.yaml
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=180m
+      - --timeout=300m
 
 presubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
1. Since we could run 80 pods load test without any issues, increased to 100 pods as per: https://github.com/kubernetes/perf-tests/pull/1029
2. Tried test run with pod creation rate 1pod / 20s locally, it failed. So keep 1pod / 33s
3. Test run time should be at least: 100 pods * 33s * 2(creation + deletion) + 60m = 170m
4. Seems test run timed out due to default decoration_config timeout (2h) from [logs](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-node-throughput/1225177332839354370), so overwrite it with 4h. Reference: https://github.com/kubernetes/test-infra/issues/7152
```
{"component":"entrypoint","file":"prow/entrypoint/run.go:164","func":"k8s.io/test-infra/prow/entrypoint.Options.ExecuteProcess","level":"error","msg":"Process did not finish before 2h0m0s timeout","time":"2020-02-06T00:00:32Z"}
... calling kube-down
Project: k8s-gce-gci-1-5-1-6-ctl-skew
Network Project: k8s-gce-gci-1-5-1-6-ctl-skew
Zone: us-west1-b
INSTANCE_GROUPS=e2e-f1fc5c95d2-42aea-minion-group
NODE_NAMES=e2e-f1fc5c95d2-42aea-minion-group-mhbb
Bringing down cluster
Deleting Managed Instance Group...
Deleting Managed Instance Group...
........{"component":"entrypoint","file":"prow/entrypoint/run.go:245","func":"k8s.io/test-infra/prow/entrypoint.gracefullyTerminate","level":"error","msg":"Process did not exit before 15s grace period","time":"2020-02-06T00:00:47Z"}
```
