### PR TITLE
kubernetes-sigs/cluster-api-provider-vsphere: Dedupe tests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -90,22 +90,6 @@ presets:
 
 presubmits:
   kubernetes-sigs/cluster-api-provider-vsphere:
-  - name: pull-cluster-api-provider-vsphere-verify-fmt
-    always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-format\.sh)'
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
-        command:
-        - hack/check-format.sh
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: pr-verify-fmt
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Verifies the Golang sources have been formatted
-
   - name: pull-cluster-api-provider-vsphere-verify-lint
     always_run: false
     run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-lint\.sh)'
@@ -121,22 +105,6 @@ presubmits:
       testgrid-tab-name: pr-verify-lint
       testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
       description: Verifies the Golang sources are linted
-
-  - name: pull-cluster-api-provider-vsphere-verify-vet
-    always_run: false
-    run_if_changed: '^((api|cmd|config|contrib|controllers|pkg)/|Makefile|hack/check-vet\.sh)'
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api-provider-vsphere
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
-        command:
-        - hack/check-vet.sh
-    annotations:
-      testgrid-dashboards: vmware-cluster-api-provider-vsphere, sig-cluster-lifecycle-cluster-api-provider-vsphere
-      testgrid-tab-name: pr-verify-vet
-      testgrid-alert-email: k8s-testing-clusterapi-vsphere+alerts@groups.vmware.com
-      description: Vets the Golang sources have been vetted
 
   - name: pull-cluster-api-provider-vsphere-verify-markdown
     always_run: false


### PR DESCRIPTION
These jobs were ultimately calling the same Makefile target in the repository, and can be removed.