### PR TITLE
branchprotector should not exit on 404

### DIFF
--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -133,7 +133,7 @@ func main() {
 		for i, err := range errors {
 			logrus.WithError(err).Error(i)
 		}
-		logrus.Fatalf("Encountered %d errors protecting branches", n)
+		logrus.Errorf("Encountered %d errors protecting branches", n)
 	}
 }
 

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -133,7 +133,7 @@ func main() {
 		for i, err := range errors {
 			logrus.WithError(err).Error(i)
 		}
-		logrus.Errorf("Encountered %d errors protecting branches", n)
+		logrus.Fatalf("Encountered %d errors protecting branches", n)
 	}
 }
 

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
@@ -400,10 +401,14 @@ func (p *protector) UpdateBranch(orgName, repo string, branchName string, branch
 		}
 	}
 
+	// github API is very sensitive if branchName contains extra characters,
+	// therefor we need to url encode the branch name.
+	branchNameForRequest := url.QueryEscape(branchName)
+
 	// The github API currently does not support listing protections for all
 	// branches of a repository. We therefore have to make individual requests
 	// for each branch.
-	currentBP, err := p.client.GetBranchProtection(orgName, repo, branchName)
+	currentBP, err := p.client.GetBranchProtection(orgName, repo, branchNameForRequest)
 	if err != nil {
 		return fmt.Errorf("get current branch protection: %v", err)
 	}

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -1010,6 +1010,26 @@ branch-protection:
 				},
 			},
 		},
+		{
+			name:     "protect branches with special characters",
+			branches: []string{"cfgdef/repo1=test_#123"},
+			config: `
+branch-protection:
+  protect: true
+  orgs:
+    cfgdef:
+`,
+			expected: []requirements{
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "test_#123",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins: &no,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
For #16177, trying to provide a start for URL encode on branchprotector, as well as change the log.Fatalf to log.Errorf to not exit the process and force pod recreation.

edit: Change of logging is not necessary.