### PR TITLE
Add new instances to scalability boskos pool

### DIFF
--- a/prow/cluster/boskos-resources.yaml
+++ b/prow/cluster/boskos-resources.yaml
@@ -573,5 +573,11 @@ resources:
     - k8s-presubmit-scale-33
     - k8s-presubmit-scale-34
     - k8s-presubmit-scale-35
+    # projects 36 - 40 are under automatic configuration, to be added shortly
+    - k8s-presubmit-scale-41
+    - k8s-presubmit-scale-42
+    - k8s-presubmit-scale-43
+    - k8s-presubmit-scale-44
+    - k8s-presubmit-scale-45
   state: dirty
   type: scalability-presubmit-project


### PR DESCRIPTION
Perf tests has a very high usage, as described in kubernetes/perf-tests#1034 

Increased pool is added in this PR.