### PR TITLE
kops staging builds: build release branches also

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -9,6 +9,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        - ^release-.*
       spec:
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200205-602500d


### PR DESCRIPTION
We typically release from a release-1.nn branch, so build those
branches also.