### PR TITLE
Crier github reporter: Allow using more than one worker

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20200214-db7f45788
         args:
-        - --github-workers=1
+        - --github-workers=5
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -90,11 +90,6 @@ func (o *options) validate() error {
 		o.gerritWorkers = 1
 	}
 
-	if o.githubWorkers > 1 {
-		logrus.Warn("github reporter only supports one worker (https://github.com/kubernetes/test-infra/issues/13306)")
-		o.githubWorkers = 1
-	}
-
 	if o.gerritWorkers+o.pubsubWorkers+o.githubWorkers+o.slackWorkers+o.gcsWorkers+o.k8sGCSWorkers <= 0 {
 		return errors.New("crier need to have at least one report worker to start")
 	}

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -191,13 +191,13 @@ func TestGitHubOptions(t *testing.T) {
 		{
 			name:              "github workers, only support single worker",
 			args:              []string{"--github-workers=5", "--github-token-path=tkpath", "--config-path=foo"},
-			expectedWorkers:   1,
+			expectedWorkers:   5,
 			expectedTokenPath: "tkpath",
 		},
 		{
 			name:              "github missing --github-token-path, uses default",
 			args:              []string{"--github-workers=5", "--config-path=foo"},
-			expectedWorkers:   1,
+			expectedWorkers:   5,
 			expectedTokenPath: "/etc/github/oauth",
 		},
 	}

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/github/report:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )
 
@@ -33,7 +34,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
+        "//prow/github/fakegithub:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -19,6 +19,13 @@ limitations under the License.
 package github
 
 import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
@@ -35,15 +42,72 @@ type Client struct {
 	gc          report.GitHubClient
 	config      config.Getter
 	reportAgent v1.ProwJobAgent
+	prLocks     *shardedLock
+}
+
+type simplePull struct {
+	org, repo string
+	number    int
+}
+
+type shardedLock struct {
+	mapLock *sync.Mutex
+	locks   map[simplePull]*sync.Mutex
+}
+
+func (s *shardedLock) getLock(key simplePull) *sync.Mutex {
+	s.mapLock.Lock()
+	defer s.mapLock.Unlock()
+	if _, exists := s.locks[key]; !exists {
+		s.locks[key] = &sync.Mutex{}
+	}
+	return s.locks[key]
+}
+
+// cleanup deletes all locks by acquiring first
+// the mapLock and then each individual lock before
+// deleting it. The individual lock must be acquired
+// because otherwise it may be held, we delete it from
+// the map, it gets recreated and acquired and two
+// routines report in parallel for the same job.
+// Note that while this function is running, no new
+// presubmit reporting can happen, as we hold the mapLock.
+func (s *shardedLock) cleanup() {
+	s.mapLock.Lock()
+	defer s.mapLock.Unlock()
+
+	for key, lock := range s.locks {
+		lock.Lock()
+		delete(s.locks, key)
+		lock.Unlock()
+	}
+}
+
+// runCleanup asynchronously runs the cleanup once per hour.
+func (s *shardedLock) runCleanup() {
+	go func() {
+		for range time.Tick(time.Hour) {
+			logrus.Debug("Starting to clean up presubmit locks")
+			startTime := time.Now()
+			s.cleanup()
+			logrus.WithField("duration", time.Since(startTime).String()).Debug("Finished cleaning up presubmit locks")
+		}
+	}()
 }
 
 // NewReporter returns a reporter client
 func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJobAgent) *Client {
-	return &Client{
+	c := &Client{
 		gc:          gc,
 		config:      cfg,
 		reportAgent: reportAgent,
+		prLocks: &shardedLock{
+			mapLock: &sync.Mutex{},
+			locks:   map[simplePull]*sync.Mutex{},
+		},
 	}
+	c.prLocks.runCleanup()
+	return c
 }
 
 // GetName returns the name of the reporter
@@ -68,6 +132,33 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 
 // Report will report via reportlib
 func (c *Client) Report(pj *v1.ProwJob) ([]*v1.ProwJob, error) {
+
+	// The github comment create/update/delete done for presubmits
+	// needs pr-level locking to avoid racing when reporting multiple
+	// jobs in parallel.
+	if pj.Spec.Type == v1.PresubmitJob {
+		key, err := lockKeyForPJ(pj)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get lockkey for job: %v", err)
+		}
+		lock := c.prLocks.getLock(*key)
+		lock.Lock()
+		defer lock.Unlock()
+	}
+
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
 	return []*v1.ProwJob{pj}, report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GitHubReporter.JobTypesToReport)
+}
+
+func lockKeyForPJ(pj *v1.ProwJob) (*simplePull, error) {
+	if pj.Spec.Type != v1.PresubmitJob {
+		return nil, fmt.Errorf("can only get lock key for presubmit jobs, was %q", pj.Spec.Type)
+	}
+	if pj.Spec.Refs == nil {
+		return nil, errors.New("pj.Spec.Refs is nil")
+	}
+	if n := len(pj.Spec.Refs.Pulls); n != 1 {
+		return nil, fmt.Errorf("prowjob doesn't have one but %d pulls", n)
+	}
+	return &simplePull{org: pj.Spec.Refs.Org, repo: pj.Spec.Refs.Repo, number: pj.Spec.Refs.Pulls[0].Number}, nil
 }

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -160,6 +160,11 @@ func (f *FakeClient) CreateComment(owner, repo string, number int, comment strin
 	return nil
 }
 
+// EditComment edits a comment. Its a stub that does nothing.
+func (f *FakeClient) EditComment(org, repo string, ID int, comment string) error {
+	return nil
+}
+
 // CreateReview adds a review to a PR
 func (f *FakeClient) CreateReview(org, repo string, number int, r github.DraftReview) error {
 	f.Reviews[number] = append(f.Reviews[number], github.Review{


### PR DESCRIPTION
This is achieved by doing pr-level locking for presubmit jobs.

Fixes https://github.com/kubernetes/test-infra/issues/13306