### PR TITLE
Azure: skip [Slow] and [Serial] on conformanced presubmit jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -40,7 +40,7 @@ presubmits:
         - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
         # Specific test args
-        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]
+        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
         - --ginkgo-parallel=30
         - --timeout=420m
         securityContext:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -40,7 +40,7 @@ presubmits:
         - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
         # Specific test args
-        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]
+        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
         - --ginkgo-parallel=30
         - --timeout=420m
         securityContext:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -40,7 +40,7 @@ presubmits:
         - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
         # Specific test args
-        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]
+        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
         - --ginkgo-parallel=30
         - --timeout=420m
         securityContext:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -40,7 +40,7 @@ presubmits:
         - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
         # Specific test args
-        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]
+        - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
         - --ginkgo-parallel=30
         - --timeout=420m
         securityContext:


### PR DESCRIPTION
Follow-up PR for https://github.com/kubernetes/test-infra/pull/16426 and https://github.com/kubernetes/test-infra/pull/16455. We should skip `[Slow]` and `[Serial]` since they are causing the presubmit jobs to be flaky.

/assign @andyzhangx @feiskyer 