### PR TITLE
Revert "Include `golang` in the test image"

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     file \
     git \
-    golang \
     jq \
     mercurial \
     openssh-client \


### PR DESCRIPTION
This reverts commit 67346807dae85f369f2dbcf965d2981a2e931ab5.

https://github.com/kubernetes/test-infra/pull/16447/commits/67346807dae85f369f2dbcf965d2981a2e931ab5#r384903302

https://github.com/kubernetes/test-infra/blob/5eb862a90b494394784a40616c195b3530fc0dae/images/kubekins-e2e/variants.yaml#L4

https://github.com/kubernetes/test-infra/blob/5eb862a90b494394784a40616c195b3530fc0dae/images/kubekins-e2e/Dockerfile#L64-L69