### PR TITLE
GA-only kind conformance test job

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -235,6 +235,47 @@ presubmits:
             memory: "9000Mi"
             # during the tests more like 3-20m is used
             cpu: 2000m
+  # conformance test against kubernetes release-1.16 branch with `kind`, skipping
+  # serial tests so it runs in ~20m
+  - name: pull-kind-conformance-parallel-1-16
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    always_run: true
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.16
+        env:
+        # skip serial tests and run with --ginkgo-parallel
+        - name: "PARALLEL"
+          value: "true"
+        args:
+        - "--job=$(JOB_NAME)"
+        - "--root=/go/src"
+        - "--repo=sigs.k8s.io/kind=$(PULL_REFS)"
+        - "--repo=k8s.io/kubernetes=release-1.16"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--scenario=execute"
+        - "--"
+        # the script must run from kubernetes, but we're checking out kind
+        - "bash"
+        - "--"
+        - "-c"
+        - "cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
   # conformance test against kubernetes release-1.15 branch with `kind`, skipping
   # serial tests so it runs in ~20m
   - name: pull-kind-conformance-parallel-1-15

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -194,9 +194,9 @@ presubmits:
             memory: "9000Mi"
             # during the tests more like 3-20m is used
             cpu: 2000m
-  # conformance test against kubernetes release-1.16 branch with `kind`, skipping
+  # conformance test against kubernetes release-1.17 branch with `kind`, skipping
   # serial tests so it runs in ~20m
-  - name: pull-kind-conformance-parallel-1-16
+  - name: pull-kind-conformance-parallel-1-17
     labels:
       preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
@@ -206,7 +206,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200227-9385733-1.17
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -215,7 +215,7 @@ presubmits:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
         - "--repo=sigs.k8s.io/kind=$(PULL_REFS)"
-        - "--repo=k8s.io/kubernetes=release-1.16"
+        - "--repo=k8s.io/kubernetes=release-1.17"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
         - "--scenario=execute"

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -427,9 +427,9 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
 
-  - name: pull-kubernetes-e2e-kind
-    optional: false
-    always_run: true
+  - name: pull-kubernetes-conformance-kind-ga-only
+    optional: true
+    always_run: false
     decorate: true
     skip_branches:
     - release-\d+\.\d+ # per-release settings
@@ -450,15 +450,10 @@ presubmits:
         - -c
         - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
         env:
-        - name: FOCUS
-          value: "."
-        # TODO(bentheelder): reduce the skip list further
-        - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
-        - name: PARALLEL
-          value: "true"
         - name: BUILD_TYPE
           value: bazel
+        - name: GA_ONLY
+          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -474,3 +469,4 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-testing-kind

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -426,3 +426,51 @@ presubmits:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
+
+  - name: pull-kubernetes-e2e-kind
+    optional: false
+    always_run: true
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/krte:v20200212-1f7b8ac-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        env:
+        - name: FOCUS
+          value: "."
+        # TODO(bentheelder): reduce the skip list further
+        - name: SKIP
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'


### PR DESCRIPTION
Enables optional, manually-triggered presubmit to run kind conformance with almost all beta APIs and features turned off.

Depends on https://github.com/kubernetes-sigs/kind/pull/1378

/hold
/cc @BenTheElder 