### PR TITLE
Update CAPA e2e test timeouts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-ci.yaml
@@ -2,8 +2,8 @@ periodics:
 - name: periodic-cluster-api-provider-aws-e2e-master
   decorate: true
   decoration_config:
-    timeout: 4h
-  interval: 5h
+    timeout: 5h
+  interval: 6h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -40,8 +40,8 @@ periodics:
 - name: periodic-cluster-api-provider-aws-e2e-release-0-4
   decorate: true
   decoration_config:
-    timeout: 4h
-  interval: 5h
+    timeout: 5h
+  interval: 6h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -321,7 +321,7 @@ postsubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     decorate: true
     decoration_config:
-      timeout: 4h
+      timeout: 5h
     max_concurrency: 1
     labels:
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -114,8 +114,8 @@ presubmits:
     optional: true
     decorate: true
     decoration_config:
-      timeout: 4h
-    max_concurrency: 5
+      timeout: 5h
+    max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -150,7 +150,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 4h
-    max_concurrency: 5
+    max_concurrency: 2
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
Currently the tests are hitting the timeout too frequently

/assign @ncdc 