### PR TITLE
[1.18] images/kubekins-e2e: Update variants.yaml (add 1.18, drop 1.14)

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -10,6 +10,11 @@ variants:
     GO_VERSION: 1.13.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
+  '1.18':
+    CONFIG: '1.18'
+    GO_VERSION: 1.13.5
+    K8S_RELEASE: stable-1.18
+    BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
     GO_VERSION: 1.13.5
@@ -24,9 +29,4 @@ variants:
     CONFIG: '1.15'
     GO_VERSION: 1.12.12
     K8S_RELEASE: stable-1.15
-    BAZEL_VERSION: 0.23.2
-  '1.14':
-    CONFIG: '1.14'
-    GO_VERSION: 1.12.12
-    K8S_RELEASE: stable-1.14
     BAZEL_VERSION: 0.23.2

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,28 +1,28 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.13.5
+    GO_VERSION: 1.13.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.13.5
+    GO_VERSION: 1.13.6
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: 1.13.5
+    GO_VERSION: 1.13.6
     K8S_RELEASE: stable-1.18
     BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
-    GO_VERSION: 1.13.5
+    GO_VERSION: 1.13.6
     K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.13.5
+    GO_VERSION: 1.13.6
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':


### PR DESCRIPTION
Release cut issue: https://github.com/kubernetes/sig-release/issues/995

Pending branch cut:
/hold

/sig release
/area release-eng
/priority important-soon

cc: @kubernetes/release-engineering @kubernetes/sig-release-admins