### PR TITLE
add mkpj utility for prow.k8s.io

### DIFF
--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -171,6 +171,18 @@ recognize this is going to depend on review latency.
 
 For more details, please refer to [How to Test a ProwJob](/prow/build_test_update.md#how-to-test-a-prowjob)
 
+## Running a Production Job
+
+Normally prow will automatically schedule your job, however if for some reason you
+need to trigger it again you have a few options:
+
+- you can use the rerun feature in prow.k8s.io to run the job again *with the same config*
+- you can use [`config/mkpj.sh`](/config/mkpj.sh) to create a prowjob CR from your local config
+- you can use `bazel run //prow/cmd/mkpj -- --job=foo ...` to create a prowjob CR from your local config
+
+For the latter two options you'll need to submit the resulting CR via `kubectl` configured against
+the prow services cluster.
+
 ## Generated Jobs
 
 There are some sets of jobs that are generated and should not be edited by hand.

--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -174,7 +174,7 @@ For more details, please refer to [How to Test a ProwJob](/prow/build_test_updat
 ## Running a Production Job
 
 Normally prow will automatically schedule your job, however if for some reason you
-need to trigger it again you have a few options:
+need to trigger it again and are a Prow administrator you have a few options:
 
 - you can use the rerun feature in prow.k8s.io to run the job again *with the same config*
 - you can use [`config/mkpj.sh`](/config/mkpj.sh) to create a prowjob CR from your local config

--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: mkpj.sh --job=foo ...
+#
+# Arguments to this script will be passed to a dockerized mkpj
+#
+# Example Usage:
+# config/mkpj.sh --job=post-test-infra-push-bootstrap | kubectl create -f -
+# (type "master" at the Base ref prompt)
+#
+# NOTE: kubectl should be pointed at the prow services cluster you intend
+# to create the prowjob in!
+#
+# You can also use bazel run //prow/cmd/mkpj instead.
+# TODO: this won't be true if we move prow to it's own repo...
+# https://github.com/kubernetes/test-infra/issues/11782
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+config="${root}/config/prow/config.yaml"
+job_config_path="${root}/config/jobs"
+
+docker run -i --rm -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"


### PR DESCRIPTION
This is a much faster way to create a prowjob inspired by pj-on-kind.sh but for creating jobs on the production prow (e.g. for an admin to trigger a postsubmit again with updated job config).

It is simpler by assuming everything must be at certain paths under config/.

use like: `config/mkpj.sh --job=post-test-infra-push-bootstrap | kubectl create -f -`