### PR TITLE
fix kind download permissions

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -240,7 +240,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -290,7 +290,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -339,7 +339,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -394,7 +394,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp -P gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."


### PR DESCRIPTION
https://prow.k8s.io/?job=pull-kubernetes-e2e-kind

something changed with `gsutil -P` kind. I suspect something with UID / GID of the file or the image we're running in. not sure why, but we don't want it preserving those bits anyhow, the goal was just to preserve the executable bit.

will write something cleaner in a future patch

/cc @aojea 