### PR TITLE
Add ixdy to boskos OWNERS

### DIFF
--- a/boskos/OWNERS
+++ b/boskos/OWNERS
@@ -2,7 +2,11 @@
 
 approvers:
 - krzyzacy
+- ixdy
 - sebastienvas
+
+reviewers:
+- ixdy
 
 labels:
 - area/boskos


### PR DESCRIPTION
I was previously a top-level approver in test-infra:
https://github.com/kubernetes/test-infra/blob/18391d89866518581e4b6de2546e16ba2b08a3be/OWNERS#L8-L11

While I'm no longer working on all of test-infra, I am now focusing on improving Boskos, so I am requesting to reinstate approval rights for just this part of the tree.

(Also adding myself to reviewers so that I have a better chance of seeing incoming changes.)

/assign @krzyzacy @sebastienvas @stevekuznetsov 

/hold