### PR TITLE
Boskos ranch: Use crd types

### DIFF
--- a/boskos/cleaner/BUILD.bazel
+++ b/boskos/cleaner/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "//boskos/mason:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
@@ -32,8 +33,11 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "//boskos/mason:go_default_library",
         "//boskos/ranch:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/boskos/cleaner/cleaner.go
+++ b/boskos/cleaner/cleaner.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/crds"
 	"k8s.io/test-infra/boskos/mason"
 )
 
@@ -47,7 +48,7 @@ type Cleaner struct {
 }
 
 type cleanerStorage interface {
-	GetDynamicResourceLifeCycles() ([]common.DynamicResourceLifeCycle, error)
+	GetDynamicResourceLifeCycles() (*crds.DRLCObjectList, error)
 }
 
 // NewCleaner creates and initialized a new Cleaner object
@@ -80,8 +81,8 @@ func (c *Cleaner) recycleAll(ctx context.Context) {
 				logrus.WithError(err).Warn("could not get resources")
 				continue
 			}
-			for _, r := range dRLCs {
-				if res, err := c.client.Acquire(r.Type, common.ToBeDeleted, common.Cleaning); err != nil {
+			for _, r := range dRLCs.Items {
+				if res, err := c.client.Acquire(r.Name, common.ToBeDeleted, common.Cleaning); err != nil {
 					logrus.WithError(err).Debug("boskos acquire failed!")
 				} else {
 					c.recycleOne(res)

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -155,11 +155,6 @@ func NewMetric(rtype string) Metric {
 	}
 }
 
-// IsInUse reports if the resource is owned by anything else than Boskos.
-func (res *Resource) IsInUse() bool {
-	return res.Owner != ""
-}
-
 // NewResource creates a new Boskos Resource.
 func NewResource(name, rtype, state, owner string, t time.Time) Resource {
 	// If no state defined, mark as Free
@@ -202,13 +197,6 @@ type UserDataNotFound struct {
 func (ud *UserDataNotFound) Error() string {
 	return fmt.Sprintf("user data ID %s does not exist", ud.ID)
 }
-
-// ResourceByUpdateTime helps sorting resources by update time
-type ResourceByUpdateTime []Resource
-
-func (ut ResourceByUpdateTime) Len() int           { return len(ut) }
-func (ut ResourceByUpdateTime) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
-func (ut ResourceByUpdateTime) Less(i, j int) bool { return ut[i].LastUpdate.Before(ut[j].LastUpdate) }
 
 // ResourceByName helps sorting resources by name
 type ResourceByName []Resource

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -167,7 +167,6 @@ func NewResource(name, rtype, state, owner string, t time.Time) Resource {
 		State:      state,
 		Owner:      owner,
 		LastUpdate: t,
-		UserData:   &UserData{},
 	}
 }
 

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -204,29 +204,6 @@ func (ut ResourceByName) Len() int           { return len(ut) }
 func (ut ResourceByName) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
 func (ut ResourceByName) Less(i, j int) bool { return ut[i].GetName() < ut[j].GetName() }
 
-// ResourceByDeleteState helps sorting resources by state, putting Tombstone first, then ToBeDeleted,
-// and sorting alphabetacally by resource name
-type ResourceByDeleteState []Resource
-
-func (ut ResourceByDeleteState) Len() int      { return len(ut) }
-func (ut ResourceByDeleteState) Swap(i, j int) { ut[i], ut[j] = ut[j], ut[i] }
-func (ut ResourceByDeleteState) Less(i, j int) bool {
-	order := map[string]int{Tombstone: 0, ToBeDeleted: 1}
-	stateIndex := func(s string) int {
-		i, ok := order[s]
-		if ok {
-			return i
-		}
-		return 2
-	}
-	indexI := stateIndex(ut[i].State)
-	indexJ := stateIndex(ut[i].State)
-	if indexI == indexJ {
-		return ut[i].GetName() < ut[j].GetName()
-	}
-	return indexI < indexJ
-}
-
 // CommaSeparatedStrings is used to parse comma separated string flag into a list of strings
 type CommaSeparatedStrings []string
 

--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -85,12 +85,6 @@ func NewDynamicResourceLifeCycleFromConfig(e ResourceEntry) DynamicResourceLifeC
 	}
 }
 
-// NewResourceFromNewDynamicResourceLifeCycle creates a resource from DynamicResourceLifeCycle given a name and a time.
-// Using this method helps make sure all the resources are created the same way.
-func NewResourceFromNewDynamicResourceLifeCycle(name string, dlrc *DynamicResourceLifeCycle, now time.Time) Resource {
-	return NewResource(name, dlrc.Type, dlrc.InitialState, "", now)
-}
-
 // Copy returns a copy of the TypeToResources
 func (t TypeToResources) Copy() TypeToResources {
 	n := TypeToResources{}

--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -153,6 +153,7 @@ type Type struct {
 
 // Object extends the runtime.Object interface. CRD are just a representation of the actual boskos object
 // which should implements the common.Item interface.
+// TODO: Should be removed, see https://github.com/kubernetes/test-infra/issues/16418
 type Object interface {
 	runtime.Object
 	GetName() string

--- a/boskos/crds/drlc_crd.go
+++ b/boskos/crds/drlc_crd.go
@@ -93,7 +93,7 @@ func (in *DRLCObject) DeepCopyObject() runtime.Object {
 	return nil
 }
 
-func (in *DRLCObject) toDynamicResourceLifeCycle() common.DynamicResourceLifeCycle {
+func (in *DRLCObject) ToDynamicResourceLifeCycle() common.DynamicResourceLifeCycle {
 	return common.DynamicResourceLifeCycle{
 		Type:         in.Name,
 		InitialState: in.Spec.InitialState,
@@ -134,7 +134,7 @@ func FromDynamicResourceLifecycle(r common.DynamicResourceLifeCycle) *DRLCObject
 
 // ToItem implements the Object interface
 func (in *DRLCObject) ToItem() common.Item {
-	return in.toDynamicResourceLifeCycle()
+	return in.ToDynamicResourceLifeCycle()
 }
 
 // FromItem implements the Object interface

--- a/boskos/crds/drlc_crd.go
+++ b/boskos/crds/drlc_crd.go
@@ -115,6 +115,23 @@ func (in *DRLCObject) fromDynamicResourceLifeCycle(r common.DynamicResourceLifeC
 	in.Spec.Needs = r.Needs
 }
 
+// FromDynamicResourceLifecycle converts a common.DynamicResourceLifeCycle into a *DRLCObject
+func FromDynamicResourceLifecycle(r common.DynamicResourceLifeCycle) *DRLCObject {
+	return &DRLCObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name: r.Type,
+		},
+		Spec: DRLCSpec{
+			InitialState: r.InitialState,
+			MinCount:     r.MinCount,
+			MaxCount:     r.MaxCount,
+			LifeSpan:     r.LifeSpan,
+			Config:       r.Config,
+			Needs:        r.Needs,
+		},
+	}
+}
+
 // ToItem implements the Object interface
 func (in *DRLCObject) ToItem() common.Item {
 	return in.toDynamicResourceLifeCycle()

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -97,7 +97,9 @@ func (in *ResourceObject) DeepCopyObject() runtime.Object {
 	return nil
 }
 
-func (in *ResourceObject) toResource() common.Resource {
+// ToResource returns the common.Resource representation for
+// a ResourceObject
+func (in *ResourceObject) ToResource() common.Resource {
 	return common.Resource{
 		Name:           in.Name,
 		Type:           in.Spec.Type,
@@ -111,7 +113,7 @@ func (in *ResourceObject) toResource() common.Resource {
 
 // ToItem implements Object interface
 func (in *ResourceObject) ToItem() common.Item {
-	return in.toResource()
+	return in.ToResource()
 }
 
 func (in *ResourceObject) fromResource(r common.Resource) {
@@ -129,6 +131,25 @@ func (in *ResourceObject) FromItem(i common.Item) {
 	r, err := common.ItemToResource(i)
 	if err == nil {
 		in.fromResource(r)
+	}
+}
+
+// FromResource converts a common.Resource to a *ResourceObject
+func FromResource(r common.Resource) *ResourceObject {
+	return &ResourceObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name: r.Name,
+		},
+		Spec: ResourceSpec{
+			Type: r.Type,
+		},
+		Status: ResourceStatus{
+			Owner:          r.Owner,
+			State:          r.State,
+			LastUpdate:     r.LastUpdate,
+			UserData:       r.UserData,
+			ExpirationDate: r.ExpirationDate,
+		},
 	}
 }
 
@@ -172,4 +193,26 @@ func (in *ResourceObjectList) DeepCopyObject() runtime.Object {
 		return c
 	}
 	return nil
+}
+
+// NewResource creates a new Boskos Resource.
+func NewResource(name, rtype, state, owner string, t time.Time) *ResourceObject {
+	// If no state defined, mark as Free
+	if state == "" {
+		state = common.Free
+	}
+
+	return &ResourceObject{
+		ObjectMeta: v1.ObjectMeta{
+			Name: name,
+		},
+		Spec: ResourceSpec{
+			Type: rtype,
+		},
+		Status: ResourceStatus{
+			State:      state,
+			Owner:      owner,
+			LastUpdate: t,
+		},
+	}
 }

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -67,11 +67,6 @@ type ResourceStatus struct {
 	ExpirationDate *time.Time       `json:"expirationDate,omitempty"`
 }
 
-// GetName returns a unique identifier for a given resource
-func (in *ResourceObject) GetName() string {
-	return in.Name
-}
-
 func (in *ResourceObject) deepCopyInto(out *ResourceObject) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -131,6 +131,9 @@ func (in *ResourceObject) FromItem(i common.Item) {
 
 // FromResource converts a common.Resource to a *ResourceObject
 func FromResource(r common.Resource) *ResourceObject {
+	if r.UserData == nil {
+		r.UserData = &common.UserData{}
+	}
 	return &ResourceObject{
 		ObjectMeta: v1.ObjectMeta{
 			Name: r.Name,
@@ -208,6 +211,7 @@ func NewResource(name, rtype, state, owner string, t time.Time) *ResourceObject 
 			State:      state,
 			Owner:      owner,
 			LastUpdate: t,
+			UserData:   &common.UserData{},
 		},
 	}
 }

--- a/boskos/handlers/BUILD.bazel
+++ b/boskos/handlers/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//boskos/common:go_default_library",
         "//boskos/crds:go_default_library",
         "//boskos/ranch:go_default_library",
+        "@com_github_go_test_deep//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",

--- a/boskos/handlers/handlers.go
+++ b/boskos/handlers/handlers.go
@@ -118,14 +118,13 @@ func handleAcquire(r *ranch.Ranch) http.HandlerFunc {
 		logrus.Infof("Request for a %v %v from %v, dest %v", state, rtype, owner, dest)
 
 		resource, err := r.Acquire(rtype, state, dest, owner, requestID)
-
 		if err != nil {
 			logrus.WithError(err).Errorf("No available resource")
 			http.Error(res, err.Error(), errorToStatus(err))
 			return
 		}
 
-		resJSON, err := json.Marshal(resource)
+		resJSON, err := json.Marshal(resource.ToResource())
 		if err != nil {
 			logrus.WithError(err).Errorf("json.Marshal failed: %v, resource will be released", resource)
 			http.Error(res, err.Error(), errorToStatus(err))

--- a/boskos/handlers/handlers.go
+++ b/boskos/handlers/handlers.go
@@ -183,10 +183,15 @@ func handleAcquireByState(r *ranch.Ranch) http.HandlerFunc {
 			return
 		}
 
+		var apiResources []common.Resource
+		for _, resource := range resources {
+			apiResources = append(apiResources, resource.ToResource())
+		}
+
 		resBytes := new(bytes.Buffer)
 
-		if err := json.NewEncoder(resBytes).Encode(resources); err != nil {
-			logrus.WithError(err).Errorf("json.Marshal failed: %v, resources will be released", resources)
+		if err := json.NewEncoder(resBytes).Encode(apiResources); err != nil {
+			logrus.WithError(err).Errorf("json.Marshal failed: %v, resources will be released", apiResources)
 			http.Error(res, err.Error(), errorToStatus(err))
 			for _, resource := range resources {
 				err := r.Release(resource.Name, state, owner)

--- a/boskos/handlers/handlers_test.go
+++ b/boskos/handlers/handlers_test.go
@@ -221,8 +221,8 @@ func TestAcquire(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error getting resource: %v", err)
 				}
-				if resources[0].Owner != "o" {
-					t.Errorf("%s - Wrong owner. Got %v, expect o", tc.name, resources[0].Owner)
+				if resources.Items[0].Status.Owner != "o" {
+					t.Errorf("%s - Wrong owner. Got %v, expect o", tc.name, resources.Items[0].Status.Owner)
 				}
 			}
 		})
@@ -356,12 +356,12 @@ func TestRelease(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error getting resource: %v", err)
 				}
-				if resources[0].State != "d" {
-					t.Errorf("%s - Wrong state. Got %v, expect d", tc.name, resources[0].State)
+				if resources.Items[0].Status.State != "d" {
+					t.Errorf("%s - Wrong state. Got %v, expect d", tc.name, resources.Items[0].Status.State)
 				}
 
-				if resources[0].Owner != "" {
-					t.Errorf("%s - Wrong owner. Got %v, expect empty", tc.name, resources[0].Owner)
+				if resources.Items[0].Status.Owner != "" {
+					t.Errorf("%s - Wrong owner. Got %v, expect empty", tc.name, resources.Items[0].Status.Owner)
 				}
 			}
 		})
@@ -701,7 +701,7 @@ func TestUpdate(t *testing.T) {
 				if err != nil {
 					t.Fatalf("error getting resources: %v", err)
 				}
-				if resources[0].LastUpdate == FakeNow {
+				if resources.Items[0].Status.LastUpdate == FakeNow {
 					t.Errorf("%s - Timestamp is not updated!", tc.name)
 				}
 			}

--- a/boskos/mason/BUILD.bazel
+++ b/boskos/mason/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
@@ -22,6 +23,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
         "//boskos/ranch:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],

--- a/boskos/mason/mason.go
+++ b/boskos/mason/mason.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/crds"
 )
 
 const (
@@ -41,10 +42,10 @@ type ConfigConverter func(string) (Masonable, error)
 
 type storageAccess interface {
 	// GetDynamicResourceLifeCycle gets an existing dynamic resource life cycle, errors otherwise
-	GetDynamicResourceLifeCycle(name string) (common.DynamicResourceLifeCycle, error)
+	GetDynamicResourceLifeCycle(name string) (*crds.DRLCObject, error)
 
 	// GetDynamicResourceLifeCycles list all dynamic resource life cycle
-	GetDynamicResourceLifeCycles() ([]common.DynamicResourceLifeCycle, error)
+	GetDynamicResourceLifeCycles() (*crds.DRLCObjectList, error)
 }
 
 type boskosClient interface {
@@ -188,9 +189,9 @@ func (m *Mason) cleanOne(ctx context.Context, res *common.Resource, leasedResour
 		logrus.WithError(err).Errorf("failed to get config for resource %s", res.Type)
 		return err
 	}
-	config, err := m.convertConfig(&configEntry)
+	config, err := m.convertConfig(drlcPtr(configEntry.ToDynamicResourceLifeCycle()))
 	if err != nil {
-		logrus.WithError(err).Errorf("failed to convert config type %s - \n%s", configEntry.Config.Type, configEntry.Config.Content)
+		logrus.WithError(err).Errorf("failed to convert config type %s - \n%s", configEntry.Spec.Config.Type, configEntry.Spec.Config.Content)
 		return err
 	}
 
@@ -283,8 +284,8 @@ func (m *Mason) recycleAll(ctx context.Context) {
 				continue
 			}
 			var configTypes []string
-			for _, c := range configs {
-				_, isRegistered := m.configConverters[c.Config.Type]
+			for _, c := range configs.Items {
+				_, isRegistered := m.configConverters[c.Spec.Config.Type]
 				if isRegistered {
 					configTypes = append(configTypes, c.GetName())
 				}
@@ -339,7 +340,7 @@ func (m *Mason) recycleOne(res *common.Resource) (*requirements, error) {
 
 	return &requirements{
 		fulfillment: common.TypeToResources{},
-		needs:       configEntry.Needs,
+		needs:       configEntry.Spec.Needs,
 		resource:    *res,
 	}, nil
 }
@@ -476,4 +477,12 @@ func (m *Mason) Stop() {
 	close(m.fulfilled)
 	m.client.ReleaseAll(common.Dirty)
 	logrus.Info("Mason stopped")
+}
+
+func resourcePtr(r common.Resource) *common.Resource {
+	return &r
+}
+
+func drlcPtr(drlc common.DynamicResourceLifeCycle) *common.DynamicResourceLifeCycle {
+	return &drlc
 }

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -26,6 +26,7 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/crds"
 	"k8s.io/test-infra/boskos/ranch"
 )
 
@@ -113,28 +114,40 @@ func createFakeBoskos(tc testConfig) (*ranch.Storage, *Client, chan releasedReso
 				res.State = common.Dirty
 				if _, ok := configNames[rtype]; !ok {
 					configNames[rtype] = true
-					s.AddDynamicResourceLifeCycle(common.DynamicResourceLifeCycle{
+					s.AddDynamicResourceLifeCycle(crds.FromDynamicResourceLifecycle(common.DynamicResourceLifeCycle{
 						Config: common.ConfigType{
 							Type:    fakeConfigType,
 							Content: emptyContent,
 						},
 						Type:  rtype,
 						Needs: *c.resourceNeeds,
-					})
+					}))
 				}
 			}
-			s.AddResource(res)
+			s.AddResource(crds.FromResource(res))
 		}
 	}
 	return s, NewClient(&fakeBoskos{ranch: r, releasedResources: names}), names
 }
 
 func (fb *fakeBoskos) Acquire(rtype, state, dest string) (*common.Resource, error) {
-	return fb.ranch.Acquire(rtype, state, dest, owner, "")
+	crd, err := fb.ranch.Acquire(rtype, state, dest, owner, "")
+	if crd != nil {
+		return resourcePtr(crd.ToResource()), err
+	}
+	return nil, err
 }
 
 func (fb *fakeBoskos) AcquireByState(state, dest string, names []string) ([]common.Resource, error) {
-	return fb.ranch.AcquireByState(state, dest, owner, names)
+	crds, err := fb.ranch.AcquireByState(state, dest, owner, names)
+	var resources []common.Resource
+	for _, crd := range crds {
+		if crd == nil {
+			continue
+		}
+		resources = append(resources, crd.ToResource())
+	}
+	return resources, err
 }
 
 func (fb *fakeBoskos) ReleaseOne(name, dest string) error {
@@ -175,12 +188,18 @@ func TestRecycleLeasedResources(t *testing.T) {
 	}
 
 	rStorage, mClient, _ := createFakeBoskos(tc)
-	res1, _ := rStorage.GetResource("type1_0")
+	res1CRD, _ := rStorage.GetResource("type1_0")
+	res1 := res1CRD.ToResource()
 	res1.State = "type2_0"
-	rStorage.UpdateResource(res1)
-	res2, _ := rStorage.GetResource("type2_0")
-	res2.UserData.Set(LeasedResources, &[]string{"type1_0"})
-	rStorage.UpdateResource(res2)
+	rStorage.UpdateResource(crds.FromResource(res1))
+	res2CRD, _ := rStorage.GetResource("type2_0")
+	res2 := res2CRD.ToResource()
+	if err := res2.UserData.Set(LeasedResources, &[]string{"type1_0"}); err != nil {
+		t.Fatalf("setting userdata failed: %v", err)
+	}
+	if _, err := rStorage.UpdateResource(crds.FromResource(res2)); err != nil {
+		t.Fatalf("failed to update: %v", err)
+	}
 	m := NewMason(1, mClient.basic, defaultWaitPeriod, defaultWaitPeriod, rStorage)
 	m.RegisterConfigConverter(fakeConfigType, fakeConfigConverter)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -193,8 +212,10 @@ func TestRecycleLeasedResources(t *testing.T) {
 		t.Errorf("Timeout")
 	}
 	m.Stop()
-	res1, _ = rStorage.GetResource("type1_0")
-	res2, _ = rStorage.GetResource("type2_0")
+	res1CRD, _ = rStorage.GetResource("type1_0")
+	res2CRD, _ = rStorage.GetResource("type2_0")
+	res1 = res1CRD.ToResource()
+	res2 = res2CRD.ToResource()
 	if res2.State != common.Cleaning {
 		t.Errorf("Resource state should be cleaning, found %s", res2.State)
 	}
@@ -231,10 +252,10 @@ func TestRecycleNoLeasedResources(t *testing.T) {
 	m.Stop()
 	res1, _ := rStorage.GetResource("type1_0")
 	res2, _ := rStorage.GetResource("type2_0")
-	if res2.State != common.Cleaning {
+	if res2.Status.State != common.Cleaning {
 		t.Errorf("Resource state should be cleaning")
 	}
-	if res1.State != common.Free {
+	if res1.Status.State != common.Free {
 		t.Errorf("Resource state should be untouched, current %s", mClient.resources["type1_0"].State)
 	}
 }
@@ -311,8 +332,8 @@ func TestCleanOne(t *testing.T) {
 				t.Errorf("unexpected error %v", err)
 				t.FailNow()
 			}
-			for _, res := range resources {
-				if res.State != common.Dirty {
+			for _, res := range resources.Items {
+				if res.Status.State != common.Dirty {
 					tt.Errorf("resource %v should be released as dirty", res)
 				}
 
@@ -343,7 +364,7 @@ func TestFulfillOne(t *testing.T) {
 	}
 	req := requirements{
 		resource:    *res,
-		needs:       conf.Needs,
+		needs:       conf.Spec.Needs,
 		fulfillment: common.TypeToResources{},
 	}
 	if err = m.fulfillOne(context.Background(), &req); err != nil {
@@ -357,10 +378,11 @@ func TestFulfillOne(t *testing.T) {
 	}
 	userRes := req.fulfillment["type1"][0]
 	leasedResource, _ := rStorage.GetResource(userRes.Name)
-	if leasedResource.State != common.Leased {
+	if leasedResource.Status.State != common.Leased {
 		t.Errorf("State should be Leased")
 	}
-	*res, _ = rStorage.GetResource(res.Name)
+	resCRD, _ := rStorage.GetResource(res.Name)
+	*res = resCRD.ToResource()
 	var leasedResources common.LeasedResources
 	if res.UserData.Extract(LeasedResources, &leasedResources); err != nil {
 		t.Errorf("unable to extract %s", LeasedResources)
@@ -425,7 +447,7 @@ loop:
 		r.UserData.Extract(LeasedResources, &leasedResources)
 		for _, name := range leasedResources {
 			r, _ := rStorage.GetResource(name)
-			l = append(l, r)
+			l = append(l, r.ToResource())
 		}
 		return
 	}
@@ -460,9 +482,9 @@ loop:
 		}
 	}
 	resources, _ := rStorage.GetResources()
-	for _, r := range resources {
-		if r.State != common.Dirty {
-			t.Errorf("state should be %s, found %s", common.Dirty, r.State)
+	for _, r := range resources.Items {
+		if r.Status.State != common.Dirty {
+			t.Errorf("state should be %s, found %s", common.Dirty, r.Status.State)
 		}
 	}
 }

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -16,7 +16,9 @@ go_test(
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/crds:go_default_library",
+        "@com_github_go_test_deep//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -39,10 +39,6 @@ type Ranch struct {
 	now func() time.Time
 }
 
-func updateTime() time.Time {
-	return time.Now()
-}
-
 // Public errors:
 
 // ResourceNotFound will be returned if requested resource does not exist.
@@ -244,10 +240,7 @@ func (r *Ranch) AcquireByState(state, dest, owner string, names []string) ([]*cr
 	}
 
 	if rNames.Len() != 0 {
-		var missingResources []string
-		for _, n := range rNames.List() {
-			missingResources = append(missingResources, n)
-		}
+		missingResources := rNames.List()
 		err := &ResourceNotFound{state}
 		logrus.WithError(err).Errorf("could not find required resources %s", strings.Join(missingResources, ", "))
 		return resources, err

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -25,7 +25,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-test/deep"
 	"github.com/sirupsen/logrus"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -63,12 +65,13 @@ func fakeTime(t time.Time) time.Time {
 	return now
 }
 
+const testNS = "test"
+
 func MakeTestRanch(objects []runtime.Object) *Ranch {
-	const ns = "test"
 	for _, obj := range objects {
-		obj.(metav1.Object).SetNamespace(ns)
+		obj.(metav1.Object).SetNamespace(testNS)
 	}
-	s, _ := NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(objects...), ns, "")
+	s, _ := NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(objects...), testNS, "")
 	s.now = func() time.Time {
 		return fakeNow
 	}
@@ -203,18 +206,18 @@ func TestAcquire(t *testing.T) {
 		}
 
 		if err == nil {
-			if res.State != tc.dest {
-				t.Errorf("%s - Wrong final state. Got %v, expected %v", tc.name, res.State, tc.dest)
+			if res.Status.State != tc.dest {
+				t.Errorf("%s - Wrong final state. Got %v, expected %v", tc.name, res.Status.State, tc.dest)
 			}
-			if !reflect.DeepEqual(*res, resources[0]) {
-				t.Errorf("%s - Wrong resource. Got %v, expected %v", tc.name, res, resources[0])
-			} else if !res.LastUpdate.After(startTime) {
+			if !reflect.DeepEqual(*res, resources.Items[0]) {
+				t.Errorf("%s - Wrong resource. Got %v, expected %v", tc.name, res, resources.Items[0])
+			} else if !res.Status.LastUpdate.After(startTime) {
 				t.Errorf("%s - LastUpdate did not update.", tc.name)
 			}
 		} else {
-			for _, res := range resources {
-				if res.LastUpdate != startTime {
-					t.Errorf("%s - LastUpdate should not update. Got %v, expected %v", tc.name, resources[0].LastUpdate, startTime)
+			for _, res := range resources.Items {
+				if res.Status.LastUpdate != startTime {
+					t.Errorf("%s - LastUpdate should not update. Got %v, expected %v", tc.name, resources.Items[0].Status.LastUpdate, startTime)
 				}
 			}
 		}
@@ -225,41 +228,41 @@ func TestAcquirePriority(t *testing.T) {
 	now := time.Now()
 	expiredFuture := now.Add(2 * testTTL)
 	owner := "tester"
-	res := common.NewResource("res", "type", common.Free, "", now)
+	res := crds.NewResource("res", "type", common.Free, "", now)
 	r := MakeTestRanch(nil)
 	r.requestMgr.now = func() time.Time { return now }
 
 	// Setting Priority, this request will fail
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1"); err == nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, "request_id_1"); err == nil {
 		t.Errorf("should fail as there are not resource available")
 	}
 	if err := r.Storage.AddResource(res); err != nil {
 		t.Fatalf("failed to add resource: %v", err)
 	}
 	// Attempting to acquire this resource without priority
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err == nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, ""); err == nil {
 		t.Errorf("should fail as there is only resource, and it is prioritizes to request_id_1")
 	}
 	// Attempting to acquire this resource with priority, which will set a place in the queue
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_2"); err == nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, "request_id_2"); err == nil {
 		t.Errorf("should fail as there is only resource, and it is prioritizes to request_id_1")
 	}
 	// Attempting with the first request
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1"); err != nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, "request_id_1"); err != nil {
 		t.Fatalf("should succeed since the request priority should match its rank in the queue. got %v", err)
 	}
 	r.Release(res.Name, common.Free, "tester")
 	// Attempting with the first request
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, "request_id_1"); err == nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, "request_id_1"); err == nil {
 		t.Errorf("should not succeed since this request has already been fulfilled")
 	}
 	// Attempting to acquire this resource without priority
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err == nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, ""); err == nil {
 		t.Errorf("should fail as request_id_2 has rank 1 now")
 	}
 	r.requestMgr.cleanup(expiredFuture)
 	// Attempting to acquire this resource without priority
-	if _, err := r.Acquire(res.Type, res.State, common.Dirty, owner, ""); err != nil {
+	if _, err := r.Acquire(res.Spec.Type, res.Status.State, common.Dirty, owner, ""); err != nil {
 		t.Errorf("request_id_2 expired, this should work now, got %v", err)
 	}
 }
@@ -314,7 +317,7 @@ func TestAcquireOnDemand(t *testing.T) {
 	}
 	if resources, err := c.Storage.GetResources(); err != nil {
 		t.Fatal(err)
-	} else if len(resources) != 1 {
+	} else if len(resources.Items) != 1 {
 		t.Fatal("A resource should have been created")
 	}
 	// Attempting to create another resource
@@ -323,7 +326,7 @@ func TestAcquireOnDemand(t *testing.T) {
 	}
 	if resources, err := c.Storage.GetResources(); err != nil {
 		t.Error(err)
-	} else if len(resources) != 1 {
+	} else if len(resources.Items) != 1 {
 		t.Errorf("No new resource should have been created")
 	}
 	// Creating another
@@ -332,7 +335,7 @@ func TestAcquireOnDemand(t *testing.T) {
 	}
 	if resources, err := c.Storage.GetResources(); err != nil {
 		t.Error(err)
-	} else if len(resources) != 2 {
+	} else if len(resources.Items) != 2 {
 		t.Errorf("Another resource should have been created")
 	}
 	// Attempting to create another
@@ -342,10 +345,10 @@ func TestAcquireOnDemand(t *testing.T) {
 	resources, err := c.Storage.GetResources()
 	if err != nil {
 		t.Error(err)
-	} else if len(resources) != 2 {
+	} else if len(resources.Items) != 2 {
 		t.Errorf("No other resource should have been created")
 	}
-	for _, res := range resources {
+	for _, res := range resources.Items {
 		c.Storage.DeleteResource(res.Name)
 	}
 	if _, err := c.Acquire(rType, common.Free, common.Busy, owner, ""); err == nil {
@@ -353,16 +356,16 @@ func TestAcquireOnDemand(t *testing.T) {
 	}
 	if resources, err := c.Storage.GetResources(); err != nil {
 		t.Error(err)
-	} else if len(resources) != 0 {
+	} else if len(resources.Items) != 0 {
 		t.Errorf("No new resource should have been created")
 	}
 }
 
 func TestRelease(t *testing.T) {
 	var lifespan = time.Minute
-	updatedRes := common.NewResource("res", "t", "d", "", fakeNow)
+	updatedRes := crds.NewResource("res", "t", "d", "", fakeNow)
 	expirationDate := fakeTime(fakeNow.Add(lifespan))
-	updatedRes.ExpirationDate = &expirationDate
+	updatedRes.Status.ExpirationDate = &expirationDate
 	var testcases = []struct {
 		name        string
 		resource    *crds.ResourceObject
@@ -371,15 +374,14 @@ func TestRelease(t *testing.T) {
 		owner       string
 		dest        string
 		expectErr   error
-		expectedRes common.Resource
+		expectedRes *crds.ResourceObject
 	}{
 		{
-			name:        "ranch has no resource",
-			resName:     "res",
-			owner:       "user",
-			dest:        "d",
-			expectErr:   &ResourceNotFound{"res"},
-			expectedRes: common.Resource{},
+			name:      "ranch has no resource",
+			resName:   "res",
+			owner:     "user",
+			dest:      "d",
+			expectErr: &ResourceNotFound{"res"},
 		},
 		{
 			name:        "wrong owner",
@@ -388,16 +390,15 @@ func TestRelease(t *testing.T) {
 			owner:       "user",
 			dest:        "d",
 			expectErr:   &OwnerNotMatch{"user", "merlin"},
-			expectedRes: common.NewResource("res", "t", "s", "merlin", startTime),
+			expectedRes: crds.NewResource("res", "t", "s", "merlin", startTime),
 		},
 		{
-			name:        "no match name",
-			resource:    newResource("foo", "t", "s", "merlin", startTime),
-			resName:     "res",
-			owner:       "user",
-			dest:        "d",
-			expectErr:   &ResourceNotFound{"res"},
-			expectedRes: common.Resource{},
+			name:      "no match name",
+			resource:  newResource("foo", "t", "s", "merlin", startTime),
+			resName:   "res",
+			owner:     "user",
+			dest:      "d",
+			expectErr: &ResourceNotFound{"res"},
 		},
 		{
 			name:        "ok",
@@ -406,7 +407,7 @@ func TestRelease(t *testing.T) {
 			owner:       "merlin",
 			dest:        "d",
 			expectErr:   nil,
-			expectedRes: common.NewResource("res", "t", "d", "", fakeNow),
+			expectedRes: crds.NewResource("res", "t", "d", "", fakeNow),
 		},
 		{
 			name:     "ok - has dynamic resource lf no lifespan",
@@ -418,11 +419,11 @@ func TestRelease(t *testing.T) {
 			owner:       "merlin",
 			dest:        "d",
 			expectErr:   nil,
-			expectedRes: common.NewResource("res", "t", "d", "", fakeNow),
+			expectedRes: crds.NewResource("res", "t", "d", "", fakeNow),
 		},
 		{
 			name:     "ok - has dynamic resource lf with lifespan",
-			resource: newResource("res", "t", "s", "merlin", startTime),
+			resource: crds.NewResource("res", "t", "s", "merlin", startTime),
 			dResource: &crds.DRLCObject{
 				ObjectMeta: metav1.ObjectMeta{Name: "t"},
 				Spec:       crds.DRLCSpec{LifeSpan: &lifespan},
@@ -436,23 +437,29 @@ func TestRelease(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		var objs []runtime.Object
-		if tc.resource != nil {
-			objs = append(objs, tc.resource)
-		}
-		if tc.dResource != nil {
-			objs = append(objs, tc.dResource)
-		}
-		c := MakeTestRanch(objs)
-		releaseErr := c.Release(tc.resName, tc.dest, tc.owner)
-		if !AreErrorsEqual(releaseErr, tc.expectErr) {
-			t.Errorf("%s - Got error %v, expected error %v", tc.name, releaseErr, tc.expectErr)
-			continue
-		}
-		res, _ := c.Storage.GetResource(tc.resName)
-		if !reflect.DeepEqual(res, tc.expectedRes) {
-			t.Errorf("Test %v: got %v, expected %v", tc.name, res, tc.expectedRes)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			var objs []runtime.Object
+			if tc.resource != nil {
+				tc.resource.Namespace = testNS
+				objs = append(objs, tc.resource)
+			}
+			if tc.dResource != nil {
+				tc.dResource.Namespace = testNS
+				objs = append(objs, tc.dResource)
+			}
+			if tc.expectedRes != nil {
+				tc.expectedRes.Namespace = testNS
+			}
+			c := MakeTestRanch(objs)
+			releaseErr := c.Release(tc.resName, tc.dest, tc.owner)
+			if !AreErrorsEqual(releaseErr, tc.expectErr) {
+				t.Fatalf("Got error %v, expected error %v", releaseErr, tc.expectErr)
+			}
+			res, _ := c.Storage.GetResource(tc.resName)
+			if diff := deep.Equal(res, tc.expectedRes); diff != nil {
+				t.Errorf("result didn't match expected, diff: %v", diff)
+			}
+		})
 	}
 }
 
@@ -540,7 +547,7 @@ func TestReset(t *testing.T) {
 				t.Errorf("failed to get resources")
 				continue
 			}
-			if !resources[0].LastUpdate.After(startTime) {
+			if !resources.Items[0].Status.LastUpdate.After(startTime) {
 				t.Errorf("%s - LastUpdate did not update.", tc.name)
 			}
 		}
@@ -618,17 +625,17 @@ func TestUpdate(t *testing.T) {
 			}
 
 			if err == nil {
-				if resources[0].Owner != tc.owner {
-					t.Errorf("%s - Wrong owner after release. Got %v, expected %v", tc.name, resources[0].Owner, tc.owner)
-				} else if resources[0].State != tc.state {
-					t.Errorf("%s - Wrong state after release. Got %v, expected %v", tc.name, resources[0].State, tc.state)
-				} else if !resources[0].LastUpdate.After(startTime) {
+				if resources.Items[0].Status.Owner != tc.owner {
+					t.Errorf("%s - Wrong owner after release. Got %v, expected %v", tc.name, resources.Items[0].Status.Owner, tc.owner)
+				} else if resources.Items[0].Status.State != tc.state {
+					t.Errorf("%s - Wrong state after release. Got %v, expected %v", tc.name, resources.Items[0].Status.State, tc.state)
+				} else if !resources.Items[0].Status.LastUpdate.After(startTime) {
 					t.Errorf("%s - LastUpdate did not update.", tc.name)
 				}
 			} else {
-				for _, res := range resources {
-					if res.LastUpdate != startTime {
-						t.Errorf("%s - LastUpdate should not update. Got %v, expected %v", tc.name, resources[0].LastUpdate, startTime)
+				for _, res := range resources.Items {
+					if res.Status.LastUpdate != startTime {
+						t.Errorf("%s - LastUpdate should not update. Got %v, expected %v", tc.name, resources.Items[0].Status.LastUpdate, startTime)
 					}
 				}
 			}
@@ -815,8 +822,8 @@ func TestSyncResources(t *testing.T) {
 	var testcases = []struct {
 		name        string
 		currentRes  []runtime.Object
-		expectedRes []common.Resource
-		expectedLCs []common.DynamicResourceLifeCycle
+		expectedRes *crds.ResourceObjectList
+		expectedLCs *crds.DRLCObjectList
 		config      *common.BoskosConfig
 	}{
 		{
@@ -839,18 +846,20 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-1", "t", common.Free, "", startTime),
-				common.NewResource("dt_1", "mason", common.Free, "", startTime),
-				common.NewResource("dt_2", "mason", common.Free, "", startTime),
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-1", "t", common.Free, "", startTime),
+				*newResource("dt_1", "mason", common.Free, "", startTime),
+				*newResource("dt_2", "mason", common.Free, "", startTime),
 			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "mason",
-					MinCount: 2,
-					MaxCount: 4,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "mason"},
+					Spec: crds.DRLCSpec{
+						MinCount: 2,
+						MaxCount: 4,
+					}},
+			}},
 		},
 		{
 			name: "empty",
@@ -873,18 +882,20 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-1", "t", common.Free, "", startTime),
-				common.NewResource("res-2", "t", common.Free, "", fakeNow),
-				common.NewResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-1", "t", common.Free, "", startTime),
+				*newResource("res-2", "t", common.Free, "", fakeNow),
+				*newResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "should not change anything",
@@ -912,17 +923,19 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-1", "t", "", "", startTime),
-				common.NewResource("dt_1", "dt", "", "", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-1", "t", "", "", startTime),
+				*newResource("dt_1", "dt", "", "", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "delete, lifecycle should not delete dynamic res until all associated resources are gone",
@@ -938,16 +951,18 @@ func TestSyncResources(t *testing.T) {
 				},
 			},
 			config: &common.BoskosConfig{},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 0,
-					MaxCount: 0,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 0,
+						MaxCount: 0,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "delete, life cycle should be deleted as all resources are deleted",
@@ -976,17 +991,19 @@ func TestSyncResources(t *testing.T) {
 				},
 			},
 			config: &common.BoskosConfig{},
-			expectedRes: []common.Resource{
-				common.NewResource("res", "t", common.Busy, "o", startTime),
-				common.NewResource("dt_1", "dt", common.Busy, "o", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res", "t", common.Busy, "o", startTime),
+				*newResource("dt_1", "dt", common.Busy, "o", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 0,
-					MaxCount: 0,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 0,
+						MaxCount: 0,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "append and delete",
@@ -1021,25 +1038,29 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-2", "t", common.Free, "", fakeNow),
-				common.NewResource("dt_1", "dt", common.ToBeDeleted, "", startTime),
-				common.NewResource("dt_2", "dt", common.Free, "", startTime),
-				common.NewResource("dt_3", "dt", common.Free, "", startTime),
-				common.NewResource("new-dynamic-res-1", "dt2", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-2", "t", common.Free, "", fakeNow),
+				*newResource("dt_1", "dt", common.ToBeDeleted, "", startTime),
+				*newResource("dt_2", "dt", common.Free, "", startTime),
+				*newResource("dt_3", "dt", common.Free, "", startTime),
+				*newResource("new-dynamic-res-1", "dt2", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
 				{
-					Type:     "dt2",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt2"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "append and delete busy",
@@ -1074,25 +1095,29 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-1", "t", common.Busy, "o", startTime),
-				common.NewResource("res-2", "t", common.Free, "", fakeNow),
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("dt_3", "dt", common.Busy, "o", startTime),
-				common.NewResource("new-dynamic-res-1", "dt2", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-1", "t", common.Busy, "o", startTime),
+				*newResource("res-2", "t", common.Free, "", fakeNow),
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("dt_3", "dt", common.Busy, "o", startTime),
+				*newResource("new-dynamic-res-1", "dt2", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
 				{
-					Type:     "dt2",
-					MinCount: 1,
-					MaxCount: 2,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt2"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "append/delete mixed type",
@@ -1111,10 +1136,10 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("res-2", "t", "free", "", fakeNow),
-				common.NewResource("res-3", "t2", "free", "", fakeNow),
-			},
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("res-2", "t", "free", "", fakeNow),
+				*newResource("res-3", "t2", "free", "", fakeNow),
+			}},
 		},
 		{
 			name: "delete expired resource",
@@ -1144,20 +1169,22 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				setExpiration(
-					common.NewResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*setExpirationCRD(
+					newResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
 					startTime),
-				common.NewResource("dt_2", "dt", common.Free, "", startTime),
-				common.NewResource("dt_4", "dt", common.Free, "", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+				*newResource("dt_2", "dt", common.Free, "", startTime),
+				*newResource("dt_4", "dt", common.Free, "", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 2,
-					MaxCount: 4,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 2,
+						MaxCount: 4,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "delete expired resource / do not delete busy",
@@ -1187,20 +1214,22 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_2", "dt", common.Free, "", startTime),
-				setExpiration(
-					common.NewResource("dt_3", "dt", common.Busy, "o", startTime),
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_2", "dt", common.Free, "", startTime),
+				*setExpirationCRD(
+					newResource("dt_3", "dt", common.Busy, "o", startTime),
 					startTime),
-				common.NewResource("dt_4", "dt", common.Busy, "o", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+				*newResource("dt_4", "dt", common.Busy, "o", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 3,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 3,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "delete expired resource, recreate up to Min",
@@ -1230,21 +1259,23 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				setExpiration(
-					common.NewResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*setExpirationCRD(
+					newResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
 					startTime),
-				common.NewResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
-				common.NewResource("dt_2", "dt", common.Free, "", startTime),
-				common.NewResource("dt_4", "dt", common.Free, "", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+				*newResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
+				*newResource("dt_2", "dt", common.Free, "", startTime),
+				*newResource("dt_4", "dt", common.Free, "", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 4,
-					MaxCount: 6,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 4,
+						MaxCount: 6,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "decrease max count with resources being deleted",
@@ -1271,19 +1302,21 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_3", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_4", "dt", common.ToBeDeleted, "", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_3", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_4", "dt", common.ToBeDeleted, "", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 1,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 1,
+					},
 				},
-			},
+			}},
 		},
 		{
 			name: "increase min count with resources being deleted",
@@ -1309,53 +1342,57 @@ func TestSyncResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("dt_2", "dt", common.ToBeDeleted, "", startTime),
-				common.NewResource("dt_3", "dt", common.ToBeDeleted, "", startTime),
-				common.NewResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("dt_2", "dt", common.ToBeDeleted, "", startTime),
+				*newResource("dt_3", "dt", common.ToBeDeleted, "", startTime),
+				*newResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 4,
-					MaxCount: 6,
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 4,
+						MaxCount: 6,
+					},
 				},
-			},
+			}},
 		},
 	}
 
 	for _, tc := range testcases {
-		c := MakeTestRanch(tc.currentRes)
-		c.Storage.SyncResources(tc.config)
-		resources, err := c.Storage.GetResources()
-		if err != nil {
-			t.Errorf("failed to get resources")
-			continue
-		}
-		sort.Stable(common.ResourceByName(resources))
-		sort.Stable(common.ResourceByName(tc.expectedRes))
-		if !reflect.DeepEqual(resources, tc.expectedRes) {
-			t.Errorf("Test %v: \n got \t\t%v, \n expected \t%v", tc.name, resources, tc.expectedRes)
-		}
-		lfs, err := c.Storage.GetDynamicResourceLifeCycles()
-		if err != nil {
-			t.Errorf("failed to get dynamic resources life cycles: %v", err)
-			continue
-		}
-		sort.SliceStable(lfs, func(i, j int) bool {
-			{
-				return lfs[i].GetName() < lfs[j].GetName()
+		t.Run(tc.name, func(t *testing.T) {
+			c := MakeTestRanch(tc.currentRes)
+			c.Storage.SyncResources(tc.config)
+			resources, err := c.Storage.GetResources()
+			if err != nil {
+				t.Fatalf("failed to get resources: %v", err)
+			}
+			if tc.expectedRes == nil {
+				tc.expectedRes = &crds.ResourceObjectList{}
+			}
+			sortResourcesLists(tc.expectedRes, resources)
+			for idx := range tc.expectedRes.Items {
+				tc.expectedRes.Items[idx].Namespace = testNS
+			}
+			if diff := deep.Equal(resources, tc.expectedRes); diff != nil {
+				t.Errorf("received resource differs from expected, diff: %v", diff)
+			}
+			lfs, err := c.Storage.GetDynamicResourceLifeCycles()
+			if err != nil {
+				t.Fatalf("failed to get dynamic resources life cycles: %v", err)
+			}
+			if tc.expectedLCs == nil {
+				tc.expectedLCs = &crds.DRLCObjectList{}
+			}
+			sortDRLCList(lfs, tc.expectedLCs)
+			for idx := range tc.expectedLCs.Items {
+				tc.expectedLCs.Items[idx].Namespace = testNS
+			}
+			if !apiequality.Semantic.DeepEqual(lfs, tc.expectedLCs) {
+				t.Errorf("received drlc do not match expected, diff: %v", deep.Equal(lfs, tc.expectedLCs))
 			}
 		})
-		sort.SliceStable(tc.expectedLCs, func(i, j int) bool {
-			{
-				return tc.expectedLCs[i].GetName() < tc.expectedLCs[j].GetName()
-			}
-		})
-		if !reflect.DeepEqual(lfs, tc.expectedLCs) {
-			t.Errorf("Test %v: \n got \t\t%v, \n expected %v", tc.name, lfs, tc.expectedLCs)
-		}
 	}
 }
 
@@ -1363,8 +1400,8 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 	var testcases = []struct {
 		name        string
 		currentRes  []runtime.Object
-		expectedRes []common.Resource
-		expectedLCs []common.DynamicResourceLifeCycle
+		expectedRes *crds.ResourceObjectList
+		expectedLCs *crds.DRLCObjectList
 	}{
 		{
 			name: "empty",
@@ -1382,17 +1419,18 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("t_1", "t", common.Free, "", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("t_1", "t", common.Free, "", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 4,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 4,
+					}},
+			}},
 		},
 		{
 			name: "delete expired free resources",
@@ -1417,31 +1455,32 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
 				// Unchanged because expiration is in the future
-				setExpiration(
-					common.NewResource("dt_1", "dt", common.Free, "", startTime),
+				*setExpirationCRD(
+					newResource("dt_1", "dt", common.Free, "", startTime),
 					fakeNow.Add(time.Hour)),
 				// Newly deleted
-				setExpiration(
-					common.NewResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
+				*setExpirationCRD(
+					newResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
 					startTime),
 				// Unchanged because owned
-				setExpiration(
-					common.NewResource("dt_3", "dt", common.Busy, "owner", startTime),
+				*setExpirationCRD(
+					newResource("dt_3", "dt", common.Busy, "owner", startTime),
 					startTime),
 				// Unchanged because already being deleted
-				setExpiration(
-					common.NewResource("dt_4", "dt", common.ToBeDeleted, "", startTime),
+				*setExpirationCRD(
+					newResource("dt_4", "dt", common.ToBeDeleted, "", startTime),
 					startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 4,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 4,
+					}},
+			}},
 		},
 		{
 			name: "no dynamic resources, nothing to make",
@@ -1454,13 +1493,14 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 0,
-					MaxCount: 4,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 0,
+						MaxCount: 4,
+					}},
+			}},
 		},
 		{
 			name: "no dynamic resources, make some",
@@ -1473,17 +1513,18 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
-				common.NewResource("new-dynamic-res-2", "dt", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
+				*newResource("new-dynamic-res-2", "dt", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 2,
-					MaxCount: 4,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 2,
+						MaxCount: 4,
+					}},
+			}},
 		},
 		{
 			name: "scale down",
@@ -1499,18 +1540,19 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_4", "dt", common.Busy, "owner", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_4", "dt", common.Busy, "owner", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					}},
+			}},
 		},
 		{
 			name: "replace some resources",
@@ -1527,19 +1569,20 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.Free, "", startTime),
-				common.NewResource("dt_2", "dt", common.Busy, "owner", startTime),
-				common.NewResource("dt_3", "dt", common.ToBeDeleted, "", startTime),
-				common.NewResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.Free, "", startTime),
+				*newResource("dt_2", "dt", common.Busy, "owner", startTime),
+				*newResource("dt_3", "dt", common.ToBeDeleted, "", startTime),
+				*newResource("new-dynamic-res-1", "dt", common.Free, "", fakeNow),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 4,
-					MaxCount: 8,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 4,
+						MaxCount: 8,
+					}},
+			}},
 		},
 		{
 			name: "scale down, busy > maxcount",
@@ -1556,19 +1599,20 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_2", "dt", common.Busy, "owner", startTime),
-				common.NewResource("dt_3", "dt", common.Busy, "owner", startTime),
-				common.NewResource("dt_4", "dt", common.Busy, "owner", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_2", "dt", common.Busy, "owner", startTime),
+				*newResource("dt_3", "dt", common.Busy, "owner", startTime),
+				*newResource("dt_4", "dt", common.Busy, "owner", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 1,
-					MaxCount: 2,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 1,
+						MaxCount: 2,
+					}},
+			}},
 		},
 		{
 			name: "delete all free when DRLC is being removed",
@@ -1585,18 +1629,19 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 					},
 				},
 			},
-			expectedRes: []common.Resource{
-				common.NewResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
-				common.NewResource("dt_4", "dt", common.Busy, "owner", startTime),
-			},
-			expectedLCs: []common.DynamicResourceLifeCycle{
+			expectedRes: &crds.ResourceObjectList{Items: []crds.ResourceObject{
+				*newResource("dt_1", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_2", "dt", common.ToBeDeleted, "", fakeNow),
+				*newResource("dt_4", "dt", common.Busy, "owner", startTime),
+			}},
+			expectedLCs: &crds.DRLCObjectList{Items: []crds.DRLCObject{
 				{
-					Type:     "dt",
-					MinCount: 0,
-					MaxCount: 0,
-				},
-			},
+					ObjectMeta: metav1.ObjectMeta{Name: "dt"},
+					Spec: crds.DRLCSpec{
+						MinCount: 0,
+						MaxCount: 0,
+					}},
+			}},
 		},
 		{
 			name: "delete DRLC when no resources remain",
@@ -1627,40 +1672,44 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
-		c := MakeTestRanch(tc.currentRes)
-		err := c.Storage.UpdateAllDynamicResources()
-		if err != nil {
-			t.Errorf("Test %v: error updating dynamic resources: %v", tc.name, err)
-			continue
-		}
-		resources, err := c.Storage.GetResources()
-		if err != nil {
-			t.Errorf("Test %v: failed to get resources: %v", tc.name, err)
-			continue
-		}
-		sort.Stable(common.ResourceByName(resources))
-		sort.Stable(common.ResourceByName(tc.expectedRes))
-		if !reflect.DeepEqual(resources, tc.expectedRes) {
-			t.Errorf("Test %v: \n got \t\t%v, \n expected \t%v", tc.name, resources, tc.expectedRes)
-		}
-		lfs, err := c.Storage.GetDynamicResourceLifeCycles()
-		if err != nil {
-			t.Errorf("Test %v: failed to get dynamic resources life cycles: %v", tc.name, err)
-			continue
-		}
-		sort.SliceStable(lfs, func(i, j int) bool {
-			{
-				return lfs[i].GetName() < lfs[j].GetName()
+		t.Run(tc.name, func(t *testing.T) {
+			c := MakeTestRanch(tc.currentRes)
+			err := c.Storage.UpdateAllDynamicResources()
+			if err != nil {
+				t.Fatalf("error updating dynamic resources: %v", err)
+			}
+			if tc.expectedRes == nil {
+				tc.expectedRes = &crds.ResourceObjectList{}
+			}
+			if tc.expectedLCs == nil {
+				tc.expectedLCs = &crds.DRLCObjectList{}
+			}
+			for idx := range tc.expectedRes.Items {
+				tc.expectedRes.Items[idx].Namespace = testNS
+			}
+			for idx := range tc.expectedLCs.Items {
+				tc.expectedLCs.Items[idx].Namespace = testNS
+			}
+			resources, err := c.Storage.GetResources()
+			if err != nil {
+				t.Fatalf("failed to get resources: %v", err)
+			}
+			sortResourcesLists(resources, tc.expectedRes)
+
+			if !reflect.DeepEqual(resources, tc.expectedRes) {
+				t.Errorf("diff:\n%v", deep.Equal(resources, tc.expectedRes))
+			}
+			lfs, err := c.Storage.GetDynamicResourceLifeCycles()
+			if err != nil {
+				t.Fatalf("failed to get dynamic resource life cycles: %v", err)
+			}
+
+			sortDRLCList(lfs, tc.expectedLCs)
+			if !apiequality.Semantic.DeepEqual(lfs, tc.expectedLCs) {
+				t.Errorf("Test %v: \n got \t\t%v, \n expected %v", tc.name, lfs, tc.expectedLCs)
+				t.Errorf("diff: %v", deep.Equal(lfs, tc.expectedLCs))
 			}
 		})
-		sort.SliceStable(tc.expectedLCs, func(i, j int) bool {
-			{
-				return tc.expectedLCs[i].GetName() < tc.expectedLCs[j].GetName()
-			}
-		})
-		if !reflect.DeepEqual(lfs, tc.expectedLCs) {
-			t.Errorf("Test %v: \n got \t\t%v, \n expected %v", tc.name, lfs, tc.expectedLCs)
-		}
 	}
 }
 
@@ -1680,7 +1729,6 @@ func newResource(name, rtype, state, owner string, t time.Time) *crds.ResourceOb
 			State:      state,
 			Owner:      owner,
 			LastUpdate: t,
-			UserData:   &common.UserData{},
 		},
 	}
 }

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -1684,3 +1684,25 @@ func newResource(name, rtype, state, owner string, t time.Time) *crds.ResourceOb
 		},
 	}
 }
+
+func sortResourcesLists(rls ...*crds.ResourceObjectList) {
+	for _, rl := range rls {
+		sort.Slice(rl.Items, func(i, j int) bool {
+			return rl.Items[i].Name < rl.Items[j].Name
+		})
+		if len(rl.Items) == 0 {
+			rl.Items = nil
+		}
+	}
+}
+
+func sortDRLCList(drlcs ...*crds.DRLCObjectList) {
+	for _, drlc := range drlcs {
+		sort.Slice(drlc.Items, func(i, j int) bool {
+			return drlc.Items[i].Name < drlc.Items[j].Name
+		})
+		if len(drlc.Items) == 0 {
+			drlc.Items = nil
+		}
+	}
+}

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -453,9 +453,6 @@ func TestRelease(t *testing.T) {
 			if !AreErrorsEqual(releaseErr, tc.expectErr) {
 				t.Fatalf("Got error %v, expected error %v", releaseErr, tc.expectErr)
 			}
-			if tc.expectedRes != nil && tc.expectedRes.Status.UserData == nil {
-				tc.expectedRes.Status.UserData = &common.UserData{}
-			}
 			res, _ := c.Storage.GetResource(tc.resName)
 			if diff := deep.Equal(res, tc.expectedRes); diff != nil {
 				t.Errorf("result didn't match expected, diff: %v", diff)
@@ -1371,6 +1368,9 @@ func TestSyncResources(t *testing.T) {
 			sortResourcesLists(tc.expectedRes, resources)
 			for idx := range tc.expectedRes.Items {
 				tc.expectedRes.Items[idx].Namespace = testNS
+				if tc.expectedRes.Items[idx].Status.UserData == nil {
+					tc.expectedRes.Items[idx].Status.UserData = &common.UserData{}
+				}
 			}
 			if diff := deep.Equal(resources, tc.expectedRes); diff != nil {
 				t.Errorf("received resource differs from expected, diff: %v", diff)
@@ -1692,6 +1692,12 @@ func TestUpdateAllDynamicResources(t *testing.T) {
 				t.Fatalf("failed to get resources: %v", err)
 			}
 			sortResourcesLists(resources, tc.expectedRes)
+			for idx := range tc.expectedRes.Items {
+				// needed to prevent test failures due to nil != empty
+				if tc.expectedRes.Items[idx].Status.UserData == nil {
+					tc.expectedRes.Items[idx].Status.UserData = &common.UserData{}
+				}
+			}
 
 			if !reflect.DeepEqual(resources, tc.expectedRes) {
 				t.Errorf("diff:\n%v", deep.Equal(resources, tc.expectedRes))
@@ -1726,6 +1732,7 @@ func newResource(name, rtype, state, owner string, t time.Time) *crds.ResourceOb
 			State:      state,
 			Owner:      owner,
 			LastUpdate: t,
+			UserData:   &common.UserData{},
 		},
 	}
 }

--- a/boskos/ranch/storage.go
+++ b/boskos/ranch/storage.go
@@ -114,10 +114,11 @@ func (s *Storage) DeleteResource(name string) error {
 
 // UpdateResource updates a resource if it exists, errors otherwise
 func (s *Storage) UpdateResource(resource *crds.ResourceObject) (*crds.ResourceObject, error) {
+	resource.Namespace = s.namespace
 	resource.Status.LastUpdate = s.now()
 
 	if err := s.client.Update(s.ctx, resource); err != nil {
-		return nil, fmt.Errorf("failed to update resources %s after patching it: %v", resource.Name, err)
+		return nil, fmt.Errorf("failed to update resources %s: %v", resource.Name, err)
 	}
 
 	return resource, nil

--- a/boskos/ranch/storage.go
+++ b/boskos/ranch/storage.go
@@ -131,6 +131,9 @@ func (s *Storage) GetResource(name string) (*crds.ResourceObject, error) {
 	if err := s.client.Get(s.ctx, nn, o); err != nil {
 		return nil, fmt.Errorf("failed to get resource %s: %v", name, err)
 	}
+	if o.Status.UserData == nil {
+		o.Status.UserData = &common.UserData{}
+	}
 
 	return o, nil
 }


### PR DESCRIPTION
This PR changes boskos ranch to use the crd types, working towards https://github.com/kubernetes/test-infra/issues/16207 and working towards https://github.com/kubernetes/test-infra/issues/15557 by not short circuiting kubes optimistic concurrency mechanism anymore.

Boskos ranch and storage are used a lot in other packages tests, which is why this PR grew so much in size. 