### PR TITLE
Kops - Reorder e2e jobs in TestGrid

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-distros.yaml
@@ -1,7 +1,7 @@
 periodics:
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagedebian9
+  name: ci-kubernetes-e2e-kops-aws-distro-imagedebian9
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15,7 +15,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-debian-9.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-debian-9.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -33,10 +33,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-debian-9
+    testgrid-tab-name: kops-aws-distro-debian-9
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagedebian10
+  name: ci-kubernetes-e2e-kops-aws-distro-imagedebian10
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -50,7 +50,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-debian-10.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-debian-10.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -68,10 +68,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-debian-10
+    testgrid-tab-name: kops-aws-distro-debian-10
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imageubuntu1604
+  name: ci-kubernetes-e2e-kops-aws-distro-imageubuntu1604
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -85,7 +85,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-ubuntu-1604.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-ubuntu-1604.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -103,10 +103,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-ubuntu-16.04
+    testgrid-tab-name: kops-aws-distro-ubuntu-16.04
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imageubuntu1804
+  name: ci-kubernetes-e2e-kops-aws-distro-imageubuntu1804
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -120,7 +120,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-ubuntu-1804.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-ubuntu-1804.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -138,10 +138,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-ubuntu-18.04
+    testgrid-tab-name: kops-aws-distro-ubuntu-18.04
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagecentos7
+  name: ci-kubernetes-e2e-kops-aws-distro-imagecentos7
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -155,7 +155,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-centos-7.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-centos-7.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=centos
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -174,10 +174,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-centos-7
+    testgrid-tab-name: kops-aws-distro-centos-7
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imageamazonlinux2
+  name: ci-kubernetes-e2e-kops-aws-distro-imageamazonlinux2
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -191,7 +191,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-amazonlinux-2.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-amazonlinux-2.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=ec2-user
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -209,10 +209,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-amazonlinux-2
+    testgrid-tab-name: kops-aws-distro-amazonlinux-2
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagerhel7
+  name: ci-kubernetes-e2e-kops-aws-distro-imagerhel7
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -226,7 +226,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-rhel-7.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-rhel-7.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=ec2-user
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -244,10 +244,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-rhel-7
+    testgrid-tab-name: kops-aws-distro-rhel-7
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagerhel8
+  name: ci-kubernetes-e2e-kops-aws-distro-imagerhel8
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -261,7 +261,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-rhel-8.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-rhel-8.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=ec2-user
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -279,10 +279,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-rhel-8
+    testgrid-tab-name: kops-aws-distro-rhel-8
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imagecoreos
+  name: ci-kubernetes-e2e-kops-aws-distro-imagecoreos
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -296,7 +296,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-coreos.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-coreos.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=core
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -314,10 +314,10 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-coreos
+    testgrid-tab-name: kops-aws-distro-coreos
 
 - interval: 8h
-  name: ci-kubernetes-e2e-kops-aws-imageflatcar
+  name: ci-kubernetes-e2e-kops-aws-distro-imageflatcar
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -331,7 +331,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-flatcar.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-distro-flatcar.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=core
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
@@ -349,4 +349,4 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-flatcar
+    testgrid-tab-name: kops-aws-distro-flatcar

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
@@ -1,0 +1,91 @@
+periodics:
+
+- interval: 30m
+  name: ci-kubernetes-e2e-kops-gce
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-gce.k8s.local
+      - --deployment=kops
+      - --env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt
+      - --extract=ci/latest
+      - --ginkgo-parallel=30
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-gce-latest
+
+- interval: 1h
+  name: ci-kubernetes-e2e-kops-gce-channelalpha
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-gce-channelalpha.k8s.local
+      - --deployment=kops
+      - --extract=ci/latest
+      - --ginkgo-parallel=30
+      - --kops-args=--channel=alpha
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-gce-channelalpha
+
+- interval: 30m
+  name: ci-kubernetes-e2e-kops-gce-ha
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-gce-ha.k8s.local
+      - --deployment=kops
+      - --extract=ci/latest
+      - --ginkgo-parallel=30
+      - --kops-args=--master-count=3
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
@@ -1,6 +1,6 @@
 periodics:
 - interval: 1h
-  name: ci-kubernetes-e2e-kops-aws
+  name: ci-kubernetes-e2e-kops-aws-latest
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -15,7 +15,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-latest.test-cncf-aws.k8s.io
       - --deployment=kops
       - --extract=ci/latest
       - --ginkgo-parallel
@@ -28,7 +28,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws
+    testgrid-tab-name: kops-aws-latest
 
 - interval: 1h
   name: ci-kubernetes-e2e-kops-aws-channelalpha
@@ -220,93 +220,3 @@ periodics:
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-updown
-
-- interval: 30m
-  name: ci-kubernetes-e2e-kops-gce
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-gce.k8s.local
-      - --deployment=kops
-      - --env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt
-      - --extract=ci/latest
-      - --ginkgo-parallel=30
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --kops-zones=us-central1-c
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
-  annotations:
-    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-gce
-
-- interval: 1h
-  name: ci-kubernetes-e2e-kops-gce-channelalpha
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-gce-channelalpha.k8s.local
-      - --deployment=kops
-      - --extract=ci/latest
-      - --ginkgo-parallel=30
-      - --kops-args=--channel=alpha
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
-      - --kops-zones=us-central1-c
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
-  annotations:
-    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-gce-channelalpha
-
-- interval: 30m
-  name: ci-kubernetes-e2e-kops-gce-ha
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-gce-ha.k8s.local
-      - --deployment=kops
-      - --extract=ci/latest
-      - --ginkgo-parallel=30
-      - --kops-args=--master-count=3
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
-      - --kops-zones=us-central1-c
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
-  annotations:
-    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-versions.yaml
@@ -1,6 +1,7 @@
 periodics:
+
 - interval: 2h
-  name: ci-kubernetes-e2e-kops-aws-1-18
+  name: ci-kubernetes-e2e-kops-aws-k8s-1-19
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -14,7 +15,39 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-1-18.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.19
+      - --ginkgo-parallel
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
+  annotations:
+    testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-aws-k8s-1.19
+
+- interval: 2h
+  name: ci-kubernetes-e2e-kops-aws-k8s-1-18
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-1-18.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
@@ -29,10 +62,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.18
+    testgrid-tab-name: kops-aws-k8s-1.18
 
 - interval: 2h
-  name: ci-kubernetes-e2e-kops-aws-1-17
+  name: ci-kubernetes-e2e-kops-aws-k8s-1-17
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -46,7 +79,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-1-17.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-17.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.17.txt
@@ -61,10 +94,10 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-1.17
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.17
+    testgrid-tab-name: kops-aws-k8s-1.17
 
 - interval: 2h
-  name: ci-kubernetes-e2e-kops-aws-1-16
+  name: ci-kubernetes-e2e-kops-aws-k8s-1-16
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -78,7 +111,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-1-16.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-k8s-1-16.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.16.txt
@@ -93,7 +126,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200221-d0671ad-1.16
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-1.16
+    testgrid-tab-name: kops-aws-k8s-1.16
 
 - interval: 8h
   name: e2e-kops-aws-k8s-1-15


### PR DESCRIPTION
There are quite a lot of jobs in the Kops TestGrid tab and would help to see them grouped by purpose.