### PR TITLE
Bump the frequency of kubeflow/examples periodic tests.

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -167,7 +167,7 @@ periodics:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow/manifests on the 0-6 release branch.
 - name: kubeflow-periodic-examples
-  interval: 8h
+  interval: 1h
   labels:
     preset-service-account: "true"
   spec:


### PR DESCRIPTION
* The kubeflow/examples periodic tests are the primary tests we use
  to ensure KF is running E2E.

* We want those to run frequently so that we can easily validate the latest
  KF deployments.