### PR TITLE
Kops - Add back subnet mask for external IP

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -402,7 +402,7 @@ func (k kops) Up() error {
 		if err := httpRead("https://v4.ifconfig.co", &b); err != nil {
 			return err
 		}
-		externalIP := strings.TrimSpace(b.String())
+		externalIP := strings.TrimSpace(b.String()) + "/32"
 		log.Printf("Using external IP for admin access: %v", externalIP)
 		k.adminAccess = externalIP
 	}


### PR DESCRIPTION
The `externalIP` variable is still incorrectly set. At the moment it's missing the `/32` at the end, as it was previously in `kops-e2e-runner.sh`:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kops/8603/pull-kops-e2e-kubernetes-aws/1230779675597344769#1:build-log.txt%3A552

Followup to #16388 and #16401.