### PR TITLE
Retest approved jobs in the Kops repo

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -155,6 +155,7 @@ periodics:
         -label:needs-rebase
         -label:needs-ok-to-test
         -label:"cncf-cla: no"
+        repo:kubernetes/kops
         repo:kubernetes/kubernetes
         repo:kubernetes/test-infra
       - --token=/etc/token/bot-github-token


### PR DESCRIPTION
Sometimes e2e tests are very flaky. Retesting over and over again is not the best use of the time for contributors. Automated retest of failed test jobs seems a good idea at this time.