### PR TITLE
Boskos cleaner as controller

### DIFF
--- a/boskos/cleaner/BUILD.bazel
+++ b/boskos/cleaner/BUILD.bazel
@@ -21,7 +21,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//boskos/cleaner/v2:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/boskos/cleaner/cleaner.go
+++ b/boskos/cleaner/cleaner.go
@@ -97,6 +97,16 @@ func (c *Cleaner) recycleAll(ctx context.Context) {
 }
 
 func (c *Cleaner) recycleOne(res *common.Resource) {
+	RecycleOne(c.client, res)
+}
+
+type RecycleBoskosClient interface {
+	AcquireByState(state, dest string, names []string) ([]common.Resource, error)
+	ReleaseOne(name, dest string) error
+	UpdateOne(name, state string, userData *common.UserData) error
+}
+
+func RecycleOne(client RecycleBoskosClient, res *common.Resource) {
 	logrus.Infof("Resource %s is being recycled", res.Name)
 	leasedResources, err := mason.CheckUserData(*res)
 	if err != nil {
@@ -104,12 +114,12 @@ func (c *Cleaner) recycleOne(res *common.Resource) {
 		return
 	}
 	if leasedResources != nil {
-		resources, err := c.client.AcquireByState(res.Name, common.Cleaning, leasedResources)
+		resources, err := client.AcquireByState(res.Name, common.Cleaning, leasedResources)
 		if err != nil {
 			logrus.WithError(err).Warningf("could not acquire some leased resources for %s", res.Name)
 		}
 		for _, r := range resources {
-			if err := c.client.ReleaseOne(r.Name, common.Dirty); err != nil {
+			if err := client.ReleaseOne(r.Name, common.Dirty); err != nil {
 				logrus.WithError(err).Warningf("could not release resource %s", r.Name)
 			} else {
 				logrus.Infof("resource %s released as %s", r.Name, common.Dirty)
@@ -117,7 +127,7 @@ func (c *Cleaner) recycleOne(res *common.Resource) {
 		}
 		// Deleting Leased Resources
 		res.UserData.Delete(mason.LeasedResources)
-		if err := c.client.UpdateOne(res.Name, res.State, common.UserDataFromMap(map[string]string{mason.LeasedResources: ""})); err != nil {
+		if err := client.UpdateOne(res.Name, res.State, common.UserDataFromMap(map[string]string{mason.LeasedResources: ""})); err != nil {
 			logrus.WithError(err).Errorf("could not update resource %s with freed leased resources", res.Name)
 		}
 	}

--- a/boskos/cleaner/v2/BUILD.bazel
+++ b/boskos/cleaner/v2/BUILD.bazel
@@ -1,0 +1,52 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cleaner.go"],
+    importpath = "k8s.io/test-infra/boskos/cleaner/v2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//boskos/cleaner:go_default_library",
+        "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/controller:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/handler:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/source:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cleaner_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//boskos/common:go_default_library",
+        "//boskos/crds:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/boskos/cleaner/v2/cleaner.go
+++ b/boskos/cleaner/v2/cleaner.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/crds"
+	"k8s.io/test-infra/boskos/mason"
+)
+
+const controllerName = "boskos-cleaner"
+
+// Add creates a new cleaner controller
+func Add(mgr manager.Manager) error {
+	reconciler := &reconciler{
+		ctx:    context.Background(),
+		client: mgr.GetClient(),
+	}
+
+	c, err := controller.New(controllerName, mgr, controller.Options{
+		Reconciler:              reconciler,
+		MaxConcurrentReconciles: 4,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create controller: %v", err)
+	}
+
+	if err := c.Watch(&source.Kind{Type: &crds.ResourceObject{}}, &handler.EnqueueRequestForObject{}); err != nil {
+		return fmt.Errorf("failed to create watch: %v", err)
+	}
+
+	return nil
+}
+
+type reconciler struct {
+	ctx       context.Context
+	client    ctrlruntimeclient.Client
+	namespace string
+}
+
+func (r *reconciler) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	err := r.reconcile(err)
+	log := logrus.WithFields("resource-name", request.Name)
+	if err != nil {
+		log.WithError(err).Error("Reconciliation error")
+	}
+	return reconcile.Result{}, err
+}
+
+func (r *reconciler) reconcile(log *logrus.Entry, request reconcile.Request) error {
+	resourceObject := &crds.ResourceObject{}
+	if err := r.client.Get(r.ctx, request); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return fmt.Errorf("failed to get object %s: %v", request.NamespacedName.String(), err)
+	}
+
+	// We only care about unowned resources in ToBeDeleted state
+	if resourceObject.Status.Owner != "" || resourceObject.Status.State != common.ToBeDeleted {
+		return nil
+	}
+
+	isDynamic, err := r.isResourceDynamic(resourceObject)
+	if err != nil {
+		return fmt.Errorf("failed to check if resource is dynamic: %v", err)
+	}
+	if !isDynamic {
+		return nil
+	}
+
+	leasedResources, err := mason.CheckUserData(*res)
+	if err != nil {
+		log.WithError(err).Warning("Could not extract mason resources from userdata")
+	} else {
+
+	}
+}
+
+func (r *reconciler) isResourceDynamic(r *crds.ResourceObject) (bool, error) {
+	drlcName := types.NamespacedName{Namespace: r.namespace, Name: resourceObject.Spec.Type}
+	err := r.client.Get(r.ctx, drlcName, &crds.DRLCObject{})
+	return kerrors.IsNotFound(err), err
+}

--- a/boskos/cleaner/v2/cleaner_test.go
+++ b/boskos/cleaner/v2/cleaner_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v2
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"k8s.io/test-infra/boskos/common"
+	"k8s.io/test-infra/boskos/crds"
+)
+
+const (
+	testNamespace    = "my-ns"
+	testResourceName = "my-resource"
+)
+
+func TestReconcile(t *testing.T) {
+	verifyResourceObjectwasIgnored := func(c ctrlruntimeclient.Client) error {
+		rO := &crds.ResourceObject{}
+		name := types.NamespacedName{Namespace: testNamespace, Name: testResourceName}
+		if err := c.Get(context.Background(), name, rO); err != nil {
+			return fmt.Errorf("failed to get object: %v", err)
+		}
+		if rO.ResourceVersion != "1" {
+			return errors.New("object got updated")
+		}
+		return nil
+	}
+
+	testCases := []struct {
+		name    string
+		objects []runtime.Object
+		verify  func(ctrlruntimeclient.Client) error
+	}{
+		{
+			name: "IsNotFound errors are ignored",
+		},
+		{
+			name: "Resources with owners are ignored",
+			objects: createTestObjects(func(rO *crds.ResourceObject, _ *crds.DRLCObject) {
+				rO.Status.Owner = "hans"
+			}),
+			verify: verifyResourceObjectwasIgnored,
+		},
+		{
+			name: "Non-dynamic resources are ignored",
+			objects: createTestObjects(func(_ *crds.ResourceObject, drlc *crds.DRLCObject) {
+				drlc.Name = "openstack-slice"
+			}),
+			verify: verifyResourceObjectwasIgnored,
+		},
+		{
+			name: "Resources not in ToBeDeleted status are ignored",
+			objects: createTestObjects(func(rO *crds.ResourceObject, _ *crds.DRLCObject) {
+				rO.Status.State = "to-be-used"
+			}),
+			verify: verifyResourceObjectwasIgnored,
+		},
+		{
+			name:    "State is updated to tombstone",
+			objects: createTestObjects(),
+			verify: func(c ctrlruntimeclient.Client) error {
+				rO := &crds.ResourceObject{}
+				name := types.NamespacedName{Namespace: testNamespace, Name: testResourceName}
+				if err := c.Get(context.Background(), name, rO); err != nil {
+					return fmt.Errorf("failed to get object: %v", err)
+				}
+				if rO.Status.State != common.Tombstone {
+					return fmt.Errorf("state was not %q but %q", common.Tombstone, rO.Status.State)
+				}
+				return nil
+			},
+		},
+	}
+
+	for idx := range testCases {
+		tc := testCases[idx]
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := fakectrlruntimeclient.NewFakeClient(tc.objects...)
+			r := &reconciler{
+				client:    client,
+				namespace: testNamespace,
+			}
+
+			request := reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: testResourceName}}
+
+			if _, err := r.Reconcile(request); err != nil {
+				t.Fatalf("reconciliation failed: %v", err)
+			}
+			if tc.verify == nil {
+				return
+			}
+			if err := tc.verify(client); err != nil {
+				t.Errorf("verification failed: %v", err)
+			}
+		})
+
+	}
+}
+
+type testObjectModifier func(*crds.ResourceObject, *crds.DRLCObject)
+
+func createTestObjects(modifiers ...testObjectModifier) []runtime.Object {
+
+	drlcObject := &crds.DRLCObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      "aws-slice",
+		},
+	}
+
+	resourceObject := &crds.ResourceObject{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       testNamespace,
+			Name:            testResourceName,
+			ResourceVersion: "1",
+		},
+		Spec: crds.ResourceSpec{
+			Type: drlcObject.Name,
+		},
+		Status: crds.ResourceStatus{
+			State: common.ToBeDeleted,
+		},
+	}
+
+	for _, modify := range modifiers {
+		modify(resourceObject, drlcObject)
+	}
+
+	return []runtime.Object{drlcObject, resourceObject}
+}

--- a/boskos/cmd/cleaner/BUILD.bazel
+++ b/boskos/cmd/cleaner/BUILD.bazel
@@ -8,12 +8,18 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//boskos/cleaner:go_default_library",
+        "//boskos/cleaner/v2:go_default_library",
         "//boskos/client:go_default_library",
         "//boskos/crds:go_default_library",
         "//boskos/ranch:go_default_library",
+        "//prow/config:go_default_library",
+        "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
+        "//prow/metrics:go_default_library",
+        "//prow/pjutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
     ],
 )
 

--- a/boskos/cmd/cleaner/example-deployment.yaml
+++ b/boskos/cmd/cleaner/example-deployment.yaml
@@ -14,38 +14,47 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: boskos-reader
+  name: boskos-cleaner
   namespace: boskos
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: boskos-crd-reader
-  labels:
-    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: boskos-cleaner
 rules:
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs: ["create"]
 - apiGroups:
   - boskos.k8s.io
   resources: ["*"]
-  verbs: ["get", "list"]
+  verbs: ["get", "list", "watch", "update"]
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+  resourceNames:
+    - boskos-cleaner-leaderlock
+  verbs:
+    - get
+    - update
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+    - events
+  verbs:
+    - create
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: boskos-crd-reader-binding
+  name: boskos-cleaner
   namespace: boskos
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: boskos-crd-reader
+  name: boskos-cleaner
 subjects:
 - kind: ServiceAccount
-  name: boskos-reader
+  name: boskos-cleaner
   namespace: boskos
 ---
 apiVersion: apps/v1
@@ -65,11 +74,11 @@ spec:
       labels:
         app: boskos-cleaner
     spec:
-      serviceAccountName: boskos-reader
+      serviceAccountName: boskos-cleaner
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-cleaner
-        image: gcr.io/sebvas-experiment/boskos/cleaner:v20190711-88440ad42
+        image: gcr.io/k8s-prow/boskos/cleaner:v20190711-88440ad42
         args:
         - --cleaner-count=25
         - --namespace=boskos

--- a/boskos/cmd/cleaner/main.go
+++ b/boskos/cmd/cleaner/main.go
@@ -123,7 +123,7 @@ func v2Main(client *client.Client) {
 	mgr, err := manager.New(cfg, manager.Options{
 		LeaderElection:          true,
 		LeaderElectionNamespace: namespace,
-		LeaderElectionID:        "boskos-cleaner",
+		LeaderElectionID:        "boskos-cleaner-leaderlock",
 		Namespace:               namespace,
 		MetricsBindAddress:      "0",
 	})

--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -65,7 +65,7 @@ func (o *KubernetesClientOptions) Client() (ctrlruntimeclient.Client, error) {
 		return fakectrlruntimeclient.NewFakeClient(), nil
 	}
 
-	cfg, err := o.cfg()
+	cfg, err := o.Cfg()
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (o *KubernetesClientOptions) CacheBackedClient(namespace string, startCache
 		return fakectrlruntimeclient.NewFakeClient(), nil
 	}
 
-	cfg, err := o.cfg()
+	cfg, err := o.Cfg()
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +128,8 @@ func (o *KubernetesClientOptions) CacheBackedClient(namespace string, startCache
 	return mgr.GetClient(), nil
 }
 
-func (o *KubernetesClientOptions) cfg() (*rest.Config, error) {
+// Cfg returns the *rest.Config for the configured cluster
+func (o *KubernetesClientOptions) Cfg() (*rest.Config, error) {
 	var cfg *rest.Config
 	var err error
 	if o.kubeConfig == "" {


### PR DESCRIPTION
This PR adds a featuregated, off-by-default, v2 implementation of the boskos cleaner.  Advantages:

* It doesn't need to do any api calls to the boskos server when there is nothing to do, thus not making the lock contention issue we have worse (current cleaner does `for sleep 15s; do acquire && clean; done`) 
* When there is work to do, it is much quicker, as it doesn't sleep each time it did something (cleaner v1 took about 28h to clean up 2k resources that didn't contain any leased resources in their userdata, or in other words: To change their state from `toBeDeleted` to `tombstone`)
* No acquiring at all needed for resources that do not contain leased resources in their userdata
* Still save to run concurrently with the boskos server even before https://github.com/kubernetes/test-infra/pull/16367 as the final `Update` call that changes the status will fail if something else updated the object in the meantime (e.G. boskos set the owner)

/assign @sebastienvas @stevekuznetsov 