### PR TITLE
Delete pipeline resources when pipeline run is deleted

### DIFF
--- a/prow/cmd/pipeline/BUILD.bazel
+++ b/prow/cmd/pipeline/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "@com_github_tektoncd_pipeline//pkg/client/clientset/versioned:go_default_library",
         "@com_github_tektoncd_pipeline//pkg/client/informers/externalversions:go_default_library",
         "@com_github_tektoncd_pipeline//pkg/client/informers/externalversions/pipeline/v1alpha1:go_default_library",
-        "@com_github_tektoncd_pipeline//pkg/client/resource/clientset/versioned:go_default_library",
         "@dev_knative_pkg//apis:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/prow/cmd/pipeline/controller.go
+++ b/prow/cmd/pipeline/controller.go
@@ -272,7 +272,6 @@ type reconciler interface {
 	getPipelineRun(context, namespace, name string) (*pipelinev1alpha1.PipelineRun, error)
 	deletePipelineRun(context, namespace, name string) error
 	createPipelineRun(context, namespace string, b *pipelinev1alpha1.PipelineRun) (*pipelinev1alpha1.PipelineRun, error)
-	createPipelineResource(context, namespace string, b *pipelinev1alpha1.PipelineResource) (*pipelinev1alpha1.PipelineResource, error)
 	pipelineID(prowjobv1.ProwJob) (string, string, error)
 	now() metav1.Time
 }
@@ -315,6 +314,7 @@ func (c *controller) deletePipelineRun(context, namespace, name string) error {
 	}
 	return p.client.TektonV1alpha1().PipelineRuns(namespace).Delete(name, &metav1.DeleteOptions{})
 }
+
 func (c *controller) createPipelineRun(context, namespace string, p *pipelinev1alpha1.PipelineRun) (*pipelinev1alpha1.PipelineRun, error) {
 	logrus.Debugf("createPipelineRun(%s,%s,%s)", context, namespace, p.Name)
 	pc, err := c.getPipelineConfig(context)
@@ -331,15 +331,6 @@ func (c *controller) createPipelineRun(context, namespace string, p *pipelinev1a
 		return err == nil, err
 	})
 	return p, err
-}
-
-func (c *controller) createPipelineResource(context, namespace string, pr *pipelinev1alpha1.PipelineResource) (*pipelinev1alpha1.PipelineResource, error) {
-	logrus.Debugf("createPipelineResource(%s,%s,%s)", context, namespace, pr.Name)
-	pc, err := c.getPipelineConfig(context)
-	if err != nil {
-		return nil, err
-	}
-	return pc.resourceClient.TektonV1alpha1().PipelineResources(namespace).Create(pr)
 }
 
 func (c *controller) now() metav1.Time {
@@ -430,21 +421,9 @@ func reconcile(c reconciler, key string) error {
 		newpj.Status.BuildID = id
 		newpj.Status.URL = url
 		newPipelineRun = true
-		pipelineRun, resources, err := makeResources(*newpj)
+		pipelineRun, err := makePipelineRun(*newpj)
 		if err != nil {
 			return fmt.Errorf("error preparing resources: %v", err)
-		}
-
-		// Create the any git resources that are needed.
-		for _, res := range resources {
-			resKey := toKey(ctx, namespace, res.Name)
-			logrus.Infof("Create PipelineResource/%s", resKey)
-			if _, err = c.createPipelineResource(ctx, namespace, &res); err != nil {
-				if !apierrors.IsAlreadyExists(err) {
-					return fmt.Errorf("create PipelineResource/%s: %v", resKey, err)
-				}
-				logrus.Warnf("Already exists: PipelineResource/%s", resKey)
-			}
 		}
 
 		logrus.Infof("Create PipelineRun/%s", key)
@@ -605,19 +584,19 @@ func makePipelineGitResource(name string, refs prowjobv1.Refs, pj prowjobv1.Prow
 	return &pr
 }
 
-// makePipeline creates a PipelineRun and a slice of PipelineResources from a ProwJob using the
-// PipelineRunSpec and git refs.
-func makeResources(pj prowjobv1.ProwJob) (*pipelinev1alpha1.PipelineRun, []pipelinev1alpha1.PipelineResource, error) {
+// makePipeline creates a PipelineRun and substitutes ProwJob managed pipeline resources with ResourceSpec instead of ResourceRef
+// so that we don't have to take care of potentially dangling created pipeline resources.
+func makePipelineRun(pj prowjobv1.ProwJob) (*pipelinev1alpha1.PipelineRun, error) {
 	// First validate.
 	if pj.Spec.PipelineRunSpec == nil {
-		return nil, nil, errors.New("no PipelineSpec defined")
+		return nil, errors.New("no PipelineSpec defined")
 	}
 	buildID := pj.Status.BuildID
 	if buildID == "" {
-		return nil, nil, errors.New("empty BuildID in status")
+		return nil, errors.New("empty BuildID in status")
 	}
 	if err := config.ValidatePipelineRunSpec(pj.Spec.Type, pj.Spec.ExtraRefs, pj.Spec.PipelineRunSpec); err != nil {
-		return nil, nil, fmt.Errorf("invalid pipeline_run_spec: %v", err)
+		return nil, fmt.Errorf("invalid pipeline_run_spec: %v", err)
 	}
 
 	p := pipelinev1alpha1.PipelineRun{
@@ -628,7 +607,7 @@ func makeResources(pj prowjobv1.ProwJob) (*pipelinev1alpha1.PipelineRun, []pipel
 	// Add parameters instead of env vars.
 	env, err := downwardapi.EnvForSpec(downwardapi.NewJobSpec(pj.Spec, buildID, pj.Name))
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	for _, key := range sets.StringKeySet(env).List() {
 		val := env[key]
@@ -642,15 +621,14 @@ func makeResources(pj prowjobv1.ProwJob) (*pipelinev1alpha1.PipelineRun, []pipel
 		})
 	}
 
-	// Create and substitute git resources.
-	resourceMap := map[string]*pipelinev1alpha1.PipelineResource{}
+	// Inject resources from prow job.
 	for i, res := range p.Spec.Resources {
 		refName := res.ResourceRef.Name
 		var refs prowjobv1.Refs
 		var suffix string
 		if refName == config.ProwImplicitGitResource {
 			if pj.Spec.Refs == nil {
-				return nil, nil, fmt.Errorf("%q requested on a ProwJob without an implicit git ref", config.ProwImplicitGitResource)
+				return nil, fmt.Errorf("%q requested on a ProwJob without an implicit git ref", config.ProwImplicitGitResource)
 			}
 			refs = *pj.Spec.Refs
 			suffix = "-implicit-ref"
@@ -661,19 +639,12 @@ func makeResources(pj prowjobv1.ProwJob) (*pipelinev1alpha1.PipelineRun, []pipel
 		} else {
 			continue
 		}
+		// Change resource ref to resource spec
 		name := pj.Name + suffix
-		if _, exists := resourceMap[name]; !exists {
-			resourceMap[name] = makePipelineGitResource(name, refs, pj)
-		}
-		resource := resourceMap[name]
-		p.Spec.Resources[i].ResourceRef.Name = resource.Name
-		p.Spec.Resources[i].ResourceRef.APIVersion = resource.APIVersion
+		resource := makePipelineGitResource(name, refs, pj)
+		p.Spec.Resources[i].ResourceRef = nil
+		p.Spec.Resources[i].ResourceSpec = &resource.Spec
 	}
 
-	resources := make([]pipelinev1alpha1.PipelineResource, 0, len(resourceMap))
-	for _, key := range sets.StringKeySet(resourceMap).List() {
-		resources = append(resources, *resourceMap[key])
-	}
-
-	return &p, resources, nil
+	return &p, nil
 }

--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -106,6 +106,7 @@ func (r *fakeReconciler) getPipelineRun(context, namespace, name string) (*pipel
 	}
 	return &p, nil
 }
+
 func (r *fakeReconciler) deletePipelineRun(context, namespace, name string) error {
 	logrus.Debugf("deletePipelineRun: ctx=%s, ns=%s, name=%s", context, namespace, name)
 	if namespace == errorDeletePipelineRun {
@@ -137,11 +138,6 @@ func (r *fakeReconciler) createPipelineRun(context, namespace string, p *pipelin
 
 func (r *fakeReconciler) pipelineID(pj prowjobv1.ProwJob) (string, string, error) {
 	return pipelineID, "", nil
-}
-
-func (r *fakeReconciler) createPipelineResource(context, namespace string, pr *pipelinev1alpha1.PipelineResource) (*pipelinev1alpha1.PipelineResource, error) {
-	logrus.Debugf("createPipelineResource: ctx=%s, ns=%s, name=%s", context, namespace, pr.GetName())
-	return pr, nil
 }
 
 type fakeLimiter struct {
@@ -269,7 +265,7 @@ func TestReconcile(t *testing.T) {
 			},
 			expectedPipelineRun: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun {
 				pj.Spec.Type = prowjobv1.PeriodicJob
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -324,7 +320,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Type = prowjobv1.PeriodicJob
 				pj.Spec.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{}
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -338,7 +334,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Type = prowjobv1.PeriodicJob
 				pj.Spec.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{}
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				p.DeletionTimestamp = &now
 				if err != nil {
 					panic(err)
@@ -354,7 +350,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Type = prowjobv1.PeriodicJob
 				pj.Spec.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{}
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -386,7 +382,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -417,7 +413,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -450,7 +446,7 @@ func TestReconcile(t *testing.T) {
 					ServiceAccountName: "robot",
 				}
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -481,7 +477,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -519,7 +515,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -559,7 +555,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -606,7 +602,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -627,7 +623,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Type = prowjobv1.PeriodicJob
 				pj.Spec.PipelineRunSpec = &pipelinev1alpha1.PipelineRunSpec{}
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -688,7 +684,7 @@ func TestReconcile(t *testing.T) {
 				pj.Spec.Agent = prowjobv1.TektonAgent
 				pj.Spec.PipelineRunSpec = &pipelineSpec
 				pj.Status.BuildID = pipelineID
-				p, _, err := makeResources(pj)
+				p, err := makePipelineRun(pj)
 				if err != nil {
 					panic(err)
 				}
@@ -878,7 +874,6 @@ func TestMakeResources(t *testing.T) {
 		name        string
 		job         func(prowjobv1.ProwJob) prowjobv1.ProwJob
 		pipelineRun func(pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun
-		resources   func(prowjobv1.ProwJob) []pipelinev1alpha1.PipelineResource
 		err         bool
 	}{
 		{
@@ -911,9 +906,6 @@ func TestMakeResources(t *testing.T) {
 				return pj
 			},
 			pipelineRun: func(pr pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun {
-				pr.Spec.Resources[0].ResourceRef = &pipelinev1alpha1.PipelineResourceRef{
-					Name: pr.Name + "-implicit-ref",
-				}
 				pr.Spec.Params[4].Value = pipelinev1alpha1.ArrayOrString{
 					Type:      pipelinev1alpha1.ParamTypeString,
 					StringVal: string(prowjobv1.PresubmitJob),
@@ -969,12 +961,19 @@ func TestMakeResources(t *testing.T) {
 						},
 					},
 				)
-				return pr
-			},
-			resources: func(pj prowjobv1.ProwJob) []pipelinev1alpha1.PipelineResource {
-				return []pipelinev1alpha1.PipelineResource{
-					*makePipelineGitResource("world-implicit-ref", *pj.Spec.Refs, pj),
+				pr.Spec.Resources = []pipelinev1alpha1.PipelineResourceBinding{
+					{
+						Name: "implicit git resource",
+						ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
+							Type: "git",
+							Params: []pipelinev1alpha1.ResourceParam{
+								{Name: "url", Value: "https://source.host/test/test.git"},
+								{Name: "revision", Value: "pull/1/head"},
+							},
+						},
+					},
 				}
+				return pr
 			},
 		},
 		{
@@ -994,19 +993,29 @@ func TestMakeResources(t *testing.T) {
 				return pj
 			},
 			pipelineRun: func(pr pipelinev1alpha1.PipelineRun) pipelinev1alpha1.PipelineRun {
-				pr.Spec.Resources[0].ResourceRef = &pipelinev1alpha1.PipelineResourceRef{
-					Name: pr.Name + "-extra-ref-0",
-				}
-				pr.Spec.Resources[1].ResourceRef = &pipelinev1alpha1.PipelineResourceRef{
-					Name: pr.Name + "-extra-ref-1",
+				pr.Spec.Resources = []pipelinev1alpha1.PipelineResourceBinding{
+					{
+						Name: "git resource A",
+						ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
+							Type: "git",
+							Params: []pipelinev1alpha1.ResourceParam{
+								{Name: "url", Value: "https://github.com/org0/.git"},
+								{Name: "revision"},
+							},
+						},
+					},
+					{
+						Name: "git resource B",
+						ResourceSpec: &pipelinev1alpha1.PipelineResourceSpec{
+							Type: "git",
+							Params: []pipelinev1alpha1.ResourceParam{
+								{Name: "url", Value: "https://github.com/org1/.git"},
+								{Name: "revision"},
+							},
+						},
+					},
 				}
 				return pr
-			},
-			resources: func(pj prowjobv1.ProwJob) []pipelinev1alpha1.PipelineResource {
-				return []pipelinev1alpha1.PipelineResource{
-					*makePipelineGitResource("world-extra-ref-0", pj.Spec.ExtraRefs[0], pj),
-					*makePipelineGitResource("world-extra-ref-1", pj.Spec.ExtraRefs[1], pj),
-				}
 			},
 		},
 		{
@@ -1042,7 +1051,7 @@ func TestMakeResources(t *testing.T) {
 				pj = tc.job(pj)
 			}
 
-			actualRun, actualResources, err := makeResources(pj)
+			actualRun, err := makePipelineRun(pj)
 			if err != nil {
 				if !tc.err {
 					t.Errorf("unexpected error: %v", err)
@@ -1110,14 +1119,6 @@ func TestMakeResources(t *testing.T) {
 
 			if !equality.Semantic.DeepEqual(actualRun, &expectedRun) {
 				t.Errorf("pipelineruns do not match:\n%s", diff.ObjectReflectDiff(&expectedRun, actualRun))
-			}
-
-			var expectedResources []pipelinev1alpha1.PipelineResource
-			if tc.resources != nil {
-				expectedResources = tc.resources(pj)
-			}
-			if !equality.Semantic.DeepEqual(actualResources, expectedResources) {
-				t.Errorf("pipelineresources do not match:\n%s", diff.ObjectReflectDiff(actualResources, expectedResources))
 			}
 		})
 	}

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -34,7 +34,6 @@ import (
 	pipelineset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	pipelineinfo "github.com/tektoncd/pipeline/pkg/client/informers/externalversions"
 	pipelineinfov1alpha1 "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1alpha1"
-	resourceset "github.com/tektoncd/pipeline/pkg/client/resource/clientset/versioned"
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -81,19 +80,13 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 }
 
 type pipelineConfig struct {
-	client         pipelineset.Interface
-	resourceClient resourceset.Interface
-	informer       pipelineinfov1alpha1.PipelineRunInformer
+	client   pipelineset.Interface
+	informer pipelineinfov1alpha1.PipelineRunInformer
 }
 
 // newPipelineConfig returns a client and informer capable of mutating and monitoring the specified config.
 func newPipelineConfig(cfg rest.Config, stop <-chan struct{}) (*pipelineConfig, error) {
 	bc, err := pipelineset.NewForConfig(&cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	rc, err := resourceset.NewForConfig(&cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -109,9 +102,8 @@ func newPipelineConfig(cfg rest.Config, stop <-chan struct{}) (*pipelineConfig, 
 	bif.Tekton().V1alpha1().PipelineRuns().Lister()
 	go bif.Start(stop)
 	return &pipelineConfig{
-		client:         bc,
-		resourceClient: rc,
-		informer:       bif.Tekton().V1alpha1().PipelineRuns(),
+		client:   bc,
+		informer: bif.Tekton().V1alpha1().PipelineRuns(),
 	}, nil
 }
 


### PR DESCRIPTION
This pull request changes the way pipeline resources are created.
We use `ResourceSpec` instead of `ResourceRef` so that pipeline resources are passed inline with pipeline runs.

Also the creation of a pipeline run and the associated pipeline resources becomes a single operation. This either succeeds or fails but cannot partially fail or succeed anymore.

This way we don't need to garbage collect pipeline resources and delete them when they are no longer referenced by the pipeline run.
