### PR TITLE
Allow running boskos without a config

### DIFF
--- a/boskos/cmd/boskos/boskos.go
+++ b/boskos/cmd/boskos/boskos.go
@@ -111,18 +111,23 @@ func main() {
 		Addr:    ":8080",
 	}
 
-	v := viper.New()
-	v.SetConfigFile(*configPath)
-	v.SetConfigType("yaml")
-	v.WatchConfig()
-	v.OnConfigChange(func(in fsnotify.Event) {
-		logrus.Infof("Updating Boskos Config")
-		if err := r.SyncConfig(*configPath); err != nil {
-			logrus.WithError(err).Errorf("Failed to update config")
-		} else {
-			logrus.Infof("Updated Boskos Config successfully")
-		}
-	})
+	// Viper defaults the configfile name to `config` and `SetConfigFile` only
+	// has an effect when the configfile name is not an empty string, so we
+	// just disable it entirely if there is no config.
+	if *configPath != "" {
+		v := viper.New()
+		v.SetConfigFile(*configPath)
+		v.SetConfigType("yaml")
+		v.WatchConfig()
+		v.OnConfigChange(func(in fsnotify.Event) {
+			logrus.Infof("Updating Boskos Config")
+			if err := r.SyncConfig(*configPath); err != nil {
+				logrus.WithError(err).Errorf("Failed to update config")
+			} else {
+				logrus.Infof("Updated Boskos Config successfully")
+			}
+		})
+	}
 
 	prometheus.MustRegister(metrics.NewResourcesCollector(r))
 	r.StartDynamicResourceUpdater(*dynamicResourceUpdatePeriod)


### PR DESCRIPTION
Mostly useful for local testing, the current behaviour of having viper emit an error, then not crash but just block forever is confusing at best:

```
$ /tmp/boskos --namespace=default --log-level=debug -dynamic-resource-update-period=0 -kubeconfig=$KUBECONFIG -config="" 
{"component":"boskos","file":"/home/alvaro/git/work/test-infra/boskos/crds/client.go:134","func":"k8s.io/test-infra/boskos/crds.(*KubernetesClientOptions).CacheBackedClient","level":"info","msg":"Cache synced","sync-duration":"100.484959ms","time":"2020-02-13T09:07:27+01:00"}
{"component":"boskos","file":"/home/alvaro/git/work/test-infra/boskos/cmd/boskos/boskos.go:103","func":"main.main","level":"info","msg":"Created storage","time":"2020-02-13T09:07:27+01:00"}
2020/02/13 09:07:27 error: Config File "config" Not Found in "[]"
```