### PR TITLE
Set up benchmarkjunit job for structured-merge-diff

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -41,3 +41,23 @@ periodics:
   annotations:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff
     testgrid-tab-name: ci-gofmt
+- name: ci-structured-merge-diff-benchmark
+  interval: 1h
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: structured-merge-diff
+    base_ref: master
+    path_alias: sigs.k8s.io/structured-merge-diff
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+      command:
+      - /benchmarkjunit
+      args:
+      - --log-file=$(ARTIFACTS)/benchmark-log.txt
+      - --output=$(ARTIFACTS)/junit_benchmarks.xml
+      - ./...
+  annotations:
+    testgrid-dashboards: sig-api-machinery-structured-merge-diff
+    testgrid-tab-name: ci-benchmark

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -36,3 +36,21 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff
       testgrid-tab-name: pr-gofmt
       testgrid-num-columns-recent: '30'
+  - name: pull-structured-merge-diff-benchmark
+    always_run: false
+    skip_report: true
+    decorate: true
+    path_alias: sigs.k8s.io/structured-merge-diff
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/benchmarkjunit:latest
+        command:
+        - /benchmarkjunit
+        args:
+        - --log-file=$(ARTIFACTS)/benchmark-log.txt
+        - --output=$(ARTIFACTS)/junit_benchmarks.xml
+        - ./...
+    annotations:
+      testgrid-dashboards: sig-api-machinery-structured-merge-diff
+      testgrid-tab-name: pr-benchmark
+      testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -584,6 +584,32 @@ postsubmits:
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion
+  - name: post-test-infra-push-image-benchmarkjunit
+    cluster: test-infra-trusted
+    run_if_changed: '^pkg/benchmarkjunit/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "benchmarkjunit"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '3'
+      description: builds and pushes the benchmarkjunit image
+    decorate: true
+    branches:
+    - master
+    spec:
+      serviceAccountName: deployer # TODO(fejta): should be pusher
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200211-v0.4-10-g26b1b47
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - --build-dir=.
+        - pkg/benchmarkjunit/
+        env:
+        - name: USE_BAZEL_VERSION
+          value: real  # Ignore .bazelversion
   - name: post-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     branches:

--- a/pkg/benchmarkjunit/Dockerfile
+++ b/pkg/benchmarkjunit/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.13-alpine
+
+COPY benchmarkjunit /benchmarkjunit
+
+ENTRYPOINT ["/benchmarkjunit"]

--- a/pkg/benchmarkjunit/cloudbuild.yaml
+++ b/pkg/benchmarkjunit/cloudbuild.yaml
@@ -1,0 +1,26 @@
+steps:
+  - name: golang:$_GO_VERSION
+    args:
+    - go
+    - build
+    - -mod=readonly
+    - -a
+    - -installsuffix=cgo
+    - -o=./pkg/benchmarkjunit/benchmarkjunit
+    - ./pkg/benchmarkjunit
+    env:
+    - CGO_ENABLED=0
+    - GOOS=linux
+    - GOARCH=amd64
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/benchmarkjunit:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/benchmarkjunit:latest
+    - ./pkg/benchmarkjunit
+substitutions:
+  _GIT_TAG: '12345'
+  _GO_VERSION: 1.13-alpine
+images:
+  - 'gcr.io/$PROJECT_ID/benchmarkjunit:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/benchmarkjunit:latest'


### PR DESCRIPTION
It would be great to use the benchmarkjunit output to track the scalability work for structured-merge-diff.

- [pkg/benchmarkjunit](https://github.com/kubernetes/test-infra/tree/master/pkg/benchmarkjunit)
- [TestGrid demo](https://testgrid.k8s.io/sig-testing-canaries#benchmark-demo&width=5&graph-metrics=avg%20op%20duration%20(ns%2Fop)&graph-metrics=test-duration-minutes&graph-metrics=op%20count&graph-metrics=MB%2Fs&graph-metrics=alloced%20B%2Fop&graph-metrics=allocs%2Fop)