### PR TITLE
Re-evaluate cherry-pick labels when a base branch changes for a PR

### DIFF
--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -101,6 +101,10 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, c
 		return nil
 	}
 
+	return ensureLabels(gc, org, repo, pr, log, cp, commentBody)
+}
+
+func ensureLabels(gc githubClient, org string, repo string, pr *github.PullRequestEvent, log *logrus.Entry, cp commentPruner, commentBody string) error {
 	issueLabels, err := gc.GetIssueLabels(org, repo, pr.Number)
 	if err != nil {
 		return err

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved.go
@@ -116,10 +116,15 @@ func handlePR(gc githubClient, log *logrus.Entry, pr *github.PullRequestEvent, c
 			} `json:"base"`
 		}
 		if err := json.Unmarshal(pr.Changes, &changes); err != nil {
-			// we're detecting this best-effort so we can forget about
-			// the event
+			// we're detecting this best-effort so we can forget about the event
 			return nil
 		}
+
+		if changes.Base.Ref.From == "" {
+			// PR base ref did not change, ignore the event
+			return nil
+		}
+
 		if branchRe.MatchString(branch) && !branchRe.MatchString(changes.Base.Ref.From) {
 			// base ref changed from a branch not allowed for cherry-picks to a branch that is allowed for cherry-picks
 			return ensureLabels(gc, org, repo, pr, log, cp, commentBody)

--- a/prow/plugins/cherrypickunapproved/cherrypick-unapproved_test.go
+++ b/prow/plugins/cherrypickunapproved/cherrypick-unapproved_test.go
@@ -178,6 +178,26 @@ func TestCherryPickUnapprovedLabel(t *testing.T) {
 			removed:        []string{},
 			expectComment:  true,
 		},
+		{
+			name:           "PR base branch master edited to release -> add cpUnapproved and comment",
+			branch:         "release-1.10",
+			previousBranch: "master",
+			action:         github.PullRequestActionEdited,
+			labels:         []string{},
+			added:          []string{labels.CpUnapproved},
+			removed:        []string{},
+			expectComment:  true,
+		},
+		{
+			name:           "PR base branch edited from release to master -> remove cpApproved and cpUnapproved",
+			branch:         "master",
+			previousBranch: "release-1.10",
+			action:         github.PullRequestActionEdited,
+			labels:         []string{labels.CpApproved, labels.CpUnapproved},
+			added:          []string{},
+			removed:        []string{labels.CpApproved, labels.CpUnapproved},
+			expectComment:  false,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/16328

When the base branch of a PR changes from a non-release branch to a release branch, we'd like to apply the `do-not-merge/cherry-pick-not-approved` label to the PR.

Similarly, when the base branch of a PR changes from a release branch to a non-release branch, we'd like to remove labels related to cherry-picks, and prune comments as needed.

The code has been refactored a decent bit to make the change, hopefully the commits are easy to follow along.