### PR TITLE
boskos: disable controller-runtime manager metrics

### DIFF
--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -98,7 +98,11 @@ func (o *KubernetesClientOptions) CacheBackedClient(namespace string, startCache
 		return nil, fmt.Errorf("failed to create CRDs: %v", err)
 	}
 
-	mgr, err := manager.New(cfg, manager.Options{LeaderElection: false, Namespace: namespace})
+	mgr, err := manager.New(cfg, manager.Options{
+		LeaderElection:     false,
+		Namespace:          namespace,
+		MetricsBindAddress: "0",
+	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to construct manager: %v", err)
 	}


### PR DESCRIPTION
The controller-runtime manager enables its own metrics serving [by default](https://github.com/kubernetes-sigs/controller-runtime/pull/510) on port 8080. This conflicts with the boskos server itself.

We probably don't need these metrics (at least not yet), so let's just disable them.

Follow-on to #16249.
x-ref https://github.com/kubernetes/test-infra/pull/16267#issuecomment-585504775

/assign @alvaroaleman @stevekuznetsov 