### PR TITLE
Add Boskos CRDs to prow/cluster, and bump Boskos back to latest

### DIFF
--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -11,6 +11,43 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dynamicresourcelifecycles.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: DRLCObject
+    listKind: DRLCCollection
+    plural: dynamicresourcelifecycles
+    singular: dynamicresourcelifecycle
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: resources.boskos.k8s.io
+spec:
+  group: boskos.k8s.io
+  names:
+    kind: ResourceObject
+    listKind: ResourceCollection
+    plural: resources
+    singular: resource
+  scope: Namespaced
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true
+---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -20,7 +20,7 @@ spec:
   group: boskos.k8s.io
   names:
     kind: DRLCObject
-    listKind: DRLCCollection
+    listKind: DRLCObjectList
     plural: dynamicresourcelifecycles
     singular: dynamicresourcelifecycle
   scope: Namespaced
@@ -38,7 +38,7 @@ spec:
   group: boskos.k8s.io
   names:
     kind: ResourceObject
-    listKind: ResourceCollection
+    listKind: ResourceObjectList
     plural: resources
     singular: resource
   scope: Namespaced
@@ -99,7 +99,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200206-f88edefe8
+        image: gcr.io/k8s-prow/boskos/boskos:v20200213-7790e5cec
         args:
         - --config=/etc/config/config
         - --namespace=test-pods


### PR DESCRIPTION
This is a revert of #16260, along with the required config changes so that Boskos hopefully won't crash.

This goes along with #16266, but it shouldn't be necessary to wait for it, since Boskos is not supposed to do anything if the CRDs already exist.

/hold
because I'm still validating these changes (and also we shouldn't merge this late in the day)

/assign @fejta 
cc @alvaroaleman 

/area boskos