### PR TITLE
Resolve no-op diff in transfigure

### DIFF
--- a/testgrid/cmd/transfigure/transfigure.sh
+++ b/testgrid/cmd/transfigure/transfigure.sh
@@ -68,12 +68,13 @@ main() {
     --oneshot \
     --output "${testgrid_dir}/${testgrid_subdir}/gen-config.yaml"
 
-  git add --all
 
   if ! git diff --quiet ; then
     echo "Transfigure did not change anything. Aborting no-op bump"
     exit 0
   fi
+
+  git add --all
 
   echo "Running kubernetes/test-infra tests..."
   bazel test //config/tests/...


### PR DESCRIPTION
The `git diff` should be run before `git add --all`, otherwise all changes will be *staged* and the conditional will *never* get executed.

fix https://github.com/istio/test-infra/issues/2368

/assign @chases2 