### PR TITLE
Network proxy e2e: Change timeouts and request to be consistent with other e2e

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -66,7 +66,7 @@ presubmits:
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
-        - --timeout=80
+        - --timeout=105
         - --scenario=kubernetes_e2e
         - --
         - --build=bazel
@@ -80,7 +80,10 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
-        - --timeout=60m
+        - --timeout=80m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
+        resources:
+          requests:
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy


### PR DESCRIPTION
Per https://github.com/kubernetes/test-infra/pull/16252#issuecomment-585369384

Using https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml#L38-L61 as template. Also updated timeouts to be consistent

/assign @krzyzacy 