### PR TITLE
Fix typo in needs-rebase GitHub query

### DIFF
--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -131,7 +131,7 @@ func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuratio
 		return nil
 	}
 	var buf bytes.Buffer
-	fmt.Fprint(&buf, "archived: false is:pr is:open")
+	fmt.Fprint(&buf, "archived:false is:pr is:open")
 	for _, org := range orgs {
 		fmt.Fprintf(&buf, " org:\"%s\"", org)
 	}


### PR DESCRIPTION
An extra space in the query caused the needs-rebase plugin's daily job to never find any pull requests.

Fixes #15954 
