### PR TITLE
Canary RBAC on sinker and horologium

### DIFF
--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -31,7 +31,7 @@ spec:
       labels:
         app: horologium
     spec:
-      # serviceAccountName: "horologium" # Uncomment for use with RBAC
+      serviceAccountName: horologium
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       labels:
         app: sinker
     spec:
-      # serviceAccountName: "sinker" # Uncomment for use with RBAC
+      serviceAccountName: sinker
       containers:
       - name: sinker
         args:


### PR DESCRIPTION
/assign @michelle192837 

Should work, and if there are problems we should be able to recover without causing a user-facing outage (just degraded service)

ref https://github.com/kubernetes/test-infra/issues/15806