### PR TITLE
kops-gce-latest: Move back to kubernetes_e2e script

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/kops/kops-periodics-gce.yaml
@@ -10,7 +10,8 @@ periodics:
     serviceAccountName: k8s-kops-test
     containers:
     - command:
-      - "kubetest"
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
       args:
       - --up
       - --test
@@ -19,6 +20,7 @@ periodics:
       - --deployment=kops
       - --extract=ci/latest
       - --ginkgo-parallel=30
+      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-central1-c


### PR DESCRIPTION
Since we can't change kubetest, it looks kubernetes_e2e script is the way to go.