### PR TITLE
Add seans3 and monopole to sig-cli testgrid OWNERS

### DIFF
--- a/config/testgrids/kubernetes/sig-cli/OWNERS
+++ b/config/testgrids/kubernetes/sig-cli/OWNERS
@@ -2,5 +2,7 @@
 
 approvers:
 - AdoHe
+- monopole
 - pwittrock
+- seans3
 - soltysh


### PR DESCRIPTION
We're expanding test coverage in sig-cli
as we add more code to cli-utils and move kustomize libs.