### PR TITLE
Add presubmit job for network proxy

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -27,6 +27,7 @@ periodics:
 
 - interval: 24h
   name: ci-kubernetes-e2e-gci-gce-network-proxy
+  decorate: true
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -45,7 +46,35 @@ periodics:
       - --ginkgo-parallel=25
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
-      - --timeout=50m
+      - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200206-f88edef-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
+
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-gce-network-proxy
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+      - args:
+        - --timeout=70
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+        - --extract=ci/latest
+        - --gcp-node-image=gci
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=25
+        - --provider=gce
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
+        - --timeout=60m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200206-f88edef-master
+    annotations:
+      testgrid-dashboards: sig-api-machinery-network-proxy


### PR DESCRIPTION
The current [network proxy job](https://k8s-testgrid.appspot.com/sig-api-machinery-network-proxy#ci-kubernetes-e2e-gci-gce-network-proxy) only tests master and doesn't test any of the PRs before they're merged.

I'm hoping that we can have a (manually triggered) presubmit so we can find issues earlier. This also allows us to trigger e2e tests on WIP branches for debugging.

@lavalamp: If you feel that this overlaps with the existing network proxy job too much, I can delete the existing job and just keep this presubmit job.

/cc @caesarxuchao 
/assign @lavalamp 