### PR TITLE
testgrids/openshift: Regenerate informing jobs

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-informing.yaml
@@ -19,7 +19,28 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-origin-installer-e2e-aws-upgrade
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/openshift/origin/issues/new
+    name: release-openshift-origin-installer-e2e-gcp-upgrade
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade
   name: redhat-openshift-informing
 test_groups:
 - gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-aws-upgrade
   name: release-openshift-origin-installer-e2e-aws-upgrade
+- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade
+  name: release-openshift-origin-installer-e2e-gcp-upgrade

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.2-informing.yaml
@@ -600,25 +600,6 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-gcp-upgrade
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-gcp-upgrade
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
     name: release-openshift-origin-installer-e2e-gcp-upgrade-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -638,33 +619,14 @@ dashboards:
       - key: body
         value: <test-url>
       url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-openstack-4.2
+    name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.2
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-openstack-4.2
-  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
-    code_search_path: https://github.com/openshift/origin/search
-    code_search_url_template:
-      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
-    file_bug_template:
-      options:
-      - key: title
-        value: 'E2E: <test-name>'
-      - key: body
-        value: <test-url>
-      url: https://github.com/openshift/origin/issues/new
-    name: release-openshift-origin-installer-e2e-openstack-serial-4.2
-    open_bug_template:
-      url: https://github.com/openshift/origin/issues/
-    open_test_template:
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    results_url_template:
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-origin-installer-e2e-openstack-serial-4.2
+    test_group_name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.2
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -737,7 +699,7 @@ test_groups:
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.2
   name: release-openshift-ocp-installer-e2e-metal-serial-4.2
-- days_of_results: 50
+- days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.2
   name: release-openshift-ocp-installer-e2e-openstack-4.2
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.2
@@ -772,17 +734,12 @@ test_groups:
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-serial-4.2
   name: release-openshift-origin-installer-e2e-gcp-serial-4.2
-- gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade
-  name: release-openshift-origin-installer-e2e-gcp-upgrade
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.2
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.2
 - days_of_results: 50
-  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-4.2
-  name: release-openshift-origin-installer-e2e-openstack-4.2
-- days_of_results: 50
-  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-openstack-serial-4.2
-  name: release-openshift-origin-installer-e2e-openstack-serial-4.2
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.2
+  name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.2
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.2
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.2

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
@@ -899,10 +899,10 @@ test_groups:
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.3
   name: release-openshift-ocp-installer-e2e-metal-serial-4.3
-- days_of_results: 33
+- days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.3
   name: release-openshift-ocp-installer-e2e-openstack-4.3
-- days_of_results: 33
+- days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.3
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.3
 - days_of_results: 50


### PR DESCRIPTION
Upgrade jobs are now part of the generic informing jobs dashboard after
openshift/ci-tools#429