### PR TITLE
Boskos: Retry on conflict

### DIFF
--- a/boskos/handlers/BUILD.bazel
+++ b/boskos/handlers/BUILD.bazel
@@ -27,8 +27,11 @@ go_test(
         "//boskos/crds:go_default_library",
         "//boskos/ranch:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/boskos/ranch/BUILD.bazel
+++ b/boskos/ranch/BUILD.bazel
@@ -19,8 +19,12 @@ go_test(
         "@com_github_go_test_deep//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )
@@ -36,11 +40,14 @@ go_library(
     deps = [
         "//boskos/common:go_default_library",
         "//boskos/crds:go_default_library",
-        "@com_github_hashicorp_go_multierror//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )

--- a/boskos/ranch/ranch.go
+++ b/boskos/ranch/ranch.go
@@ -24,7 +24,11 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
 
 	"k8s.io/test-infra/boskos/common"
 	"k8s.io/test-infra/boskos/crds"
@@ -124,76 +128,80 @@ func (r *Ranch) Acquire(rType, state, dest, owner, requestID string) (*crds.Reso
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
 
-	logger.Debug("Determining request priority...")
-	ts := acquireRequestPriorityKey{rType: rType, state: state}
-	rank, new := r.requestMgr.GetRank(ts, requestID)
-	logger.WithFields(logrus.Fields{"rank": rank, "new": new}).Debug("Determined request priority.")
+	var returnRes *crds.ResourceObject
+	return returnRes, retryOnConflict(retry.DefaultBackoff, func() error {
+		logger.Debug("Determining request priority...")
+		ts := acquireRequestPriorityKey{rType: rType, state: state}
+		rank, new := r.requestMgr.GetRank(ts, requestID)
+		logger.WithFields(logrus.Fields{"rank": rank, "new": new}).Debug("Determined request priority.")
 
-	resources, err := r.Storage.GetResources()
-	if err != nil {
-		logger.WithError(err).Errorf("could not get resources")
-		return nil, &ResourceNotFound{rType}
-	}
-	logger.Debugf("Considering %d resources.", len(resources.Items))
-
-	// For request priority we need to go over all the list until a matching rank
-	matchingResoucesCount := 0
-	typeCount := 0
-	for idx := range resources.Items {
-		res := resources.Items[idx]
-		if rType != res.Spec.Type {
-			continue
-		}
-		typeCount++
-
-		if state != res.Status.State || res.Status.Owner != "" {
-			continue
-		}
-		matchingResoucesCount++
-
-		if matchingResoucesCount < rank {
-			continue
-		}
-		logger = logger.WithField("resource", res.Name)
-		res.Status.Owner = owner
-		res.Status.State = dest
-		logger.Debug("Updating resource.")
-		updatedRes, err := r.Storage.UpdateResource(&res)
+		resources, err := r.Storage.GetResources()
 		if err != nil {
-			logger.WithError(err).Errorf("could not update resource %s", res.Name)
-			return nil, err
+			logger.WithError(err).Errorf("could not get resources")
+			return &ResourceNotFound{rType}
 		}
-		// Deleting this request since it has been fulfilled
-		if requestID != "" {
-			logger.Debug("Cleaning up requests.")
-			r.requestMgr.Delete(ts, requestID)
-		}
-		logger.Debug("Successfully acquired resource.")
-		return updatedRes, nil
-	}
+		logger.Debugf("Considering %d resources.", len(resources.Items))
 
-	if new {
-		logger.Debug("Checking for associated dynamic resource type...")
-		lifeCycle, err := r.Storage.GetDynamicResourceLifeCycle(rType)
-		// Assuming error means no associated dynamic resource.
-		if err == nil {
-			if typeCount < lifeCycle.Spec.MaxCount {
-				logger.Debug("Adding new dynamic resources...")
-				res := newResourceFromNewDynamicResourceLifeCycle(r.Storage.generateName(), lifeCycle, r.now())
-				if err := r.Storage.AddResource(res); err != nil {
-					logger.WithError(err).Warningf("unable to add a new resource of type %s", rType)
-				}
-				logger.Infof("Added dynamic resource %s of type %s", res.Name, res.Spec.Type)
+		// For request priority we need to go over all the list until a matching rank
+		matchingResoucesCount := 0
+		typeCount := 0
+		for idx := range resources.Items {
+			res := resources.Items[idx]
+			if rType != res.Spec.Type {
+				continue
 			}
-		} else {
-			logrus.WithError(err).Debug("Failed listing DRLC")
-		}
-	}
+			typeCount++
 
-	if typeCount > 0 {
-		return nil, &ResourceNotFound{rType}
-	}
-	return nil, &ResourceTypeNotFound{rType}
+			if state != res.Status.State || res.Status.Owner != "" {
+				continue
+			}
+			matchingResoucesCount++
+
+			if matchingResoucesCount < rank {
+				continue
+			}
+			logger = logger.WithField("resource", res.Name)
+			res.Status.Owner = owner
+			res.Status.State = dest
+			logger.Debug("Updating resource.")
+			updatedRes, err := r.Storage.UpdateResource(&res)
+			if err != nil {
+				logger.WithError(err).Errorf("could not update resource %s", res.Name)
+				return err
+			}
+			// Deleting this request since it has been fulfilled
+			if requestID != "" {
+				logger.Debug("Cleaning up requests.")
+				r.requestMgr.Delete(ts, requestID)
+			}
+			logger.Debug("Successfully acquired resource.")
+			returnRes = updatedRes
+			return nil
+		}
+
+		if new {
+			logger.Debug("Checking for associated dynamic resource type...")
+			lifeCycle, err := r.Storage.GetDynamicResourceLifeCycle(rType)
+			// Assuming error means no associated dynamic resource.
+			if err == nil {
+				if typeCount < lifeCycle.Spec.MaxCount {
+					logger.Debug("Adding new dynamic resources...")
+					res := newResourceFromNewDynamicResourceLifeCycle(r.Storage.generateName(), lifeCycle, r.now())
+					if err := r.Storage.AddResource(res); err != nil {
+						logger.WithError(err).Warningf("unable to add a new resource of type %s", rType)
+					}
+					logger.Infof("Added dynamic resource %s of type %s", res.Name, res.Spec.Type)
+				}
+			} else {
+				logrus.WithError(err).Debug("Failed listing DRLC")
+			}
+		}
+
+		if typeCount > 0 {
+			return &ResourceNotFound{rType}
+		}
+		return &ResourceTypeNotFound{rType}
+	})
 }
 
 // AcquireByState checks out resources of a given type without an owner,
@@ -212,40 +220,45 @@ func (r *Ranch) AcquireByState(state, dest, owner string, names []string) ([]*cr
 		return nil, fmt.Errorf("must provide names of expected resources")
 	}
 
-	rNames := sets.NewString(names...)
+	var returnRes []*crds.ResourceObject
+	return returnRes, retryOnConflict(retry.DefaultBackoff, func() error {
+		rNames := sets.NewString(names...)
 
-	allResources, err := r.Storage.GetResources()
-	if err != nil {
-		logrus.WithError(err).Errorf("could not get resources")
-		return nil, &ResourceNotFound{state}
-	}
-
-	var resources []*crds.ResourceObject
-
-	for idx := range allResources.Items {
-		res := allResources.Items[idx]
-		if state != res.Status.State || res.Status.Owner != "" || !rNames.Has(res.Name) {
-			continue
-		}
-
-		res.Status.Owner = owner
-		res.Status.State = dest
-		updatedRes, err := r.Storage.UpdateResource(&res)
+		allResources, err := r.Storage.GetResources()
 		if err != nil {
-			logrus.WithError(err).Errorf("could not update resource %s", res.Name)
-			return nil, err
+			logrus.WithError(err).Errorf("could not get resources")
+			return &ResourceNotFound{state}
 		}
-		resources = append(resources, updatedRes)
-		rNames.Delete(res.Name)
-	}
 
-	if rNames.Len() != 0 {
-		missingResources := rNames.List()
-		err := &ResourceNotFound{state}
-		logrus.WithError(err).Errorf("could not find required resources %s", strings.Join(missingResources, ", "))
-		return resources, err
-	}
-	return resources, nil
+		var resources []*crds.ResourceObject
+
+		for idx := range allResources.Items {
+			res := allResources.Items[idx]
+			if state != res.Status.State || res.Status.Owner != "" || !rNames.Has(res.Name) {
+				continue
+			}
+
+			res.Status.Owner = owner
+			res.Status.State = dest
+			updatedRes, err := r.Storage.UpdateResource(&res)
+			if err != nil {
+				logrus.WithError(err).Errorf("could not update resource %s", res.Name)
+				return err
+			}
+			resources = append(resources, updatedRes)
+			rNames.Delete(res.Name)
+		}
+
+		if rNames.Len() != 0 {
+			missingResources := rNames.List()
+			err := &ResourceNotFound{state}
+			logrus.WithError(err).Errorf("could not find required resources %s", strings.Join(missingResources, ", "))
+			returnRes = resources
+			return err
+		}
+		returnRes = resources
+		return nil
+	})
 }
 
 // Release unsets owner for target resource and move it to a new state.
@@ -259,34 +272,36 @@ func (r *Ranch) Release(name, dest, owner string) error {
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
 
-	res, err := r.Storage.GetResource(name)
-	if err != nil {
-		logrus.WithError(err).Errorf("unable to release resource %s", name)
-		return &ResourceNotFound{name}
-	}
-	if owner != res.Status.Owner {
-		return &OwnerNotMatch{request: owner, owner: res.Status.Owner}
-	}
-
-	res.Status.Owner = ""
-	res.Status.State = dest
-
-	if lf, err := r.Storage.GetDynamicResourceLifeCycle(res.Spec.Type); err == nil {
-		// Assuming error means not existing as the only way to differentiate would be to list
-		// all resources and find the right one which is more costly.
-		if lf.Spec.LifeSpan != nil {
-			expirationTime := r.now().Add(*lf.Spec.LifeSpan)
-			res.Status.ExpirationDate = &expirationTime
+	return retryOnConflict(retry.DefaultBackoff, func() error {
+		res, err := r.Storage.GetResource(name)
+		if err != nil {
+			logrus.WithError(err).Errorf("unable to release resource %s", name)
+			return &ResourceNotFound{name}
 		}
-	} else {
-		res.Status.ExpirationDate = nil
-	}
+		if owner != res.Status.Owner {
+			return &OwnerNotMatch{request: owner, owner: res.Status.Owner}
+		}
 
-	if _, err := r.Storage.UpdateResource(res); err != nil {
-		logrus.WithError(err).Errorf("could not update resource %s", res.Name)
-		return err
-	}
-	return nil
+		res.Status.Owner = ""
+		res.Status.State = dest
+
+		if lf, err := r.Storage.GetDynamicResourceLifeCycle(res.Spec.Type); err == nil {
+			// Assuming error means not existing as the only way to differentiate would be to list
+			// all resources and find the right one which is more costly.
+			if lf.Spec.LifeSpan != nil {
+				expirationTime := r.now().Add(*lf.Spec.LifeSpan)
+				res.Status.ExpirationDate = &expirationTime
+			}
+		} else {
+			res.Status.ExpirationDate = nil
+		}
+
+		if _, err := r.Storage.UpdateResource(res); err != nil {
+			logrus.WithError(err).Errorf("could not update resource %s", res.Name)
+			return err
+		}
+		return nil
+	})
 }
 
 // Update updates the timestamp of a target resource.
@@ -302,26 +317,28 @@ func (r *Ranch) Update(name, owner, state string, ud *common.UserData) error {
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
 
-	res, err := r.Storage.GetResource(name)
-	if err != nil {
-		logrus.WithError(err).Errorf("could not find resource %s for update", name)
-		return &ResourceNotFound{name}
-	}
-	if owner != res.Status.Owner {
-		return &OwnerNotMatch{request: owner, owner: res.Status.Owner}
-	}
-	if state != res.Status.State {
-		return &StateNotMatch{res.Status.State, state}
-	}
-	if res.Status.UserData == nil {
-		res.Status.UserData = &common.UserData{}
-	}
-	res.Status.UserData.Update(ud)
-	if _, err := r.Storage.UpdateResource(res); err != nil {
-		logrus.WithError(err).Errorf("could not update resource %s", res.Name)
-		return err
-	}
-	return nil
+	return retryOnConflict(retry.DefaultBackoff, func() error {
+		res, err := r.Storage.GetResource(name)
+		if err != nil {
+			logrus.WithError(err).Errorf("could not find resource %s for update", name)
+			return &ResourceNotFound{name}
+		}
+		if owner != res.Status.Owner {
+			return &OwnerNotMatch{request: owner, owner: res.Status.Owner}
+		}
+		if state != res.Status.State {
+			return &StateNotMatch{res.Status.State, state}
+		}
+		if res.Status.UserData == nil {
+			res.Status.UserData = &common.UserData{}
+		}
+		res.Status.UserData.Update(ud)
+		if _, err := r.Storage.UpdateResource(res); err != nil {
+			logrus.WithError(err).Errorf("could not update resource %s", res.Name)
+			return err
+		}
+		return nil
+	})
 }
 
 // Reset unstucks a type of stale resource to a new state.
@@ -334,29 +351,31 @@ func (r *Ranch) Reset(rtype, state string, expire time.Duration, dest string) (m
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
 
-	ret := make(map[string]string)
-
-	resources, err := r.Storage.GetResources()
-	if err != nil {
-		logrus.WithError(err).Errorf("cannot find resources")
-		return nil, err
-	}
-
-	for idx := range resources.Items {
-		res := resources.Items[idx]
-		if rtype != res.Spec.Type || state != res.Status.State || res.Status.Owner == "" || r.now().Sub(res.Status.LastUpdate) < expire {
-			continue
+	var ret map[string]string
+	return ret, retryOnConflict(retry.DefaultBackoff, func() error {
+		ret = make(map[string]string)
+		resources, err := r.Storage.GetResources()
+		if err != nil {
+			logrus.WithError(err).Errorf("cannot find resources")
+			return err
 		}
 
-		ret[res.Name] = res.Status.Owner
-		res.Status.Owner = ""
-		res.Status.State = dest
-		if _, err := r.Storage.UpdateResource(&res); err != nil {
-			logrus.WithError(err).Errorf("could not update resource %s", res.Name)
-			return ret, err
+		for idx := range resources.Items {
+			res := resources.Items[idx]
+			if rtype != res.Spec.Type || state != res.Status.State || res.Status.Owner == "" || r.now().Sub(res.Status.LastUpdate) < expire {
+				continue
+			}
+
+			ret[res.Name] = res.Status.Owner
+			res.Status.Owner = ""
+			res.Status.State = dest
+			if _, err := r.Storage.UpdateResource(&res); err != nil {
+				logrus.WithError(err).Errorf("could not update resource %s", res.Name)
+				return err
+			}
 		}
-	}
-	return ret, nil
+		return nil
+	})
 }
 
 // SyncConfig updates resource list from a file
@@ -370,10 +389,7 @@ func (r *Ranch) SyncConfig(configPath string) error {
 	}
 	r.resourcesLock.Lock()
 	defer r.resourcesLock.Unlock()
-	if err := r.Storage.SyncResources(config); err != nil {
-		return err
-	}
-	return nil
+	return r.Storage.SyncResources(config)
 }
 
 // StartDynamicResourceUpdater starts a goroutine which periodically
@@ -462,4 +478,44 @@ func (r *Ranch) AllMetrics() ([]common.Metric, error) {
 // Using this method helps make sure all the resources are created the same way.
 func newResourceFromNewDynamicResourceLifeCycle(name string, dlrc *crds.DRLCObject, now time.Time) *crds.ResourceObject {
 	return crds.NewResource(name, dlrc.Name, dlrc.Spec.InitialState, "", now)
+}
+
+// retryOnConflict is a copy of https://godoc.org/k8s.io/client-go/util/retry#RetryOnConflict
+// that only differs in the isConflict check, we use a variant that supports wrapped errors.
+// TODO: Simplify this by using retry.OnError once we have a sufficiently new client-go dependency
+func retryOnConflict(backoff wait.Backoff, fn func() error) error {
+	var lastConflictErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case isConflict(err):
+			lastConflictErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if err == wait.ErrWaitTimeout {
+		err = lastConflictErr
+	}
+	return err
+}
+
+func isConflict(err error) bool {
+	if kerrors.IsConflict(err) {
+		return true
+	}
+	if x, ok := err.(interface{ Unwrap() error }); ok {
+		return isConflict(x.Unwrap())
+	}
+	if aggregate, ok := err.(utilerrors.Aggregate); ok {
+		for _, err := range aggregate.Errors() {
+			if isConflict(err) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This PR adds retrying on conflicts to the boskos handlers, in order to resolve the occasional `the object has been modified; please apply your changes to the latest version and try again` errors we are seeing and that will presumably vastly increase once we remove the global lock.

Fixes  https://github.com/openshift/release/issues/7183

/assign @ixdy @bbguimaraes 