### PR TITLE
Include `golang` in the test image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     file \
     git \
+    golang \
     jq \
     mercurial \
     openssh-client \


### PR DESCRIPTION
This is important for a project written by `golang`.


see the discussion here: https://github.com/kubernetes/kubernetes/pull/88399#discussion_r383107339