### PR TITLE
Add following dashboard tabs under https://k8s-testgrid.appspot.com/c…

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -162,6 +162,11 @@ dashboards:
       test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
       alert_options:
         alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OKE, v1.15 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.15 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.15
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
     - name: OKE, v1.14 (release)
       description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
       test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.14
@@ -170,11 +175,6 @@ dashboards:
     - name: OKE, v1.13 (release)
       description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
       test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.13
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OKE, v1.12 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
-      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
       alert_options:
         alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
 
@@ -282,6 +282,11 @@ dashboards:
       test_group_name: cloud-provider-oci-e2e-conformance-stable-v1.13
       alert_options:
         alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
+    - name: OKE, v1.15 (release)
+      description: Runs conformance tests using kubetest against kubernetes release 1.15 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
+      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.15
+      alert_options:
+        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
     - name: OKE, v1.14 (release)
       description: Runs conformance tests using kubetest against kubernetes release 1.14 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
       test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.14
@@ -290,11 +295,6 @@ dashboards:
     - name: OKE, v1.13 (release)
       description: Runs conformance tests using kubetest against kubernetes release 1.13 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
       test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.13
-      alert_options:
-        alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
-    - name: OKE, v1.12 (release)
-      description: Runs conformance tests using kubetest against kubernetes release 1.12 stable tag on Oracle Cloud Infrastructure Container Engine for Kubernetes
-      test_group_name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
       alert_options:
         alert_mail_to_addresses: cncf_ci_dashboard_ww_grp@oracle.com
 
@@ -540,14 +540,14 @@ test_groups:
 - name: cloud-provider-oci-e2e-conformance-stable-v1.13
   gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci/e2e-conformance-stable-1.13
 
+- name: cloud-provider-oci-oke-e2e-conformance-stable-v1.15
+  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.15
+
 - name: cloud-provider-oci-oke-e2e-conformance-stable-v1.14
   gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.14
 
 - name: cloud-provider-oci-oke-e2e-conformance-stable-v1.13
   gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.13
-
-- name: cloud-provider-oci-oke-e2e-conformance-stable-v1.12
-  gcs_prefix: k8s-conformance-oracle-cloud/cloud-provider-oci-oke/e2e-conformance-stable-1.12
 
 # Docker node conformance test group
 - name: ce18.09-ubuntu16.04-k8s1.13.x-conformance


### PR DESCRIPTION
Add following dashboard tabs under https://k8s-testgrid.appspot.com/conformance-all:

OCI Container Engine for Kubernetes(OKE), v1.15 (release)

Removed following dashboard tabs under https://k8s-testgrid.appspot.com/conformance-all:

OCI Container Engine for Kubernetes(OKE), v1.12 (release)