### PR TITLE
cleanup kind ipv6 job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -60,14 +60,6 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     spec:
-      # run on the ubuntu node pool, which has ipv6 modules
-      tolerations:
-      - key: "dedicated"
-        operator: "Equal"
-        value: "ubuntu"
-        effect: "NoSchedule"
-      nodeSelector:
-        dedicated: "ubuntu"
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
         env:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -46,54 +46,6 @@ presubmits:
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-misc
       description: Runs conformance tests using kind and the conformance image
-  - name: pull-kubernetes-conformance-kind-ipv6
-    branches:
-    - master
-    always_run: false
-    skip_report: false
-    max_concurrency: 8
-    optional: true
-    labels:
-      preset-service-account: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200220-47050c4-master
-        env:
-        # enable IPV6 in bootstrap image
-        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
-          value: "true"
-        # tell kind CI script to use ipv6
-        - name: "IP_FAMILY"
-          value: "ipv6"
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--root=/go/src"
-        - "--repo=k8s.io/kubernetes=$(PULL_REFS)"
-        - "--repo=sigs.k8s.io/kind=master"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--scenario=execute"
-        - "--"
-        - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
-    annotations:
-      testgrid-dashboards: sig-testing-kind
-      description: Use kind to run e2e Conformance tests against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
-      testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com
-      testgrid-num-failures-to-alert: "15"
 
   - name: pull-kubernetes-conformance-kind-ipv6-parallel
     branches:


### PR DESCRIPTION
The job wasn't running for a long time 
https://testgrid.k8s.io/sig-testing-kind#pull-kubernetes-conformance-kind-ipv6

probably since we removed the tolerations for the IPv6 jobs, so I assume it's safe to remove the job.
However, I split it in 2 commits, one removing the tolerations only, just in case we want to recover it in the future we can revert.