### PR TITLE
Add POC k/k make test jobs using a cache.

### DIFF
--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -1,0 +1,58 @@
+periodics:
+  - interval: 1h
+    name: ci-kubernetes-generate-make-test-cache
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+          command:
+            - runner.sh
+            - bash
+          args:
+            - -c
+            - |
+              local result=0
+              # Run the tests as usual
+              GO111MODULE=off go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum || result=$?
+              time make test KUBE_TIMEOUT="--timeout=600s" || result=$?
+              # Send the cache off to gcs
+              time tar -czf cache.tar.gz -C _output/local/go cache/ || result=$?
+              time gsutil cp cache.tar.gz gs://kubernetes-jenkins/cache/poc/k8s-test-cache.tar.gz || result=$?
+              exit $result
+  - interval: 15m
+    name: ci-kubernetes-cached-make-test
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
+    decorate: true
+    extra_refs:
+      - org: kubernetes
+        repo: kubernetes
+        base_ref: master
+        path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+          command:
+            - runner.sh
+            - bash
+          args:
+            - -c
+            - |
+              # Restore the cache
+              time gsutil cp gs://kubernetes-jenkins/cache/poc/k8s-test-cache.tar.gz cache.tar.gz
+              mkdir -p _output/local/go/
+              time tar -xzf cache.tar.gz -C _output/local/go
+              # Run tests as usual
+              local result=0
+              GO111MODULE=off go install k8s.io/kubernetes/vendor/gotest.tools/gotestsum || result=$?
+              time make test KUBE_TIMEOUT="--timeout=600s" || result=$?
+              exit $result


### PR DESCRIPTION
Adds two jobs:

* An hourly periodic that runs `make test` and ships the result off to GCS
* A more frequent periodic that retrieves the cache from GCS and runs `make test`

The jobs reuse the kubernetes-jenkins buckets with a new `cache` root level folder. It uses gzip compression, which apparently achieves a reasonable balance between size reduction (2.2 GB -> 446 MB in my tests) and decompression time (~15 seconds on my machine).

For now all the logic is in the prowjob, which is much easier — it might belong elsewhere in future (or it might not, given that this is strictly CI implementation details…).

/cc @BenTheElder 