### PR TITLE
Run network proxy CI on both httpconnect and grpc mode

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -26,7 +26,7 @@ periodics:
     testgrid-tab-name: gci-gce-proto
 
 - interval: 2h
-  name: ci-kubernetes-e2e-gci-gce-network-proxy
+  name: ci-kubernetes-e2e-gci-gce-network-proxy-http-connect
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -39,6 +39,32 @@ periodics:
       - --
       - --check-leaked-resources
       - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+      - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
+      - --extract=ci/latest
+      - --gcp-node-image=gci
+      - --gcp-zone=us-west1-b
+      - --ginkgo-parallel=25
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+  annotations:
+    testgrid-dashboards: sig-api-machinery-network-proxy
+- interval: 2h
+  name: ci-kubernetes-e2e-gci-gce-network-proxy-grpc
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=80
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+      - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=grpc
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -52,7 +78,7 @@ periodics:
 
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-e2e-gce-network-proxy
+  - name: pull-kubernetes-e2e-gce-network-proxy-http-connect
     always_run: false
     labels:
       preset-service-account: "true"
@@ -75,11 +101,50 @@ presubmits:
         - --cluster=
         - --extract=local
         - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+        - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --gcp-project=k8s-network-proxy-e2e
         - --ginkgo-parallel=30
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy-http-connect
+        - --provider=gce
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
+        - --timeout=80m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200303-28c7418-master
+        resources:
+          requests:
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-api-machinery-network-proxy
+  - name: pull-kubernetes-e2e-gce-network-proxy-grpc
+    always_run: false
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=105
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --extract=local
+        - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
+        - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=grpc
+        - --gcp-node-image=gci
+        - --gcp-zone=us-west1-b
+        - --gcp-project=k8s-network-proxy-e2e
+        - --ginkgo-parallel=30
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy-grpc
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m


### PR DESCRIPTION
Run network proxy CI on both httpconnect and grpc mode. I changed the interval to 1h for more data points before the code freeze. (Will revert back to 2h afterwards)

/cc @caesarxuchao 
/assign @krzyzacy 

/hold
(until https://github.com/kubernetes/kubernetes/pull/88869 is merged)
