### PR TITLE
    Adding support for having unique HMAC token per github repository or organization.

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -100,7 +100,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -139,7 +139,7 @@ type Server struct {
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// TODO: Move webhook handling logic out of hook binary so that we don't have to import all
 	// plugins just to validate the webhook.
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -61,7 +61,7 @@ type server struct {
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator())
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
 	if !ok {
 		return
 	}

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//prow/errorutil:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
         "@org_golang_x_oauth2//:go_default_library",
     ],
 )

--- a/prow/github/hmac.go
+++ b/prow/github/hmac.go
@@ -20,11 +20,31 @@ import (
 	"crypto/hmac"
 	"crypto/sha1"
 	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 	"strings"
+	"time"
 )
 
+// hmacSecret contains a hmac token and its expiration time.
+type hmacSecret struct {
+	Value  string    `json:"value"`
+	Expiry time.Time `json:"expiry"`
+}
+
+// hmacsForRepo contains all hmac tokens configured for a repo, org or globally.
+type hmacsForRepo []hmacSecret
+
 // ValidatePayload ensures that the request payload signature matches the key.
-func ValidatePayload(payload []byte, sig string, key []byte) bool {
+func ValidatePayload(payload []byte, sig string, tokenGenerator func() []byte) bool {
+	var event GenericEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		logrus.WithError(err).Info("validatePayload couldn't unmarshal the github event payload")
+		return false
+	}
+
 	if !strings.HasPrefix(sig, "sha1=") {
 		return false
 	}
@@ -33,10 +53,23 @@ func ValidatePayload(payload []byte, sig string, key []byte) bool {
 	if err != nil {
 		return false
 	}
-	mac := hmac.New(sha1.New, key)
-	mac.Write(payload)
-	expected := mac.Sum(nil)
-	return hmac.Equal(sb, expected)
+
+	hmacs, err := extractHmacs(event.Repo.FullName, tokenGenerator)
+	if err != nil {
+		logrus.WithError(err).Error("couldn't unmarshal the hmac secret")
+		return false
+	}
+
+	// If we have a match with any valid hmac, we can validate successfully.
+	for _, key := range hmacs {
+		mac := hmac.New(sha1.New, key)
+		mac.Write(payload)
+		expected := mac.Sum(nil)
+		if hmac.Equal(sb, expected) {
+			return true
+		}
+	}
+	return false
 }
 
 // PayloadSignature returns the signature that matches the payload.
@@ -45,4 +78,47 @@ func PayloadSignature(payload []byte, key []byte) string {
 	mac.Write(payload)
 	sum := mac.Sum(nil)
 	return "sha1=" + hex.EncodeToString(sum)
+}
+
+// extractHmacs returns all *valid* HMAC tokens for given repository/organization.
+// It considers only the tokens at the most specific level configured for the given repo.
+// For example : if a token for repo is present and it doesn't match the repo, we will
+// not try to find a match with org level token. However if no token is present for repo,
+// we will try to match with org level.
+func extractHmacs(repo string, tokenGenerator func() []byte) ([][]byte, error) {
+	t := tokenGenerator()
+	repoToTokenMap := map[string]hmacsForRepo{}
+
+	if err := yaml.Unmarshal(t, &repoToTokenMap); err != nil {
+		// To keep backward compatibility, we are going to assume that in case of error,
+		// whole file is a single line hmac token.
+		//TODO : Once this code has been released and file has been moved to new format,
+		// we should delete this code and return error.
+		logrus.WithError(err).Info("couldn't unmarshal the hmac secret as hierarchical file. Parsing as single token format")
+		return [][]byte{t}, nil
+	}
+
+	orgName := strings.Split(repo, "/")[0]
+
+	if val, ok := repoToTokenMap[repo]; ok {
+		return extractValidTokens(val), nil
+	}
+	if val, ok := repoToTokenMap[orgName]; ok {
+		return extractValidTokens(val), nil
+	}
+	if val, ok := repoToTokenMap["*"]; ok {
+		return extractValidTokens(val), nil
+	}
+	return nil, errors.New("Invalid content in secret file. Global token doesn't exist.")
+}
+
+// extractValidTokens return valid tokens for any given level of tree. Validity is determined based on time till they are valid.
+func extractValidTokens(allTokens hmacsForRepo) [][]byte {
+	var validTokens [][]byte
+	for _, token := range allTokens {
+		if token.Expiry.After(time.Now()) {
+			validTokens = append(validTokens, []byte(token.Value))
+		}
+	}
+	return validTokens
 }

--- a/prow/github/hmac_test.go
+++ b/prow/github/hmac_test.go
@@ -20,53 +20,53 @@ import (
 	"testing"
 )
 
+var globalSecret = `
+'*':
+  - value: abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var defaultTokenGenerator = func() []byte {
+	return []byte(globalSecret)
+}
+
 // echo -n 'BODY' | openssl dgst -sha1 -hmac KEY
 func TestValidatePayload(t *testing.T) {
 	var testcases = []struct {
-		payload string
-		sig     string
-		key     string
-		valid   bool
+		payload        string
+		sig            string
+		tokenGenerator func() []byte
+		valid          bool
 	}{
 		{
 			"{}",
 			"sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580",
-			"abc",
+			defaultTokenGenerator,
 			true,
 		},
 		{
 			"{}",
 			"db5c76f4264d0ad96cf21baec394964b4b8ce580",
-			"abc",
+			defaultTokenGenerator,
 			false,
 		},
 		{
 			"{}",
 			"",
-			"abc",
+			defaultTokenGenerator,
 			false,
-		},
-		{
-			"",
-			"sha1=cc47e3c0aa0c2984454476d061108c0b110177ae",
-			"abc",
-			true,
-		},
-		{
-			"",
-			"sha1=fbdb1d1b18aa6c08324b7d64b71fb76370690e1d",
-			"",
-			true,
 		},
 		{
 			"{}",
 			"",
-			"abc",
+			defaultTokenGenerator,
 			false,
 		},
 	}
 	for _, tc := range testcases {
-		if ValidatePayload([]byte(tc.payload), tc.sig, []byte(tc.key)) != tc.valid {
+		if ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator) != tc.valid {
 			t.Errorf("Wrong validation for %+v", tc)
 		}
 	}

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -209,6 +209,13 @@ const (
 	PullRequestActionReadyForReview PullRequestEventAction = "ready_for_review"
 )
 
+// GenericEvent is a lightweight struct containing just Sender and Repo as all events are expected to have this information.
+// https://developer.github.com/webhooks/#payloads
+type GenericEvent struct {
+	Sender User `json:"sender"`
+	Repo   Repo `json:"repository"`
+}
+
 // PullRequestEvent is what GitHub sends us when a PR is changed.
 type PullRequestEvent struct {
 	Action      PullRequestEventAction `json:"action"`

--- a/prow/github/webhooks.go
+++ b/prow/github/webhooks.go
@@ -28,7 +28,7 @@ import (
 // the provided hmac secret. It returns the event type, the event guid,
 // the payload of the request, whether the webhook is valid or not,
 // and finally the resultant HTTP status code
-func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) (string, string, []byte, bool, int) {
+func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func() []byte) (string, string, []byte, bool, int) {
 	defer r.Body.Close()
 
 	// Header checks: It must be a POST with an event type and a signature.
@@ -62,7 +62,7 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, hmacSecret []byte) 
 		return "", "", nil, false, http.StatusInternalServerError
 	}
 	// Validate the payload with our HMAC secret.
-	if !ValidatePayload(payload, sig, hmacSecret) {
+	if !ValidatePayload(payload, sig, tokenGenerator) {
 		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature")
 		return "", "", nil, false, http.StatusForbidden
 	}

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -40,11 +40,67 @@ var ice = github.IssueCommentEvent{
 	},
 }
 
+var repoLevelSecret = `
+'*':
+  - value: key1
+    expiry: 9999-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+foo:
+  - value: key3
+    expiry: 9999-10-02T15:00:00Z
+  - value: key4
+    expiry: 2018-10-02T15:00:00Z
+foo/bar:
+  - value: 123abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key6
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var orgLevelSecret = `
+'*':
+  - value: key1
+    expiry: 9999-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+foo:
+  - value: 123abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key4
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var globalSecret = `
+'*':
+  - value: 123abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var expiredGlobalSecret = `
+'*':
+  - value: 123abc
+    expiry: 2019-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var missingMatchingSecret = `
+somerandom:
+  - value: 123abc
+    expiry: 2019-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+`
+
+var secretInOldFormat = `123abc`
+
 // TestHook sets up a hook.Server and then sends a fake webhook at it. It then
 // ensures that a fake plugin is called.
 func TestHook(t *testing.T) {
 	called := make(chan bool, 1)
-	secret := []byte("123abc")
 	payload, err := json.Marshal(&ice)
 	if err != nil {
 		t.Fatalf("Marshalling ICE: %v", err)
@@ -65,22 +121,94 @@ func TestHook(t *testing.T) {
 		OwnersClient: repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
 	}
 	metrics := NewMetrics()
-
-	getSecret := func() []byte {
-		return []byte("123abc")
+	var testcases = []struct {
+		name           string
+		secret         []byte
+		tokenGenerator func() []byte
+		shouldSucceed  bool
+	}{
+		{
+			name:   "Token present at repository level.",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(repoLevelSecret)
+			},
+			shouldSucceed: true,
+		},
+		{
+			name:   "Token present at org level.",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(orgLevelSecret)
+			},
+			shouldSucceed: true,
+		},
+		{
+			name:   "Token present at global level.",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(globalSecret)
+			},
+			shouldSucceed: true,
+		},
+		{
+			name:   "Token not matching at any level.",
+			secret: []byte("123abcd"),
+			tokenGenerator: func() []byte {
+				return []byte(repoLevelSecret)
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:   "Token matching but expired.",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(expiredGlobalSecret)
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:   "Token matching at organization level but repo level token mismatch.",
+			secret: []byte("key3"),
+			tokenGenerator: func() []byte {
+				return []byte(expiredGlobalSecret)
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:   "Token not matching anywhere (wildcard token missing).",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(expiredGlobalSecret)
+			},
+			shouldSucceed: false,
+		},
+		{
+			name:   "Secret in old format.",
+			secret: []byte("123abc"),
+			tokenGenerator: func() []byte {
+				return []byte(secretInOldFormat)
+			},
+			shouldSucceed: true,
+		},
 	}
 
-	s := httptest.NewServer(&Server{
-		ClientAgent:    clientAgent,
-		Plugins:        pa,
-		ConfigAgent:    ca,
-		Metrics:        metrics,
-		TokenGenerator: getSecret,
-	})
-	defer s.Close()
-	if err := phony.SendHook(s.URL, "issues", payload, secret); err != nil {
-		t.Fatalf("Error sending hook: %v", err)
+	for _, tc := range testcases {
+		t.Logf("Running scenario %q", tc.name)
+
+		s := httptest.NewServer(&Server{
+			ClientAgent:    clientAgent,
+			Plugins:        pa,
+			ConfigAgent:    ca,
+			Metrics:        metrics,
+			TokenGenerator: tc.tokenGenerator,
+		})
+		defer s.Close()
+		if err := phony.SendHook(s.URL, "issues", payload, tc.secret); (err != nil) == tc.shouldSucceed {
+			t.Fatalf("Error sending hook: %v", err)
+		}
 	}
+
 	select {
 	case <-called: // All good.
 	case <-time.After(time.Second):

--- a/prow/hook/server.go
+++ b/prow/hook/server.go
@@ -53,7 +53,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, resp := github.ValidateWebhook(w, r, s.TokenGenerator())
+	eventType, eventGUID, payload, ok, resp := github.ValidateWebhook(w, r, s.TokenGenerator)
 	if counter, err := s.Metrics.ResponseCounter.GetMetricWithLabelValues(strconv.Itoa(resp)); err != nil {
 		logrus.WithFields(logrus.Fields{
 			"status-code": resp,

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -32,7 +32,24 @@ func TestServeHTTPErrors(t *testing.T) {
 	pa.Set(&plugins.Configuration{})
 
 	getSecret := func() []byte {
-		return []byte("abc")
+		var repoLevelSecret = `
+'*':
+  - value: abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key2
+    expiry: 2018-10-02T15:00:00Z
+foo:
+  - value: key3
+    expiry: 9999-10-02T15:00:00Z
+  - value: key4
+    expiry: 2018-10-02T15:00:00Z
+foo/bar:
+  - value: 123abc
+    expiry: 9999-10-02T15:00:00Z
+  - value: key6
+    expiry: 2018-10-02T15:00:00Z
+`
+		return []byte(repoLevelSecret)
 	}
 
 	s := &Server{


### PR DESCRIPTION
Adding support for having unique HMAC token per github repository or organization.

New secret file would look like this : 
```
'*':
  - value: key1
    expiry: 9999-10-02T15:00:00Z
  - value: key2
    expiry: 2018-10-02T15:00:00Z
foo:
  - value: key3
    expiry: 9999-10-02T15:00:00Z
  - value: key4
    expiry: 2018-10-02T15:00:00Z
foo/bar:
  - value: 123abc
    expiry: 9999-10-02T15:00:00Z
  - value: key6
    expiry: 2018-10-02T15:00:00Z
```

https://docs.google.com/document/d/1m3nFfPt95kbe6BQdWp5BrZMSPkBo5mFb2nuMq1OeE24/edit?ts=5e1f65f9#heading=h.6dyyhz5krl9v