### PR TITLE
Azure: enable securityContext in pull-azuredisk-csi-driver-unit

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -43,6 +43,8 @@ presubmits:
         - --
         - make
         - unit-test
+        securityContext:
+          privileged: true
     annotations:
       testgrid-dashboards: provider-azure-azuredisk-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-azuredisk-csi-driver-unit


### PR DESCRIPTION
In order to create the credentials in azuredisk unit tests, here we should enable the securityContext.

Related PR: https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/270
/cc @andyzhangx 
