### PR TITLE
Revert "Revert "Use workload identity for grandmatriach, boskos-janitor

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -24,16 +24,7 @@ spec:
         - --resource-type=gke-project
         - --pool-size=20
         - --
-        - --service_account=/etc/service-account/service-account.json
         - --hours=0
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -61,16 +52,7 @@ spec:
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project
         - --pool-size=20
         - --
-        - --service_account=/etc/service-account/service-account.json
         - --hours=0
-        volumeMounts:
-        - mountPath: /etc/service-account
-          name: service
-          readOnly: true
-      volumes:
-      - name: service
-        secret:
-          secretName: service-account
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/prow/cluster/grandmatriarch.yaml
+++ b/prow/cluster/grandmatriarch.yaml
@@ -58,14 +58,4 @@ spec:
       - name: bakery
         image: gcr.io/k8s-prow/grandmatriarch:v20200225-55a0aacbd
         args:
-        - /etc/robot/service-account.json
         - http-cookiefile
-        volumeMounts:
-        - mountPath: /etc/robot
-          name: robot
-          readOnly: true
-      volumes:
-      - name: robot
-        secret:
-          defaultMode: 420
-          secretName: service-account


### PR DESCRIPTION
This reverts commit 9da9fee58b92f5f55fd29cb641bdf2820d1ca329.

/hold

/assign @michelle192837 @ixdy @Katharine 

Looks similar to https://github.com/kubernetes/test-infra/issues/16303 and applying the same fix on GKE side of things.