### PR TITLE
Kops - Reduce interval for CoreDNS e2e tests

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics.yaml
@@ -128,7 +128,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-containerd
 
-- interval: 30m
+- interval: 4h
   name: ci-kubernetes-e2e-kops-aws-coredns
   labels:
     preset-service-account: "true"
@@ -155,8 +155,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200206-f88edef-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-coredns


### PR DESCRIPTION
The CoreDNS test starts now, so we don't need it to start so often.
Also, will change to stable image, even if change is not yet merged there.