### PR TITLE
update kubetest install instructions to be usable

### DIFF
--- a/kubetest/README.md
+++ b/kubetest/README.md
@@ -34,7 +34,7 @@ the image for general e2e tests.
 
 ## Installation
 
-Please run `go get -u k8s.io/test-infra/kubetest` to install kubetest.
+Please clone this repo and then run `GO111MODULE=on go install ./kubetest` from the clone.
 
 Common alternatives:
 ```


### PR DESCRIPTION
go get does not work because `replace` is not respected. cloning the repo and then installing with modules enabled from the clone does.

cc @fejta 