### PR TITLE
only create non-existent device nodes

### DIFF
--- a/prow/cluster/create-loop-devs_daemonset.yaml
+++ b/prow/cluster/create-loop-devs_daemonset.yaml
@@ -34,8 +34,9 @@ spec:
         - |
           while true; do
             for i in $(seq 0 100); do
-                rm -f /dev/loop$i
-                mknod /dev/loop$i b 7 $i
+                if ! [ -e /dev/loop$i ]; then
+                  mknod /dev/loop$i b 7 $i
+                fi
             done
             sleep 100000000
           done


### PR DESCRIPTION
we already fixed the bad entries, we don't need to keep using rm