### PR TITLE
Use benchmarkjunit image for benchmark jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -467,15 +467,13 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    # TODO(wojtek-t): Can we use the current Go version from Kubernetes?
-    - image: golang:latest
+    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
       command:
-      - go
+      - /benchmarkjunit
       args:
-      - run
-      - ./pkg/benchmarkjunit
       - --log-file=$(ARTIFACTS)/benchmark-log.txt
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
+      - --pass-on-error
       - ../kubernetes/pkg/...
       - ../kubernetes/plugin/...
       - ../kubernetes/vendor/k8s.io/apimachinery/...

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -48,19 +48,14 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: golang:latest
+    - image: gcr.io/k8s-testimages/benchmarkjunit:latest
       command:
-      - go
+      - /benchmarkjunit
       args:
-      - run
-      - ./pkg/benchmarkjunit
       - --log-file=$(ARTIFACTS)/benchmark-log.txt
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - --pass-on-error
       - ./experiment/dummybenchmarks/...
-      env:
-      - name: GO111MODULE
-        value: "on"
   annotations:
     testgrid-alert-email: colew@google.com
     testgrid-dashboards: sig-testing-canaries


### PR DESCRIPTION
This change updates the config jobs to use the new benchmarkjunit image, since it's now working properly e.g. [sig-api-machinery-structured-merge-diff#ci-benchmark](https://testgrid.k8s.io/sig-api-machinery-structured-merge-diff#ci-benchmark&graph-metrics=allocs%2Fop&graph-metrics=op%20count&graph-metrics=alloced%20B%2Fop)

Also, the scalability job has some broken benchmark tests (https://github.com/kubernetes/kubernetes/issues/79464), so add `--pass-on-error` to this job.

For https://github.com/kubernetes/kubernetes/issues/86935.