### PR TITLE
Pin triage job to working image.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -29,7 +29,7 @@ periodics:
   interval: 30m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/triage:latest
+    - image: gcr.io/k8s-testimages/triage:v20191223-1c70f8f
       imagePullPolicy: Always
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS


### PR DESCRIPTION
/assign @BenTheElder 

The `ci-test-infra-triage` job started failing after an image update: https://k8s-testgrid.appspot.com/sig-testing-misc#triage

It is unclear why this image was updated at all. The [image pushing job](https://github.com/kubernetes/test-infra/blob/3062eb53138492444411c27b6bbacd0fc2a8572f/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L269-L300) should only run when the `triage` directory is changed, but ran yesterday ([run](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-triage/1225129139170709510)) even though there were [no recent changes to the directory](https://github.com/kubernetes/test-infra/commits/master/triage). :confused: 
/shrug