### PR TITLE
Fix terminate dupes to reflect changes in passed in slice.

### DIFF
--- a/prow/pjutil/abort.go
+++ b/prow/pjutil/abort.go
@@ -127,6 +127,9 @@ func TerminateOlderJobs(pjc patchClient, log *logrus.Entry, pjs []prowapi.ProwJo
 		if err := pjc.Patch(context.Background(), &toCancel, ctrlruntimeclient.MergeFrom(prevPJ)); err != nil {
 			return err
 		}
+
+		// Update the cancelled jobs entry in pjs.
+		pjs[cancelIndex] = toCancel
 	}
 
 	return nil


### PR DESCRIPTION
This fixes a bug in which plank terminates a duplicate job in the `triggered` state, but continues on to handle the job in `syncTriggeredJobs` in the same sync loop because it is still referencing the stale, unterminated version of the ProwJob resource. The termination logic sets the completion time and sets the state to `aborted` after which the sync logic sets the state to `pending`. This explains how we got into a corrupted state with a ProwJob that had a completion time, but was still pending. 

This bug has been in our code for a while, but was only just exposed by duplicate job triggering leading to duplicate termination of a job that was still in the triggered state.
fixes: https://github.com/kubernetes/test-infra/issues/16338
I confirmed that the unit test I added fails without the fix.

Side note: A ProwJob admission controller could have caught and prevented this outage by validating consistency between the job state and the completion time.

/assign @fejta @Katharine @michelle192837 