### PR TITLE
ci-k8sio-cip: run every hour

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1090,7 +1090,7 @@ periodics:
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
 # ci-k8sio-cip runs daily, to make sure that the destination GCRs do not deviate
 # away from the intent of the manifest.
-- interval: 4h
+- interval: 1h
   cluster: test-infra-trusted
   max_concurrency: 1
   # This name is the "job name", passed in as "--job=NAME" for mkpj.


### PR DESCRIPTION
We are trying to run the backfill [1] mostly continuously to minimize
the promoter's downtime for new promotions.

Even without the backfill, we would still want this to run more
frequently as a sanity check anyway.

[1]: https://github.com/kubernetes/k8s.io/pull/632