### PR TITLE
releng: Update variants (kubekins, krte) to include new Go versions

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,32 +1,32 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.13.6
+    GO_VERSION: 1.13.8
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.13.6
+    GO_VERSION: 1.13.8
     K8S_RELEASE: stable
     BAZEL_VERSION: 0.23.2
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: 1.13.6
+    GO_VERSION: 1.13.8
     K8S_RELEASE: latest-1.18
     BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
-    GO_VERSION: 1.13.6
+    GO_VERSION: 1.13.8
     K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.13.6
+    GO_VERSION: 1.13.8
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 0.23.2
   '1.15':
     CONFIG: '1.15'
-    GO_VERSION: 1.12.12
+    GO_VERSION: 1.12.17
     K8S_RELEASE: stable-1.15
     BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
- experimental --> 1.16 @ go1.13.8
- 1.15 @ go1.12.17

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @cblecker 
cc: @dims @liggitt @listx @kubernetes/release-engineering 

ref: https://github.com/kubernetes/release/issues/1134
/hold until https://github.com/kubernetes/kubernetes/pull/88617 and https://github.com/kubernetes/kubernetes/pull/88618 merge