### PR TITLE
Kops - Set interval to 1h for Cilium network plugins test

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-network-plugins.yaml
@@ -102,7 +102,7 @@ periodics:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-canal
 
-- interval: 4h
+- interval: 1h
   name: ci-kubernetes-e2e-kops-aws-cni-cilium
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
There were quite a few changes in Cilium lately and would help to get more results before the next release.