### PR TITLE
Kops - Set interval to 8h for network plugins tests

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-network-plugins.yaml
@@ -1,6 +1,6 @@
 periodics:
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-amazon-vpc
   labels:
     preset-service-account: "true"
@@ -34,7 +34,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-amazon-vpc
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-calico
   labels:
     preset-service-account: "true"
@@ -68,7 +68,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-calico
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-canal
   labels:
     preset-service-account: "true"
@@ -102,7 +102,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-canal
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-cilium
   labels:
     preset-service-account: "true"
@@ -136,7 +136,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-cilium
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-flannel
   labels:
     preset-service-account: "true"
@@ -170,7 +170,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-flannel
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-kopeio
   labels:
     preset-service-account: "true"
@@ -204,7 +204,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-kopeio
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-weave
   labels:
     preset-service-account: "true"
@@ -238,7 +238,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-weave
 
-- interval: 4h
+- interval: 8h
   name: ci-kubernetes-e2e-kops-aws-cni-lyft
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Most tests are stable enough to increase the interval to 8h.