### PR TITLE
releng: Fix kubekins-e2e version marker for 1.18

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -13,7 +13,7 @@ variants:
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: 1.13.6
-    K8S_RELEASE: stable-1.18
+    K8S_RELEASE: latest-1.18
     BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'


### PR DESCRIPTION
Fixes a [failure in the kubekins-e2e image push](https://prow.k8s.io/log?job=post-test-infra-push-kubekins-e2e&id=1229855326333833217) because the `latest-1.18` version marker doesn't exist yet.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/priority critical-urgent
/assign @fejta @stevekuznetsov 
cc: @kubernetes/release-engineering 
ref: https://github.com/kubernetes/test-infra/pull/16341