### PR TITLE
bugzilla plugin: add /bugzilla qa command

### DIFF
--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fakegithub
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -717,5 +718,11 @@ func (f *FakeClient) UpdatePullRequest(org, repo string, number int, title, body
 	if body != nil {
 		pr.Body = *body
 	}
+	return nil
+}
+
+// Query simply exists to allow the fake client to match the interface for packages that need it.
+// It does not modify the passed interface at all.
+func (f *FakeClient) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
 	return nil
 }

--- a/prow/plugins/bugzilla/BUILD.bazel
+++ b/prow/plugins/bugzilla/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/labels:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -18,6 +18,7 @@ limitations under the License.
 package bugzilla
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -25,6 +26,7 @@ import (
 	"strconv"
 	"strings"
 
+	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/bugzilla"
@@ -36,8 +38,9 @@ import (
 )
 
 var (
-	titleMatch   = regexp.MustCompile(`(?i)^.*?Bug ([0-9]+):`)
-	commandMatch = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
+	titleMatch          = regexp.MustCompile(`(?i)^.*?Bug ([0-9]+):`)
+	refreshCommandMatch = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
+	qaCommandMatch      = regexp.MustCompile(`(?mi)^/bugzilla assign-qa\s*$`)
 )
 
 const (
@@ -150,6 +153,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		WhoCanUse:   "Anyone",
 		Examples:    []string{"/bugzilla refresh"},
 	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/bugzilla assign-qa",
+		Description: "Assign PR to QA contact specified in Bugzilla",
+		Featured:    false,
+		WhoCanUse:   "Anyone",
+		Examples:    []string{"/bugzilla assign-qa"},
+	})
 	return pluginHelp, nil
 }
 
@@ -159,6 +169,7 @@ type githubClient interface {
 	GetIssueLabels(org, repo string, number int) ([]github.Label, error)
 	AddLabel(owner, repo string, number int, label string) error
 	RemoveLabel(owner, repo string, number int, label string) error
+	Query(ctx context.Context, q interface{}, vars map[string]interface{}) error
 }
 
 func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error {
@@ -268,8 +279,14 @@ func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericComment
 	if gce.Action != github.GenericCommentActionCreated {
 		return nil, nil
 	}
-	// Make sure they are requesting a bug refresh
-	if !commandMatch.MatchString(gce.Body) {
+	// Make sure they are requesting a valid command
+	var assign bool
+	switch {
+	case refreshCommandMatch.MatchString(gce.Body):
+		assign = false
+	case qaCommandMatch.MatchString(gce.Body):
+		assign = true
+	default:
 		return nil, nil
 	}
 	var (
@@ -280,7 +297,7 @@ func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericComment
 
 	// We don't support linking issues to Bugs
 	if !gce.IsPR {
-		log.Debug("Bug refresh requested on an issue, ignoring")
+		log.Debug("Bugzilla command requested on an issue, ignoring")
 		return nil, gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, gce.User.Login, `Bugzilla bug referencing is only supported for Pull Requests, not issues.`))
 	}
 
@@ -290,7 +307,7 @@ func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericComment
 		return nil, err
 	}
 
-	e := &event{org: org, repo: repo, baseRef: pr.Base.Ref, number: number, merged: pr.Merged, body: gce.Body, htmlUrl: gce.HTMLURL, login: gce.User.Login}
+	e := &event{org: org, repo: repo, baseRef: pr.Base.Ref, number: number, merged: pr.Merged, body: gce.Body, htmlUrl: gce.HTMLURL, login: gce.User.Login, assign: assign}
 	mat := titleMatch.FindStringSubmatch(pr.Title)
 	if mat == nil {
 		e.missing = true
@@ -312,11 +329,61 @@ type event struct {
 	number, bugId        int
 	missing, merged      bool
 	body, htmlUrl, login string
+	assign               bool
 }
 
 func (e *event) comment(gc githubClient) func(body string) error {
 	return func(body string) error {
 		return gc.CreateComment(e.org, e.repo, e.number, plugins.FormatResponseRaw(e.body, e.htmlUrl, e.login, body))
+	}
+}
+
+type queryUser struct {
+	Login githubql.String
+}
+
+type queryNode struct {
+	User queryUser `graphql:"... on User"`
+}
+
+type queryEdge struct {
+	Node queryNode
+}
+
+type querySearch struct {
+	Edges []queryEdge
+}
+
+/* emailToLoginQuery is a graphql query struct that should result in this graphql query:
+   {
+     search(type: USER, query: "email", first: 5) {
+       edges {
+         node {
+           ... on User {
+             login
+           }
+         }
+       }
+     }
+   }
+*/
+type emailToLoginQuery struct {
+	Search querySearch `graphql:"search(type:USER query:$email first:5)"`
+}
+
+// processQueryResult generates a response based on a populated emailToLoginQuery
+func processQuery(query *emailToLoginQuery, email string, log *logrus.Entry) string {
+	switch len(query.Search.Edges) {
+	case 0:
+		return fmt.Sprintf("No GitHub users were found matching the public email listed for the QA contact in Bugzilla (%s), skipping assignment.", email)
+	case 1:
+		return fmt.Sprintf("/assign @%s", query.Search.Edges[0].Node.User.Login)
+	default:
+		response := fmt.Sprintf("Multiple GitHub users were found matching the public email listed for the QA contact in Bugzilla (%s), skipping assignment. List of users with matching email:", email)
+		for _, edge := range query.Search.Edges {
+			response += fmt.Sprintf("\n\t- %s", edge.Node.User.Login)
+		}
+		return response
 	}
 }
 
@@ -375,6 +442,26 @@ To reference a bug, add 'Bug XXX:' to the title of this pull request and request
 				}
 				if changed {
 					response += " The bug has been updated to refer to the pull request using the external bug tracker."
+				}
+			}
+			// if bug is valid and qa command was used, identify qa contact via email
+			if e.assign {
+				if bug.QAContactDetail == nil {
+					response += fmt.Sprintf(bugLink+" does not have a QA contact, skipping assignment", e.bugId, bc.Endpoint(), e.bugId)
+				} else if bug.QAContactDetail.Email == "" {
+					response += fmt.Sprintf("QA contact for "+bugLink+" does not have a listed email, skipping assignment", e.bugId, bc.Endpoint(), e.bugId)
+				} else {
+					query := &emailToLoginQuery{}
+					email := bug.QAContactDetail.Email
+					queryVars := map[string]interface{}{
+						"email": githubql.String(email),
+					}
+					err := gc.Query(context.Background(), query, queryVars)
+					if err != nil {
+						log.WithError(err).Error("Failed to run graphql github query")
+						return comment(formatError(fmt.Sprintf("querying GitHub for users with public email (%s)", email), bc.Endpoint(), e.bugId, err))
+					}
+					response += fmt.Sprint("\n", processQuery(query, email, log))
 				}
 			}
 		} else {


### PR DESCRIPTION
Adds a `/bugzilla qa` command that assigns the qa contact for a bugzilla bug to the PR. To identify the github username, a graphql query is done based on the email for the QA contact in bugzilla. If the QA contact's GitHub public email is the email listed in bugzilla, the query should be able to identify the correct user.

This command also runs a refresh to make sure that the bug is valid, and only assigns a QA contact if validation succeeds.

/cc @stevekuznetsov 