### PR TITLE
Kops - increase node count for HA test

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
@@ -53,6 +53,7 @@ periodics:
       - --extract=ci/latest
       - --ginkgo-parallel=30
       - --kops-args=--master-count=3
+      - --kops-nodes=6
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-west-2a,us-west-2b,us-west-2c


### PR DESCRIPTION
One of the multi-zone tests is failing because pods arent being spread across zones properly.
I'm seeing if this is a resource constraint issue by increasing the node count from 4 to 6 (2 in each zone)

prow job: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-ha-uswest2/1231571022914785281

You can see in the kubetest command that the node count is 4. That correlates with the default value for the [argument I'm setting in kubernetes_e2e.py](https://github.com/kubernetes/test-infra/blob/3b9445fd77251c4111f469a9851f000d2f1854af/scenarios/kubernetes_e2e.py#L726-L727)