### PR TITLE
E2E-Topology Manager - Update image file

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -326,7 +326,7 @@ periodics:
           - --deployment=node
           - --gcp-project=k8s-jkns-ci-node-e2e
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-topology-manager.yaml
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
           - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce


### PR DESCRIPTION
Use the same image file as used for CPU Manager
E2E tests.

Signed-off-by: vpickard <vpickard@redhat.com>