### PR TITLE
Create a gencred image and a ProwJob to publish it automatically.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -610,6 +610,32 @@ postsubmits:
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion
+  - name: post-test-infra-push-gencred
+    cluster: test-infra-trusted
+    run_if_changed: '^gencred/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "gencred"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '3'
+      description: builds and pushes the gencred image
+    decorate: true
+    branches:
+    - ^master$
+    spec:
+      serviceAccountName: deployer # TODO(fejta): should be pusher
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200211-v0.4-10-g26b1b47
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - --build-dir=.
+        - gencred/
+        env:
+        - name: USE_BAZEL_VERSION
+          value: real  # Ignore .bazelversion
   - name: post-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     branches:

--- a/gencred/Dockerfile
+++ b/gencred/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM golang:1.13-alpine
+
+COPY gencred /gencred
+
+ENTRYPOINT ["/gencred"]

--- a/gencred/cloudbuild.yaml
+++ b/gencred/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+  - name: golang:$_GO_VERSION
+    args:
+    - go
+    - build
+    - -mod=readonly
+    - -a
+    - -installsuffix=cgo
+    - -o=./gencred/gencred
+    - ./gencred
+    env:
+    - CGO_ENABLED=0
+    - GOOS=linux
+    - GOARCH=amd64
+  - name: gcr.io/cloud-builders/docker
+    args:
+    - build
+    - --tag=gcr.io/$PROJECT_ID/gencred:$_GIT_TAG
+    - --tag=gcr.io/$PROJECT_ID/gencred:latest
+    - ./gencred
+substitutions:
+  _GIT_TAG: '12345'
+  _GO_VERSION: 1.13-alpine
+images:
+  - 'gcr.io/$PROJECT_ID/gencred:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/gencred:latest'


### PR DESCRIPTION
Running gencred currently requires cloning the entire repo and building from source with the correct version of bazel. A container image will be faster and require fewer dependencies.
Based on https://github.com/kubernetes/test-infra/pull/16301
/assign @clarketm 
/cc @Katharine 