### PR TITLE
[1.18] releng: Update Slack whitelisted Branch Managers

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -226,36 +226,35 @@ slack:
     - k8s-ci-robot # future home of tide
     - k8s-release-robot # anago
     branch_whitelist:
-        release-1.14:
-            - aleksandra-malinowska # Patch Release Team
-            - dougm # Patch Release Team
-            - feiskyer # Patch Release Team
-            - hoegaarden # Patch Release Team
-            - idealhack # Patch Release Team
-            - tpepper # Patch Release Team
         release-1.15:
-            - aleksandra-malinowska # Patch Release Team
             - dougm # Patch Release Team
             - feiskyer # Patch Release Team
             - hoegaarden # Patch Release Team
             - idealhack # Patch Release Team
+            - justaugustus # Patch Release Team
             - tpepper # Patch Release Team
         release-1.16:
-            - aleksandra-malinowska # Patch Release Team
             - dougm # Patch Release Team
             - feiskyer # Patch Release Team
             - hoegaarden # Patch Release Team
             - idealhack # Patch Release Team
+            - justaugustus # Patch Release Team
             - tpepper # Patch Release Team
         release-1.17:
-            - aleksandra-malinowska # Patch Release Team
-            - bubblemelon # Branch Manager
+            - dougm # Patch Release Team
+            - feiskyer # Patch Release Team
+            - hoegaarden # Patch Release Team
+            - idealhack # Patch Release Team
+            - justaugustus # Patch Release Team
+            - tpepper # Patch Release Team
+        release-1.18:
             - cpanato # Branch Manager
             - dougm # Patch Release Team
             - feiskyer # Patch Release Team
             - hoegaarden # Patch Release Team
             - idealhack # Patch Release Team
-            - justaugustus # Branch Manager
+            - justaugustus # Patch Release Team
+            - saschagrunert # Branch Manager
             - tpepper # Patch Release Team
         feature-serverside-apply:
             - lavalamp # feature-serverside-apply "branch manager"


### PR DESCRIPTION
- Update Slack repo/branch whitelists for 1.18 (ref: https://github.com/kubernetes/sig-release/issues/995)

Pending branch cut:
/hold

/sig release
/area release-eng
/assign @tpepper @justaugustus 
/cc @saschagrunert @hasheddan 