### PR TITLE
Boskos: Increase QPS and burst

### DIFF
--- a/boskos/crds/client.go
+++ b/boskos/crds/client.go
@@ -83,6 +83,8 @@ func (o *KubernetesClientOptions) CacheBackedClient(namespace string, startCache
 	if err != nil {
 		return nil, err
 	}
+	cfg.QPS = 100
+	cfg.Burst = 200
 
 	mgr, err := manager.New(cfg, manager.Options{
 		LeaderElection:     false,


### PR DESCRIPTION
This PR increases the QPS and burst settings for boskos to make sure we don't get limited on that.