### PR TITLE
Kops - Don't use computeMetadata for retrieving public IP

### DIFF
--- a/images/kubekins-e2e/kops-e2e-runner.sh
+++ b/images/kubekins-e2e/kops-e2e-runner.sh
@@ -59,16 +59,6 @@ if [[ "${KOPS_DEPLOY_LATEST_KUBE:-}" =~ ^[yY]$ ]]; then
   e2e_args+=(--kops-kubernetes-version="${KOPS_KUBE_RELEASE_URL}/${KOPS_KUBE_LATEST}")
 fi
 
-EXTERNAL_IP=$(curl -SsL -H 'Metadata-Flavor: Google' 'http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip' || true)
-if [[ -z "${EXTERNAL_IP}" ]]; then
-  # Running outside GCE
-  echo
-  echo "WARNING: Getting external IP from instance metadata failed, assuming not running on GCE."
-  echo
-  EXTERNAL_IP=$(curl 'http://v4.ifconfig.co')
-fi
-e2e_args+=(--kops-admin-access="${EXTERNAL_IP}/32")
-
 # Define a custom instance lister for cluster/log-dump/log-dump.sh.
 function log_dump_custom_get_instances() {
   local -r role=$1

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -399,6 +399,14 @@ func (k kops) Up() error {
 	}
 	if k.adminAccess != "" {
 		createArgs = append(createArgs, "--admin-access", k.adminAccess)
+	} else {
+		var b bytes.Buffer
+		if err := httpRead("https://v4.ifconfig.co", &b); err != nil {
+			return err
+		}
+		externalIP := strings.TrimSpace(b.String())
+		log.Printf("Using external IP for admin access: %v", externalIP)
+		k.adminAccess = externalIP
 	}
 
 	// Since https://github.com/kubernetes/kubernetes/pull/80655 conformance now require node ports to be open to all nodes


### PR DESCRIPTION
Since workload identity was enabled on the e2e clusters, [presubmit jobs have been failing](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8539/pull-kops-e2e-kubernetes-aws/1230307779906899968#1:build-log.txt%3A438) because the computeMetadata endpoints are no longer available.

We were relying on it to get our public ip, falling back to ifconfig.co.
The fallback logic wasnt working though: the response body isn't empty, its `Not Found`.
I'm moving the logic from kops-e2e-runner.sh, which our periodic jobs have already been migrated away from, to kubetest and only using ifconfig.co. This way both our presubmit and periodic e2e jobs use the same logic for restricting access to the clusters. And it gets us one step closer to moving off of kops-e2e-runner.sh entirely :) 

I'm not a big fan of relying on this third party service for such a simple use case, so if anyone has better ideas on how to get our public IP any feedback would be appreciated.