### PR TITLE
Enable nullglob in autobump/bump.sh

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+shopt -s nullglob
 
 # bump.sh is used to update references to Prow component images hosted at gcr.io/k8s-prow/*
 # Specifically it does the following:


### PR DESCRIPTION
If any directories listed in `COMPONENT_FILE_DIR` and empty of `yaml` files then they will expand to the literal value: `some-dir/*.yaml` resulting in an error when the [`sed`](https://github.com/kubernetes/test-infra/blob/26e76aaf721b9263c8188ef3f4a0486e56d282a2/prow/cmd/autobump/bump.sh#L80) is run for that path. IMO, non-matching globs should be ignored. 

> **nullglob**
> If set, Bash allows filename patterns which match no files to expand to a null string, rather than themselves.

xref: https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html

/assign @cjwagner 
