### PR TITLE
Run post-deploy job on changes under "examples" folder

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -45,7 +45,7 @@ postsubmits:
     branches:
     - ^master$
     always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test)/|Dockerfile|Makefile)'
+    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg|test|examples)/|Dockerfile|Makefile)'
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     max_concurrency: 1


### PR DESCRIPTION
Because those example yaml files goes into cluster-api-provider-vsphere/ci/manifests container image.

otherwise, when PR changing files under examples, it will not trigger a new manifest image.

Signed-off-by: Hui Luo <luoh@vmware.com>

cc @akutz @codenrhoden 