### PR TITLE
Enable merge commit blocker plugin on the Kops repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -628,6 +628,7 @@ plugins:
   - stage
 
   kubernetes/kops:
+  - mergecommitblocker
   - milestone
   - milestoneapplier
 


### PR DESCRIPTION
I think this would be good to reduce some clutter in PRs and prompt PR authors to clean up their branches so that reviewers don't have to.

/cc @justinsb