### PR TITLE
Fix version of kubernetes in kubemark-500 tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -355,7 +355,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-500
-      - --extract=ci/latest
+      - --extract=ci/latest-1.14
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -228,7 +228,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-500
-      - --extract=ci/latest
+      - --extract=ci/latest-1.15
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -229,7 +229,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-500
-      - --extract=ci/latest
+      - --extract=ci/latest-1.16
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -276,7 +276,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-500
-      - --extract=ci/latest
+      - --extract=ci/latest-1.17
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -158,7 +158,7 @@ periodics:
     fork-per-release: "true"
     fork-per-release-cron: 0 3 * * *, 0 9 * * *, 0 15 * * *, 0 21 * * *
     fork-per-release-generic-suffix: "true"
-    fork-per-release-replacements: "kubemark-500Nodes -> kubemark-500Nodes-{{.Version}}, perf-tests=master -> perf-tests=release-{{.Version}}, gcp-project=k8s-jenkins-blocking-kubemark -> gcp-project-type=scalability-project, us-central1-f -> us-east1-b"
+    fork-per-release-replacements: "kubemark-500Nodes -> kubemark-500Nodes-{{.Version}}, extract=ci/latest -> extract=ci/latest-{{.Version}}, perf-tests=master -> perf-tests=release-{{.Version}}, gcp-project=k8s-jenkins-blocking-kubemark -> gcp-project-type=scalability-project, us-central1-f -> us-east1-b"
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-master-500
     testgrid-num-failures-to-alert: '1'


### PR DESCRIPTION
Per-release kubemark-500 jobs tested incorrect (master) version of k8s.

/cc wojtek-t justaugustus