### PR TITLE
Add namespace for crier

### DIFF
--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -15,6 +15,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: default
   name: crier
   labels:
     app: crier


### PR DESCRIPTION
/assign @michelle192837 

This was getting created in the `test-pods` namespace