### PR TITLE
Add periodic job for basic SCTP e2e test cases

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -536,7 +536,7 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master
 - interval: 12h
-  name: ci-basic-sctp-e2e
+  name: ci-kubernetes-e2e-gce-sctp
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -551,14 +551,10 @@ periodics:
       - --env=KUBE_FEATURE_GATES=SCTPSupport=true
       - --env=ALLOW_PRIVILEGED=true
       - --env=NET_PLUGIN=kubenet
-      - --cluster=
-      - --deployment=gke
-      - --extract=ci/latest
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
+      - --gcp-master-image=gci
       - --gcp-node-image=gci
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
+      - --gcp-zone=us-west1-b
+      - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:SCTP\]
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -535,3 +535,36 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-network\]\sServices --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master
+- interval: 12h
+  name: ci-basic-sctp-e2e
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:         
+    - args:
+      - --timeout=320
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=KUBE_FEATURE_GATES=SCTPSupport=true
+      - --env=ALLOW_PRIVILEGED=true
+      - --env=NET_PLUGIN=kubenet
+      - --cluster=
+      - --deployment=gke
+      - --extract=ci/latest
+      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-c
+      - --gke-environment=test
+      - --provider=gke
+      - --test_args=--ginkgo.focus=\[Feature:SCTP\]
+      - --timeout=300m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master
+  annotations:
+    testgrid-dashboards: sig-network-sctp
+    testgrid-tab-name: e2e-basic-sctp
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-alert-stale-results-hours: '24'
+    description: "Basic e2e tests for SCTP support"

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -536,12 +536,12 @@ periodics:
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master
 - interval: 12h
-  name: ci-kubernetes-e2e-gce-sctp
+  name: ci-kubernetes-e2e-gci-gce-basic-sctp
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
-    containers:         
+    containers:
     - args:
       - --timeout=320
       - --bare
@@ -551,6 +551,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=SCTPSupport=true
       - --env=ALLOW_PRIVILEGED=true
       - --env=NET_PLUGIN=kubenet
+      - --extract=ci/latest
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -558,9 +559,3 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:SCTP\]
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200401-d2349a1-master
-  annotations:
-    testgrid-dashboards: sig-network-sctp
-    testgrid-tab-name: e2e-basic-sctp
-    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
-    testgrid-alert-stale-results-hours: '24'
-    description: "Basic e2e tests for SCTP support"

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -112,6 +112,12 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gce-lb-finalizer
       base_options: include-filter-by-regex=\[sig-network\]
       description: load balancer tests with finalizer protection for master branch
+    - name: gci-gce-basic-sctp
+      test_group_name: ci-kubernetes-e2e-gci-gce-basic-sctp
+      base_options: include-filter-by-regex=\[sig-network\]
+      description: network gci-gce SCTP support basic e2e tests for master branch
+      alert_options:
+        alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
 
 - name: sig-network-gke
   dashboard_tab:


### PR DESCRIPTION
We would like to add a new periodic job to kubernetes/sig-network to test the basic SCTP related e2e test cases.
The enhancement doc: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#basic-tests

The PR for the e2e test cases: 
https://github.com/kubernetes/kubernetes/pull/88196
