### PR TITLE
Use right perf-tests version in old kubemark tests

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.14.yaml
@@ -347,9 +347,7 @@ periodics:
     containers:
     - args:
       - --repo=k8s.io/kubernetes=release-1.14
-      # Use newer perf-tests branch with additional fixes for kubemark
-      # This mismatch is intended only for release branches older than 1.16
-      - --repo=k8s.io/perf-tests=release-1.16
+      - --repo=k8s.io/perf-tests=release-1.14
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -220,9 +220,7 @@ periodics:
     containers:
     - args:
       - --repo=k8s.io/kubernetes=release-1.15
-      # Use newer perf-tests branch with additional fixes for kubemark
-      # This mismatch is intended only for release branches older than 1.16
-      - --repo=k8s.io/perf-tests=release-1.16
+      - --repo=k8s.io/perf-tests=release-1.15
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Use right perf-tests version in old kubemark tests.
Old perf-tests branches support kubemark now.
Tested with manual prow run.

First updating periodics, then - presubmits.

Ref:
- https://github.com/kubernetes/kubernetes/issues/87200 - ci-kubernetes-kubemark-500-gce failing on 1.14 & 1.15
- Updates to perf-tests branches:
  - https://github.com/kubernetes/perf-tests/pull/1019 - Cherry-pick prometheus logic from master (1.14)
  - https://github.com/kubernetes/perf-tests/pull/1015 - Cherry-pick prometheus logic from master (1.15)


/cc wojtek-t mm4tt justaugustus