### PR TITLE
Increase the test timeout on the unit coverage job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -150,7 +150,7 @@ periodics:
       - |
         local result=0
         GO111MODULE=off go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum || result=$?
-        make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" || result=$?
+        make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" KUBE_TIMEOUT="--timeout=300s" || result=$?
         grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
         go tool cover -html="${ARTIFACTS}/filtered.cov" -o "${ARTIFACTS}/filtered.html" || result=$?
         exit $result


### PR DESCRIPTION
A few of the tests tend to time out in CI. Try increasing the timeouts and see if they fail less.

(There is also at least one test that tends to fail because it is more timing dependent than it probably should be, which will almost certainly not be improved by this.)

/cc @BenTheElder 