### PR TITLE
Remove gce-windows-2019-containerd-master from release informing

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -549,53 +549,6 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.18
       name: ""
       resources: {}
-- annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.18-informing,
-      sig-node-containerd
-    testgrid-tab-name: gce-windows-2019-containerd-1.18
-  decorate: true
-  decoration_config:
-    timeout: 4h0m0s
-  extra_refs:
-  - base_ref: master
-    org: kubernetes-sigs
-    path_alias: k8s.io/windows-testing
-    repo: windows-testing
-  interval: 4h
-  labels:
-    preset-common-gce-windows: "true"
-    preset-e2e-gce-windows: "true"
-    preset-e2e-gce-windows-containerd: "true"
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-e2e-windows-containerd-gce-1-18
-  spec:
-    containers:
-    - args:
-      - --check-leaked-resources
-      - --cluster=
-      - --extract=ci/k8s-beta
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=8
-      - --provider=gce
-      - --gcp-nodes=2
-      - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/run-e2e.sh
-      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]
-        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
-      - --test-cmd-args=--node-os-distro=windows
-      - --timeout=230m
-      command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      env:
-      - name: WINDOWS_NODE_OS_DISTRIBUTION
-        value: win2019
-      - name: PREPULL_YAML
-        value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.18
-      name: ""
-      resources: {}
 postsubmits:
   kubernetes/kubernetes:
   - annotations:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -325,7 +325,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
-    testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing, sig-node-containerd
+    testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -327,6 +327,53 @@ periodics:
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
+- name: ci-kubernetes-e2e-windows-containerd-gce-1-18
+  decorate: true
+  decoration_config:
+    timeout: 4h0m0s
+  extra_refs:
+  - base_ref: master
+    org: kubernetes-sigs
+    path_alias: k8s.io/windows-testing
+    repo: windows-testing
+  interval: 4h
+  labels:
+    preset-common-gce-windows: "true"
+    preset-e2e-gce-windows: "true"
+    preset-e2e-gce-windows-containerd: "true"
+    preset-k8s-ssh: "true"
+    preset-service-account: "true"
+  spec:
+    containers:
+    - args:
+      - --check-leaked-resources
+      - --cluster=
+      - --extract=ci/k8s-beta
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=8
+      - --provider=gce
+      - --gcp-nodes=2
+      - --test=false
+      - --test-cmd=$GOPATH/src/k8s.io/windows-testing/gce/run-e2e.sh
+      - --test-cmd-args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\]|\[sig-windows\]
+        --ginkgo.skip=\[LinuxOnly\]|\[Serial\]|\[Feature:.+\] --minStartupPods=8
+      - --test-cmd-args=--node-os-distro=windows
+      - --timeout=230m
+      command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      env:
+      - name: WINDOWS_NODE_OS_DISTRIBUTION
+        value: win2019
+      - name: PREPULL_YAML
+        value: prepull-head.yaml
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.18
+      name: ""
+      resources: {}
+  annotations:
+    testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
+    testgrid-tab-name: gce-windows-2019-containerd-1.18
+
 - name: ci-kubernetes-e2e-windows-node-throughput
   interval: 6h
   labels:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -323,8 +323,6 @@ periodics:
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-master
   annotations:
-    fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE


### PR DESCRIPTION
This test is currently a WIP and is constantly failing without providing accurate signal. This removes it from `sig-release-master-informing` until it is ready. Ref: https://github.com/kubernetes/kubernetes/issues/86788

/cc @droslean @alejandrox1 @Random-Liu @kubernetes/ci-signal
/sig windows 