### PR TITLE
Remove mention of non-existent Tide query limitations.

### DIFF
--- a/prow/cmd/tide/config.md
+++ b/prow/cmd/tide/config.md
@@ -70,7 +70,6 @@ The field to search token correspondence is based on the following mapping:
 * `author` -> `author:batman`
 * `reviewApprovedRequired` -> `review:approved`
 
-**Important**: Each query must return a different set of PRs. No two queries are allowed to contain the same PR.
 
 Every PR that needs to be rebased or is failing required statuses is filtered from the pool before processing
 


### PR DESCRIPTION
I noticed this is wrong. We dedup PRs from multiple queries here: https://github.com/kubernetes/test-infra/blob/cff045cb7349c5b78cf90c6db6697885334fbe6a/prow/tide/tide.go#L358

/assign @stevekuznetsov @fejta 