### PR TITLE
Kops - Update contained e2e ssh user

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -83,14 +83,14 @@ periodics:
       args:
       - --cluster=e2e-kops-aws-containerd.test-cncf-aws.k8s.io
       - --deployment=kops
-      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --extract=release/latest
       - --ginkgo-parallel
       - --kops-args=--container-runtime=containerd --networking=calico --image=136693071363/debian-10-amd64-20200210-166
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-ssh-user=ec2-user
+      - --kops-ssh-user=admin
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints


### PR DESCRIPTION
Base image for the containerd e2e was changed to Debian 10, but not the user. Fixing it now:
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-containerd/1235737091673952259

```
Mar  6 01:35:43.564: INFO: Getting external IP address for ip-172-20-39-113.eu-west-2.compute.internal
Mar  6 01:35:43.564: INFO: SSH "ls /proc/net/nf_conntrack" on ip-172-20-39-113.eu-west-2.compute.internal(3.10.224.243:22)
error dialing ec2-user@3.10.224.243:22: 'ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain', retrying
Mar  6 01:35:49.995: INFO: ssh ec2-user@3.10.224.243:22: command:   ls /proc/net/nf_conntrack
Mar  6 01:35:49.995: INFO: ssh ec2-user@3.10.224.243:22: stdout:    ""
Mar  6 01:35:49.995: INFO: ssh ec2-user@3.10.224.243:22: stderr:    ""
Mar  6 01:35:49.995: INFO: ssh ec2-user@3.10.224.243:22: exit code: 0
Mar  6 01:35:49.995: FAIL: Unexpected error:
    <*errors.errorString | 0xc002720520>: {
        s: "failed running \"ls /proc/net/nf_conntrack\": error getting SSH client to ec2-user@3.10.224.243:22: 'ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain' (exit code 0, stderr )",
    }
```