### PR TITLE
trigger upload-boskos-config job when boskos-resources is updated

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -614,7 +614,7 @@ postsubmits:
     cluster: test-infra-trusted
     branches:
     - master
-    run_if_changed: '^boskos/.*$'
+    run_if_changed: '^prow/cluster/boskos-resources.yaml$'
     decorate: true
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher


### PR DESCRIPTION
The `boskos-resources.yaml` file was moved out of `boskos/` in #14276, but the trigger for the job that updates the configmap was not changed.

Somehow things mostly just worked - I guess there were frequent-enough changes to `boskos/`?