### PR TITLE
Make tide use workload identity for GCP auth

### DIFF
--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -41,7 +41,6 @@ spec:
         - --github-endpoint=https://api.github.com
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
-        - --gcs-credentials-file=/etc/service-account/service-account.json
         - --history-uri=gs://k8s-prow/tide-history.json
         - --status-path=gs://k8s-prow/tide-status-checkpoint.yaml
         ports:
@@ -57,9 +56,6 @@ spec:
         - name: job-config
           mountPath: /etc/job-config
           readOnly: true
-        - name: service-account
-          mountPath: /etc/service-account
-          readOnly: true
       volumes:
       - name: oauth
         secret:
@@ -70,6 +66,3 @@ spec:
       - name: job-config
         configMap:
           name: job-config
-      - name: service-account
-        secret:
-          secretName: tide-history-service-account


### PR DESCRIPTION
/assign @cjwagner @michelle192837 

ref #15806 https://github.com/kubernetes/test-infra/issues/16464

```console
$ gsutil iam get gs://k8s-prow
{
...
    {
      "members": [
        "serviceAccount:control-plane@k8s-prow.iam.gserviceaccount.com",
        "serviceAccount:tide-history@k8s-prow.iam.gserviceaccount.com"
      ],
      "role": "roles/storage.objectAdmin"
    }
...
}
$ workload-identity/bind-service-accounts.sh k8s-prow us-central1-f prow default tide control-plane@k8s-prow.iam.gserviceaccount.com
ALREADY MEMBER: serviceAccount:k8s-prow.svc.id.goog[default/tide] has roles/iam.workloadIdentityUser for control-plane@k8s-prow.iam.gserviceaccount.com.
+++ kubectl run --rm=true -i --generator=run-pod/v1 --context=gke_k8s-prow_us-central1-f_prow --namespace=default --serviceaccount=tide --image=google/cloud-sdk:slim workload-identity-test-17
DONE: --context=gke_k8s-prow_us-central1-f_prow --namespace=default serviceaccounts/tide acts as control-plane@k8s-prow.iam.gserviceaccount.com
```