### PR TITLE
Add labels field to PullRequest github type

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -232,6 +232,7 @@ type PullRequest struct {
 	Number             int               `json:"number"`
 	HTMLURL            string            `json:"html_url"`
 	User               User              `json:"user"`
+	Labels             []Label           `json:"labels"`
 	Base               PullRequestBranch `json:"base"`
 	Head               PullRequestBranch `json:"head"`
 	Title              string            `json:"title"`


### PR DESCRIPTION
The GitHub API provides a `labels` field when getting pull requests, as well as when sending pull request events.

I noticed Prow plugins make a GitHub API call to get issue labels on pull request events. Adding this field to the struct would ensure this data is consumed from the pull request event.