### PR TITLE
use curl to avoid gsutil failing to auth

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -240,7 +240,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x $(which kind) && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -290,7 +290,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x $(which kind) && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -339,7 +339,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x $(which kind) && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."
@@ -394,7 +394,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - gsutil cp gs://bentheelder-kind-ci-builds/latest/kind-linux-amd64 "${PATH%%:*}/kind" && chmod +x $(which kind) && gsutil cat gs://bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x $(which kind) && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
         - name: FOCUS
           value: "."


### PR DESCRIPTION
i don't know why it's even authenticating when the bucket is public read, but the timing of the error appearing lines up to workload identity.

also the error is about the bucket already existing rather than auth, but this is my hunch.

using curl instead of gsutil should avoid the problem

fyi @amwat 
/cc @aojea 
xref: https://github.com/kubernetes-sigs/kind/issues/1342