### PR TITLE
[Deck] Add material theme config

### DIFF
--- a/prow/cmd/deck/template/base.html
+++ b/prow/cmd/deck/template/base.html
@@ -30,7 +30,7 @@
   <link rel="stylesheet" type="text/css" href="/static/extensions/style.css">
   <link href="https://fonts.googleapis.com/css?family=Roboto:400,700" rel="stylesheet">
   <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
-  <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.indigo-pink.min.css">
+  <link rel="stylesheet" href="https://code.getmdl.io/1.3.0/material.{{if branding.MaterialTheme}}{{branding.MaterialTheme}}{{else}}indigo-pink{{end}}.min.css">
   <script type="text/javascript" src="/static/extensions/script.js"></script>
   <script defer src="https://code.getmdl.io/1.3.0/material.min.js"></script>
   {{block "scripts" .Arguments}}{{end}}
@@ -44,8 +44,7 @@
 <div class="mdl-layout mdl-js-layout mdl-layout--fixed-header">
   <header class="mdl-layout__header"{{if branding.HeaderColor}} style="background-color: {{branding.HeaderColor}};"{{end}}>
     <div class="mdl-layout__header-row">
-      <a href="/"
-         class="logo"><img src="{{or branding.Logo $defaultLogo}}" alt="kubernetes logo" class="logo"/></a>
+      <a href="/" class="logo"><img src="{{or branding.Logo $defaultLogo}}" alt="kubernetes logo" class="logo"/></a>
       <span class="mdl-layout-title header-title">{{block "pageTitle" .Arguments}}{{template "title" .}}{{end}}</span>
     </div>
   </header>

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -649,6 +649,9 @@ type Branding struct {
 	BackgroundColor string `json:"background_color,omitempty"`
 	// HeaderColor is the color of the header.
 	HeaderColor string `json:"header_color,omitempty"`
+	// MaterialTheme is the color theme used for material-design-lite see https://getmdl.io/customize/
+	// default is indigo-pink
+	MaterialTheme string `json:"material_theme,omitempty"`
 }
 
 // PubSubSubscriptions maps GCP projects to a list of Topics.


### PR DESCRIPTION
This pull request adds a branding config to customize material design theme.

If not defined the default indigo-pink theme is used, but the user can change it in the deck branding config.

It's definitely useless but i thought it would be fun to be able to change it ;-)