### PR TITLE
[1.18] releng: Update milestoneappliers for 1.18

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -297,10 +297,10 @@ milestone_applier:
     master: v1.18
   kubernetes/kubernetes:
     master: v1.18
+    release-1.18: v1.18
     release-1.17: v1.17
     release-1.16: v1.16
     release-1.15: v1.15
-    release-1.14: v1.14
   kubernetes/release:
     master: v1.18
   kubernetes/sig-release:


### PR DESCRIPTION
- Release cut issue: https://github.com/kubernetes/sig-release/issues/995

Pending branch cut:
/hold


/sig release
/area release-eng

cc: @kubernetes/release-engineering @kubernetes/sig-release-admins