### PR TITLE
Kops - add e2e periodic job for testing coredns

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -128,6 +128,38 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-containerd
 
+- interval: 30m
+  name: ci-kubernetes-e2e-kops-aws-coredns
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+    preset-e2e-platform-aws: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-coredns.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --extract=ci/latest
+      - --ginkgo-parallel
+      - --kops-overrides=spec.kubeDNS.provider=CoreDNS
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200206-f88edef-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-coredns
+
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-newrunner
   labels:


### PR DESCRIPTION
I copied the `kops-aws` job, renamed it, and set the kops-overrides field:

https://github.com/kubernetes/kops/blob/5dc38b911f2f6d7953f275c75f77f8197bc72bfa/pkg/commands/set_cluster.go#L98

I'll adjust the interval once we confirm the job is functional. Once we switch the default from KubeDNS to CoreDNS we can remove this job.