### PR TITLE
Add storage for alertmanager to allow persisting silences.

### DIFF
--- a/prow/cluster/monitoring/prow_alertmanager.yaml
+++ b/prow/cluster/monitoring/prow_alertmanager.yaml
@@ -14,3 +14,14 @@ spec:
     runAsUser: 1000
   serviceAccountName: alertmanager
   version: v0.15.2
+  storage: # Note that this section is immutable so changes require deleting and recreating the resource.
+    volumeClaimTemplate:
+      metadata:
+        name: prometheus
+      spec:
+        accessModes:
+        - "ReadWriteOnce"
+        storageClassName: "standard"
+        resources:
+          requests:
+            storage: 10Gi


### PR DESCRIPTION
Adding storage for the alert manager will allow us to silence alerts and have the silences persist across pod restarts (which happen whenever changes are merged to `/prow/cluster/`).

@hongkailiu noted that this section of the Alertmanager resource is immutable so our deployment automation will fail to apply the changes. We'll need to delete the alertmanager resource manually and recreate it (or let the deployment automation recreate it). We'll also need to do this again if the storage section ever changes. I don't know of a way to avoid this, but if anyone else does please share.

/hold
/assign @michelle192837 @fejta 
/cc @hongkailiu 