### PR TITLE
Boskos: Test by creating kube objects rather than boskos api objects

### DIFF
--- a/boskos/OWNERS
+++ b/boskos/OWNERS
@@ -1,13 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- krzyzacy
 - ixdy
+- krzyzacy
 - sebastienvas
 
 reviewers:
-- ixdy
 - alvaroaleman
+- ixdy
 
 labels:
 - area/boskos

--- a/boskos/handlers/BUILD.bazel
+++ b/boskos/handlers/BUILD.bazel
@@ -23,7 +23,10 @@ go_test(
     deps = [
         "//boskos/client:go_default_library",
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "//boskos/ranch:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -15,7 +15,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
This PR changes the boskos handler and ranch tests to inject the pre-existing objects into the kube client rather than creating them via the storages `AddResource`/`AddDynamicResourceLifeCycle`. 

The motivation is to make sure that when fixing https://github.com/kubernetes/test-infra/issues/16207 the interaction with kube stays the same.

For reference, here are the conversion funcs:
* Resource: https://github.com/kubernetes/test-infra/blob/3320c5e4ca6e2b2d16b44c359c1dc06af5e770dd/boskos/crds/resource_crd.go#L100-L125
* DLRC: https://github.com/kubernetes/test-infra/blob/3320c5e4ca6e2b2d16b44c359c1dc06af5e770dd/boskos/crds/drlc_crd.go#L96-L116

I strongly recommend to look at the diff without whitespace changes.

/assign @stevekuznetsov @ixdy 
