### PR TITLE
Add resource requests for smd benchmark jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -58,6 +58,13 @@ periodics:
       - --log-file=$(ARTIFACTS)/benchmark-log.txt
       - --output=$(ARTIFACTS)/junit_benchmarks.xml
       - ./...
+      resources:
+        requests:
+          cpu: "6000m"
+          memory: "6Gi"
+        limits:
+          cpu: "6000m"
+          memory: "6Gi"
   annotations:
     testgrid-dashboards: sig-api-machinery-structured-merge-diff
     testgrid-tab-name: ci-benchmark

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -50,6 +50,13 @@ presubmits:
         - --log-file=$(ARTIFACTS)/benchmark-log.txt
         - --output=$(ARTIFACTS)/junit_benchmarks.xml
         - ./...
+        resources:
+          requests:
+            cpu: "6000m"
+            memory: "6Gi"
+          limits:
+            cpu: "6000m"
+            memory: "6Gi"
     annotations:
       testgrid-dashboards: sig-api-machinery-structured-merge-diff
       testgrid-tab-name: pr-benchmark


### PR DESCRIPTION
As mentioned by @BenTheElder, benchmark jobs should set resource requests.

This change sets resource requests for the structured-merge-diff jobs.

For https://github.com/kubernetes/kubernetes/issues/86935.

cc @apelisse 