### PR TITLE
releng: Enable kube-cross image building/pushing

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -1,0 +1,27 @@
+postsubmits:
+  kubernetes/release:
+    - name: post-release-push-image-kube-cross
+      cluster: test-infra-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^images\/build\/cross\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: deployer # TODO(fejta): use pusher
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200213-0032cdb
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - images/build/cross
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers


### PR DESCRIPTION
Add an image-pushing job for the kube-cross image.
ref: https://github.com/kubernetes/release/issues/1133, https://github.com/kubernetes/kubernetes/pull/88562, https://github.com/kubernetes/release/pull/1140

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @Katharine @BenTheElder
cc: @kubernetes/release-engineering @cblecker @liggitt @dims 