### PR TITLE
[Pipeline] Fix nil pointer when accessing config

### DIFF
--- a/prow/cmd/pipeline/dev.yaml
+++ b/prow/cmd/pipeline/dev.yaml
@@ -17,8 +17,18 @@ spec:
       - name: pipeline
         image: gcr.io/k8s-testimages/pipeline:latest  # Note: not gcr.io/k8s-prow for dev
         imagePullPolicy: Always  # Good practice for dev/debugging, bad for prod
+        args:
+        - --config=/etc/config/config.yaml
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          # This should be the name of the config map for your prow instance
+          name: config
 ---
-
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/prow/cmd/pipeline/main_test.go
+++ b/prow/cmd/pipeline/main_test.go
@@ -29,10 +29,17 @@ func TestOptions(t *testing.T) {
 		expected *options
 		err      bool
 	}{{
-		name:     "defaults work",
+		name:     "defaults don't work (set --config to prow config.yaml file)",
 		expected: &options{},
+		err:      true,
 	}, {
-		name: "error when providing both kubedonfig and build-cluter options ",
+		name: "only config works",
+		args: []string{"--config=/etc/config.yaml"},
+		expected: &options{
+			configPath: "/etc/config.yaml",
+		},
+	}, {
+		name: "error when providing both kubeconfig and build-cluter options ",
 		args: []string{"--all-contexts=true", "--tot-url=https://tot",
 			"--kubeconfig=/root/kubeconfig", "--config=/etc/config.yaml",
 			"--build-cluster=/etc/build-cluster.yaml"},
@@ -40,7 +47,7 @@ func TestOptions(t *testing.T) {
 			allContexts:  true,
 			totURL:       "https://tot",
 			kubeconfig:   "/root/kubeconfig",
-			config:       "/etc/config.yaml",
+			configPath:   "/etc/config.yaml",
 			buildCluster: "/etc/build-cluster.yaml",
 		},
 		err: true,
@@ -52,7 +59,7 @@ func TestOptions(t *testing.T) {
 			allContexts: true,
 			totURL:      "https://tot",
 			kubeconfig:  "/root/kubeconfig",
-			config:      "/etc/config.yaml",
+			configPath:  "/etc/config.yaml",
 		},
 	}}
 	for _, tc := range cases {


### PR DESCRIPTION
This PR fixes https://github.com/kubernetes/test-infra/issues/16120

When the prow config is not set on the command line, the config returned by the config agent is `nil`.
This must be verified before accessing properties and use fallback/default values when it is `nil`.