### PR TITLE
Move chases2 from reviewer to owner

### DIFF
--- a/config/OWNERS
+++ b/config/OWNERS
@@ -5,7 +5,6 @@ approvers:
 - krzyzacy
 - spiffxp
 - wojtek-t
-reviewers:
 - chases2
 labels:
 - area/config


### PR DESCRIPTION
Being a 'reviewer' sends me routine reviews that should be handled by lower-level owners, because `assign` prioritizes reviewers to review. However, I'd still like to assist with config changes when they are large-scale or specific to test visibility on TestGrid. This seems like the best OWNERS configuration that achieves both.

/assign @cblecker @krzyzacy @spiffxp @wojtek-t 