### PR TITLE
First pass migrating off of kubernetes_e2e for kops_gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
@@ -5,15 +5,15 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
-  decorate: true
-  decoration_config:
-    timeout: 140m
   spec:
     containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200226-84852b3-master
       args:
+      - --bare
+      - --timeout=120
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
       - --cluster=e2e-kops-gce-latest.k8s.local
       - --deployment=kops
       - --env=KOPS_PUBLISH_GREEN_PATH=gs://kops-ci/bin/latest-ci-gce-green.txt
@@ -24,8 +24,6 @@ periodics:
       - --kops-zones=us-central1-c
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200226-84852b3-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-latest

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
@@ -5,6 +5,9 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200226-84852b3-master


### PR DESCRIPTION
Big picture: I want to get GCE tests enabled for PRs. In order to do this, there's a need to shuffle some things around and probably move the kops tests out of the cloud-provider section (perhaps into cluster-lifecycle). 
When I started to dig in, i discovered that folks want us to stop using kube_e2e.py. This is an attempt to migrate to kubetest on this job, just to see how it works and get our story straight.