### PR TITLE
Avoid second call to config.ApproveFor

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -263,7 +263,7 @@ func handleReview(log *logrus.Entry, ghc githubClient, oc ownersClient, githubCo
 		ghc,
 		repo,
 		githubConfig,
-		config.ApproveFor(re.Repo.Owner.Login, re.Repo.Name),
+		opts,
 		&state{
 			org:       re.Repo.Owner.Login,
 			repo:      re.Repo.Name,


### PR DESCRIPTION
/assign @stevekuznetsov 
We can just reuse `opts` from above...