### PR TITLE
cm2kc: clustermap file to kubeconfig file converter

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -78,6 +78,7 @@ filegroup(
         "//prow/cmd/branchprotector:all-srcs",
         "//prow/cmd/checkconfig:all-srcs",
         "//prow/cmd/clonerefs:all-srcs",
+        "//prow/cmd/cm2kc:all-srcs",
         "//prow/cmd/config-bootstrapper:all-srcs",
         "//prow/cmd/crier:all-srcs",
         "//prow/cmd/deck:all-srcs",

--- a/prow/cmd/cm2kc/BUILD.bazel
+++ b/prow/cmd/cm2kc/BUILD.bazel
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/test-infra/prow/cmd/cm2kc",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//prow/kube:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+        "@io_k8s_client_go//tools/clientcmd/api/v1:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "cm2kc",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
+    embed = [":go_default_library"],
+    deps = ["@com_github_spf13_pflag//:go_default_library"],
+)

--- a/prow/cmd/cm2kc/README.md
+++ b/prow/cmd/cm2kc/README.md
@@ -19,6 +19,23 @@ The following is a list of supported options for `cm2kc`:
 
 ## Examples
 
+#### Add a kubeconfig file in a secret: `kubeconfig` from a clustermap file in another secret: `build-cluster` for context: `my-context`.
+
+The following command will:
+1. Get a *clustermap* formatted secret: `build-cluster` in key: `cluster` for context: `my-context`.
+1. Base64 decode the secret.
+1. Convert the *clustermap* data to a *kubeconfig* format.
+1. Create a *kubeconfig* formatted secret: `kubeconfig` in key: `config` for context: `my-context` from the converted data.
+
+```shell
+kubectl --context=my-context get secrets build-cluster -o jsonpath='{.data.cluster}' |
+  base64 -d |
+  bazel run //prow/cmd/cm2kc |
+  kubectl --context=my-context create secret generic kubeconfig --from-file=config=/dev/stdin
+```
+
+Lastly, to begin using this in Prow, update the volume mount and replace `--build-cluster` with `--kubeconfig` in the [deployment](https://github.com/istio/test-infra/pull/1713) of each relevant Prow component (e.g. crier, deck, plank, and sinker).
+
 #### Create a kubeconfig file at path `/path/to/kubeconfig.yaml` from a clustermap file at path `/path/to/clustermap.yaml`.
 
 Ensure the *clustermap* file exists at the specified `--input` path:  

--- a/prow/cmd/cm2kc/README.md
+++ b/prow/cmd/cm2kc/README.md
@@ -1,0 +1,86 @@
+# cm2kc (clustermap to kubeconfig)
+
+## Description
+
+`cm2kc` is a CLI tool used to convert a [clustermap file][clustermap docs] to a [kubeconfig file][kubeconfig docs].
+
+## Usage
+
+```shell
+bazel run //prow/cmd/cm2kc -- <options>
+```
+
+The following is a list of supported options for `cm2kc`:
+
+```console
+  -i, --input string    Input clustermap file. (default "/dev/stdin")
+  -o, --output string   Output kubeconfig file. (default "/dev/stdout")
+```
+
+## Examples
+
+#### Create a kubeconfig file at path `/path/to/kubeconfig.yaml` from a clustermap file at path `/path/to/clustermap.yaml`.
+
+Ensure the *clustermap* file exists at the specified `--input` path:  
+ 
+```yaml
+# /path/to/clustermap.yaml
+
+default:
+  clientCertificate: fake-default-client-cert
+  clientKey: fake-default-client-key
+  clusterCaCertificate: fake-default-ca-cert
+  endpoint: https://1.2.3.4
+build:
+  clientCertificate: fake-build-client-cert
+  clientKey: fake-build-client-key
+  clusterCaCertificate: fake-build-ca-cert
+  endpoint: https://5.6.7.8
+```
+
+Execute `cm2kc` specifying an `--input` path to the *clustermap* file and an `--output` path to the desired location of the generated *kubeconfig* file: 
+
+```shell
+bazel run //prow/cmd/cm2kc -- --input=/path/to/clustermap.yaml --output=/path/to/kubeconfig.yaml
+```
+
+The following *kubeconfig* file will be created at the specified `--output` path:  
+
+```yaml
+# /path/to/kubeconfig.yaml
+
+apiVersion: v1
+clusters:
+- name: default
+  cluster:
+    certificate-authority-data: fake-default-ca-cert
+    server: https://1.2.3.4
+- name: build
+  cluster:
+    certificate-authority-data: fake-build-ca-cert
+    server: https://5.6.7.8
+contexts:
+- name: default
+  context:
+    cluster: default
+    user: default
+- name: build
+  context:
+    cluster: build
+    user: build
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    client-certificate-data: fake-default-ca-cert
+    client-key-data: fake-default-ca-cert
+- name: build
+  user:
+    client-certificate-data: fake-build-ca-cert
+    client-key-data: fake-build-ca-cert
+```
+
+[clustermap docs]: https://github.com/kubernetes/test-infra/blob/1c7d9a4ae0f2ae1e0c11d8357f47163d18521b84/prow/getting_started_deploy.md#run-test-pods-in-different-clusters
+[kubeconfig docs]: https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/

--- a/prow/cmd/cm2kc/main.go
+++ b/prow/cmd/cm2kc/main.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	flag "github.com/spf13/pflag"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api/v1"
+	"sigs.k8s.io/yaml"
+
+	"k8s.io/test-infra/prow/kube"
+)
+
+const (
+	// defaultInput is the default input source.
+	defaultInput = "/dev/stdin"
+	// defaultOutput is the default output source.
+	defaultOutput = "/dev/stdout"
+)
+
+// options are the available command-line flags.
+type options struct {
+	input  string
+	output string
+}
+
+// parseFlags parses the command-line flags.
+func (o *options) parseFlags() {
+	flag.StringVarP(&o.input, "input", "i", defaultInput, "Input cluster map file.")
+	flag.StringVarP(&o.output, "output", "o", defaultOutput, "Output kubeconfig file.")
+
+	flag.Parse()
+}
+
+// printErrAndExit prints an error message to stderr and exits with a status code.
+func printErrAndExit(err error, code int) {
+	_, _ = fmt.Fprintln(os.Stderr, err.Error())
+	os.Exit(code)
+}
+
+// createKubeConfigFromClusterMap creates a standard kube config from a cluster map.
+func createKubeConfigFromClusterMap(cm map[string]kube.Cluster) ([]byte, error) {
+	config := clientcmdapi.Config{
+		APIVersion:     "v1",
+		Kind:           "Config",
+		Clusters:       []clientcmdapi.NamedCluster{},
+		AuthInfos:      []clientcmdapi.NamedAuthInfo{},
+		Contexts:       []clientcmdapi.NamedContext{},
+		CurrentContext: kube.DefaultClusterAlias,
+	}
+
+	for name, cluster := range cm {
+		config.Clusters = append(config.Clusters, clientcmdapi.NamedCluster{
+			Name: name,
+			Cluster: clientcmdapi.Cluster{
+				Server:                   cluster.Endpoint,
+				CertificateAuthorityData: cluster.ClusterCACertificate,
+			},
+		})
+		config.AuthInfos = append(config.AuthInfos, clientcmdapi.NamedAuthInfo{
+			Name: name,
+			AuthInfo: clientcmdapi.AuthInfo{
+				ClientCertificateData: cluster.ClientCertificate,
+				ClientKeyData:         cluster.ClientKey,
+			},
+		})
+		config.Contexts = append(config.Contexts, clientcmdapi.NamedContext{
+			Name: name,
+			Context: clientcmdapi.Context{
+				Cluster:  name,
+				AuthInfo: name,
+			},
+		})
+	}
+
+	return yaml.Marshal(config)
+}
+
+// main entry point.
+func main() {
+	var o options
+
+	o.parseFlags()
+
+	in, err := ioutil.ReadFile(o.input)
+	if err != nil {
+		printErrAndExit(err, 1)
+	}
+
+	cm, err := kube.UnmarshalClusterMap(in)
+	if err != nil {
+		printErrAndExit(err, 1)
+	}
+
+	kc, err := createKubeConfigFromClusterMap(cm)
+	if err != nil {
+		printErrAndExit(err, 1)
+	}
+
+	dir := filepath.Dir(o.output)
+	if err = os.MkdirAll(dir, os.ModePerm); err != nil {
+		printErrAndExit(err, 1)
+	}
+
+	if err = ioutil.WriteFile(o.output, kc, 0644); err != nil {
+		printErrAndExit(err, 1)
+	}
+}

--- a/prow/cmd/cm2kc/main_test.go
+++ b/prow/cmd/cm2kc/main_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/pflag"
+)
+
+const (
+	testDir = "testdata"
+)
+
+func resolvePath(t *testing.T, filename string) string {
+	name := strings.ToLower(filepath.Base(t.Name()))
+	return filepath.Join(testDir, strings.ToLower(name), name+filename)
+}
+
+func TestGenjobs(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		args   []string
+		equal  bool
+	}{
+		{
+			name:  "single cluster",
+			args:  []string{},
+			equal: true,
+		},
+		{
+			name:  "multiple clusters",
+			args:  []string{},
+			equal: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			in := resolvePath(t, "_in.yaml")
+			outE := resolvePath(t, "_out.yaml")
+
+			expected, err := ioutil.ReadFile(outE)
+			if err != nil {
+				t.Errorf("Failed reading expected output file %v: %v", outE, err)
+			}
+
+			tmpDir, err := ioutil.TempDir("", "")
+			if err != nil {
+				t.Errorf("Failed creating temp file: %v", err)
+			}
+			defer os.Remove(tmpDir)
+
+			outA := filepath.Join(tmpDir, "out.yaml")
+
+			os.Args = []string{"cm2kc"}
+			pflag.CommandLine = pflag.NewFlagSet(os.Args[0], pflag.ExitOnError)
+			os.Args = append(os.Args, test.args...)
+			os.Args = append(os.Args, "--input="+in, "--output="+outA)
+			main()
+
+			actual, err := ioutil.ReadFile(outA)
+			if err != nil {
+				t.Errorf("Failed reading actual output file %v: %v", outA, err)
+			}
+
+			t.Logf("expected (%v):\n%v\n", test.name, string(expected))
+			t.Logf("actual (%v):\n%v\n", test.name, string(actual))
+
+			if os.Getenv("REFRESH_GOLDEN") == "true" {
+				if err = ioutil.WriteFile(outE, actual, 0644); err != nil {
+					t.Errorf("Failed writing expected output file %v: %v", outE, err)
+				}
+				expected = actual
+			}
+
+			equal := bytes.Equal(expected, actual)
+			if equal != test.equal {
+				t.Errorf("Expected output equality to be: %t.", test.equal)
+			}
+		})
+	}
+}

--- a/prow/cmd/cm2kc/testdata/multiple_clusters/multiple_clusters_in.yaml
+++ b/prow/cmd/cm2kc/testdata/multiple_clusters/multiple_clusters_in.yaml
@@ -1,0 +1,10 @@
+default:
+  clientCertificate: YQo=
+  clientKey: Ygo=
+  clusterCaCertificate: Ywo=
+  endpoint: https://1.2.3.4
+build:
+  clientCertificate: ZA==
+  clientKey: ZQ==
+  clusterCaCertificate: Zg==
+  endpoint: https://5.6.7.8

--- a/prow/cmd/cm2kc/testdata/multiple_clusters/multiple_clusters_out.yaml
+++ b/prow/cmd/cm2kc/testdata/multiple_clusters/multiple_clusters_out.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Zg==
+    server: https://5.6.7.8
+  name: build
+- cluster:
+    certificate-authority-data: Ywo=
+    server: https://1.2.3.4
+  name: default
+contexts:
+- context:
+    cluster: build
+    user: build
+  name: build
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: build
+  user:
+    client-certificate-data: ZA==
+    client-key-data: ZQ==
+- name: default
+  user:
+    client-certificate-data: YQo=
+    client-key-data: Ygo=

--- a/prow/cmd/cm2kc/testdata/single_cluster/single_cluster_in.yaml
+++ b/prow/cmd/cm2kc/testdata/single_cluster/single_cluster_in.yaml
@@ -1,0 +1,5 @@
+default:
+  clientCertificate: YQo=
+  clientKey: Ygo=
+  clusterCaCertificate: Ywo=
+  endpoint: https://1.2.3.4

--- a/prow/cmd/cm2kc/testdata/single_cluster/single_cluster_out.yaml
+++ b/prow/cmd/cm2kc/testdata/single_cluster/single_cluster_out.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: Ywo=
+    server: https://1.2.3.4
+  name: default
+contexts:
+- context:
+    cluster: default
+    user: default
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users:
+- name: default
+  user:
+    client-certificate-data: YQo=
+    client-key-data: Ygo=


### PR DESCRIPTION
`cm2kc` is a CLI tool used to convert a **clustermap file** to a **kubeconfig file**.

fix https://github.com/kubernetes/test-infra/issues/16381

> Note: `input` and `output` can be piped to/from `kubectl` (or other) commands.

> FYI: unless there is utility in preservation, this tool will be deleted along with https://github.com/kubernetes/test-infra/pull/14724 in **May 2020**.