### PR TITLE
Use workload identity for grandmatriach, boskos-janitor

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -24,16 +24,7 @@ spec:
         - --resource-type=gke-project
         - --pool-size=20
         - --
-        - --service_account=/etc/service-account/service-account.json
         - --hours=0
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +52,7 @@ spec:
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project
         - --pool-size=20
         - --
-        - --service_account=/etc/service-account/service-account.json
         - --hours=0
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -58,14 +58,4 @@ spec:
       - name: bakery
         image: gcr.io/k8s-prow/grandmatriarch:v20200224-3b3c9d343
         args:
-        - /etc/robot/service-account.json
         - http-cookiefile
-        volumeMounts:
-        - mountPath: /etc/robot
-          name: robot
-          readOnly: true
-      volumes:
-      - name: robot
-        secret:
-          defaultMode: 420
-          secretName: service-account


### PR DESCRIPTION
ref #15806 #16464 

/assign @michelle192837 

```console
fejta@fejta3:~/src/gh/test-infra$ ./workload-identity/bind-service-accounts.sh k8s-prow-builds us-central1-f prow test-pods boskos-janitor pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+ gcloud iam service-accounts add-iam-policy-binding --project=kubernetes-jenkins-pull --role=roles/iam.workloadIdentityUser '--member=serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/boskos-janitor]' pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
Updated IAM policy for serviceAccount [pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com].
Sleeping 2m to allow credentials to propagate..
+++ kubectl run --rm=true -i --generator=run-pod/v1 --context=gke_k8s-prow-builds_us-central1-f_prow --namespace=test-pods --serviceaccount=boskos-janitor --image=google/cloud-sdk:slim workload-identity-test-37
DONE: --context=gke_k8s-prow-builds_us-central1-f_prow --namespace=test-pods serviceaccounts/boskos-janitor acts as pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
fejta@fejta3:~/src/gh/test-infra$ ./workload-identity/bind-service-accounts.sh k8s-prow-builds us-central1-f prow test-pods grandmatriarch pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
+ gcloud iam service-accounts add-iam-policy-binding --project=kubernetes-jenkins-pull --role=roles/iam.workloadIdentityUser '--member=serviceAccount:k8s-prow-builds.svc.id.goog[test-pods/grandmatriarch]' pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
Updated IAM policy for serviceAccount [pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com].
Sleeping 2m to allow credentials to propagate..
+++ kubectl run --rm=true -i --generator=run-pod/v1 --context=gke_k8s-prow-builds_us-central1-f_prow --namespace=test-pods --serviceaccount=grandmatriarch --image=google/cloud-sdk:slim workload-identity-test-35
DONE: --context=gke_k8s-prow-builds_us-central1-f_prow --namespace=test-pods serviceaccounts/grandmatriarch acts as pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
```