### PR TITLE
Kops - update one job to use the new kops service account

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-misc.yaml
@@ -134,13 +134,13 @@ periodics:
 - interval: 1h
   name: e2e-kops-aws-misc-newrunner
   labels:
-    preset-service-account: "true"
     preset-aws-ssh: "true"
     preset-aws-credential: "true"
   decorate: true
   decoration_config:
     timeout: 140m
   spec:
+    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh


### PR DESCRIPTION
This allows the job to use workload identity rather than the static credentials provided by the preset. followup to #16442.

We can confirm the service account is working if we don't see the `curl https://v4.ifconfig.co` log statement seen [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-newrunner/1232860282150195200#1:build-log.txt%3A156) because it will no longer be falling back to ifconfig.co.

If this goes well I'll roll it out to all kops E2E jobs.

ref #15806