### PR TITLE
Enable dotglob in bump.sh

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -17,6 +17,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+shopt -s dotglob
 shopt -s nullglob
 
 # bump.sh is used to update references to Prow component images hosted at gcr.io/k8s-prow/*


### PR DESCRIPTION
Enable **dotglob** to match `.prow.yaml` and other dot prefixed files that may need to be bumped.

> dotglob
> If set, Bash includes filenames beginning with a ‘.’ in the results of filename expansion. The filenames ‘.’ and ‘..’ must always be matched explicitly, even if dotglob is set.

https://www.gnu.org/software/bash/manual/html_node/The-Shopt-Builtin.html

#### Before
```bash
$ bash -c 'ls *.yaml'
ls: cannot access '*.yaml': No such file or directory
```

#### After
```bash
$ bash -c 'shopt -s dotglob; ls *.yaml'
.prow.yaml
```
