### PR TITLE
prow cluster: fix and/or create loop devices

### DIFF
--- a/prow/cluster/create-loop-devs_daemonset.yaml
+++ b/prow/cluster/create-loop-devs_daemonset.yaml
@@ -34,9 +34,8 @@ spec:
         - |
           while true; do
             for i in $(seq 0 100); do
-                if ! [ -e /dev/loop$i ]; then
-                    mknod /dev/loop$i c 7 $i
-                fi
+                rm -f /dev/loop$i
+                mknod /dev/loop$i b 7 $i
             done
             sleep 100000000
           done


### PR DESCRIPTION
They have to be *block* devices, of course. Fixes
91d8162c04426c04c722d4ede95e39786606bdf7.

/assign @BenTheElder 