### PR TITLE
prow/config: enabled code freeze for 1.18

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -447,6 +447,31 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    - release-1.18
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-kind
+    - needs-rebase
+    - needs-sig
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.18
+    includedBranches:
+    - master
+    - release-1.18
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
/hold

This is to be merged on `Thu March 5th EOD`

until [Tue March 17th](https://github.com/kubernetes/sig-release/tree/master/releases/release-1.18) Code Thaw

/sig release
/area release-eng
/milestone v1.18
/priority important-soon
/cc @kubernetes/release-engineering
/assign @alejandrox1 