### PR TITLE
Sidecar OOMs when lots of small files in the artifact directories

### DIFF
--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
     ],
 )
 


### PR DESCRIPTION
We are seeing 5-20GB allocations in a few seconds in the sidecar when it begins uploading artifacts to GCS, and the end result was OOMKills and instability on the cluster.

GCS Writer sets a default chunk size of 8MB and allocates that up front.  As per the docs on ChunkSize, we should set a smaller chunk size when uploading lots of small files.

In the future we may need to limit max parallelism to a few hundred simultaneous uploads.

Turns:

```
3232.02MB 99.83% 99.83%  3232.02MB 99.83%  google.golang.org/api/gensupport.NewMediaBuffer
 0.02MB 0.00061% 99.83%  3232.28MB 99.83%  google.golang.org/api/gensupport.NewInfoFromMedia
```

into:

```
Type: inuse_space
Time: Mar 6, 2020 at 1:06pm (EST)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top30
Showing nodes accounting for 289.41MB, 96.86% of 298.78MB total
Dropped 191 nodes (cum <= 1.49MB)
      flat  flat%   sum%        cum   cum%
  286.32MB 95.83% 95.83%   286.32MB 95.83%  google.golang.org/api/gensupport.NewMediaBuffer
    1.81MB  0.61% 96.44%     1.81MB  0.61%  runtime.malg
    0.97MB  0.32% 96.76%     1.58MB  0.53%  io.copyBuffer
    0.21MB 0.069% 96.83%     4.01MB  1.34%  google.golang.org/api/storage/v1.(*ObjectsInsertCall).doRequest
    0.07MB 0.025% 96.86%   287.05MB 96.07%  google.golang.org/api/gensupport.NewInfoFromMedia
    0.02MB 0.0065% 96.86%     1.77MB  0.59%  k8s.io/test-infra/prow/pod-utils/gcs.upload
```