### PR TITLE
Gencred: perform SubjectAccessReview for authorization checks

### DIFF
--- a/gencred/pkg/serviceaccount/BUILD.bazel
+++ b/gencred/pkg/serviceaccount/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//gencred/pkg/kubeconfig:go_default_library",
+        "@io_k8s_api//authorization/v1beta1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//rbac/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
@@ -34,9 +35,12 @@ go_test(
     srcs = ["serviceaccount_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "@io_k8s_api//authorization/v1beta1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
+        "@io_k8s_client_go//testing:go_default_library",
     ],
 )

--- a/gencred/pkg/serviceaccount/serviceaccount.go
+++ b/gencred/pkg/serviceaccount/serviceaccount.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 
+	authorizationv1beta1 "k8s.io/api/authorization/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,42 +30,69 @@ import (
 )
 
 const (
-	// clusterRoleBindingName is the name for the cluster administrator ClusterRoleBinding.
+	// clusterRole is the ClusterRole role reference for created ClusterRoleBinding.
+	clusterRole = "cluster-admin"
+	// clusterRoleBindingName is the name for the created ClusterRoleBinding.
 	clusterRoleBindingName = "serviceaccount-cluster-admin-crb"
-	// serviceAccountName is the name for the cluster administrator ServiceAccount.
+	// serviceAccountName is the name for the created ServiceAccount.
 	serviceAccountName = "serviceaccount-cluster-admin"
 )
+
+// checkSAAuth checks authorization for required cluster service account (SA) resources.
+func checkSAAuth(clientset kubernetes.Interface) error {
+	client := clientset.AuthorizationV1beta1().SelfSubjectAccessReviews()
+
+	if sar, err := client.Create(
+		&authorizationv1beta1.SelfSubjectAccessReview{
+			Spec: authorizationv1beta1.SelfSubjectAccessReviewSpec{
+				ResourceAttributes: &authorizationv1beta1.ResourceAttributes{
+					Group:    "authentication.k8s.io",
+					Verb:     "impersonate",
+					Resource: clusterRole,
+				},
+			},
+		}); err != nil {
+		return fmt.Errorf("impersonate %s: %v", clusterRole, err)
+	} else if !sar.Status.Allowed {
+		return fmt.Errorf("not authorized to impersonate %s", clusterRole)
+	}
+
+	return nil
+}
 
 // getOrCreateSA gets existing or creates new service account (SA).
 func getOrCreateSA(clientset kubernetes.Interface) ([]byte, []byte, error) {
 	client := clientset.CoreV1().ServiceAccounts(corev1.NamespaceDefault)
 
-	// Get ServiceAccount if exists.
-	if saObj, err := client.Get(serviceAccountName, metav1.GetOptions{}); err == nil {
-		return getSASecrets(clientset, saObj)
+	// Check SelfSubjectAccessReviews are allowed.
+	if err := checkSAAuth(clientset); err != nil {
+		return nil, nil, err
 	}
 
-	// Generate a Kubernetes ServiceAccount object.
-	saObj := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: serviceAccountName,
-		},
-	}
+	// Create ServiceAccount if not exists.
+	if _, err := client.Get(serviceAccountName, metav1.GetOptions{}); err != nil {
+		// Generate a Kubernetes ServiceAccount object.
+		saObj := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceAccountName,
+			},
+		}
 
-	// Create ServiceAccount.
-	_, err := client.Create(saObj)
-	if err != nil {
-		return nil, nil, fmt.Errorf("create SA: %v", err)
+		// Create ServiceAccount.
+		_, err := client.Create(saObj)
+		if err != nil {
+			return nil, nil, fmt.Errorf("create SA: %v", err)
+		}
 	}
 
 	// Get/Create ClusterRoleBinding.
-	err = getOrCreateCRB(clientset)
+	err := getOrCreateCRB(clientset)
 	if err != nil {
 		return nil, nil, fmt.Errorf("get or create CRB: %v", err)
 	}
 
 	// Get ServiceAccount.
-	saObj, err = client.Get(serviceAccountName, metav1.GetOptions{})
+	saObj, err := client.Get(serviceAccountName, metav1.GetOptions{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("get SA: %v", err)
 	}
@@ -85,7 +113,7 @@ func getOrCreateCRB(clientset kubernetes.Interface) error {
 	crbObj := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{Name: clusterRoleBindingName},
 		Subjects:   []rbacv1.Subject{{Kind: "ServiceAccount", Name: serviceAccountName, Namespace: corev1.NamespaceDefault}},
-		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: "cluster-admin"},
+		RoleRef:    rbacv1.RoleRef{Kind: "ClusterRole", Name: clusterRole},
 	}
 
 	// Create ClusterRoleBinding.


### PR DESCRIPTION
Perform `SelfSubjectRulesReview` in `gencred` before creating cluster resources for *serviceaccount* credentials.