### PR TITLE
Register gcr.io helper for docker before the build

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -100,10 +100,6 @@ def main(args):
         print >>sys.stderr, 'build already exists, exit'
         sys.exit(0)
 
-    # Configure docker client for gcr.io authentication to allow communication
-    # with non-public registries.
-    check_no_stdout('gcloud', 'auth', 'configure-docker')
-
     env = {
         # Skip gcloud update checking; do we still need this?
         'CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK': 'true',
@@ -132,6 +128,10 @@ def main(args):
         push_build_args.append('--allow-dup')
     if args.skip_update_latest:
         push_build_args.append('--noupdatelatest')
+    if args.register_gcloud_helper:
+        # Configure docker client for gcr.io authentication to allow communication
+        # with non-public registries.
+        check_no_stdout('gcloud', 'auth', 'configure-docker')
 
     for key, value in env.items():
         os.environ[key] = value
@@ -169,5 +169,8 @@ if __name__ == '__main__':
         '--skip-update-latest', action='store_true', help='Do not update the latest file')
     PARSER.add_argument(
         '--push-build-script', default='../release/push-build.sh', help='location of push-build.sh')
+    PARSER.add_argument(
+        '--register-gcloud-helper', action='store_true',
+        help='Register gcloud as docker credentials helper')
     ARGS = PARSER.parse_args()
     main(ARGS)

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -100,6 +100,10 @@ def main(args):
         print >>sys.stderr, 'build already exists, exit'
         sys.exit(0)
 
+    # Configure docker client for gcr.io authentication to allow communication
+    # with non-public registries.
+    check_no_stdout('gcloud', 'auth', 'configure-docker')
+
     env = {
         # Skip gcloud update checking; do we still need this?
         'CLOUDSDK_COMPONENT_MANAGER_DISABLE_UPDATE_CHECK': 'true',


### PR DESCRIPTION
This allows build dependencies to be sourced from gcr.io registries that
require authentication.