### PR TITLE
kubetest: rm mentions of hack/e2e.go

### DIFF
--- a/kubetest/README.md
+++ b/kubetest/README.md
@@ -181,41 +181,41 @@ as a sibling to `kubernetes/kubernetes`). This will cause tests to run from the
 skew directory, potentially to upgrade/downgrade kubernetes to another version.
 
 A simple example is:<br>
-`kubetest --up --check-version-skew=false --extract=v1.8.0-beta.1 
---extract=v1.7.5 --upgrade_args=--ginkgo.focus="Feature:SomeUpgrade" 
+`kubetest --up --check-version-skew=false --extract=v1.8.0-beta.1
+--extract=v1.7.5 --upgrade_args=--ginkgo.focus="Feature:SomeUpgrade"
 --gcp-project=google.com:some-project`
 
-The command runs all (and only) upgrade tests tagged with `Feature:SomeUpgrade` 
+The command runs all (and only) upgrade tests tagged with `Feature:SomeUpgrade`
 label on GCE. The command downloads `v1.7.5` and `v1.8.0-beta.1` releases,
-unzips downloaded files, and runs the tests to upgrade the cluster from `v1.7.5` 
+unzips downloaded files, and runs the tests to upgrade the cluster from `v1.7.5`
 to `v1.8.0-beta.1`. You will be able to find 2 new directories named `kubernetes`
 and `kubernetes_skew` at current directory. `kubernetes` is the directory
-corresponding to release indicated by first `--extract` flag, while `kubernetes_skew` 
+corresponding to release indicated by first `--extract` flag, while `kubernetes_skew`
 corresponds to second flag.
 
 Note that order of the 2 `--extract` flags matters: `--extract=v2 --extract=v1` means
-upgrading from v1 to v2. The command does not run other e2e tests after completing 
-the upgrade tests. If you want to run the e2e tests, specify also `--test` and 
+upgrading from v1 to v2. The command does not run other e2e tests after completing
+the upgrade tests. If you want to run the e2e tests, specify also `--test` and
 `--test_args` flags.
 
-Tips: CI upgrade tests listed at [sig-cluster-lifecycle config] show flags used in the real CI 
+Tips: CI upgrade tests listed at [sig-cluster-lifecycle config] show flags used in the real CI
 test environment, which is a good source to learn more about how the flags are used.
 
 ### Staging
 
-If you want to create a new release with your own changes, you have to upload built 
+If you want to create a new release with your own changes, you have to upload built
 manifests to gcs. The command is very similar:
-`kubetest --build --stage=gs://some/path/to/v1.8.0-beta.1  --check-version-skew=false 
---extract=gs://some/path/to/v1.8.0-beta.1  --extract=v1.7.5 
---upgrade_args=--ginkgo.focus="Feature:SomeUpgrade" 
+`kubetest --build --stage=gs://some/path/to/v1.8.0-beta.1  --check-version-skew=false
+--extract=gs://some/path/to/v1.8.0-beta.1  --extract=v1.7.5
+--upgrade_args=--ginkgo.focus="Feature:SomeUpgrade"
 --gcp-project=google.com:some-project`
 
-If you already have release of a specific version, you do not need to fetch the 
-release again. For instance, if you have `v1.7.5` release and its directory is at the 
+If you already have release of a specific version, you do not need to fetch the
+release again. For instance, if you have `v1.7.5` release and its directory is at the
 right path, the command below does the same as above:
-`kubetest --build --stage=gs://some/path/to/v1.8.0-beta.1  --check-version-skew=false 
---extract=gs://some/path/to/v1.8.0-beta.1 
---upgrade_args=--ginkgo.focus="Feature:SomeUpgrade" 
+`kubetest --build --stage=gs://some/path/to/v1.8.0-beta.1  --check-version-skew=false
+--extract=gs://some/path/to/v1.8.0-beta.1
+--upgrade_args=--ginkgo.focus="Feature:SomeUpgrade"
 --gcp-project=google.com:some-project`
 
 [bootstrap.py]: /jenkins/bootstrap.py

--- a/kubetest/README.md
+++ b/kubetest/README.md
@@ -22,10 +22,6 @@ The e2e lifecycle may:
 * turn `--down` the cluster after completing testing,
 * `--timeout` after a particular duration (allowing extra time to clean up).
 
-Note that developers frequently use `kubetest` by calling `go run hack/e2e.go`
-in the `kubernetes/kubernetes` repository. This `hack/e2e.go` program is a
-wrapper around updating `kubetest` (at most once a day) before calling it.
-
 If you're making a change to kubetest, watch the canary jobs after it has merged;
 these run the latest images of `kubekins-e2e`, and thus don't have to wait
 for a version bump in the prow config.  The canary jobs are used to give early
@@ -38,7 +34,6 @@ Please clone this repo and then run `GO111MODULE=on go install ./kubetest` from 
 
 Common alternatives:
 ```
-go run hack/e2e.go  # from kubernetes/kubernetes
 go install k8s.io/test-infra/kubetest  # if you check out test-infra
 bazel run //kubetest  # use bazel to build and run
 ```

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -170,7 +170,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.runtimeConfig, "runtime-config", "batch/v2alpha1=true", "If set, API versions can be turned on or off while bringing up the API server.")
 	flag.StringVar(&o.stage.dockerRegistry, "registry", "", "Push images to the specified docker registry (e.g. gcr.io/a-test-project)")
 	flag.StringVar(&o.save, "save", "", "Save credentials to gs:// path on --up if set (or load from there if not --up)")
-	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/hack/e2e.go")
+	flag.BoolVar(&o.skew, "skew", false, "If true, run tests in another version at ../kubernetes/kubernetes_skew")
 	flag.BoolVar(&o.soak, "soak", false, "If true, job runs in soak mode")
 	flag.DurationVar(&o.soakDuration, "soak-duration", 7*24*time.Hour, "Maximum age of a soak cluster before it gets recycled")
 	flag.Var(&o.stage, "stage", "Upload binaries to gs://bucket/devel/job-suffix if set")


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/pull/84696 the `hack/e2e.go` is no longer part of kubernetes repo, so let's stop mentioning it.

(the biggest part of this PR Is actually whitespace cleanup in README.md which was performed by my $EDITOR. For the sake of cleaner review I put it into a separate commit)

/kind cleanup
/release-note-none

