### PR TITLE
support running build with bazel version requested in .bazelversion

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -21,11 +21,16 @@ presubmits:
       containers:
       - image: launcher.gcr.io/google/bazel:0.25.2
         command:
-        - bash
+        - ../test-infra/hack/bazel.sh
         args:
-        - -c
-        - |
-          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
+        - build
+        - --config=remote
+        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
+        - --
+        - //...
+        - -//vendor/...
+        - -//build/...
+        - //build/release-tars
   - name: pull-kubernetes-bazel-test
     decorate: true
     always_run: true

--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -69,9 +69,12 @@ RUN wget -q "https://storage.googleapis.com/golang/${GO_TARBALL}" && \
     rm "${GO_TARBALL}"
 
 # install bazel
+COPY ./install-bazel.sh /
+ENV BAZEL_VERSION 0.25.2
+RUN bash /install-bazel.sh
+
 ARG BAZEL_VERSION_ARG
 ENV BAZEL_VERSION=${BAZEL_VERSION_ARG}
-COPY ./install-bazel.sh /
 RUN bash /install-bazel.sh
 
 # if UPGRADE_DOCKER_ARG, then install the latest docker over whatever we have

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -35,7 +35,7 @@ substitutions:
   _CONFIG: master
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
-  _BAZEL_VERSION: 0.23.2
+  _BAZEL_VERSION: 0.25.2
   _UPGRADE_DOCKER: 'false'
   _CFSSL_VERSION: R1.2
 options:

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -3,7 +3,7 @@ variants:
     CONFIG: experimental
     GO_VERSION: 1.13.8
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.28.1
+    BAZEL_VERSION: 2.2.0
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -9,7 +9,7 @@ variants:
     CONFIG: master
     GO_VERSION: 1.13.8
     K8S_RELEASE: stable
-    BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: 0.25.2
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: 1.13.8


### PR DESCRIPTION
This allows a commit in a seperate repo to upgrade bazel in a commit
before changing the default version. If the requested version is not
installed in the build image, we fall back to the default.

This also install 2.2.0 in the CI image but does not switch the default.