### PR TITLE
sig-cluster-lifecycle: using "cluster" instead of "init" presubmits job for etcdadm project

### DIFF
--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-etcdadm
       testgrid-tab-name: pr-verify
-  - name: pull-etcdadm-test-init
+  - name: pull-etcdadm-test-cluster
     labels:
       preset-dind-enabled: "true"
     path_alias: "sigs.k8s.io/etcdadm"
@@ -27,7 +27,7 @@ presubmits:
           privileged: true
         command:
         - "runner.sh"
-        - "./test/e2e/init.sh"
+        - "./test/e2e/cluster.sh"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-etcdadm
-      testgrid-tab-name: pr-test-init
+      testgrid-tab-name: pr-test-cluster


### PR DESCRIPTION
To improve [etcdadm](https://github.com/kubernetes-sigs/etcdadm) e2e tests, add `cluster.sh` to test create etcd cluster. Now update the etcdadm init presubmit job, using "cluster" instead of init.

Related issues: https://github.com/kubernetes-sigs/etcdadm/issues/149
Related pr: https://github.com/kubernetes-sigs/etcdadm/pull/150