### PR TITLE
kubetest: add AKS deployer

### DIFF
--- a/kubetest/BUILD.bazel
+++ b/kubetest/BUILD.bazel
@@ -3,8 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "aks.go",
+        "aksengine.go",
         "anywhere.go",
-        "azure.go",
         "azure_helpers.go",
         "bash.go",
         "build.go",
@@ -38,6 +39,7 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_aws_aws_sdk_go//service/ec2:go_default_library",
         "@com_github_azure_azure_sdk_for_go//services/authorization/mgmt/2015-07-01/authorization:go_default_library",
+        "@com_github_azure_azure_sdk_for_go//services/containerservice/mgmt/2019-10-01/containerservice:go_default_library",
         "@com_github_azure_azure_sdk_for_go//services/preview/msi/mgmt/2015-08-31-preview/msi:go_default_library",
         "@com_github_azure_azure_sdk_for_go//services/resources/mgmt/2018-05-01/resources:go_default_library",
         "@com_github_azure_azure_storage_blob_go//azblob:go_default_library",

--- a/kubetest/aks.go
+++ b/kubetest/aks.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
+	"github.com/Azure/go-autorest/autorest/azure"
+	uuid "github.com/satori/go.uuid"
+	"golang.org/x/crypto/ssh"
+)
+
+type aksDeployer struct {
+	azureCreds    *Creds
+	azureClient   *AzureClient
+	templateUrl   string
+	outputDir     string
+	resourceGroup string
+	resourceName  string
+	location      string
+	k8sVersion    string
+}
+
+func newAksDeployer() (*aksDeployer, error) {
+	if err := validateAksFlags(); err != nil {
+		return nil, err
+	}
+
+	creds, err := getAzCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get azure credentials: %v", err)
+	}
+	env, err := azure.EnvironmentFromName(*aksAzureEnv)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine azure environment: %v", err)
+	}
+
+	var client *AzureClient
+	if client, err = getAzureClient(env,
+		creds.SubscriptionID,
+		creds.ClientID,
+		creds.TenantID,
+		creds.ClientSecret,
+	); err != nil {
+		return nil, fmt.Errorf("error trying to get Azure Client: %v", err)
+	}
+
+	tempdir, err := ioutil.TempDir(os.Getenv("HOME"), "aks")
+	if err != nil {
+		return nil, fmt.Errorf("error creating tempdir: %v", err)
+	}
+
+	return &aksDeployer{
+		azureCreds:    creds,
+		azureClient:   client,
+		templateUrl:   *aksTemplateURL,
+		outputDir:     tempdir,
+		resourceGroup: *aksResourceGroupName,
+		resourceName:  *aksResourceName,
+		location:      *aksLocation,
+		k8sVersion:    *aksOrchestratorRelease,
+	}, nil
+}
+
+func validateAksFlags() error {
+	if *aksCredentialsFile == "" {
+		return fmt.Errorf("no credentials file path specified")
+	}
+	if *aksResourceName == "" {
+		*aksResourceName = "kubetest-" + uuid.NewV1().String()
+	}
+	if *aksResourceGroupName == "" {
+		*aksResourceGroupName = *aksResourceName
+	}
+	if *aksDNSPrefix == "" {
+		*aksDNSPrefix = *aksResourceName
+	}
+	return nil
+}
+
+func (a *aksDeployer) Up() error {
+	log.Printf("Creating AKS cluster %v in resource group %v", a.resourceName, a.resourceGroup)
+	templateFile, err := downloadFromURL(a.templateUrl, path.Join(a.outputDir, "kubernetes.json"), 2)
+	if err != nil {
+		return fmt.Errorf("error downloading AKS cluster template: %v with error %v", a.templateUrl, err)
+	}
+
+	template, err := ioutil.ReadFile(templateFile)
+	if err != nil {
+		return fmt.Errorf("failed to read downloaded cluster template file: %v", err)
+	}
+
+	var model containerservice.ManagedCluster
+	if err := json.Unmarshal(template, &model); err != nil {
+		return fmt.Errorf("failed to unmarshal managedcluster model: %v", err)
+	}
+
+	_, sshPublicKey, err := newSSHKeypair(4096)
+	if err != nil {
+		return fmt.Errorf("failed to generate ssh key for cluster creation: %v", err)
+	}
+
+	*(*model.LinuxProfile.SSH.PublicKeys)[0].KeyData = string(sshPublicKey)
+	model.ManagedClusterProperties.DNSPrefix = aksDNSPrefix
+	model.ManagedClusterProperties.ServicePrincipalProfile.ClientID = &a.azureCreds.ClientID
+	model.ManagedClusterProperties.ServicePrincipalProfile.Secret = &a.azureCreds.ClientSecret
+	model.Location = &a.location
+	model.ManagedClusterProperties.KubernetesVersion = &a.k8sVersion
+
+	future, err := a.azureClient.managedClustersClient.CreateOrUpdate(context.Background(), a.resourceGroup, a.resourceName, model)
+	if err != nil {
+		return fmt.Errorf("failed to start cluster creation: %v", err)
+	}
+
+	if err := future.WaitForCompletionRef(context.Background(), a.azureClient.managedClustersClient.Client); err != nil {
+		return fmt.Errorf("failed long async cluster creation: %v", err)
+	}
+
+	credentialList, err := a.azureClient.managedClustersClient.ListClusterAdminCredentials(context.Background(), a.resourceGroup, a.resourceName)
+	if err != nil {
+		return fmt.Errorf("failed to list kubeconfigs: %v", err)
+	}
+	if credentialList.Kubeconfigs == nil || len(*credentialList.Kubeconfigs) < 1 {
+		return fmt.Errorf("no kubeconfigs available for the aks cluster")
+	}
+
+	kubeconfigPath := path.Join(a.outputDir, "kubeconfig")
+	if err := ioutil.WriteFile(kubeconfigPath, *(*credentialList.Kubeconfigs)[0].Value, 0644); err != nil {
+		return fmt.Errorf("failed to write kubeconfig out")
+	}
+
+	os.Setenv("KUBECONFIG", kubeconfigPath)
+
+	return nil
+}
+
+func (a *aksDeployer) IsUp() error { return isUp(a) }
+
+func (a *aksDeployer) DumpClusterLogs(localPath, gcsPath string) error {
+	if !*aksDumpClusterLogs {
+		log.Print("Skipping DumpClusterLogs")
+		return nil
+	}
+
+	if err := os.Setenv("ARTIFACTS", localPath); err != nil {
+		return err
+	}
+
+	logDumper := func() error {
+		// Extract log dump script and manifest from cloud-provider-azure repo
+		const logDumpURLPrefix string = "https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/hack/log-dump/"
+		logDumpScript, err := downloadFromURL(logDumpURLPrefix+"log-dump.sh", path.Join(a.outputDir, "log-dump.sh"), 2)
+		if err != nil {
+			return fmt.Errorf("error downloading log dump script: %v", err)
+		}
+		if err := control.FinishRunning(exec.Command("chmod", "+x", logDumpScript)); err != nil {
+			return fmt.Errorf("error changing access permission for %s: %v", logDumpScript, err)
+		}
+		if _, err := downloadFromURL(logDumpURLPrefix+"log-dump-daemonset.yaml", path.Join(a.outputDir, "log-dump-daemonset.yaml"), 2); err != nil {
+			return fmt.Errorf("error downloading log dump manifest: %v", err)
+		}
+
+		if err := control.FinishRunning(exec.Command("bash", "-c", logDumpScript)); err != nil {
+			return fmt.Errorf("error running log collection script %s: %v", logDumpScript, err)
+		}
+		return nil
+	}
+
+	return logDumper()
+}
+
+// NB(alexeldeib): order of execution is when running scalability tests is:
+// kubemarkUp -> IsUp -> TestSetup -> Up -> TestSetup
+// When executing other tests, the order is:
+// Up -> TestSetup
+// The kubeconfig must be available during kubemark tests, so we have to set it both in TestSetup and in Up.
+// The masterIP and masterInternalIP must be available for all tests.
+func (a *aksDeployer) TestSetup() error {
+	credentialList, err := a.azureClient.managedClustersClient.ListClusterAdminCredentials(context.Background(), a.resourceGroup, a.resourceName)
+	if err != nil {
+		return fmt.Errorf("failed to list kubeconfigs: %v", err)
+	}
+	if credentialList.Kubeconfigs == nil || len(*credentialList.Kubeconfigs) < 1 {
+		return fmt.Errorf("no kubeconfigs available for the aks cluster")
+	}
+
+	kubeconfigPath := path.Join(a.outputDir, "kubeconfig")
+	if err := ioutil.WriteFile(kubeconfigPath, *(*credentialList.Kubeconfigs)[0].Value, 0644); err != nil {
+		return fmt.Errorf("failed to write kubeconfig out")
+	}
+
+	masterIP, err := control.Output(exec.Command(
+		"az", "aks", "show",
+		"-g", *aksResourceGroupName,
+		"-n", *aksResourceName,
+		"--query", "fqdn", "-o", "tsv"))
+	if err != nil {
+		return fmt.Errorf("failed to get masterIP: %v", err)
+	}
+	masterInternalIP := masterIP
+
+	if err := os.Setenv("KUBE_MASTER_IP", strings.TrimSpace(string(masterIP))); err != nil {
+		return err
+	}
+
+	// MASTER_IP variable is required by the clusterloader. It requires to have master ip provided,
+	// due to master being unregistered.
+	if err := os.Setenv("MASTER_IP", strings.TrimSpace(string(masterIP))); err != nil {
+		return err
+	}
+
+	// MASTER_INTERNAL_IP variable is needed by the clusterloader2 when running on kubemark clusters.
+	if err := os.Setenv("MASTER_INTERNAL_IP", strings.TrimSpace(string(masterInternalIP))); err != nil {
+		return err
+	}
+
+	os.Setenv("KUBECONFIG", kubeconfigPath)
+
+	return nil
+}
+
+func (a *aksDeployer) Down() error {
+	log.Printf("Deleting AKS cluster %v in resource group %v", a.resourceName, a.resourceGroup)
+	future, err := a.azureClient.managedClustersClient.Delete(context.Background(), a.resourceGroup, a.resourceName)
+	if err != nil {
+		res := future.Response()
+		if res != nil && res.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("failed to start cluster deletion: %v", err)
+	}
+	return future.WaitForCompletionRef(context.Background(), a.azureClient.managedClustersClient.Client)
+}
+
+func (a *aksDeployer) GetClusterCreated(_ string) (time.Time, error) { return time.Now(), nil }
+
+// KubectlCommand uses the default command configuration.
+func (a *aksDeployer) KubectlCommand() (*exec.Cmd, error) { return nil, nil }
+
+func newSSHKeypair(bits int) (private, public []byte, err error) {
+	// Private Key generation
+	privateKey, err := rsa.GenerateKey(rand.Reader, bits)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Validate Private Key
+	err = privateKey.Validate()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get ASN.1 DER format
+	privDER := x509.MarshalPKCS1PrivateKey(privateKey)
+
+	// pem.Block
+	privBlock := pem.Block{
+		Type:    "RSA PRIVATE KEY",
+		Headers: nil,
+		Bytes:   privDER,
+	}
+
+	// Private key in PEM format
+	privBytes := pem.EncodeToMemory(&privBlock)
+
+	publicKey, err := ssh.NewPublicKey(&privateKey.PublicKey)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pubBytes := ssh.MarshalAuthorizedKey(publicKey)
+
+	return privBytes, pubBytes, nil
+}

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -35,7 +35,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pelletier/go-toml"
 	"k8s.io/test-infra/kubetest/e2e"
 	"k8s.io/test-infra/kubetest/process"
 	"k8s.io/test-infra/kubetest/util"
@@ -139,7 +138,7 @@ type Config struct {
 	Creds Creds
 }
 
-type Cluster struct {
+type aksEngineDeployer struct {
 	ctx                              context.Context
 	credentials                      *Creds
 	location                         string
@@ -180,12 +179,12 @@ type Cluster struct {
 }
 
 // IsAzureStackCloud return true if the cloud is AzureStack
-func (c *Cluster) isAzureStackCloud() bool {
+func (c *aksEngineDeployer) isAzureStackCloud() bool {
 	return c.azureCustomCloudURL != "" && strings.EqualFold(c.azureEnvironment, AzureStackCloud)
 }
 
 // SetCustomCloudProfileEnvironment retrieves the endpoints from Azure Stack metadata endpoint and sets the values for azure.Environment
-func (c *Cluster) SetCustomCloudProfileEnvironment() error {
+func (c *aksEngineDeployer) SetCustomCloudProfileEnvironment() error {
 	var environmentJSON string
 	if c.isAzureStackCloud() {
 		env := azure.Environment{}
@@ -252,21 +251,6 @@ func (c *Cluster) SetCustomCloudProfileEnvironment() error {
 		}
 
 		os.Setenv("AZURE_ENVIRONMENT_FILEPATH", tmpFileName)
-	}
-	return nil
-}
-
-func (c *Cluster) getAzCredentials() error {
-	content, err := ioutil.ReadFile(*aksCredentialsFile)
-	log.Printf("Reading credentials file %v", *aksCredentialsFile)
-	if err != nil {
-		return fmt.Errorf("error reading credentials file %v %v", *aksCredentialsFile, err)
-	}
-	config := Config{}
-	err = toml.Unmarshal(content, &config)
-	c.credentials = &config.Creds
-	if err != nil {
-		return fmt.Errorf("error parsing credentials file %v %v", *aksCredentialsFile, err)
 	}
 	return nil
 }
@@ -341,7 +325,7 @@ func checkParams() error {
 	return nil
 }
 
-func newAKSEngine() (*Cluster, error) {
+func newAKSEngine() (*aksEngineDeployer, error) {
 	if err := checkParams(); err != nil {
 		return nil, fmt.Errorf("error creating Azure K8S cluster: %v", err)
 	}
@@ -356,7 +340,7 @@ func newAKSEngine() (*Cluster, error) {
 		}
 	}
 
-	c := Cluster{
+	c := aksEngineDeployer{
 		ctx:                              context.Background(),
 		apiModelPath:                     *aksTemplateURL,
 		name:                             *aksResourceName,
@@ -389,7 +373,11 @@ func newAKSEngine() (*Cluster, error) {
 		useManagedIdentity:               false,
 		identityName:                     "",
 	}
-	c.getAzCredentials()
+	creds, err := getAzCredentials()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get azure credentials: %v", err)
+	}
+	c.credentials = creds
 	c.azureBlobContainerURL = fmt.Sprintf(azureBlobContainerURLTemplate, c.credentials.StorageAccountName, os.Getenv("AZ_STORAGE_CONTAINER_NAME"))
 	c.customKubeBinaryURL = fmt.Sprintf("%s/%s", c.azureBlobContainerURL, fmt.Sprintf(k8sNodeTarballTemplate, k8sVersion))
 	c.aksCustomWinBinariesURL = fmt.Sprintf("%s/%s", c.azureBlobContainerURL, fmt.Sprintf(winZipTemplate, k8sVersion))
@@ -439,7 +427,7 @@ func getAKSDeploymentMethod(k8sRelease string) aksDeploymentMethod {
 	return customHyperkube
 }
 
-func (c *Cluster) populateAPIModelTemplate() error {
+func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 	var err error
 	v := AKSEngineAPIModel{}
 	if c.apiModelPath != "" {
@@ -612,7 +600,7 @@ func appendAddonToAPIModel(v *AKSEngineAPIModel, addon KubernetesAddon) {
 	v.Properties.OrchestratorProfile.KubernetesConfig.Addons = append(v.Properties.OrchestratorProfile.KubernetesConfig.Addons, addon)
 }
 
-func (c *Cluster) getAKSEngine(retry int) error {
+func (c *aksEngineDeployer) getAKSEngine(retry int) error {
 	downloadPath := path.Join(os.Getenv("HOME"), "aks-engine.tar.gz")
 	f, err := os.Create(downloadPath)
 	if err != nil {
@@ -658,14 +646,14 @@ func (c *Cluster) getAKSEngine(retry int) error {
 
 }
 
-func (c *Cluster) generateARMTemplates() error {
+func (c *aksEngineDeployer) generateARMTemplates() error {
 	if err := control.FinishRunning(exec.Command(c.aksEngineBinaryPath, "generate", c.apiModelPath, "--output-directory", c.outputDir)); err != nil {
 		return fmt.Errorf("failed to generate ARM templates: %v.", err)
 	}
 	return nil
 }
 
-func (c *Cluster) loadARMTemplates() error {
+func (c *aksEngineDeployer) loadARMTemplates() error {
 	var err error
 	template, err := ioutil.ReadFile(path.Join(c.outputDir, "azuredeploy.json"))
 	if err != nil {
@@ -690,7 +678,7 @@ func (c *Cluster) loadARMTemplates() error {
 	return nil
 }
 
-func (c *Cluster) getAzureClient(ctx context.Context) error {
+func (c *aksEngineDeployer) getAzureClient(ctx context.Context) error {
 	// instantiate Azure Resource Manager Client
 	env, err := azure.EnvironmentFromName(c.azureEnvironment)
 	var client *AzureClient
@@ -715,7 +703,7 @@ func (c *Cluster) getAzureClient(ctx context.Context) error {
 	return nil
 }
 
-func (c *Cluster) createCluster() error {
+func (c *aksEngineDeployer) createCluster() error {
 	var err error
 	kubecfgDir, _ := ioutil.ReadDir(path.Join(c.outputDir, "kubeconfig"))
 	kubecfg := path.Join(c.outputDir, "kubeconfig", kubecfgDir[0].Name())
@@ -752,7 +740,7 @@ func (c *Cluster) createCluster() error {
 	return nil
 }
 
-func (c *Cluster) populateAzureCloudConfig(isVMSS bool) error {
+func (c *aksEngineDeployer) populateAzureCloudConfig(isVMSS bool) error {
 	// CLOUD_CONFIG is required when running Azure-specific e2e tests
 	// See https://github.com/kubernetes/kubernetes/blob/master/hack/ginkgo-e2e.sh#L113-L118
 	cc := map[string]string{
@@ -786,7 +774,7 @@ func (c *Cluster) populateAzureCloudConfig(isVMSS bool) error {
 	return nil
 }
 
-func (c *Cluster) dockerLogin() error {
+func (c *aksEngineDeployer) dockerLogin() error {
 	cwd, _ := os.Getwd()
 	log.Printf("CWD %v", cwd)
 	cmd := &exec.Cmd{}
@@ -874,7 +862,7 @@ func getImageVersion(projectPath string) string {
 	return strings.TrimSpace(string(output))
 }
 
-func (c *Cluster) buildAzureCloudComponents() error {
+func (c *aksEngineDeployer) buildAzureCloudComponents() error {
 	log.Println("Building cloud controller manager and cloud node manager.")
 
 	// Set environment variables for building cloud components' images
@@ -901,7 +889,7 @@ func (c *Cluster) buildAzureCloudComponents() error {
 	return nil
 }
 
-func (c *Cluster) buildHyperkube() error {
+func (c *aksEngineDeployer) buildHyperkube() error {
 	var pushCmd *exec.Cmd
 	os.Setenv("VERSION", k8sVersion)
 	log.Println("Building hyperkube.")
@@ -929,7 +917,7 @@ func (c *Cluster) buildHyperkube() error {
 	return nil
 }
 
-func (c *Cluster) uploadToAzureStorage(filePath string) (string, error) {
+func (c *aksEngineDeployer) uploadToAzureStorage(filePath string) (string, error) {
 	credential, err := azblob.NewSharedKeyCredential(c.credentials.StorageAccountName, c.credentials.StorageAccountKey)
 	if err != nil {
 		return "", fmt.Errorf("new shared key credential: %v", err)
@@ -951,29 +939,6 @@ func (c *Cluster) uploadToAzureStorage(filePath string) (string, error) {
 	blobURLString := blobURL.URL()
 	log.Printf("Uploaded %s to %s", filePath, blobURLString.String())
 	return blobURLString.String(), nil
-}
-
-func downloadFromURL(url string, destination string, retry int) (string, error) {
-	f, err := os.Create(destination)
-	if err != nil {
-		return "", err
-	}
-	defer f.Close()
-
-	for i := 0; i < retry; i++ {
-		log.Printf("downloading %v from %v", destination, url)
-		if err := httpRead(url, f); err == nil {
-			break
-		}
-		err = fmt.Errorf("url=%s failed get %v: %v", url, destination, err)
-		if i == retry-1 {
-			return "", err
-		}
-		log.Println(err)
-		sleep(time.Duration(i) * time.Second)
-	}
-	f.Chmod(0644)
-	return destination, nil
 }
 
 func getZipBuildScript(buildScriptURL string, retry int) (string, error) {
@@ -1000,7 +965,7 @@ func getZipBuildScript(buildScriptURL string, retry int) (string, error) {
 	return downloadPath, nil
 }
 
-func (c *Cluster) buildWinZip() error {
+func (c *aksEngineDeployer) buildWinZip() error {
 	zipName := fmt.Sprintf(winZipTemplate, k8sVersion)
 	buildFolder := path.Join(os.Getenv("HOME"), "winbuild")
 	zipPath := path.Join(os.Getenv("HOME"), zipName)
@@ -1022,7 +987,7 @@ func (c *Cluster) buildWinZip() error {
 	return nil
 }
 
-func (c *Cluster) Up() error {
+func (c *aksEngineDeployer) Up() error {
 	var err error
 	if c.apiModelPath != "" {
 		templateFile, err := downloadFromURL(c.apiModelPath, path.Join(c.outputDir, "kubernetes.json"), 2)
@@ -1059,7 +1024,7 @@ func (c *Cluster) Up() error {
 	return nil
 }
 
-func (c *Cluster) Build(b buildStrategy) error {
+func (c *aksEngineDeployer) Build(b buildStrategy) error {
 	if c.aksDeploymentMethod == customHyperkube && !areAllDockerImagesExist(c.customHyperkubeImage) {
 		// Build k8s without any special environment variables
 		if err := b.Build(); err != nil {
@@ -1136,12 +1101,12 @@ func (c *Cluster) Build(b buildStrategy) error {
 	return nil
 }
 
-func (c *Cluster) Down() error {
+func (c *aksEngineDeployer) Down() error {
 	log.Printf("Deleting resource group: %v.", c.resourceGroup)
 	return c.azureClient.DeleteResourceGroup(c.ctx, c.resourceGroup)
 }
 
-func (c *Cluster) DumpClusterLogs(localPath, gcsPath string) error {
+func (c *aksEngineDeployer) DumpClusterLogs(localPath, gcsPath string) error {
 	if !*aksDumpClusterLogs {
 		log.Print("Skipping DumpClusterLogs")
 		return nil
@@ -1201,11 +1166,11 @@ func (c *Cluster) DumpClusterLogs(localPath, gcsPath string) error {
 	return nil
 }
 
-func (c *Cluster) GetClusterCreated(clusterName string) (time.Time, error) {
+func (c *aksEngineDeployer) GetClusterCreated(clusterName string) (time.Time, error) {
 	return time.Time{}, errors.New("not implemented")
 }
 
-func (c *Cluster) TestSetup() error {
+func (c *aksEngineDeployer) TestSetup() error {
 	// set env vars required by the ccm e2e tests
 	if *testCcm {
 		if err := os.Setenv("K8S_AZURE_TENANTID", c.credentials.TenantID); err != nil {
@@ -1262,16 +1227,16 @@ func (c *Cluster) TestSetup() error {
 	return nil
 }
 
-func (c *Cluster) IsUp() error {
+func (c *aksEngineDeployer) IsUp() error {
 	return isUp(c)
 }
 
-func (c *Cluster) KubectlCommand() (*exec.Cmd, error) {
+func (c *aksEngineDeployer) KubectlCommand() (*exec.Cmd, error) {
 	return exec.Command("kubectl"), nil
 }
 
 // BuildTester returns a standard ginkgo-script tester or a custom one if testCcm is enabled
-func (c *Cluster) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
+func (c *aksEngineDeployer) BuildTester(o *e2e.BuildTesterOptions) (e2e.Tester, error) {
 	if *testCcm {
 		return &GinkgoCCMTester{}, nil
 	}

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -19,16 +19,19 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
+	"github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2019-10-01/containerservice"
 	"github.com/Azure/azure-sdk-for-go/services/preview/msi/mgmt/2015-08-31-preview/msi"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/pelletier/go-toml"
 	uuid "github.com/satori/go.uuid"
 )
 
@@ -185,12 +188,13 @@ type AgentPoolProfile struct {
 }
 
 type AzureClient struct {
-	environment         azure.Environment
-	subscriptionID      string
-	deploymentsClient   resources.DeploymentsClient
-	groupsClient        resources.GroupsClient
-	msiClient           msi.UserAssignedIdentitiesClient
-	authorizationClient authorization.RoleAssignmentsClient
+	environment           azure.Environment
+	subscriptionID        string
+	deploymentsClient     resources.DeploymentsClient
+	groupsClient          resources.GroupsClient
+	msiClient             msi.UserAssignedIdentitiesClient
+	authorizationClient   authorization.RoleAssignmentsClient
+	managedClustersClient containerservice.ManagedClustersClient
 }
 
 type FeatureFlags struct {
@@ -331,6 +335,20 @@ func getOAuthConfig(env azure.Environment, subscriptionID, tenantID string) (*ad
 	return oauthConfig, nil
 }
 
+func getAzCredentials() (*Creds, error) {
+	content, err := ioutil.ReadFile(*aksCredentialsFile)
+	log.Printf("Reading credentials file %v", *aksCredentialsFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading credentials file %v %v", *aksCredentialsFile, err)
+	}
+	config := Config{}
+	err = toml.Unmarshal(content, &config)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing credentials file %v %v", *aksCredentialsFile, err)
+	}
+	return &config.Creds, nil
+}
+
 func getAzureClient(env azure.Environment, subscriptionID, clientID, tenantID, clientSecret string) (*AzureClient, error) {
 	oauthConfig, err := getOAuthConfig(env, subscriptionID, tenantID)
 	if err != nil {
@@ -347,12 +365,13 @@ func getAzureClient(env azure.Environment, subscriptionID, clientID, tenantID, c
 
 func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *adal.ServicePrincipalToken) *AzureClient {
 	c := &AzureClient{
-		environment:         env,
-		subscriptionID:      subscriptionID,
-		deploymentsClient:   resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		groupsClient:        resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
-		msiClient:           msi.NewUserAssignedIdentitiesClient(subscriptionID),
-		authorizationClient: authorization.NewRoleAssignmentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		environment:           env,
+		subscriptionID:        subscriptionID,
+		deploymentsClient:     resources.NewDeploymentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		groupsClient:          resources.NewGroupsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		msiClient:             msi.NewUserAssignedIdentitiesClient(subscriptionID),
+		authorizationClient:   authorization.NewRoleAssignmentsClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
+		managedClustersClient: containerservice.NewManagedClustersClientWithBaseURI(env.ResourceManagerEndpoint, subscriptionID),
 	}
 
 	authorizer := autorest.NewBearerAuthorizer(armSpt)
@@ -361,8 +380,32 @@ func getClient(env azure.Environment, subscriptionID, tenantID string, armSpt *a
 	c.groupsClient.Authorizer = authorizer
 	c.msiClient.Authorizer = authorizer
 	c.authorizationClient.Authorizer = authorizer
+	c.managedClustersClient.Authorizer = authorizer
 
 	return c
+}
+
+func downloadFromURL(url string, destination string, retry int) (string, error) {
+	f, err := os.Create(destination)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	for i := 0; i < retry; i++ {
+		log.Printf("downloading %v from %v", destination, url)
+		if err := httpRead(url, f); err == nil {
+			break
+		}
+		err = fmt.Errorf("url=%s failed get %v: %v", url, destination, err)
+		if i == retry-1 {
+			return "", err
+		}
+		log.Println(err)
+		sleep(time.Duration(i) * time.Second)
+	}
+	f.Chmod(0644)
+	return destination, nil
 }
 
 func stringPointer(s string) *string {

--- a/kubetest/build.go
+++ b/kubetest/build.go
@@ -50,7 +50,7 @@ func (b *buildStrategy) Set(value string) error {
 		}
 	}
 	switch value {
-	case "bazel", "e2e", "host-go", "quick", "release", "gce-windows-bazel":
+	case "bazel", "e2e", "host-go", "quick", "release", "gce-windows-bazel", "":
 		*b = buildStrategy(value)
 		return nil
 	}


### PR DESCRIPTION
This PR breaks the single existing deployer for AKS into two Azure deployers, one using AKS-Engine and one for AKS. Currently they share a lot of flags, and I haven't gone into a deep effort to dedupe or shuffle some of these around since they're use somewhat deeply throughout kubetest. I wanted to open this as-is and start getting feedback/validation before I attempted any major cleanup.

I'll open a separate PR in k/k shortly with some of the even-less-polished bash to integrate with kubemark and clusterloader2 for scalability tests.