### PR TITLE
kubetest2: Add myself and amwat as kubetest2 reviewers

### DIFF
--- a/kubetest2/OWNERS
+++ b/kubetest2/OWNERS
@@ -4,6 +4,10 @@ approvers:
 - BenTheElder
 - krzyzacy
 
+reviewers:
+- amwat
+- cofyc
+
 labels:
 # TODO(bentheelder): should we add a kubetest2 label?
 - area/kubetest


### PR DESCRIPTION
it seems that this subproject is not being continued. however, as for k8s app (operator, driver etc), it's much easier to use than `kubetest` and extensive solution if they want to test against with more than one Kubernetes provider.
I'm using it now and would like to maintain it.