### PR TITLE
Use util.Repo in prow/tide and prow/config

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1985,3 +1985,44 @@ func SetPostsubmitRegexes(ps []Postsubmit) error {
 	}
 	return nil
 }
+
+// OrgRepo supercedes org/repo string handling
+type OrgRepo struct {
+	Org  string
+	Repo string
+}
+
+func (repo OrgRepo) String() string {
+	return fmt.Sprintf("%s/%s", repo.Org, repo.Repo)
+}
+
+// NewOrgRepo creates a OrgRepo from org/repo string
+func NewOrgRepo(orgRepo string) *OrgRepo {
+	parts := strings.Split(orgRepo, "/")
+	switch len(parts) {
+	case 1:
+		return &OrgRepo{Org: parts[0]}
+	case 2:
+		return &OrgRepo{Org: parts[0], Repo: parts[1]}
+	default:
+		return nil
+	}
+}
+
+// OrgReposToStrings converts a list of OrgRepo to its String() equivalent
+func OrgReposToStrings(vs []OrgRepo) []string {
+	vsm := make([]string, len(vs))
+	for i, v := range vs {
+		vsm[i] = v.String()
+	}
+	return vsm
+}
+
+// StringsToOrgRepos converts a list of org/repo strings to its OrgRepo equivalent
+func StringsToOrgRepos(vs []string) []OrgRepo {
+	vsm := make([]OrgRepo, len(vs))
+	for i, v := range vs {
+		vsm[i] = *NewOrgRepo(v)
+	}
+	return vsm
+}

--- a/prow/config/inrepoconfig_test.go
+++ b/prow/config/inrepoconfig_test.go
@@ -397,7 +397,7 @@ func TestDefaultProwYAMLGetter_RejectsNonGitHubRepo(t *testing.T) {
 	if err := lg.MakeFakeRepo(identifier, ""); err != nil {
 		t.Fatalf("Making fake repo: %v", err)
 	}
-	expectedErrMsg := `didn't get two but 1 results when splitting repo identifier "my-repo"`
+	expectedErrMsg := `didn't get two results when splitting repo identifier "my-repo"`
 	if _, err := defaultProwYAMLGetter(&Config{}, gc, identifier, ""); err == nil || err.Error() != expectedErrMsg {
 		t.Errorf("Error %v does not have expected message %s", err, expectedErrMsg)
 	}

--- a/prow/config/tide_test.go
+++ b/prow/config/tide_test.go
@@ -148,8 +148,9 @@ func TestMergeMethod(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		if ti.MergeMethod(test.org, test.repo) != test.expected {
-			t.Errorf("Expected merge method %q but got %q for %s/%s", test.expected, ti.MergeMethod(test.org, test.repo), test.org, test.repo)
+		actual := ti.MergeMethod(OrgRepo{Org: test.org, Repo: test.repo})
+		if actual != test.expected {
+			t.Errorf("Expected merge method %q but got %q for %s/%s", test.expected, actual, test.org, test.repo)
 		}
 	}
 }
@@ -220,7 +221,7 @@ func TestMergeTemplate(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		actual := ti.MergeCommitTemplate(test.org, test.repo)
+		actual := ti.MergeCommitTemplate(OrgRepo{Org: test.org, Repo: test.repo})
 
 		if actual.TitleTemplate != test.expected.TitleTemplate || actual.BodyTemplate != test.expected.BodyTemplate {
 			t.Errorf("Expected title \"%v\", body \"%v\", but got title \"%v\", body \"%v\" for %v/%v", test.expected.TitleTemplate, test.expected.BodyTemplate, actual.TitleTemplate, actual.BodyTemplate, test.org, test.repo)

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/git/v2:go_default_library",

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -57,7 +58,7 @@ type githubClient interface {
 }
 
 // HelpProvider construct the pluginhelp.PluginHelp for this plugin.
-func HelpProvider(_ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The cherrypick plugin is used for cherrypicking PRs across branches. For every successful cherrypick invocation a new PR is opened against the target branch and assigned to the requester. If the parent PR contains a release note, it is copied to the cherrypick PR.`,
 	}

--- a/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/plugin/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/external-plugins/needs-rebase/plugin",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/external-plugins/needs-rebase/plugin/plugin.go
+++ b/prow/external-plugins/needs-rebase/plugin/plugin.go
@@ -26,6 +26,7 @@ import (
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -58,7 +59,7 @@ type commentPruner interface {
 
 // HelpProvider constructs the PluginHelp for this plugin that takes into account enabled repositories.
 // HelpProvider defines the type for function that construct the PluginHelp for plugins.
-func HelpProvider(_ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 			Description: `The needs-rebase plugin manages the '` + labels.NeedsRebase + `' label by removing it from Pull Requests that are mergeable and adding it to those which are not.
 The plugin reacts to commit changes on PRs in addition to periodically scanning all open PRs for any changes to mergeability that could have resulted from changes in other PRs.`,

--- a/prow/external-plugins/refresh/BUILD.bazel
+++ b/prow/external-plugins/refresh/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
         "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
-        "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
     ],

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -33,14 +33,13 @@ import (
 	"k8s.io/test-infra/prow/github/report"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pluginhelp"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 const pluginName = "refresh"
 
 var refreshRe = regexp.MustCompile(`(?mi)^/refresh\s*$`)
 
-func helpProvider(_ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The refresh plugin is used for refreshing status contexts in PRs. Useful in case GitHub breaks down.`,
 	}

--- a/prow/pluginhelp/externalplugins/BUILD.bazel
+++ b/prow/pluginhelp/externalplugins/BUILD.bazel
@@ -6,8 +6,8 @@ go_library(
     importpath = "k8s.io/test-infra/prow/pluginhelp/externalplugins",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/pluginhelp:go_default_library",
-        "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/pluginhelp/externalplugins/externalplugins.go
+++ b/prow/pluginhelp/externalplugins/externalplugins.go
@@ -28,13 +28,13 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/pluginhelp"
-	"k8s.io/test-infra/prow/plugins"
 )
 
 // ExternalPluginHelpProvider is a func type that returns a PluginHelp struct for an external
 // plugin based on the specified enabledRepos.
-type ExternalPluginHelpProvider func([]plugins.Repo) (*pluginhelp.PluginHelp, error)
+type ExternalPluginHelpProvider func([]config.OrgRepo) (*pluginhelp.PluginHelp, error)
 
 // ServeExternalPluginHelp returns a HandlerFunc that serves plugin help information that is
 // provided by the specified ExternalPluginHelpProvider.
@@ -60,7 +60,7 @@ func ServeExternalPluginHelp(mux *http.ServeMux, log *logrus.Entry, provider Ext
 				serverError("reading request body", err)
 				return
 			}
-			var enabledRepos []plugins.Repo
+			var enabledRepos []config.OrgRepo
 			if err := json.Unmarshal(b, &enabledRepos); err != nil {
 				serverError("unmarshaling request body", err)
 				return

--- a/prow/pluginhelp/hook/BUILD.bazel
+++ b/prow/pluginhelp/hook/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/pluginhelp/hook",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",

--- a/prow/pluginhelp/hook/BUILD.bazel
+++ b/prow/pluginhelp/hook/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = ["hook_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",

--- a/prow/pluginhelp/hook/hook.go
+++ b/prow/pluginhelp/hook/hook.go
@@ -34,6 +34,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
@@ -75,7 +76,7 @@ func NewHelpAgent(pa pluginAgent, ghc githubClient) *HelpAgent {
 	}
 }
 
-func (ha *HelpAgent) generateNormalPluginHelp(config *plugins.Configuration, revMap map[string][]plugins.Repo) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
+func (ha *HelpAgent) generateNormalPluginHelp(config *plugins.Configuration, revMap map[string][]prowconfig.OrgRepo) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
 	pluginHelp = map[string]pluginhelp.PluginHelp{}
 	for name, provider := range plugins.HelpProviders() {
 		allPlugins = append(allPlugins, name)
@@ -94,7 +95,7 @@ func (ha *HelpAgent) generateNormalPluginHelp(config *plugins.Configuration, rev
 	return
 }
 
-func (ha *HelpAgent) generateExternalPluginHelp(config *plugins.Configuration, revMap map[string][]plugins.Repo) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
+func (ha *HelpAgent) generateExternalPluginHelp(config *plugins.Configuration, revMap map[string][]prowconfig.OrgRepo) (allPlugins []string, pluginHelp map[string]pluginhelp.PluginHelp) {
 	externals := map[string]plugins.ExternalPlugin{}
 	for _, exts := range config.ExternalPlugins {
 		for _, ext := range exts {
@@ -198,7 +199,7 @@ func allRepos(config *plugins.Configuration, orgToRepos map[string]sets.String) 
 }
 
 func externalHelpProvider(log *logrus.Entry, endpoint string) externalplugins.ExternalPluginHelpProvider {
-	return func(enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+	return func(enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 		u, err := url.Parse(endpoint)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing url: %s err: %v", endpoint, err)
@@ -231,28 +232,28 @@ func externalHelpProvider(log *logrus.Entry, endpoint string) externalplugins.Ex
 // reversePluginMaps inverts the Configuration.Plugins and Configuration.ExternalPlugins maps and
 // expands any org strings to org/repo strings.
 // The returned values map plugin names to the set of org/repo strings they are enabled on.
-func reversePluginMaps(config *plugins.Configuration, orgToRepos map[string]sets.String) (normal, external map[string][]plugins.Repo) {
-	normal = map[string][]plugins.Repo{}
+func reversePluginMaps(config *plugins.Configuration, orgToRepos map[string]sets.String) (normal, external map[string][]prowconfig.OrgRepo) {
+	normal = map[string][]prowconfig.OrgRepo{}
 	for repo, enabledPlugins := range config.Plugins {
-		var repos []plugins.Repo
+		var repos []prowconfig.OrgRepo
 		if !strings.Contains(repo, "/") {
 			if flattened, ok := orgToRepos[repo]; ok {
-				repos = plugins.StringsToRepos(flattened.List())
+				repos = prowconfig.StringsToOrgRepos(flattened.List())
 			}
 		} else {
-			repos = []plugins.Repo{*plugins.NewRepo(repo)}
+			repos = []prowconfig.OrgRepo{*prowconfig.NewOrgRepo(repo)}
 		}
 		for _, plugin := range enabledPlugins {
 			normal[plugin] = append(normal[plugin], repos...)
 		}
 	}
-	external = map[string][]plugins.Repo{}
+	external = map[string][]prowconfig.OrgRepo{}
 	for repo, extPlugins := range config.ExternalPlugins {
-		var repos []plugins.Repo
+		var repos []prowconfig.OrgRepo
 		if flattened, ok := orgToRepos[repo]; ok {
-			repos = plugins.StringsToRepos(flattened.List())
+			repos = prowconfig.StringsToOrgRepos(flattened.List())
 		} else {
-			repos = []plugins.Repo{*plugins.NewRepo(repo)}
+			repos = []prowconfig.OrgRepo{*prowconfig.NewOrgRepo(repo)}
 		}
 		for _, plugin := range extPlugins {
 			external[plugin.Name] = append(external[plugin.Name], repos...)

--- a/prow/pluginhelp/hook/hook_test.go
+++ b/prow/pluginhelp/hook/hook_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
@@ -75,8 +76,8 @@ func TestGeneratePluginHelp(t *testing.T) {
 	externalplugins.ServeExternalPluginHelp(
 		mux,
 		logrus.WithField("plugin", "helpful-external"),
-		func(enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
-			if got, expected := enabledRepos, []plugins.Repo{{Org: "org1", Repo: "repo1"}}; !reflect.DeepEqual(got, expected) {
+		func(enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
+			if got, expected := enabledRepos, []prowconfig.OrgRepo{{Org: "org1", Repo: "repo1"}}; !reflect.DeepEqual(got, expected) {
 				t.Errorf("Plugin 'helpful-external' expected to be enabled on repos %q, but got %q.", expected, got)
 			}
 			return &helpfulExternalHelp, nil
@@ -181,8 +182,8 @@ func TestGeneratePluginHelp(t *testing.T) {
 func registerNormalPlugins(t *testing.T, pluginsToEvents map[string][]string, pluginHelp map[string]pluginhelp.PluginHelp, expectedRepos map[string][]string) {
 	for plugin, events := range pluginsToEvents {
 		plugin := plugin
-		helpProvider := func(_ *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
-			if got, expected := sets.NewString(plugins.ReposToStrings(enabledRepos)...), sets.NewString(expectedRepos[plugin]...); !got.Equal(expected) {
+		helpProvider := func(_ *plugins.Configuration, enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
+			if got, expected := sets.NewString(prowconfig.OrgReposToStrings(enabledRepos)...), sets.NewString(expectedRepos[plugin]...); !got.Equal(expected) {
 				t.Errorf("Plugin '%s' expected to be enabled on repos %q, but got %q.", plugin, expected.List(), got.List())
 			}
 			help := pluginHelp[plugin]

--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -96,7 +96,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequestEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	doNot := func(b bool) string {
 		if b {
 			return ""

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1764,14 +1764,14 @@ func TestHandlePullRequest(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/assign/BUILD.bazel
+++ b/prow/plugins/assign/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     srcs = ["assign.go"],
     importpath = "k8s.io/test-infra/prow/plugins/assign",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -40,7 +41,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The assign plugin assigns or requests reviews from users. Specific users can be assigned with the command '/assign @user1' or have reviews requested of them with the command '/cc @user1'. If no users are specified, the commands default to targeting the user who created the command. Assignments and requested reviews can be removed in the same way that they are added by prefixing the commands with 'un'.",

--- a/prow/plugins/blockade/BUILD.bazel
+++ b/prow/plugins/blockade/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/blockade",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",
@@ -33,6 +34,7 @@ go_test(
     srcs = ["blockade_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",

--- a/prow/plugins/blockade/blockade.go
+++ b/prow/plugins/blockade/blockade.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -59,7 +60,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin cannot be triggered manually.
 	blockConfig := map[string]string{}
 	for _, repo := range enabledRepos {

--- a/prow/plugins/blockade/blockade_test.go
+++ b/prow/plugins/blockade/blockade_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
@@ -355,14 +356,14 @@ func TestHandle(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/blunderbuss/BUILD.bazel
+++ b/prow/plugins/blunderbuss/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/blunderbuss",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
@@ -36,6 +37,7 @@ go_test(
     srcs = ["blunderbuss_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",

--- a/prow/plugins/blunderbuss/blunderbuss.go
+++ b/prow/plugins/blunderbuss/blunderbuss.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -57,7 +58,7 @@ func configString(reviewCount int) string {
 	return fmt.Sprintf("Blunderbuss is currently configured to request reviews from %d reviewer%s.", reviewCount, pluralSuffix)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	var reviewCount int
 	if config.Blunderbuss.ReviewerCount != nil {
 		reviewCount = *config.Blunderbuss.ReviewerCount

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -32,6 +32,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/repoowners"
@@ -777,14 +778,14 @@ func TestHandlePullRequestEvent(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name               string
 		config             *plugins.Configuration
-		enabledRepos       []plugins.Repo
+		enabledRepos       []config.OrgRepo
 		err                bool
 		configInfoIncludes []string
 	}{

--- a/prow/plugins/branchcleaner/BUILD.bazel
+++ b/prow/plugins/branchcleaner/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     srcs = ["branchcleaner.go"],
     importpath = "k8s.io/test-infra/prow/plugins/branchcleaner",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/branchcleaner/branchcleaner.go
+++ b/prow/plugins/branchcleaner/branchcleaner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -34,7 +35,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 		Description: "The branchcleaner plugin automatically deletes source branches for merged PRs between two branches on the same repository. This is helpful to keep repos that don't allow forking clean."}, nil
 }

--- a/prow/plugins/bugzilla/BUILD.bazel
+++ b/prow/plugins/bugzilla/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/bugzilla:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/bugzilla/BUILD.bazel
+++ b/prow/plugins/bugzilla/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//prow/bugzilla:go_default_library",
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/bugzilla"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -49,7 +50,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	configInfo := make(map[string]string)
 	for _, repo := range enabledRepos {
 		opts := config.Bugzilla.OptionsForRepo(repo.Org, repo.Repo)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/test-infra/prow/bugzilla"
+	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -90,7 +91,7 @@ orgs:
 	}
 
 	pc := &plugins.Configuration{Bugzilla: config}
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []prowconfig.OrgRepo{
 		{Org: "some-org", Repo: "some-repo"},
 		{Org: "my-org", Repo: "some-repo"},
 		{Org: "my-org", Repo: "my-repo"},

--- a/prow/plugins/buildifier/BUILD.bazel
+++ b/prow/plugins/buildifier/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     srcs = ["buildifier.go"],
     importpath = "k8s.io/test-infra/prow/plugins/buildifier",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/genfiles:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/buildifier/buildifier.go
+++ b/prow/plugins/buildifier/buildifier.go
@@ -31,6 +31,7 @@ import (
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/genfiles"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
@@ -49,7 +50,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The buildifier plugin runs buildifier on changes made to Bazel files in a PR. It then creates a new review on the pull request and leaves warnings at the appropriate lines of code.",

--- a/prow/plugins/cat/BUILD.bazel
+++ b/prow/plugins/cat/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     srcs = ["cat.go"],
     importpath = "k8s.io/test-infra/prow/plugins/cat",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/cat/cat.go
+++ b/prow/plugins/cat/cat.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -54,7 +55,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The cat plugin adds a cat image to an issue or PR in response to the `/meow` command.",
 		Config: map[string]string{

--- a/prow/plugins/cherrypickunapproved/BUILD.bazel
+++ b/prow/plugins/cherrypickunapproved/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/cherrypickunapproved",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -41,7 +42,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the 'Config' and Description' fields are necessary because this
 	// plugin does not react to any commands.
 	pluginHelp := &pluginhelp.PluginHelp{

--- a/prow/plugins/cla/BUILD.bazel
+++ b/prow/plugins/cla/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
     srcs = ["cla.go"],
     importpath = "k8s.io/test-infra/prow/plugins/cla",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/cla/cla.go
+++ b/prow/plugins/cla/cla.go
@@ -24,6 +24,7 @@ import (
 
 	"regexp"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -65,7 +66,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleCommentEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The {WhoCanUse, Usage, Examples, Config} fields are omitted because this plugin cannot be
 	// manually triggered and is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -584,47 +584,6 @@ type RequireMatchingLabel struct {
 	GracePeriodDuration time.Duration `json:"-"`
 }
 
-// Repo supercedes org/repo string handling
-type Repo struct {
-	Org  string
-	Repo string
-}
-
-func (repo Repo) String() string {
-	return fmt.Sprintf("%s/%s", repo.Org, repo.Repo)
-}
-
-// NewRepo creates a Repo from org/repo string
-func NewRepo(orgRepo string) *Repo {
-	parts := strings.Split(orgRepo, "/")
-	switch len(parts) {
-	case 1:
-		return &Repo{Org: parts[0]}
-	case 2:
-		return &Repo{Org: parts[0], Repo: parts[1]}
-	default:
-		return nil
-	}
-}
-
-// ReposToStrings converts a list of Repo to its String() equivalent
-func ReposToStrings(vs []Repo) []string {
-	vsm := make([]string, len(vs))
-	for i, v := range vs {
-		vsm[i] = v.String()
-	}
-	return vsm
-}
-
-// StringsToRepos converts a list of org/repo strings to its Repo equivalent
-func StringsToRepos(vs []string) []Repo {
-	vsm := make([]Repo, len(vs))
-	for i, v := range vs {
-		vsm[i] = *NewRepo(v)
-	}
-	return vsm
-}
-
 // validate checks the following properties:
 // - Org, Regexp, MissingLabel, and GracePeriod must be non-empty.
 // - Repo does not contain a '/' (should use Org+Repo).

--- a/prow/plugins/dco/BUILD.bazel
+++ b/prow/plugins/dco/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     srcs = ["dco.go"],
     importpath = "k8s.io/test-infra/prow/plugins/dco",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -66,7 +67,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleCommentEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	configInfo := map[string]string{}
 	for _, repo := range enabledRepos {
 		opts := config.DcoFor(repo.Org, repo.Repo)

--- a/prow/plugins/docs-no-retest/BUILD.bazel
+++ b/prow/plugins/docs-no-retest/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/docs-no-retest",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/docs-no-retest/docs-no-retest.go
+++ b/prow/plugins/docs-no-retest/docs-no-retest.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"regexp"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -47,7 +48,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The {WhoCanUse, Usage, Examples, Config} fields are omitted because this plugin cannot be
 	// manually triggered and is not configurable.
 	return &pluginhelp.PluginHelp{

--- a/prow/plugins/dog/BUILD.bazel
+++ b/prow/plugins/dog/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/dog",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/dog/dog.go
+++ b/prow/plugins/dog/dog.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -53,7 +54,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The dog plugin adds a dog image to an issue or PR in response to the `/woof` command.",

--- a/prow/plugins/golint/BUILD.bazel
+++ b/prow/plugins/golint/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = ["golint_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
@@ -23,6 +24,7 @@ go_library(
     srcs = ["golint.go"],
     importpath = "k8s.io/test-infra/prow/plugins/golint",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/genfiles:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/golint/golint.go
+++ b/prow/plugins/golint/golint.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/lint"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/genfiles"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
@@ -48,7 +49,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The golint plugin runs golint on changes made to *.go files in a PR. It then creates a new review on the pull request and leaves golint warnings at the appropriate lines of code.",
 		Config: map[string]string{

--- a/prow/plugins/golint/golint_test.go
+++ b/prow/plugins/golint/golint_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
@@ -813,14 +814,14 @@ func TestModifiedGoFiles(t *testing.T) {
 
 func TestHelpProvider(t *testing.T) {
 	half := 0.5
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/goose/BUILD.bazel
+++ b/prow/plugins/goose/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     srcs = ["goose.go"],
     importpath = "k8s.io/test-infra/prow/plugins/goose",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/goose/goose.go
+++ b/prow/plugins/goose/goose.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -51,7 +52,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The goose plugin adds a goose image to an issue or PR in response to the `/honk` command.",
 		Config: map[string]string{

--- a/prow/plugins/heart/BUILD.bazel
+++ b/prow/plugins/heart/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     srcs = ["heart.go"],
     importpath = "k8s.io/test-infra/prow/plugins/heart",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/heart/heart.go
+++ b/prow/plugins/heart/heart.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -47,7 +48,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The {WhoCanUse, Usage, Examples} fields are omitted because this plugin is not triggered with commands.
 	return &pluginhelp.PluginHelp{
 			Description: "The heart plugin celebrates certain GitHub actions with the reaction emojis. Emojis are added to pull requests that make additions to OWNERS or OWNERS_ALIASES files and to comments left by specified \"adorees\".",

--- a/prow/plugins/help/BUILD.bazel
+++ b/prow/plugins/help/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     srcs = ["help.go"],
     importpath = "k8s.io/test-infra/prow/plugins/help",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/help/help.go
+++ b/prow/plugins/help/help.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -59,7 +60,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The help plugin provides commands that add or remove the '" + labels.Help + "' and the '" + labels.GoodFirstIssue + "' labels from issues.",

--- a/prow/plugins/hold/BUILD.bazel
+++ b/prow/plugins/hold/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/hold",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -48,7 +49,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(PluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The hold plugin allows anyone to add or remove the '" + labels.Hold + "' Label from a pull request in order to temporarily prevent the PR from merging without withholding approval.",

--- a/prow/plugins/invalidcommitmsg/BUILD.bazel
+++ b/prow/plugins/invalidcommitmsg/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/invalidcommitmsg",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -58,7 +59,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
 			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages contain @ mentions or keywords which can automatically close issues.",

--- a/prow/plugins/label/BUILD.bazel
+++ b/prow/plugins/label/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = ["label_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
@@ -24,6 +25,7 @@ go_library(
     srcs = ["label.go"],
     importpath = "k8s.io/test-infra/prow/plugins/label",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -51,7 +52,7 @@ func configString(labels []string) string {
 	return fmt.Sprintf("The label plugin will work on %s and %s labels.", strings.Join(formattedLabels[:len(formattedLabels)-1], ", "), formattedLabels[len(formattedLabels)-1])
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	labels := []string{}
 	labels = append(labels, defaultLabels...)
 	labels = append(labels, config.Label.AdditionalLabels...)

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
@@ -569,14 +570,14 @@ func TestLabel(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name               string
 		config             *plugins.Configuration
-		enabledRepos       []plugins.Repo
+		enabledRepos       []config.OrgRepo
 		err                bool
 		configInfoIncludes []string
 	}{

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = ["lgtm_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/plugins:go_default_library",
@@ -27,6 +28,7 @@ go_library(
     srcs = ["lgtm.go"],
     importpath = "k8s.io/test-infra/prow/plugins/lgtm",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -65,7 +66,7 @@ func init() {
 	plugins.RegisterReviewEventHandler(PluginName, handlePullRequestReviewEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	configInfo := map[string]string{}
 	for _, repo := range enabledRepos {
 		opts := config.LgtmFor(repo.Org, repo.Repo)

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/plugins"
@@ -1185,14 +1186,14 @@ func TestRemoveTreeHashComment(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name               string
 		config             *plugins.Configuration
-		enabledRepos       []plugins.Repo
+		enabledRepos       []config.OrgRepo
 		err                bool
 		configInfoIncludes []string
 		configInfoExcludes []string

--- a/prow/plugins/lifecycle/BUILD.bazel
+++ b/prow/plugins/lifecycle/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/plugins/lifecycle",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/lifecycle/lifecycle.go
+++ b/prow/plugins/lifecycle/lifecycle.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -36,7 +37,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler("lifecycle", lifecycleHandleGenericComment, help)
 }
 
-func help(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func help(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "Close, reopen, flag and/or unflag an issue or PR as frozen/stale/rotten",
 	}

--- a/prow/plugins/mergecommitblocker/BUILD.bazel
+++ b/prow/plugins/mergecommitblocker/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/mergecommitblocker",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",

--- a/prow/plugins/mergecommitblocker/mergecommitblocker.go
+++ b/prow/plugins/mergecommitblocker/mergecommitblocker.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
@@ -44,7 +45,7 @@ func init() {
 }
 
 // helpProvider provides information on the plugin
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
 		Description: fmt.Sprintf("The merge commit blocker plugin adds the %s label to pull requests that contain merge commits", labels.MergeCommits),

--- a/prow/plugins/milestone/BUILD.bazel
+++ b/prow/plugins/milestone/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/milestone",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	prowconfig "k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -53,14 +54,14 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []prowconfig.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	msgForTeam := func(team plugins.Milestone) string {
 		return fmt.Sprintf(milestoneTeamMsg, team.MaintainersTeam, team.MaintainersID)
 	}
 
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The milestone plugin allows members of a configurable GitHub team to set the milestone on an issue or pull request.",
-		Config: func(repos []plugins.Repo) map[string]string {
+		Config: func(repos []prowconfig.OrgRepo) map[string]string {
 			configMap := make(map[string]string)
 			for _, repo := range repos {
 				team, exists := config.RepoMilestone[repo.String()]

--- a/prow/plugins/milestoneapplier/BUILD.bazel
+++ b/prow/plugins/milestoneapplier/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/milestoneapplier",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/milestoneapplier/milestoneapplier.go
+++ b/prow/plugins/milestoneapplier/milestoneapplier.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -41,7 +42,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	configInfo := map[string]string{}
 	for _, repo := range enabledRepos {
 		var branchesToMilestone []string

--- a/prow/plugins/milestonestatus/BUILD.bazel
+++ b/prow/plugins/milestonestatus/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/milestonestatus",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -53,7 +54,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	msgForTeam := func(team plugins.Milestone) string {
 		return fmt.Sprintf(milestoneTeamMsg, team.MaintainersTeam, team.MaintainersID)
 	}

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -135,7 +135,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The override plugin allows repo admins to force a github status context to pass",
 	}

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -759,7 +759,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		help, err := helpProvider(&tc.config, []plugins.Repo{})
+		help, err := helpProvider(&tc.config, []config.OrgRepo{})
 		if err != nil {
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		}

--- a/prow/plugins/owners-label/BUILD.bazel
+++ b/prow/plugins/owners-label/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/owners-label",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -36,7 +37,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 			Description: "The owners-label plugin automatically adds labels to PRs based on the files they touch. Specifically, the 'labels' sections of OWNERS files are used to determine which labels apply to the changes.",
 		},

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -57,7 +57,7 @@ var (
 
 // HelpProvider defines the function type that construct a pluginhelp.PluginHelp for enabled
 // plugins. It takes into account the plugins configuration and enabled repositories.
-type HelpProvider func(config *Configuration, enabledRepos []Repo) (*pluginhelp.PluginHelp, error)
+type HelpProvider func(config *Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error)
 
 // HelpProviders returns the map of registered plugins with their associated HelpProvider.
 func HelpProviders() map[string]HelpProvider {

--- a/prow/plugins/pony/BUILD.bazel
+++ b/prow/plugins/pony/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/pony",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/pony/pony.go
+++ b/prow/plugins/pony/pony.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -60,7 +61,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The pony plugin adds a pony image to an issue or PR in response to the `/pony` command.",

--- a/prow/plugins/project/BUILD.bazel
+++ b/prow/plugins/project/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/project",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -71,7 +72,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	projectConfig := config.Project
 	configInfo := map[string]string{}
 	for _, repo := range enabledRepos {

--- a/prow/plugins/projectmanager/BUILD.bazel
+++ b/prow/plugins/projectmanager/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/projectmanager",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
@@ -18,6 +19,7 @@ go_test(
     srcs = ["projectmanager_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/projectmanager/projectmanager.go
+++ b/prow/plugins/projectmanager/projectmanager.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -70,7 +71,7 @@ func init() {
 	plugins.RegisterIssueHandler(pluginName, handleIssueOrPullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	projectConfig := config.ProjectManager
 	if len(projectConfig.OrgRepos) == 0 {
 		pluginHelp := &pluginhelp.PluginHelp{

--- a/prow/plugins/projectmanager/projectmanager_test.go
+++ b/prow/plugins/projectmanager/projectmanager_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/plugins"
@@ -755,7 +756,7 @@ func checkCards(expectedColumnCards, projectColumnCards map[int][]github.Project
 
 func TestHelpProvider(t *testing.T) {
 	var i int = 0
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
@@ -766,7 +767,7 @@ func TestHelpProvider(t *testing.T) {
 	cases := []struct {
 		name           string
 		config         *plugins.Configuration
-		enabledRepos   []plugins.Repo
+		enabledRepos   []config.OrgRepo
 		expectedConfig string
 		expectedKey    string
 		err            bool

--- a/prow/plugins/releasenote/BUILD.bazel
+++ b/prow/plugins/releasenote/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     srcs = ["releasenote.go"],
     importpath = "k8s.io/test-infra/prow/plugins/releasenote",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/releasenote/releasenote.go
+++ b/prow/plugins/releasenote/releasenote.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -76,7 +77,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: `The releasenote plugin implements a release note process that uses a markdown 'releasenote' code block to associate a release note with a pull request. Until the 'releasenote' block in the pull request body is populated the PR will be assigned the '` + ReleaseNoteLabelNeeded + `' label.
 <br>There are three valid types of release notes that can replace this label:

--- a/prow/plugins/require-matching-label/BUILD.bazel
+++ b/prow/plugins/require-matching-label/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/require-matching-label",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/require-matching-label/require-matching-label.go
+++ b/prow/plugins/require-matching-label/require-matching-label.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -69,7 +70,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	descs := make([]string, 0, len(config.RequireMatchingLabel))
 	for _, cfg := range config.RequireMatchingLabel {
 		descs = append(descs, cfg.Describe())

--- a/prow/plugins/requiresig/BUILD.bazel
+++ b/prow/plugins/requiresig/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/requiresig",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/requiresig/requiresig.go
+++ b/prow/plugins/requiresig/requiresig.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -68,7 +69,7 @@ func init() {
 	plugins.RegisterIssueHandler(pluginName, handleIssue, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	url := config.RequireSIG.GroupListURL
 	if url == "" {
 		url = "<no url provided>"

--- a/prow/plugins/retitle/BUILD.bazel
+++ b/prow/plugins/retitle/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     srcs = ["retitle.go"],
     importpath = "k8s.io/test-infra/prow/plugins/retitle",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/retitle/retitle.go
+++ b/prow/plugins/retitle/retitle.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -41,7 +42,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericCommentEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	var configMsg string
 	if config.Retitle.AllowClosedIssues {
 		configMsg = "The retitle plugin also allows retitling closed/merged issues and PRs."

--- a/prow/plugins/shrug/BUILD.bazel
+++ b/prow/plugins/shrug/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/shrug",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/shrug/shrug.go
+++ b/prow/plugins/shrug/shrug.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -51,7 +52,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: labels.Shrug,

--- a/prow/plugins/sigmention/BUILD.bazel
+++ b/prow/plugins/sigmention/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/sigmention",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/sigmention/sigmention.go
+++ b/prow/plugins/sigmention/sigmention.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -58,7 +59,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	return &pluginhelp.PluginHelp{
 			Description: `The sigmention plugin responds to SIG (Special Interest Group) GitHub team mentions like '@kubernetes/sig-testing-bugs'. The plugin responds in two ways:
 <ol><li> The appropriate 'sig/*' and 'kind/*' labels are applied to the issue or pull request. In this case 'sig/testing' and 'kind/bug'.</li>

--- a/prow/plugins/size/BUILD.bazel
+++ b/prow/plugins/size/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
     srcs = ["size_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -24,6 +25,7 @@ go_library(
     srcs = ["size.go"],
     importpath = "k8s.io/test-infra/prow/plugins/size",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/genfiles:go_default_library",
         "//prow/gitattributes:go_default_library",
         "//prow/github:go_default_library",

--- a/prow/plugins/size/size.go
+++ b/prow/plugins/size/size.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/genfiles"
 	"k8s.io/test-infra/prow/gitattributes"
 	"k8s.io/test-infra/prow/github"
@@ -48,7 +49,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	sizes := sizesOrDefault(config.Size)
 	return &pluginhelp.PluginHelp{
 			Description: "The size plugin manages the 'size/*' labels, maintaining the appropriate label on each pull request as it is updated. Generated files identified by the config file '.generated_files' at the repo root are ignored. Labels are applied based on the total number of lines of changes (additions and deletions).",

--- a/prow/plugins/size/size_test.go
+++ b/prow/plugins/size/size_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -648,14 +649,14 @@ func TestHandlePR(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/skip/skip.go
+++ b/prow/plugins/skip/skip.go
@@ -50,7 +50,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The skip plugin allows users to clean up GitHub stale commit statuses for non-blocking jobs on a PR.",
 	}

--- a/prow/plugins/slackevents/BUILD.bazel
+++ b/prow/plugins/slackevents/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
     srcs = ["slackevents_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/plugins:go_default_library",
@@ -23,6 +24,7 @@ go_library(
     srcs = ["slackevents.go"],
     importpath = "k8s.io/test-infra/prow/plugins/slackevents",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/plugins"
@@ -319,14 +320,14 @@ func TestComment(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/stage/BUILD.bazel
+++ b/prow/plugins/stage/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/stage",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/stage/stage.go
+++ b/prow/plugins/stage/stage.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -40,7 +41,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler("stage", stageHandleGenericComment, help)
 }
 
-func help(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func help(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "Label the stage of an issue as alpha/beta/stable",

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -43,7 +43,7 @@ func init() {
 	plugins.RegisterPushEventHandler(PluginName, handlePush, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	configInfo := map[string]string{}
 	for _, repo := range enabledRepos {
 		trigger := config.TriggerFor(repo.Org, repo.Repo)

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -39,14 +39,14 @@ import (
 )
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/updateconfig/BUILD.bazel
+++ b/prow/plugins/updateconfig/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
     srcs = ["updateconfig.go"],
     importpath = "k8s.io/test-infra/prow/plugins/updateconfig",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -33,6 +33,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/kube"
@@ -49,7 +50,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	var configInfo map[string]string
 	if len(enabledRepos) == 1 {
 		msg := ""

--- a/prow/plugins/verify-owners/BUILD.bazel
+++ b/prow/plugins/verify-owners/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/verify-owners",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
@@ -24,6 +25,7 @@ go_test(
     srcs = ["verify-owners_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/git/localgit:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
@@ -57,7 +58,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(PluginName, handleGenericCommentEvent, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: fmt.Sprintf("The verify-owners plugin validates %s and %s files and ensures that they always contain collaborators of the org, if they are modified in a PR. On validation failure it automatically adds the '%s' label to the PR, and a review comment on the incriminating file(s).", ownersFileName, ownersAliasesFileName, labels.InvalidOwners),
 	}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/git/localgit"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -582,14 +583,14 @@ func makePatch(b []byte) string {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name               string
 		config             *plugins.Configuration
-		enabledRepos       []plugins.Repo
+		enabledRepos       []config.OrgRepo
 		err                bool
 		configInfoIncludes []string
 	}{

--- a/prow/plugins/welcome/BUILD.bazel
+++ b/prow/plugins/welcome/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/welcome",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
@@ -37,6 +38,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -48,7 +49,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, enabledRepos []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	welcomeConfig := map[string]string{}
 	for _, repo := range enabledRepos {
 		messageTemplate := welcomeMessageForRepo(config, repo.Org, repo.Repo)

--- a/prow/plugins/welcome/welcome_test.go
+++ b/prow/plugins/welcome/welcome_test.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -427,14 +428,14 @@ func TestPluginConfig(t *testing.T) {
 }
 
 func TestHelpProvider(t *testing.T) {
-	enabledRepos := []plugins.Repo{
+	enabledRepos := []config.OrgRepo{
 		{Org: "org1", Repo: "repo"},
 		{Org: "org2", Repo: "repo"},
 	}
 	cases := []struct {
 		name         string
 		config       *plugins.Configuration
-		enabledRepos []plugins.Repo
+		enabledRepos []config.OrgRepo
 		err          bool
 	}{
 		{

--- a/prow/plugins/wip/BUILD.bazel
+++ b/prow/plugins/wip/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/wip",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/pluginhelp"
@@ -55,7 +56,7 @@ func init() {
 	plugins.RegisterPullRequestHandler(PluginName, handlePullRequest, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
 			Description: "The wip (Work In Progress) plugin applies the '" + labels.WorkInProgress + "' Label to pull requests whose title starts with 'WIP' or are in the 'draft' stage, and removes it from pull requests when they remove the title prefix or become ready for review. The '" + labels.WorkInProgress + "' Label is typically used to block a pull request from merging while it is still in progress.",

--- a/prow/plugins/yuks/BUILD.bazel
+++ b/prow/plugins/yuks/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     srcs = ["yuks.go"],
     importpath = "k8s.io/test-infra/prow/plugins/yuks",
     deps = [
+        "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/plugins/yuks/yuks.go
+++ b/prow/plugins/yuks/yuks.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
@@ -45,7 +46,7 @@ func init() {
 	plugins.RegisterGenericCommentHandler(pluginName, handleGenericComment, helpProvider)
 }
 
-func helpProvider(config *plugins.Configuration, _ []plugins.Repo) (*pluginhelp.PluginHelp, error) {
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// The Config field is omitted because this plugin is not configurable.
 	pluginHelp := &pluginhelp.PluginHelp{
 		Description: "The yuks plugin comments with jokes in response to the `/joke` command.",

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -841,7 +841,7 @@ func prNumbers(prs []PullRequest) []int {
 }
 
 func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker) ([]PullRequest, []config.Presubmit, error) {
-	batchLimit := c.config().Tide.BatchSizeLimit(sp.org, sp.repo)
+	batchLimit := c.config().Tide.BatchSizeLimit(config.OrgRepo{Org: sp.org, Repo: sp.repo})
 	if batchLimit < 0 {
 		sp.log.Debug("Batch merges disabled by configuration in this repo.")
 		return nil, nil, nil
@@ -967,8 +967,9 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 	log := sp.log.WithField("merge-targets", prNumbers(prs))
 	for i, pr := range prs {
 		log := log.WithFields(pr.logFields())
-		mergeMethod := c.config().Tide.MergeMethod(sp.org, sp.repo)
-		commitTemplates := c.config().Tide.MergeCommitTemplate(sp.org, sp.repo)
+		repo := config.OrgRepo{Org: sp.org, Repo: sp.repo}
+		mergeMethod := c.config().Tide.MergeMethod(repo)
+		commitTemplates := c.config().Tide.MergeCommitTemplate(repo)
 		squashLabel := c.config().Tide.SquashLabel
 		rebaseLabel := c.config().Tide.RebaseLabel
 		mergeLabel := c.config().Tide.MergeLabel


### PR DESCRIPTION
Relates to #16223
I had to move the struct to its own package to avoid circular dependency between prow/plugins and prow/config.
/assign @alvaroaleman 