### PR TITLE
Report cloud-provider-huaweicloud conformance to testgrid

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -6,6 +6,7 @@ dashboard_groups:
     - conformance-gce
     - conformance-kind
     - conformance-cloud-provider-openstack
+    - conformance-cloud-provider-huaweicloud
     - conformance-alibaba-cloud-provider
     - conformance-cloud-provider-vsphere
     - conformance-vsphere
@@ -211,6 +212,12 @@ dashboards:
       test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16
       alert_options:
         alert_mail_to_addresses: davanum+testgrid@gmail.com
+
+- name: conformance-cloud-provider-huaweicloud
+  dashboard_tab:
+    - name: Huawei Cloud Provider, v1.17
+      description: Runs conformance tests using kubetest against kubernetes v1.17 with cloud-provider-huaweicloud
+      test_group_name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
 
 - name: conformance-alibaba-cloud-provider
   dashboard_tab:
@@ -508,6 +515,10 @@ test_groups:
   gcs_prefix: k8s-conformance-openstack/periodic-logs/ci-cloud-provider-openstack-acceptance-test-e2e-conformance-stable-branch-v1.16
   alert_stale_results_hours: 24
   num_failures_to_alert: 1
+
+# cloud-provider-huaweicloud e2e conformance Test Groups
+- name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
+  gcs_prefix: k8s-conform-huaweicloud/cloud-provider-huaweicloud/e2e-conformance-release-v1.17
 
 # Alibaba Cloud Provider Test Groups
 - name: cloud-provider-aibaba-cloud-e2e-conformance-release-v1.14


### PR DESCRIPTION
This PR adds a dashboard for cloud-provider-huaweicloud conformance tests as per [contributing-test-results](https://github.com/kubernetes/test-infra/blob/92e4176fa4877ba1823eabfc576fe1665f8f3762/docs/contributing-test-results.md#contributing-test-results).

- The conformance test logs have been uploaded to GCS bucket via [upload_e2e.py](https://github.com/kubernetes/test-infra/blob/92e4176fa4877ba1823eabfc576fe1665f8f3762/testgrid/conformance/upload_e2e.py).
- The GCS bucket is world-readable.