### PR TITLE
boskos: update entrypoint for janitor after directory restructure

### DIFF
--- a/boskos/cmd/janitor/BUILD.bazel
+++ b/boskos/cmd/janitor/BUILD.bazel
@@ -54,7 +54,7 @@ prow_image(
     entrypoint = [
         "/bin/sh",
         "-c",
-        "/bin/echo started && /app/boskos/janitor/app.binary \"$@\"",
+        "/bin/echo started && /app/boskos/cmd/janitor/app.binary \"$@\"",
         "--",
     ],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
The boskos janitor has been crashlooping since the last prow push. 

The logs make the issue fairly obvious - one path I forgot to include in https://github.com/kubernetes/test-infra/pull/16152:
```
started
--: 1: --: /app/boskos/janitor/app.binary: not found
```

/assign @BenTheElder 