### PR TITLE
Boskos: add option to serve Prometheus resource metrics from core server

### DIFF
--- a/boskos/BUILD.bazel
+++ b/boskos/BUILD.bazel
@@ -43,6 +43,7 @@ filegroup(
         "//boskos/crds:all-srcs",
         "//boskos/handlers:all-srcs",
         "//boskos/mason:all-srcs",
+        "//boskos/metrics:all-srcs",
         "//boskos/ranch:all-srcs",
         "//boskos/storage:all-srcs",
     ],

--- a/boskos/cmd/boskos/BUILD.bazel
+++ b/boskos/cmd/boskos/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//boskos/crds:go_default_library",
         "//boskos/handlers:go_default_library",
+        "//boskos/metrics:go_default_library",
         "//boskos/ranch:go_default_library",
         "//prow/config:go_default_library",
         "//prow/interrupts:go_default_library",

--- a/boskos/cmd/metrics/BUILD.bazel
+++ b/boskos/cmd/metrics/BUILD.bazel
@@ -23,12 +23,12 @@ go_library(
     deps = [
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",
+        "//boskos/metrics:go_default_library",
         "//prow/config:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -30,12 +30,12 @@ import (
 const (
 	// Busy state defines a resource being used.
 	Busy = "busy"
+	// Cleaning state defines a resource being cleaned
+	Cleaning = "cleaning"
 	// Dirty state defines a resource that needs cleaning
 	Dirty = "dirty"
 	// Free state defines a resource that is usable
 	Free = "free"
-	// Cleaning state defines a resource being cleaned
-	Cleaning = "cleaning"
 	// Leased state defines a resource being leased in order to make a new resource
 	Leased = "leased"
 	// ToBeDeleted is used for resources about to be deleted, they will be verified by a cleaner which mark them as tombstone
@@ -44,6 +44,19 @@ const (
 	Tombstone = "tombstone"
 	// Other is used to agglomerate unspecified states for metrics reporting
 	Other = "other"
+)
+
+var (
+	// KnownStates is the set of all known states, excluding "other".
+	KnownStates = []string{
+		Busy,
+		Cleaning,
+		Dirty,
+		Free,
+		Leased,
+		ToBeDeleted,
+		Tombstone,
+	}
 )
 
 // UserData is a map of Name to user defined interface, serialized into a string
@@ -131,6 +144,15 @@ type Metric struct {
 	Current map[string]int `json:"current"`
 	Owners  map[string]int `json:"owner"`
 	// TODO: implements state transition metrics
+}
+
+// NewMetric returns a new Metric struct.
+func NewMetric(rtype string) Metric {
+	return Metric{
+		Type:    rtype,
+		Current: map[string]int{},
+		Owners:  map[string]int{},
+	}
 }
 
 // IsInUse reports if the resource is owned by anything else than Boskos.

--- a/boskos/metrics/BUILD.bazel
+++ b/boskos/metrics/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["resources.go"],
+    importpath = "k8s.io/test-infra/boskos/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//boskos/common:go_default_library",
+        "//boskos/ranch:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["resources_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//boskos/common:go_default_library"],
+)

--- a/boskos/metrics/resources.go
+++ b/boskos/metrics/resources.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/ranch"
+)
+
+const (
+	// ResourcesMetricName is the name of the Prometheus metric used to monitor Boskos resources.
+	ResourcesMetricName = "boskos_resourcess"
+	// ResourcesMetricDescription is the description for the Prometheus metric used to monitor Boskos resources.
+	ResourcesMetricDescription = "Number of resources recorded in Boskos by resource type and state."
+)
+
+var (
+	// ResourcesMetricLabels is the list of labels used for the Prometheus metric used to monitor Boskos resources.
+	ResourcesMetricLabels = []string{"type", "state"}
+)
+
+type resourcesCollector struct {
+	boskosResources *prometheus.Desc
+	ranch           *ranch.Ranch
+}
+
+// NewResourcesCollector returns a collector which exports the current counts of
+// Boskos resources, segmented by resource type and state.
+func NewResourcesCollector(ranch *ranch.Ranch) prometheus.Collector {
+	return resourcesCollector{
+		boskosResources: prometheus.NewDesc(ResourcesMetricName, ResourcesMetricDescription, ResourcesMetricLabels, nil),
+		ranch:           ranch,
+	}
+}
+
+func (rc resourcesCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- rc.boskosResources
+}
+
+func (rc resourcesCollector) Collect(ch chan<- prometheus.Metric) {
+	metrics, err := rc.ranch.AllMetrics()
+	if err != nil {
+		logrus.WithError(err).Error("failed to get metrics")
+	}
+	NormalizeResourceMetrics(metrics, common.KnownStates, func(rtype, state string, count float64) {
+		ch <- prometheus.MustNewConstMetric(rc.boskosResources, prometheus.GaugeValue, count, rtype, state)
+	})
+}
+
+// NormalizeResourceMetrics "normalizes" the list of provided Metrics by
+// bucketing any state not in states into the "Other" state, and by ensuring
+// every state in states has some count (even if zero).
+// It then applies the function for each combination of resource type and state.
+func NormalizeResourceMetrics(metrics []common.Metric, states []string, updateFunc func(rtype, state string, count float64)) {
+	knownStates := sets.NewString(states...)
+	for _, metric := range metrics {
+		countsByState := map[string]float64{}
+		// Set default value of 0 for all known states
+		for _, state := range states {
+			countsByState[state] = 0
+		}
+		for state, value := range metric.Current {
+			if !knownStates.Has(state) {
+				state = common.Other
+			}
+			countsByState[state] += float64(value)
+		}
+		for state, count := range countsByState {
+			updateFunc(metric.Type, state, count)
+		}
+	}
+}

--- a/boskos/metrics/resources_test.go
+++ b/boskos/metrics/resources_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/metrics"
+)
+
+func TestNormalizeResourceMetrics(t *testing.T) {
+	type update struct {
+		rtype string
+		state string
+		count float64
+	}
+	testCases := []struct {
+		name            string
+		metrics         []common.Metric
+		states          []string
+		expectedUpdates []update
+	}{
+		{
+			name:            "No metrics",
+			states:          common.KnownStates,
+			expectedUpdates: []update{},
+		},
+		{
+			name: "one metric",
+			metrics: []common.Metric{
+				{
+					Type: "foo-project",
+					Current: map[string]int{
+						"free":  2,
+						"dirty": 5,
+					},
+				},
+			},
+			states: []string{"free", "dirty", "busy"},
+			expectedUpdates: []update{
+				{"foo-project", "busy", 0},
+				{"foo-project", "dirty", 5},
+				{"foo-project", "free", 2},
+			},
+		},
+		{
+			name: "one metric, no currents",
+			metrics: []common.Metric{
+				{
+					Type: "foo-project",
+				},
+			},
+			states: []string{"free", "dirty", "busy"},
+			expectedUpdates: []update{
+				{"foo-project", "busy", 0},
+				{"foo-project", "dirty", 0},
+				{"foo-project", "free", 0},
+			},
+		},
+		{
+			name: "multiple metrics with extra states",
+			metrics: []common.Metric{
+				{
+					Type: "bar-project",
+					Current: map[string]int{
+						"free":     6,
+						"dirty":    0,
+						"chilling": 5,
+						"busy":     2,
+					},
+				},
+				{
+					Type: "baz-project",
+					Current: map[string]int{
+						"dirty": 3,
+					},
+				},
+				{
+					Type: "foo-project",
+					Current: map[string]int{
+						"free":   2,
+						"leased": 2,
+					},
+				},
+				{
+					Type: "not-so-extra",
+					Current: map[string]int{
+						"extra": 0,
+					},
+				},
+			},
+			states: []string{"free", "dirty"},
+			expectedUpdates: []update{
+				{"bar-project", "dirty", 0},
+				{"bar-project", "free", 6},
+				{"bar-project", "other", 7}, // chillling + busy
+				{"baz-project", "dirty", 3},
+				{"baz-project", "free", 0},
+				{"foo-project", "dirty", 0},
+				{"foo-project", "free", 2},
+				{"foo-project", "other", 2}, // leased
+				{"not-so-extra", "dirty", 0},
+				{"not-so-extra", "free", 0},
+				{"not-so-extra", "other", 0}, // extra
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		updates := []update{}
+		metrics.NormalizeResourceMetrics(tc.metrics, tc.states, func(rtype, state string, count float64) {
+			updates = append(updates, update{rtype, state, count})
+		})
+		sort.Slice(updates, func(i, j int) bool {
+			if updates[i].rtype != updates[j].rtype {
+				return updates[i].rtype < updates[j].rtype
+			}
+			if updates[i].state != updates[j].state {
+				return updates[i].state < updates[j].state
+			}
+			return updates[i].count < updates[j].count
+		})
+		if !reflect.DeepEqual(tc.expectedUpdates, updates) {
+			t.Errorf("%s: expected %v, got %v", tc.name, tc.expectedUpdates, updates)
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a flag `--serve-resource-metrics` to the Boskos core, which if enabled, will cause Boskos to serve metrics on resources via Prometheus.

These metrics previously were served via the `boskos-metrics` component, but since we are already scraping the Boskos core server for HTTP metrics, we may as well scrape resource metrics from there, too. This also means that adding a new type of resource won't require updating the `boskos-metrics` deployment - we'll just automatically start serving metrics for the new type.

I've put this behind a flag (disabled by default) since I'm not sure whether Prometheus would do the right thing scraping the same metric from two different sources. Ideally we'd push out the config change to stop scraping the `boskos-metrics` service at the same time we flip this flag.

Addresses #16001. I'll wait to close that issue until we actually deploy this.

cc @stevekuznetsov @alvaroaleman