### PR TITLE
Prow/metrics: Fix registry defaulting

### DIFF
--- a/prow/metrics/BUILD.bazel
+++ b/prow/metrics/BUILD.bazel
@@ -41,7 +41,13 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["http_test.go"],
+    srcs = [
+        "http_test.go",
+        "metrics_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["@io_k8s_utils//diff:go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "@io_k8s_utils//diff:go_default_library",
+    ],
 )

--- a/prow/metrics/metrics.go
+++ b/prow/metrics/metrics.go
@@ -34,7 +34,7 @@ import (
 const metricsPort = 9090
 
 // ExposeMetricsWithRegistry chooses whether to serve or push metrics for the service with the registry
-func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway, reg *prometheus.Registry) {
+func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway, reg prometheus.Gatherer) {
 	if pushGateway.Endpoint != "" {
 		pushMetrics(component, pushGateway.Endpoint, pushGateway.Interval.Duration)
 		if pushGateway.ServeMetrics {

--- a/prow/metrics/metrics_test.go
+++ b/prow/metrics/metrics_test.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"net/http"
+	"testing"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestExposeMetrics(t *testing.T) {
+	ExposeMetrics("my-component", config.PushGateway{})
+	resp, err := http.Get("http://127.0.0.1:9090/metrics")
+	if err != nil {
+		t.Errorf("failed getting metrics: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("resonse status was not 200 but %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
This caused a NPD, because the nil `*prometheus.Registry` passed into `serveMetrics` that accepts a `prometheus.Gatherer` caused its check if the gatherer is nil to always return false, as an interface is only nil if both its type and value are unset.