### PR TITLE
GCE Windows: specify version-specific manifest of test containers to prepull.

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -423,6 +423,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-1.14.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-1.14
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -434,6 +434,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-1.15.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-1.15
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -439,6 +439,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-1.16.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-1.16
 
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -492,6 +492,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-1.17.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-1.17
       name: ""
       resources: {}

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -90,6 +90,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win1909"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       - name: OVERRIDE_NODE_BINARY_TAR_URL
         value: "https://storage.googleapis.com/kubernetes-release/release/v1.17.2/kubernetes-node-windows-amd64.tar.gz"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
@@ -134,6 +136,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
   annotations:
     fork-per-release: "true"
@@ -176,6 +180,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win1909"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
   annotations:
     fork-per-release: "true"
@@ -218,6 +224,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
@@ -262,6 +270,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
   annotations:
     testgrid-dashboards: google-windows
@@ -304,6 +314,8 @@ periodics:
       env:
       - name: WINDOWS_NODE_OS_DISTRIBUTION
         value: "win2019"
+      - name: PREPULL_YAML
+        value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
   annotations:
     fork-per-release: "true"
@@ -409,6 +421,8 @@ presubmits:
         env:
         - name: WINDOWS_NODE_OS_DISTRIBUTION
           value: "win2019"
+        - name: PREPULL_YAML
+          value: "prepull-head.yaml"
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200213-a79910c-master
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
This PR takes advantage of the changes in https://github.com/kubernetes-sigs/windows-testing/pull/126 to prepull the right set of test containers onto Windows test nodes. This may reduce test flakiness due to tests failing to pull their test containers in time (Windows containers can take 5+ minutes to download and extract).