### PR TITLE
Kops - add priority path to canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -220,6 +220,7 @@ periodics:
       - --kops-etcd-version=3.2.24
       - --kops-master-count=3
       - --kops-multiple-zones
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
@@ -248,6 +249,7 @@ periodics:
       - --deployment=kops
       - --extract=ci/latest
       - --ginkgo-parallel=30
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-central1-c
       - --provider=gce


### PR DESCRIPTION
Kops was using the kubectl in the default PATH of the image which caused e2e failures due to recent kubectl changes.

This updates the jobs to use the [kubectl binaries downloaded from the k8s version under test](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-aws-canary/1225902532610494464#1:build-log.txt%3A157).

The remaining Kops e2e jobs [have already been updated](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml) with this flag

This was a side-effect of moving off the kubekins-e2e image's [kops-e2e-runner.sh](https://github.com/kubernetes/test-infra/blob/18391d89866518581e4b6de2546e16ba2b08a3be/images/kubekins-e2e/kops-e2e-runner.sh#L41) script. Perhaps we can have kubetest update the PATH automatically since it is already downloading and extracting the binaries.