### PR TITLE
releng: Remove ci-release-anago-stage job

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -61,28 +61,6 @@ presubmits:
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
 periodics:
-- interval: 2h
-  name: ci-release-anago-stage
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: release
-    base_ref: master
-    path_alias: k8s.io/release
-  spec:
-    #erviceAccountName: deployer -- TODO- this is not valid for the untrusted cluster, fix
-    containers:
-    - image: gcr.io/k8s-staging-release-test/k8s-cloud-builder:latest
-      command:
-        - ./gcbmgr
-      args:
-        - stage
-        - master
-        - --attended
-  annotations:
-    testgrid-dashboards: sig-release-releng-informing
-    testgrid-alert-email: release-managers@kubernetes.io
-
 # package tests
 - name: periodic-release-verify-packages-debs
   interval: 6h


### PR DESCRIPTION
~The gcbmgr/anago staging test is currently failing because it's
attempting to mount in a secret ('deployer-service-account') that
doesn't exist on the standard Prow clusters.~

~The job will continue to fail after this merges, but likely because Prow
doesn't have access to run GCB jobs within the kubernetes-release-test
GCP project. Once we see the next set of errors, we can go about
adjusting IAM on the releng staging account to support this.~

---

Deciding instead to remove this job, as we're not quite ready to make this work.
Closes: https://github.com/kubernetes/kubernetes/issues/88804

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @Katharine @saschagrunert @hasheddan @tpepper @hoegaarden
ref: https://testgrid.k8s.io/sig-release-releng-informing#ci-release-anago-stage, https://github.com/kubernetes/release/pull/1052, https://github.com/kubernetes/test-infra/pull/16074, https://github.com/kubernetes/release/pull/1081, https://github.com/kubernetes/release/pull/1082