### PR TITLE
Fix network proxy e2e presubmit to point to PR

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -27,14 +27,13 @@ periodics:
 
 - interval: 24h
   name: ci-kubernetes-e2e-gci-gce-network-proxy
-  decorate: true
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
     containers:
     - args:
-      - --timeout=70
+      - --timeout=80
       - --bare
       - --scenario=kubernetes_e2e
       - --
@@ -55,18 +54,19 @@ presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce-network-proxy
     always_run: false
-    decorate: true
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"
     spec:
       containers:
       - args:
-        - --timeout=70
-        - --bare
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy
+        - --timeout=80
         - --scenario=kubernetes_e2e
         - --
-        - --check-leaked-resources
         - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
         - --extract=ci/latest
         - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -63,7 +63,6 @@ presubmits:
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy
         - --timeout=80
         - --scenario=kubernetes_e2e
         - --
@@ -72,6 +71,7 @@ presubmits:
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=25
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=60m


### PR DESCRIPTION
Fix network proxy e2e presubmit to point to PR instead of the master branch.

`decorate: true` was also accidentally added and we are not using pod utilities so it should be removed.

/cc @BenTheElder 
/assign @lavalamp 