### PR TITLE
Kops - decrease frequency of new CoreDNS E2E job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -128,7 +128,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-containerd
 
-- interval: 30m
+- interval: 4h
   name: ci-kubernetes-e2e-kops-aws-coredns
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Once we confirm the job is stable we don't need it to run as often.