### PR TITLE
Revert "test: change some test regions due to quota issue"

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -233,7 +233,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.18
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz
@@ -288,7 +288,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.18
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -82,7 +82,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.15
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
@@ -132,7 +132,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.15
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -82,7 +82,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.16
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
@@ -132,7 +132,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.16
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -82,7 +82,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.17
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz
@@ -185,7 +185,7 @@ presubmits:
         - --aksengine-mastervmsize=Standard_DS2_v2
         - --aksengine-agentvmsize=Standard_DS2_v2
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -142,7 +142,7 @@ presubmits:
         - --aksengine-creds=$(AZURE_CREDENTIALS)
         - --aksengine-orchestratorRelease=1.18
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
@@ -200,7 +200,7 @@ presubmits:
         - --aksengine-mastervmsize=Standard_DS2_v2
         - --aksengine-agentvmsize=Standard_DS2_v2
         - --aksengine-deploy-custom-k8s
-        - --aksengine-location=eastus
+        - --aksengine-location=westus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/in-tree.json
         - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz


### PR DESCRIPTION
Reverts kubernetes/test-infra#16565
Let's consider reverting this PR since https://testgrid.k8s.io/provider-azure-presubmit#pr-k8s-azure-disk-e2e-vmss-master and https://testgrid.k8s.io/provider-azure-presubmit#pr-k8s-azure-file-e2e-master are experiencing quota issue. As shown in the log, there are only 10 cores available in eastus, which is definitely not enough to run a lot of jobs at the same time (westus2 & eastus2 have 100 cores respectively).

I noticed that there were a lot of unused public IPs in the subscription, which could the cause of the issue you were experiencing. I've manually deleted them so you don't have to worry about having the same issue again.

/assign @chewong