### PR TITLE
Prow: restrict decorate.VolumeMountPaths validation to equality

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -36,6 +36,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"gopkg.in/robfig/cron.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/yaml"
 
-	pipelinev1alpha1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
@@ -1805,7 +1805,7 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec) error {
 			}
 		}
 		for _, prowMountPath := range decorate.VolumeMountPaths() {
-			if strings.HasPrefix(mount.MountPath, prowMountPath) || strings.HasPrefix(prowMountPath, mount.MountPath) {
+			if mount.MountPath == prowMountPath {
 				errs = append(errs, fmt.Errorf("mount %s at %s conflicts with decoration mount at %s", mount.Name, mount.MountPath, prowMountPath))
 			}
 		}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -638,7 +638,7 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "reject conflicting mount paths (decorate in user)",
+			name: "accept conflicting mount path parent",
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",
@@ -647,7 +647,7 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		},
 		{
-			name: "reject conflicting mount paths (user in decorate)",
+			name: "accept conflicting mount path child",
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",


### PR DESCRIPTION
Kubernetes permits nested volume mounts - it only asserts that [mounts paths are unique]( https://github.com/kubernetes/kubernetes/blob/79e1ad2f4bbd05b1e56b7b57b63b2c1d67b90156/pkg/apis/core/validation/validation.go#L2349-L2351). Restricting this in `validatePodSpec` prevents optimizations such as caching the go module cache in a persistent volume (https://github.com/istio/test-infra/issues/2425). Child and/or parent mounts should be permitted for extensibility.

details: https://github.com/istio/test-infra/pull/2456#issuecomment-593754537