### PR TITLE
kubernetes-sigs/kubebuilder: update presubmit config with plugins feature branch matching

### DIFF
--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -7,6 +7,7 @@ presubmits:
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
+    - ^feature/plugins-.+$
     spec:
       containers:
       - image: golang:1.13
@@ -25,6 +26,7 @@ presubmits:
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
+    - ^feature/plugins-.+$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
@@ -54,6 +56,7 @@ presubmits:
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
+    - ^feature/plugins-.+$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
@@ -83,6 +86,7 @@ presubmits:
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
+    - ^feature/plugins-.+$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
@@ -112,6 +116,7 @@ presubmits:
     path_alias: sigs.k8s.io/kubebuilder
     branches:
     - ^master$
+    - ^feature/plugins-.+$
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master


### PR DESCRIPTION
To test plugin feature work like https://github.com/kubernetes-sigs/kubebuilder/pull/1290.

/cc @DirectXMan12 @mengqiy @pwittrock 