### PR TITLE
prow: kubernetes/k8s.io: add blockade regexps

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -170,6 +170,11 @@ blockades:
   blockregexps:
   - 'manifests/.*/promoter-manifest\.yaml$'
   explanation: "Changes to the metadata pose a security risk. This PR must be explicitly approved by k8s.io repo admins."
+- repos:
+  - kubernetes/k8s.io
+  blockregexps:
+  - 'images/legacy-backfill/images\.yaml$'
+  explanation: "Changes to the backfill manifests are forbidden, as they are effectively frozen. This PR must be explicitly approved by k8s.io repo admins."
 
 blunderbuss:
   max_request_count: 2

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -165,6 +165,11 @@ blockades:
   blockregexps:
   - ^anago|branchff|build\/|changelog-update|compile-release-tools|debian\/|find_green_build|gcb\/|gcbmgr|lib\/|prin|push-build.sh|release-notify|relnotes|rpm\/
   explanation: "Changes to certain release tools can affect our ability to test, build, and release Kubernetes. This PR must be explicitly approved by SIG Release repo admins."
+- repos:
+  - kubernetes/k8s.io
+  blockregexps:
+  - 'manifests/.*/promoter-manifest\.yaml$'
+  explanation: "Changes to the metadata pose a security risk. This PR must be explicitly approved by k8s.io repo admins."
 
 blunderbuss:
   max_request_count: 2

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -173,7 +173,7 @@ blockades:
 - repos:
   - kubernetes/k8s.io
   blockregexps:
-  - 'images/legacy-backfill/images\.yaml$'
+  - 'images/DO-NOT-MODIFY-legacy-backfill/images\.yaml$'
   explanation: "Changes to the backfill manifests are forbidden, as they are effectively frozen. This PR must be explicitly approved by k8s.io repo admins."
 
 blunderbuss:


### PR DESCRIPTION
These changes add some blockades for sensitive files containing metadata for the promoter.

Related discussion: https://github.com/kubernetes/k8s.io/pull/623#discussion_r387265898

/cc @justaugustus @thockin 