### PR TITLE
Push first benchmarkjunit image

### DIFF
--- a/pkg/benchmarkjunit/prowjob_example.yaml
+++ b/pkg/benchmarkjunit/prowjob_example.yaml
@@ -9,16 +9,11 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: golang:latest
+    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
       command:
-      - go
+      - /benchmarkjunit
       args:
-      - run
-      - ./pkg/benchmarkjunit
       - --log-file=$(ARTIFACTS)/benchmark-log.txt
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - --pass-on-error
       - ./experiment/dummybenchmarks/...
-      env:
-      - name: GO111MODULE
-        value: "on"


### PR DESCRIPTION
This change touches pkg/benchmarkjunit/ to trigger an image push for the new benchmarkjunit image:

https://github.com/kubernetes/test-infra/blob/1ad4058320838e02cd28c643a8f102217456637a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L587-L589

Once merged, this will push benchmarkjunit:latest, which has not run yet:
https://testgrid.k8s.io/sig-testing-images#benchmarkjunit

As a bonus, this change updates the example prow config to use the benchmarkjunit image.

Follow up to https://github.com/kubernetes/test-infra/pull/16301 for https://github.com/kubernetes/kubernetes/issues/86935.

This change should fix the other new benchmark jobs configured that run w/ the benchmarkjunit image.