### PR TITLE
Kops - decrease ginkgo parallelism for HA tests

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
@@ -51,7 +51,7 @@ periodics:
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --extract=ci/latest
-      - --ginkgo-parallel=30
+      - --ginkgo-parallel=10
       - --kops-args=--master-count=3
       - --kops-nodes=6
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64


### PR DESCRIPTION
Trying to get the multi-zone scheduling test to pass, it might be inbalancing zones due to resources, so we're trying to reduce the amount of resources on the cluster at a given time.