### PR TITLE
Allow resultstore exporter to just export specific buckets.

### DIFF
--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata/junit:go_default_library",
+        "@com_github_googlecloudplatform_testgrid//pb/config:go_default_library",
         "@com_github_googlecloudplatform_testgrid//resultstore:go_default_library",
         "@com_github_googlecloudplatform_testgrid//util/gcs:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/experiment/resultstore/main_test.go
+++ b/experiment/resultstore/main_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	configpb "github.com/GoogleCloudPlatform/testgrid/pb/config"
+
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
 )
@@ -146,6 +148,99 @@ func TestInsertLink(t *testing.T) {
 				t.Errorf("changed %t != expected %t", changed, tc.changed)
 			case !reflect.DeepEqual(tc.expected, tc.input):
 				t.Errorf("metadata %#v != expected %#v", tc.input, tc.expected)
+			}
+		})
+	}
+}
+
+func TestFilterBuckets(t *testing.T) {
+	cases := []struct {
+		name     string
+		groups   []configpb.TestGroup
+		paths    []string
+		expected []configpb.TestGroup
+		err      bool
+	}{
+		{
+			name: "no paths works",
+			groups: []configpb.TestGroup{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+			expected: []configpb.TestGroup{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+		},
+		{
+			name: "bad paths error",
+			groups: []configpb.TestGroup{
+				{
+					Name: "foo",
+				},
+				{
+					Name: "bar",
+				},
+			},
+			paths: []string{"!!!://!!!"},
+			err:   true,
+		},
+		{
+			name: "bad groups error",
+			groups: []configpb.TestGroup{
+				{
+					Name:      "foo",
+					GcsPrefix: "oh\n/yeah",
+				},
+				{
+					Name: "bar",
+				},
+			},
+			paths: []string{"gs://ignored"},
+			err:   true,
+		},
+		{
+			name: "filter buckets",
+			groups: []configpb.TestGroup{
+				{
+					Name:      "yes",
+					GcsPrefix: "included/bucket",
+				},
+				{
+					Name:      "no",
+					GcsPrefix: "excluded/bucket",
+				},
+			},
+			paths: []string{"gs://included"},
+			expected: []configpb.TestGroup{
+				{
+					Name:      "yes",
+					GcsPrefix: "included/bucket",
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := filterBuckets(tc.groups, tc.paths...)
+			switch {
+			case err != nil:
+				if !tc.err {
+					t.Errorf("unexpected error: %v", err)
+				}
+			case tc.err:
+				t.Error("failed to received expected error")
+			case !reflect.DeepEqual(tc.expected, actual):
+				t.Errorf("filterBuckets() got %v, want %v", actual, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
This is necessary because it will attempt to write a field to the finished.json, and
it may not have authorization to do that for all buckets in the config.

/assign @tony-yang @michelle192837 