### PR TITLE
aws-janitor - only detach ENIs if they're attached

### DIFF
--- a/boskos/aws-janitor/resources/network_interface.go
+++ b/boskos/aws-janitor/resources/network_interface.go
@@ -55,11 +55,13 @@ func (NetworkInterfaces) MarkAndSweep(sess *session.Session, account string, reg
 	}
 
 	for _, eni := range toDelete {
-		detachInput := &ec2.DetachNetworkInterfaceInput{
-			AttachmentId: aws.String(eni.AttachmentID),
-		}
-		if _, err := svc.DetachNetworkInterface(detachInput); err != nil {
-			klog.Warningf("%s: detach failed: %v", eni.ARN(), err)
+		if eni.AttachmentID != "" {
+			detachInput := &ec2.DetachNetworkInterfaceInput{
+				AttachmentId: aws.String(eni.AttachmentID),
+			}
+			if _, err := svc.DetachNetworkInterface(detachInput); err != nil {
+				klog.Warningf("%s: detach failed: %v", eni.ARN(), err)
+			}
 		}
 
 		deleteInput := &ec2.DeleteNetworkInterfaceInput{


### PR DESCRIPTION
I noticed in [this aws-janitor run](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1227720685078450176) that it tried to detach an ENI that wasn't attached to anything: `detach failed: MissingParameter: The request must contain the parameter attachmentId`.

Now we'll only call `DetachNetworkInterface` if the ENI has an AttachmentId.