### PR TITLE
Fix "dog" plugin example

### DIFF
--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -63,7 +63,7 @@ func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.
 		Description: "Add a dog image to the issue or PR",
 		Featured:    false,
 		WhoCanUse:   "Anyone",
-		Examples:    []string{"/woof", "/bark", "this-is-{fine|not-fine|unbearable}"},
+		Examples:    []string{"/woof", "/bark", "/this-is-{fine|not-fine|unbearable}"},
 	})
 	return pluginHelp, nil
 }


### PR DESCRIPTION
Prow plugin "dog" will respond to `/this-is-fine`,  not `this-is-fine` as documented [here](https://prow.k8s.io/command-help).