### PR TITLE
boskos: add some useful print columns to the CRDs

### DIFF
--- a/prow/cluster/boskos.yaml
+++ b/prow/cluster/boskos.yaml
@@ -29,6 +29,19 @@ spec:
   - name: v1
     served: true
     storage: true
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The dynamic resource type.
+    JSONPath: .spec.config.type
+  - name: Min-Count
+    type: integer
+    description: The minimum count requested.
+    JSONPath: .spec.min-count
+  - name: Max-Count
+    type: integer
+    description: The maximum count requested.
+    JSONPath: .spec.max-count
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -47,6 +60,22 @@ spec:
   - name: v1
     served: true
     storage: true
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The resource type.
+    JSONPath: .spec.type
+  - name: State
+    type: string
+    description: The current state of the resource.
+    JSONPath: .status.state
+  - name: Owner
+    type: string
+    description: The current owner of the resource.
+    JSONPath: .status.owner
+  - name: Last-Updated
+    type: date
+    JSONPath: .status.lastUpdate
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
These sorts of changes are really easy to make now that we have the CRDs saved separately!

Example output:
```console
$ kubectl get resources -n test-pods
NAME                                   TYPE                            STATE         OWNER      LAST-UPDATED
2160cd1c-ab32-4f7c-b265-85990c6dbafd   autoscaled-resource             toBeDeleted              20m
333acc01-f764-4d0f-9d19-175e7887f21a   autoscaled-resource             toBeDeleted              20m
3aa06789-1855-4c36-896d-142250be6b49   autoscaled-resource             toBeDeleted              10m
b32ce72f-2999-4eb6-aed8-dbade2873f3f   autoscaled-resource             free                     35s
e341354c-bb97-4320-8f4e-210c1fbebfeb   autoscaled-resource             busy          ixdy       91s
capa-user-00                           aws-account                     dirty                    18h
...
kubernetes-petset                      gce-project                     dirty                    18h


$ kubectl get dynamicresourcelifecycles -n test-pods
NAME                  TYPE                MIN-COUNT   MAX-COUNT
autoscaled-resource                       2           5
gke-cluster           GCPResourceConfig   1           2
```

/assign @alvaroaleman 
cc @fejta @stevekuznetsov 
/area boskos