### PR TITLE
Revert "fixing sig-cli e2e job error"

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -102,7 +102,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-c
+      - --gcp-zone=us-west1-b
       - --gke-environment=test
       - --provider=gke
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8


### PR DESCRIPTION
e2e job failing with
```
W0222 16:51:54.204] ERROR: (gcloud.container.clusters.create) ResponseError: code=400, message=Location "us-west1-c" does not exist
```

Reverts kubernetes/test-infra#15867

xref: https://github.com/kubernetes/kubernetes/issues/87092