### PR TITLE
Add service account

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -16,6 +16,7 @@ spec:
         app: boskos-janitor
     spec:
       terminationGracePeriodSeconds: 300
+      serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor
         image: gcr.io/k8s-prow/boskos/janitor:v20200226-fd34fd5f2
@@ -44,6 +45,7 @@ spec:
         app: boskos-janitor-nongke
     spec:
       terminationGracePeriodSeconds: 300
+      serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor-nongke
         image: gcr.io/k8s-prow/boskos/janitor:v20200226-fd34fd5f2


### PR DESCRIPTION
/assign @cjwagner 

Already applied this to the cluster (as it definitely won't work without it)

Working with this change:

```console
who@where$ kubectl --context=k8s-prow-builds -n test-pods logs -f --max-log-requests=50 boskos-janitor-768dc5c7b9-r9qf2

{"level":"info","msg":"Initialized boskos client!","time":"2020-02-27T19:50:51Z"}
{"level":"info","msg":"Acquired resources k8s-e2e-gke-prod-smoke of type gke-project","time":"2020-02-27T19:50:51Z"}
{"level":"info","msg":"executing janitor: /bin/gcp_janitor.py --project=k8s-e2e-gke-prod-smoke --hours=0","time":"2020-02-27T19:50:51Z"}
{"error":"resources not found","level":"info","msg":"no available resource gke-project","time":"2020-02-27T19:50:51Z"}
{"level":"info","msg":"Acquired resources jenkins-gke-e2e-serial of type gke-project","time":"2020-02-27T19:51:51Z"}
{"level":"info","msg":"executing janitor: /bin/gcp_janitor.py --project=jenkins-gke-e2e-serial --hours=0","time":"2020-02-27T19:51:51Z"}
{"level":"info","msg":"Acquired resources gke-up-c1-4-clat-up-clu of type gke-project","time":"2020-02-27T19:51:51Z"}
{"level":"info","msg":"executing janitor: /bin/gcp_janitor.py --project=gke-up-c1-4-clat-up-clu --hours=0","time":"2020-02-27T19:51:51Z"}
{"error":"resources not found","level":"info","msg":"no available resource gke-project","time":"2020-02-27T19:51:51Z"}
{"level":"info","msg":"successfully cleaned up resource k8s-e2e-gke-prod-smoke","time":"2020-02-27T19:52:20Z"}
```