### PR TITLE
[Deck] Add agent check for showing log icon on the main page

### DIFF
--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -499,6 +499,7 @@ function redraw(fz: FuzzySearch): void {
             spec: {
                 type = "",
                 job = "",
+                agent = "",
                 refs: {org = "", repo = "", repo_link = "", base_sha = "", base_link = "", pulls = [], base_ref = ""} = {},
             },
             status: {startTime, completionTime = "", state = "", pod_name, build_id = "", url = ""},
@@ -569,7 +570,7 @@ function redraw(fz: FuzzySearch): void {
         displayedJob++;
         const r = document.createElement("tr");
         r.appendChild(cell.state(state));
-        if (pod_name) {
+        if ((agent === "kubernetes" && pod_name) || agent !== "kubernetes") {
             const logIcon = icon.create("description", "Build log");
             logIcon.href = `log?job=${job}&id=${build_id}`;
             const c = document.createElement("td");

--- a/prow/cmd/jenkins-operator/README.md
+++ b/prow/cmd/jenkins-operator/README.md
@@ -68,6 +68,10 @@ clicks the `Build log` button of a Jenkins job (`agent: jenkins`).
 `jenkins-operator` forwards the request to Jenkins and serves back
 the response.
 
+**NOTE:** Deck will display the `Build log` button on the main page when the agent is not `kubernetes`
+regardless the external agent log was configured on the server side. Deck has no way to know if the server
+side configuration is consistent when rendering jobs on the main page.
+
 ## Job configuration
 
 Below follows the Prow configuration for a Jenkins job:


### PR DESCRIPTION
This PR adds a check for job agent when determining if the log icon must appear on the main page.

When the agent is `kubernetes` it doesn't change anything.
When an external agent is used (`tekton-pipeline` or `jenkins`), the icon is shown.

The external agent log should be configured on the server side for this to work correctly, see `ExternalAgentLog` struct.
https://github.com/kubernetes/test-infra/blob/f5dd3ee0e9db3b4c67073815b399aa66a1620d2e/prow/config/config.go#L624-L641
