### PR TITLE
Add an optional parallel ga-only conformance presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -470,3 +470,49 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-kind
+
+  - name: pull-kubernetes-conformance-kind-ga-only-parallel
+    optional: true
+    always_run: true
+    decorate: true
+    skip_branches:
+    - release-\d+\.\d+ # per-release settings
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/krte:v20200212-1f7b8ac-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        env:
+        - name: BUILD_TYPE
+          value: bazel
+        - name: GA_ONLY
+          value: "true"
+        - name: PARALLEL
+          value: "true"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "9000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-num-failures-to-alert: '10'
+      testgrid-alert-stale-results-hours: '24'
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: sig-testing-kind


### PR DESCRIPTION
Part of https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/20191023-conformance-without-beta.md

Would have flagged https://github.com/kubernetes/kubernetes/pull/87759#issuecomment-595279933

Making this optional for now, we can consider making it required once we gain confidence with it. It doesn't include serial tests, but it does ensure clusters can start up successfully.