### PR TITLE
Metrics: Also expose controller-runtime metrics

### DIFF
--- a/prow/metrics/BUILD.bazel
+++ b/prow/metrics/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_github_prometheus_common//expfmt:go_default_library",
         "@com_github_prometheus_common//model:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/metrics:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This PR changes the metrics package to use a prometheus.Gatherers
to combine the metrics from the prometheus default registry and
and from the controller-runtime registry.

This gives us some nice additional metrics, some of which are even
reported when c-r is not used, like the ones for workqueues.