### PR TITLE
Kops - update kops-aws-canary job to use more nodes

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -220,6 +220,7 @@ periodics:
       - --kops-etcd-version=3.2.24
       - --kops-master-count=3
       - --kops-multiple-zones
+      - --kops-nodes=6
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws


### PR DESCRIPTION
[This job is failing](https://testgrid.k8s.io/sig-cluster-lifecycle-kops#kops-aws-canary) due to the same test as the [kops-aws-ha-uswest2](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-ha-uswest2/1231617074644652039) job.
Pods werent being spread across zones due to resource constraints.
Increasing the number of nodes from 4 to 6 (2 per zone) fixed the issue in kops-aws-ha-uswest2 so I'm making the same change to kops-aws-canary.

Followup to https://github.com/kubernetes/test-infra/pull/16440