### PR TITLE
prow/interrupts: Do not handle the ABRT signal

### DIFF
--- a/prow/interrupts/interrupts.go
+++ b/prow/interrupts/interrupts.go
@@ -76,7 +76,7 @@ var signalsLock = sync.Mutex{}
 // signals allows for injection of mock signals in testing
 var signals = func() <-chan os.Signal {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGABRT)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 	return sig
 }
 


### PR DESCRIPTION
ABRT is typically a debugging signal and is not used by Kube
during termination. By registering for it we hide the very useful
in-process "dump all goroutine state on a wedged go process"
default go runtime behavior. Since this package is included by init,
any of our tools that use it won't be able to leverage that
function.

Remove ABRT from being automatically handled, and allow prow
to crash on ABRT. A developer debugging one of these processes
would have to manually clean up anyway (or they could fire TERM
and then ABRT).

/assign @stevekuznetsov