### PR TITLE
[genyaml] only document the first item in a sequence

### DIFF
--- a/pkg/genyaml/BUILD.bazel
+++ b/pkg/genyaml/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//pkg/genyaml/testdata/pointer_types:go_default_library",
         "//pkg/genyaml/testdata/primitive_types:go_default_library",
         "//pkg/genyaml/testdata/private_members:go_default_library",
+        "//pkg/genyaml/testdata/sequence_items:go_default_library",
         "@in_gopkg_yaml_v3//:go_default_library",
     ],
 )
@@ -52,6 +53,7 @@ filegroup(
         "//pkg/genyaml/testdata/pointer_types:test-data",
         "//pkg/genyaml/testdata/primitive_types:test-data",
         "//pkg/genyaml/testdata/private_members:test-data",
+        "//pkg/genyaml/testdata/sequence_items:test-data",
         "//pkg/genyaml/testdata/set_path_overwrite:test-data",
         "//pkg/genyaml/testdata/single_path:test-data",
     ],
@@ -82,6 +84,7 @@ filegroup(
         "//pkg/genyaml/testdata/pointer_types:all-srcs",
         "//pkg/genyaml/testdata/primitive_types:all-srcs",
         "//pkg/genyaml/testdata/private_members:all-srcs",
+        "//pkg/genyaml/testdata/sequence_items:all-srcs",
         "//pkg/genyaml/testdata/set_path_overwrite:all-srcs",
         "//pkg/genyaml/testdata/single_path:all-srcs",
     ],

--- a/pkg/genyaml/genyaml_test.go
+++ b/pkg/genyaml/genyaml_test.go
@@ -37,6 +37,7 @@ import (
 	pointers "k8s.io/test-infra/pkg/genyaml/testdata/pointer_types"
 	primitives "k8s.io/test-infra/pkg/genyaml/testdata/primitive_types"
 	private "k8s.io/test-infra/pkg/genyaml/testdata/private_members"
+	sequence "k8s.io/test-infra/pkg/genyaml/testdata/sequence_items"
 )
 
 const (
@@ -420,6 +421,22 @@ func TestGenYAML(t *testing.T) {
 			name:      "private members",
 			structObj: private.NewPerson("gamer123", "password123"),
 			expected:  true,
+		},
+		{
+			name: "sequence items",
+			structObj: &sequence.Recipe{
+				Ingredients: []sequence.Ingredient{
+					{
+						Name:   "potatoes",
+						Amount: 1,
+					},
+					{
+						Name:   "eggs",
+						Amount: 2,
+					},
+				},
+			},
+			expected: true,
 		},
 		{
 			name: "interface types",

--- a/pkg/genyaml/testdata/nested_structs/nested_structs.yaml
+++ b/pkg/genyaml/testdata/nested_structs/nested_structs.yaml
@@ -9,10 +9,7 @@ Children:
 
     # Name of child
     Name: Jimbo
-  - # Age of child
-    Age: 5
-
-    # Name of child
+  - Age: 5
     Name: Jenny
 
 

--- a/pkg/genyaml/testdata/pointer_types/pointer_types.yaml
+++ b/pkg/genyaml/testdata/pointer_types/pointer_types.yaml
@@ -5,8 +5,5 @@ employees:
 
     # Name of employee
     Name: Jim
-  - # Age of employee
-    Age: 21
-
-    # Name of employee
+  - Age: 21
     Name: Jane

--- a/pkg/genyaml/testdata/sequence_items/BUILD.bazel
+++ b/pkg/genyaml/testdata/sequence_items/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["example_config.go"],
+    importpath = "k8s.io/test-infra/pkg/genyaml/testdata/sequence_items",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "test-data",
+    srcs = glob(["*"]),
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/genyaml/testdata/sequence_items/example_config.go
+++ b/pkg/genyaml/testdata/sequence_items/example_config.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sequence_items
+
+type Recipe struct {
+	// Ingredients is a list of things required for the recipe.
+	Ingredients []Ingredient `json:"ingredients"`
+}
+
+type Ingredient struct {
+	// Name is the ingredient's name.
+	Name string `json:"name"`
+	// Amount is how much of this is needed.
+	Amount int `json:"amount"`
+}

--- a/pkg/genyaml/testdata/sequence_items/sequence_items.yaml
+++ b/pkg/genyaml/testdata/sequence_items/sequence_items.yaml
@@ -1,0 +1,9 @@
+# Ingredients is a list of things required for the recipe.
+ingredients:
+  - # Amount is how much of this is needed.
+    amount: 1
+
+    # Name is the ingredient's name.
+    name: potatoes
+  - amount: 2
+    name: eggs


### PR DESCRIPTION
In my project I have a sample structure with an array consisting of 6 items. Having genyaml document the same 6 items (each having 4 fields) is just unnecessary and redundant.

This PR changes the comment injection so that only the first item in a sequence is commented. This of course assumes that sequences don't use interfaces, where each child could be of different types.

The PR also introduces a `EncodeYaml` function so that people can inject their own customized encoder (I use this to reduce the default indentation from 4 to 2 spaces).