### PR TITLE
approve: add debug logging

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -165,6 +165,7 @@ func handleGenericCommentEvent(pc plugins.Agent, ce github.GenericCommentEvent) 
 
 func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, ce *github.GenericCommentEvent) error {
 	if ce.Action != github.GenericCommentActionCreated || !ce.IsPR || ce.IssueState == "closed" {
+		log.Debug("Event is not a creation of a comment on an open PR, skipping.")
 		return nil
 	}
 
@@ -175,14 +176,17 @@ func handleGenericComment(log *logrus.Entry, ghc githubClient, oc ownersClient, 
 
 	opts := config.ApproveFor(ce.Repo.Owner.Login, ce.Repo.Name)
 	if !isApprovalCommand(botName, opts.LgtmActsAsApprove, &comment{Body: ce.Body, Author: ce.User.Login}) {
+		log.Debug("Comment does not constitute approval, skipping event.")
 		return nil
 	}
 
+	log.Debug("Resolving pull request...")
 	pr, err := ghc.GetPullRequest(ce.Repo.Owner.Login, ce.Repo.Name, ce.Number)
 	if err != nil {
 		return err
 	}
 
+	log.Debug("Resolving repository owners...")
 	repo, err := oc.LoadRepoOwners(ce.Repo.Owner.Login, ce.Repo.Name, pr.Base.Ref)
 	if err != nil {
 		return err
@@ -222,6 +226,7 @@ func handleReviewEvent(pc plugins.Agent, re github.ReviewEvent) error {
 
 func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubConfig config.GitHubOptions, config *plugins.Configuration, re *github.ReviewEvent) error {
 	if re.Action != github.ReviewActionSubmitted && re.Action != github.ReviewActionDismissed {
+		log.Debug("Event is not a creation or dismissal of a review on an open PR, skipping.")
 		return nil
 	}
 
@@ -236,15 +241,18 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 	// genericCommentEventHandler handle this event. Approval commands override
 	// review state.
 	if isApprovalCommand(botName, opts.LgtmActsAsApprove, &comment{Body: re.Review.Body, Author: re.Review.User.Login}) {
+		log.Debug("Review constitutes approval, skipping event.")
 		return nil
 	}
 
 	// Check for an approval command via review state. If none exists, don't
 	// handle this event.
 	if !isApprovalState(botName, opts.ConsiderReviewState(), &comment{Author: re.Review.User.Login, ReviewState: re.Review.State}) {
+		log.Debug("Review does not constitute approval, skipping event.")
 		return nil
 	}
 
+	log.Debug("Resolving repository owners...")
 	repo, err := oc.LoadRepoOwners(re.Repo.Owner.Login, re.Repo.Name, re.PullRequest.Base.Ref)
 	if err != nil {
 		return err
@@ -286,6 +294,7 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, oc ownersClient, git
 		pre.Action != github.PullRequestActionReopened &&
 		pre.Action != github.PullRequestActionSynchronize &&
 		pre.Action != github.PullRequestActionLabeled {
+		log.Debug("Pull request event action cannot constitute approval, skipping...")
 		return nil
 	}
 	botName, err := ghc.BotName()
@@ -294,9 +303,11 @@ func handlePullRequest(log *logrus.Entry, ghc githubClient, oc ownersClient, git
 	}
 	if pre.Action == github.PullRequestActionLabeled &&
 		(pre.Label.Name != labels.Approved || pre.Sender.Login == botName || pre.PullRequest.State == "closed") {
+		log.Debug("Pull request label event does not constitute approval, skipping...")
 		return nil
 	}
 
+	log.Debug("Resolving repository owners...")
 	repo, err := oc.LoadRepoOwners(pre.Repo.Owner.Login, pre.Repo.Name, pre.PullRequest.Base.Ref)
 	if err != nil {
 		return err


### PR DESCRIPTION
We are seeing events where the approval plugin never takes action, or
takes quite a long time to do so. Often there are no logs whatsoever in
these cases. This change adds some debug logging to the cases where the
plugin would have exited without logging anything at all in order to
help us identify why such actions occur.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @alvaroaleman @petr-muller 