### PR TITLE
Allow time for serial GA-only conformance run

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -439,7 +439,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decoration_config:
-      timeout: 60m
+      timeout: 2h # allow plenty of time for a serial conformance run
     path_alias: k8s.io/kubernetes
     spec:
       containers:


### PR DESCRIPTION
I copied the timeout from a parallel run, serial takes longer.

/assign @BenTheElder 