### PR TITLE
Revert boskos to v20200206-f88edefe8

### DIFF
--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -62,7 +62,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200212-1f7b8ac1d
+        image: gcr.io/k8s-prow/boskos/boskos:v20200206-f88edefe8
         args:
         - --config=/etc/config/config
         - --namespace=test-pods


### PR DESCRIPTION
Boskos is crashlooping, likely due to #16206, which changed some of the custom resource definitions:

```
E0212 22:31:57.049418       1 reflector.go:125] external/io_k8s_client_go/tools/cache/reflector.go:98: Failed to list *crds.DRLCObject: no kind "DRLCCollection" is registered for version "boskos.k8s.io/v1" in scheme "pkg/runtime/scheme.go:101"
E0212 22:31:57.803985       1 reflector.go:125] external/io_k8s_client_go/tools/cache/reflector.go:98: Failed to list *crds.ResourceObject: no kind "ResourceCollection" is registered for version "boskos.k8s.io/v1" in scheme "pkg/runtime/scheme.go:101"
{"component":"boskos","error":"timeout waiting for cache sync","file":"boskos/cmd/boskos/boskos.go:96","func":"main.main","level":"fatal","msg":"unable to get client","time":"2020-02-12T22:31:57Z"}
```

We'll need to figure out an appropriate migration strategy. In the interim, let's get Boskos running again.

/assign @fejta 