### PR TITLE
Azure: reuse k8s builds when possible & add an option to enable node-problem-detector

### DIFF
--- a/kubetest/azure_test.go
+++ b/kubetest/azure_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 var deploytMethodMap = map[aksDeploymentMethod]string{
-	normal:              "normal",
+	noop:                "noop",
 	customHyperkube:     "custom hyperkube",
 	customK8sComponents: "custom k8s components",
 }
@@ -37,13 +37,13 @@ func TestGetDeploymentMethod(t *testing.T) {
 			desc:                         "k8s 1.16 without custom k8s",
 			k8sRelease:                   "1.16",
 			customK8s:                    false,
-			expectedAKSDeploytmentMethod: normal,
+			expectedAKSDeploytmentMethod: noop,
 		},
 		{
 			desc:                         "k8s 1.17 without custom k8s",
 			k8sRelease:                   "1.17",
 			customK8s:                    false,
-			expectedAKSDeploytmentMethod: normal,
+			expectedAKSDeploytmentMethod: noop,
 		},
 		{
 			desc:                         "k8s 1.16 with custom k8s",
@@ -61,13 +61,13 @@ func TestGetDeploymentMethod(t *testing.T) {
 			desc:                         "using k8s release instead of k8s version",
 			k8sRelease:                   "1.17.0",
 			customK8s:                    true,
-			expectedAKSDeploytmentMethod: normal,
+			expectedAKSDeploytmentMethod: noop,
 		},
 		{
 			desc:                         "using an invalid k8s version",
 			k8sRelease:                   "invalid",
 			customK8s:                    true,
-			expectedAKSDeploytmentMethod: normal,
+			expectedAKSDeploytmentMethod: noop,
 		},
 	}
 


### PR DESCRIPTION
This PR changes the logic on how we tag images and artifacts built by `kubetest`. Instead of using `BUILD_ID` as the image version, which is unique for each job, using projects' git commits as the image/artifact version allows us to only build K8s and other components when the projects have new commits. If no new commit is found, we only build `test/e2e/e2e.test`, `cmd/kubectl` and `ginkgo`, which are the only dependencies when running upstream E2E tests. This can reduce most jobs' duration by 15-20 minutes.

This PR also adds an option to enable `node-problem-detector` addon in the API model.

/assign @feiskyer 