### PR TITLE
Remove HTML generation for unit coverage.

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -152,7 +152,6 @@ periodics:
         GO111MODULE=off go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum || result=$?
         make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" KUBE_TIMEOUT="--timeout=300s" || result=$?
         grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
-        go tool cover -html="${ARTIFACTS}/filtered.cov" -o "${ARTIFACTS}/filtered.html" || result=$?
         exit $result
       securityContext:
         privileged: true


### PR DESCRIPTION
This is broken, though it used to work. I blame staging, somehow.

It's probably also not critical as part of an MVP, so... :woman_shrugging: 

/cc @BenTheElder 