### PR TITLE
Boskos remove item interface

### DIFF
--- a/boskos/cleaner/v2/cleaner.go
+++ b/boskos/cleaner/v2/cleaner.go
@@ -100,7 +100,7 @@ func (r *reconciler) reconcile(log *logrus.Entry, request reconcile.Request) err
 		return nil
 	}
 
-	commonResourceObject := resourceObject.ToItem().(common.Resource)
+	commonResourceObject := resourceObject.ToResource()
 	cleaner.RecycleOne(r.boskosClient, &commonResourceObject)
 
 	resourceObject.Status.State = common.Tombstone

--- a/boskos/client/client.go
+++ b/boskos/client/client.go
@@ -249,8 +249,8 @@ func (c *Client) ReleaseAll(dest string) error {
 	}
 	var allErrors error
 	for _, r := range resources {
-		c.storage.Delete(r.GetName())
-		err := c.Release(r.GetName(), dest)
+		c.storage.Delete(r.Name)
+		err := c.Release(r.Name, dest)
 		if err != nil {
 			allErrors = multierror.Append(allErrors, err)
 		}
@@ -287,7 +287,7 @@ func (c *Client) UpdateAll(state string) error {
 	}
 	var allErrors error
 	for _, r := range resources {
-		if err := c.Update(r.GetName(), state, nil); err != nil {
+		if err := c.Update(r.Name, state, nil); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 			continue
 		}
@@ -312,12 +312,7 @@ func (c *Client) SyncAll() error {
 		return nil
 	}
 	var allErrors error
-	for _, i := range resources {
-		r, err := common.ItemToResource(i)
-		if err != nil {
-			allErrors = multierror.Append(allErrors, err)
-			continue
-		}
+	for _, r := range resources {
 		if err := c.Update(r.Name, r.State, nil); err != nil {
 			allErrors = multierror.Append(allErrors, err)
 			continue
@@ -338,7 +333,7 @@ func (c *Client) UpdateOne(name, state string, userData *common.UserData) error 
 	if err != nil {
 		return fmt.Errorf("no resource name %v", name)
 	}
-	if err := c.Update(r.GetName(), state, userData); err != nil {
+	if err := c.Update(r.Name, state, userData); err != nil {
 		return err
 	}
 	return c.updateLocalResource(r, state, userData)
@@ -364,18 +359,14 @@ func (c *Client) HasResource() bool {
 
 // private methods
 
-func (c *Client) updateLocalResource(i common.Item, state string, data *common.UserData) error {
-	res, err := common.ItemToResource(i)
-	if err != nil {
-		return err
-	}
+func (c *Client) updateLocalResource(res common.Resource, state string, data *common.UserData) error {
 	res.State = state
 	if res.UserData == nil {
 		res.UserData = data
 	} else {
 		res.UserData.Update(data)
 	}
-	_, err = c.storage.Update(res)
+	_, err := c.storage.Update(res)
 	return err
 }
 

--- a/boskos/common/common.go
+++ b/boskos/common/common.go
@@ -70,11 +70,6 @@ type UserDataMap map[string]string
 // LeasedResources is a list of resources name that used in order to create another resource by Mason
 type LeasedResources []string
 
-// Item interfaces for resources and configs
-type Item interface {
-	GetName() string
-}
-
 // Duration is a wrapper around time.Duration that parses times in either
 // 'integer number of nanoseconds' or 'duration string' formats and serializes
 // to 'duration string' format.
@@ -202,7 +197,7 @@ type ResourceByName []Resource
 
 func (ut ResourceByName) Len() int           { return len(ut) }
 func (ut ResourceByName) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
-func (ut ResourceByName) Less(i, j int) bool { return ut[i].GetName() < ut[j].GetName() }
+func (ut ResourceByName) Less(i, j int) bool { return ut[i].Name < ut[j].Name }
 
 // CommaSeparatedStrings is used to parse comma separated string flag into a list of strings
 type CommaSeparatedStrings []string
@@ -225,9 +220,6 @@ func (r *CommaSeparatedStrings) Set(value string) error {
 func (r *CommaSeparatedStrings) Type() string {
 	return "commaSeparatedStrings"
 }
-
-// GetName implements the Item interface used for storage
-func (res Resource) GetName() string { return res.Name }
 
 // UnmarshalJSON implements JSON Unmarshaler interface
 func (ud *UserData) UnmarshalJSON(data []byte) error {
@@ -298,13 +290,4 @@ func (ud *UserData) FromMap(m UserDataMap) {
 	for key, value := range m {
 		ud.Store(key, value)
 	}
-}
-
-// ItemToResource casts a Item back to a Resource
-func ItemToResource(i Item) (Resource, error) {
-	res, ok := i.(Resource)
-	if !ok {
-		return Resource{}, fmt.Errorf("expected item to be of type Resource, was %T", i)
-	}
-	return res, nil
 }

--- a/boskos/common/mason_config.go
+++ b/boskos/common/mason_config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package common
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/google/uuid"
@@ -63,10 +62,7 @@ type DRLCByName []DynamicResourceLifeCycle
 
 func (ut DRLCByName) Len() int           { return len(ut) }
 func (ut DRLCByName) Swap(i, j int)      { ut[i], ut[j] = ut[j], ut[i] }
-func (ut DRLCByName) Less(i, j int) bool { return ut[i].GetName() < ut[j].GetName() }
-
-// GetName implements the Item interface used for storage
-func (res DynamicResourceLifeCycle) GetName() string { return res.Type }
+func (ut DRLCByName) Less(i, j int) bool { return ut[i].Type < ut[j].Type }
 
 // NewDynamicResourceLifeCycleFromConfig parse the a ResourceEntry into a DynamicResourceLifeCycle
 func NewDynamicResourceLifeCycleFromConfig(e ResourceEntry) DynamicResourceLifeCycle {
@@ -92,15 +88,6 @@ func (t TypeToResources) Copy() TypeToResources {
 		n[k] = v
 	}
 	return n
-}
-
-// ItemToDynamicResourceLifeCycle casts a Item back to a Resource
-func ItemToDynamicResourceLifeCycle(i Item) (DynamicResourceLifeCycle, error) {
-	res, ok := i.(DynamicResourceLifeCycle)
-	if !ok {
-		return DynamicResourceLifeCycle{}, fmt.Errorf("cannot construct Resource from received object %v", i)
-	}
-	return res, nil
 }
 
 // GenerateDynamicResourceName generates a unique name for dynamic resources

--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -32,7 +32,6 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/prow/interrupts"
 )
 
@@ -40,7 +39,6 @@ import (
 type KubernetesClientOptions struct {
 	inMemory   bool
 	kubeConfig string
-	namespace  string
 }
 
 // AddFlags adds kube client flags to existing FlagSet.
@@ -148,23 +146,6 @@ func (o *KubernetesClientOptions) Cfg() (*rest.Config, error) {
 type Type struct {
 	Kind, ListKind   string
 	Singular, Plural string
-	Object           Object
-	Collection       Collection
-}
-
-// Object extends the runtime.Object interface. CRD are just a representation of the actual boskos object
-// which should implements the common.Item interface.
-// TODO: Should be removed, see https://github.com/kubernetes/test-infra/issues/16418
-type Object interface {
-	runtime.Object
-	GetName() string
-	FromItem(item common.Item)
-	ToItem() common.Item
-}
-
-// Collection is a list of Object interface.
-type Collection interface {
-	runtime.Object
-	SetItems([]Object)
-	GetItems() []Object
+	Object           runtime.Object
+	Collection       runtime.Object
 }

--- a/boskos/crds/drlc_crd.go
+++ b/boskos/crds/drlc_crd.go
@@ -105,16 +105,6 @@ func (in *DRLCObject) ToDynamicResourceLifeCycle() common.DynamicResourceLifeCyc
 	}
 }
 
-func (in *DRLCObject) fromDynamicResourceLifeCycle(r common.DynamicResourceLifeCycle) {
-	in.ObjectMeta.Name = r.Type
-	in.Spec.InitialState = r.InitialState
-	in.Spec.MinCount = r.MinCount
-	in.Spec.MaxCount = r.MaxCount
-	in.Spec.LifeSpan = r.LifeSpan
-	in.Spec.Config = r.Config
-	in.Spec.Needs = r.Needs
-}
-
 // FromDynamicResourceLifecycle converts a common.DynamicResourceLifeCycle into a *DRLCObject
 func FromDynamicResourceLifecycle(r common.DynamicResourceLifeCycle) *DRLCObject {
 	return &DRLCObject{
@@ -130,37 +120,6 @@ func FromDynamicResourceLifecycle(r common.DynamicResourceLifeCycle) *DRLCObject
 			Needs:        r.Needs,
 		},
 	}
-}
-
-// ToItem implements the Object interface
-func (in *DRLCObject) ToItem() common.Item {
-	return in.ToDynamicResourceLifeCycle()
-}
-
-// FromItem implements the Object interface
-func (in *DRLCObject) FromItem(i common.Item) {
-	c, err := common.ItemToDynamicResourceLifeCycle(i)
-	if err == nil {
-		in.fromDynamicResourceLifeCycle(c)
-	}
-}
-
-// GetItems implements the Collection interface
-func (in *DRLCObjectList) GetItems() []Object {
-	var items []Object
-	for idx := range in.Items {
-		items = append(items, &in.Items[idx])
-	}
-	return items
-}
-
-// SetItems implements the Collection interface
-func (in *DRLCObjectList) SetItems(objects []Object) {
-	var items []DRLCObject
-	for _, b := range objects {
-		items = append(items, *(b.(*DRLCObject)))
-	}
-	in.Items = items
 }
 
 func (in *DRLCObjectList) deepCopyInto(out *DRLCObjectList) {

--- a/boskos/crds/resource_crd.go
+++ b/boskos/crds/resource_crd.go
@@ -106,29 +106,6 @@ func (in *ResourceObject) ToResource() common.Resource {
 	}
 }
 
-// ToItem implements Object interface
-func (in *ResourceObject) ToItem() common.Item {
-	return in.ToResource()
-}
-
-func (in *ResourceObject) fromResource(r common.Resource) {
-	in.Name = r.Name
-	in.Spec.Type = r.Type
-	in.Status.Owner = r.Owner
-	in.Status.State = r.State
-	in.Status.LastUpdate = r.LastUpdate
-	in.Status.UserData = r.UserData
-	in.Status.ExpirationDate = r.ExpirationDate
-}
-
-// FromItem implements Object interface
-func (in *ResourceObject) FromItem(i common.Item) {
-	r, err := common.ItemToResource(i)
-	if err == nil {
-		in.fromResource(r)
-	}
-}
-
 // FromResource converts a common.Resource to a *ResourceObject
 func FromResource(r common.Resource) *ResourceObject {
 	if r.UserData == nil {
@@ -149,24 +126,6 @@ func FromResource(r common.Resource) *ResourceObject {
 			ExpirationDate: r.ExpirationDate,
 		},
 	}
-}
-
-// GetItems implements Collection interface
-func (in *ResourceObjectList) GetItems() []Object {
-	var items []Object
-	for idx := range in.Items {
-		items = append(items, &in.Items[idx])
-	}
-	return items
-}
-
-// SetItems implements Collection interface
-func (in *ResourceObjectList) SetItems(objects []Object) {
-	var items []ResourceObject
-	for _, b := range objects {
-		items = append(items, *(b.(*ResourceObject)))
-	}
-	in.Items = items
 }
 
 func (in *ResourceObjectList) deepCopyInto(out *ResourceObjectList) {

--- a/boskos/mason/mason.go
+++ b/boskos/mason/mason.go
@@ -142,7 +142,7 @@ func (m *Mason) RegisterConfigConverter(name string, fn ConfigConverter) error {
 func (m *Mason) convertConfig(configEntry *common.DynamicResourceLifeCycle) (Masonable, error) {
 	fn, ok := m.configConverters[configEntry.Config.Type]
 	if !ok {
-		return nil, fmt.Errorf("config type %s is not supported", configEntry.GetName())
+		return nil, fmt.Errorf("config type %s is not supported", configEntry.Type)
 	}
 	return fn(configEntry.Config.Content)
 }

--- a/boskos/storage/storage.go
+++ b/boskos/storage/storage.go
@@ -26,74 +26,74 @@ import (
 
 // PersistenceLayer defines a simple interface to persists Boskos Information
 type PersistenceLayer interface {
-	Add(i common.Item) error
+	Add(r common.Resource) error
 	Delete(name string) error
-	Update(i common.Item) (common.Item, error)
-	Get(name string) (common.Item, error)
-	List() ([]common.Item, error)
+	Update(r common.Resource) (common.Resource, error)
+	Get(name string) (common.Resource, error)
+	List() ([]common.Resource, error)
 }
 
 type inMemoryStore struct {
-	items map[string]common.Item
-	lock  sync.RWMutex
+	resources map[string]common.Resource
+	lock      sync.RWMutex
 }
 
 // NewMemoryStorage creates an in memory persistence layer
 func NewMemoryStorage() PersistenceLayer {
 	return &inMemoryStore{
-		items: map[string]common.Item{},
+		resources: map[string]common.Resource{},
 	}
 }
 
-func (im *inMemoryStore) Add(i common.Item) error {
+func (im *inMemoryStore) Add(r common.Resource) error {
 	im.lock.Lock()
 	defer im.lock.Unlock()
-	_, ok := im.items[i.GetName()]
+	_, ok := im.resources[r.Name]
 	if ok {
-		return fmt.Errorf("item %s already exists", i.GetName())
+		return fmt.Errorf("resource %s already exists", r.Name)
 	}
-	im.items[i.GetName()] = i
+	im.resources[r.Name] = r
 	return nil
 }
 
 func (im *inMemoryStore) Delete(name string) error {
 	im.lock.Lock()
 	defer im.lock.Unlock()
-	_, ok := im.items[name]
+	_, ok := im.resources[name]
 	if !ok {
 		return fmt.Errorf("cannot find item %s", name)
 	}
-	delete(im.items, name)
+	delete(im.resources, name)
 	return nil
 }
 
-func (im *inMemoryStore) Update(i common.Item) (common.Item, error) {
+func (im *inMemoryStore) Update(r common.Resource) (common.Resource, error) {
 	im.lock.Lock()
 	defer im.lock.Unlock()
-	_, ok := im.items[i.GetName()]
+	_, ok := im.resources[r.Name]
 	if !ok {
-		return nil, fmt.Errorf("cannot find item %s", i.GetName())
+		return common.Resource{}, fmt.Errorf("cannot find item %s", r.Name)
 	}
-	im.items[i.GetName()] = i
-	return i, nil
+	im.resources[r.Name] = r
+	return r, nil
 }
 
-func (im *inMemoryStore) Get(name string) (common.Item, error) {
+func (im *inMemoryStore) Get(name string) (common.Resource, error) {
 	im.lock.RLock()
 	defer im.lock.RUnlock()
-	i, ok := im.items[name]
+	r, ok := im.resources[name]
 	if !ok {
-		return nil, fmt.Errorf("cannot find item %s", name)
+		return common.Resource{}, fmt.Errorf("cannot find item %s", name)
 	}
-	return i, nil
+	return r, nil
 }
 
-func (im *inMemoryStore) List() ([]common.Item, error) {
+func (im *inMemoryStore) List() ([]common.Resource, error) {
 	im.lock.RLock()
 	defer im.lock.RUnlock()
-	var items []common.Item
-	for _, i := range im.items {
-		items = append(items, i)
+	var resources []common.Resource
+	for _, r := range im.resources {
+		resources = append(resources, r)
 	}
-	return items, nil
+	return resources, nil
 }

--- a/boskos/storage/storage_test.go
+++ b/boskos/storage/storage_test.go
@@ -51,27 +51,18 @@ func TestAddDelete(t *testing.T) {
 				t.Errorf("unable to add %s, %v", res.Name, err)
 			}
 		}
-		items, err := s.List()
+		returnedResources, err := s.List()
 		if err != nil {
 			t.Errorf("unable to list resources, %v", err)
 		}
-		var rResources []common.Resource
-		for _, i := range items {
-			var r common.Resource
-			r, err = common.ItemToResource(i)
-			if err != nil {
-				t.Errorf("unable to convert resource, %v", err)
-			}
-			rResources = append(rResources, r)
+		sort.Stable(common.ResourceByName(returnedResources))
+		if !reflect.DeepEqual(resources, returnedResources) {
+			t.Errorf("received resources (%v) do not match resources (%v)", resources, returnedResources)
 		}
-		sort.Stable(common.ResourceByName(rResources))
-		if !reflect.DeepEqual(resources, rResources) {
-			t.Errorf("received resources (%v) do not match resources (%v)", resources, rResources)
-		}
-		for _, i := range items {
-			err = s.Delete(i.GetName())
+		for _, r := range returnedResources {
+			err = s.Delete(r.Name)
 			if err != nil {
-				t.Errorf("unable to delete resource %s.%v", i.GetName(), err)
+				t.Errorf("unable to delete resource %s.%v", r.Name, err)
 			}
 		}
 		eResources, err := s.List()
@@ -98,13 +89,9 @@ func TestUpdateGet(t *testing.T) {
 		if _, err := s.Update(uRes); err != nil {
 			t.Errorf("unable to update resource %v", err)
 		}
-		i, err := s.Get(oRes.Name)
+		res, err := s.Get(oRes.Name)
 		if err != nil {
 			t.Errorf("unable to get resource, %v", err)
-		}
-		res, err := common.ItemToResource(i)
-		if err != nil {
-			t.Errorf("unable to convert resource, %v", err)
 		}
 		if !reflect.DeepEqual(uRes, res) {
 			t.Errorf("expected (%v) and received (%v) do not match", uRes, res)


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/16418

This PR:

* Removes the `boskos/common.Item` interface, because it is implemented by both the crds and the internal types, causing a great deal of confusion as to what a function that takes/returns an `Item`actually want. Furthermore, all `Items` where converted at some point to a concrete type via a `FromItem` function. which was based on type assertion and only worked for one concrete type
* Removes the `boskos/crds.Object` interface, because that interface is already covered by the superset of `runtime.Object + metav1.Object` after the `{Get,Set}Item` functions are removed.
* Removes the `bokos/crds.Collecetion` interface, because it only provides Setters and Getters for a public attribute of the underlying type. Also, it is unused.

/assign @ixdy 