### PR TITLE
Configure docker with gcr.io credentials

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -90,6 +90,7 @@ mkdir -p "${GOPATH}/bin"
 # Authenticate gcloud, allow failures
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}" || true
+  gcloud auth configure-docker
 fi
 
 # Use a reproducible build date based on the most recent git commit timestamp.


### PR DESCRIPTION
At the moment while gcloud service account is configured if GOOGLE_APPLICATION_CREDENTIALS is set, docker isn't, thus if a build attempts to pull dependencies from registry that's only accessible when authenticated, the pull fails:
```
Step 1/16 : FROM gcr.io/my-private-registry/kube-cross:v1.13.8b4-1
unauthorized: You don't have the needed permissions to perform this operation, \
and you may have invalid credentials. To authenticate your request, follow \
the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```
This patch makes allows both gcloud/gsutil operations to work as expected as well as docker pull.