### PR TITLE
Azure: update various azure-related job configurations

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -25,6 +25,8 @@ presubmits:
   - name: pull-cloud-provider-azure-e2e
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 5h
     path_alias: sigs.k8s.io/cloud-provider-azure
     branches:
     - master
@@ -70,7 +72,6 @@ presubmits:
         # Specific test args
         - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
         - --ginkgo-parallel=30
-        - --timeout=420m
         securityContext:
           privileged: true
     annotations:
@@ -82,6 +83,8 @@ presubmits:
   - name: pull-cloud-provider-azure-e2e-ccm
     always_run: true
     decorate: true
+    decoration_config:
+      timeout: 5h
     path_alias: sigs.k8s.io/cloud-provider-azure
     branches:
     - master
@@ -127,7 +130,6 @@ presubmits:
         # Specific test args
         - --test-ccm
         - --ginkgo-parallel=30
-        - --timeout=420m
         securityContext:
           privileged: true
     annotations:
@@ -161,6 +163,8 @@ periodics:
   # cloud-provider-azure-master runs Azure specific tests periodically.
   name: cloud-provider-azure-master
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -206,7 +210,6 @@ periodics:
       # Specific test args
       - --test-ccm
       - --ginkgo-parallel=30
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -218,6 +221,8 @@ periodics:
   # cloud-provider-azure-autoscaling runs node autoscaling tests periodically.
   name: cloud-provider-azure-autoscaling
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -263,7 +268,6 @@ periodics:
       # Specific test args
       - --test-ccm
       - --ginkgo-parallel=1
-      - --timeout=420m
       securityContext:
         privileged: true
       env:
@@ -278,6 +282,8 @@ periodics:
   # cloud-provider-azure-conformance runs Kubernetes conformance tests periodically.
   name: cloud-provider-azure-conformance
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -323,7 +329,6 @@ periodics:
       # Specific test args
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
       - --ginkgo-parallel=30
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -335,6 +340,8 @@ periodics:
   # cloud-provider-azure-slow runs Kubernetes slow tests periodically.
   name: cloud-provider-azure-slow
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -380,7 +387,6 @@ periodics:
       # Specific test args
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       - --ginkgo-parallel=4
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -392,6 +398,8 @@ periodics:
   # cloud-provider-azure-serial runs Kubernetes serial tests periodically.
   name: cloud-provider-azure-serial
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -439,7 +447,6 @@ periodics:
       # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
       - --test_args=--num-nodes=2 --ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|regular\sresource\susage\stracking\sresource\stracking\sfor|validates\sMaxPods\slimit\snumber\sof\spods\sthat\sare\sallowed\sto\srun --minStartupPods=8
       - --ginkgo-parallel=1
-      - --timeout=600m
       securityContext:
         privileged: true
       env:
@@ -458,6 +465,8 @@ periodics:
   # cloud-provider-azure-master-vmss runs Azure specific tests periodically on VMSS.
   name: cloud-provider-azure-master-vmss
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -503,7 +512,6 @@ periodics:
       # Specific test args
       - --test-ccm
       - --ginkgo-parallel=30
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -515,6 +523,8 @@ periodics:
   # cloud-provider-azure-conformance-vmss runs Kubernetes conformance tests periodically on VMSS.
   name: cloud-provider-azure-conformance-vmss
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -560,7 +570,6 @@ periodics:
       # Specific test args
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
       - --ginkgo-parallel=30
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -572,6 +581,8 @@ periodics:
   # cloud-provider-azure-slow-vmss runs Kubernetes slow tests periodically on VMSS.
   name: cloud-provider-azure-slow-vmss
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -617,7 +628,6 @@ periodics:
       # Specific test args
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       - --ginkgo-parallel=4
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -629,6 +639,8 @@ periodics:
   # cloud-provider-azure-multiple-zones runs Kubernetes multiple availability zones tests periodically.
   name: cloud-provider-azure-multiple-zones
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -675,7 +687,6 @@ periodics:
       # Check https://github.com/kubernetes-sigs/cloud-provider-azure/issues/224 for the status of each skipped test
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|Delete.Grace.Period|runs.ReplicaSets.to.verify.preemption.running.path|client.go.should.negotiate|should.contain.custom.columns.for.each.resource|Network.should.set.TCP.CLOSE_WAIT.timeout|PodSecurityPolicy
       - --ginkgo-parallel=15
-      - --timeout=420m
       securityContext:
         privileged: true
   annotations:
@@ -688,6 +699,8 @@ periodics:
 - interval: 4h
   name: ci-kubernetes-kubemark-100-azure-test
   decorate: true
+  decoration_config:
+    timeout: 5h
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-scalability, provider-azure-periodic
     testgrid-tab-name: ci-kubernetes-kubemark-100-azure-test
@@ -715,6 +728,8 @@ periodics:
 - interval: 4h
   name: ci-kubernetes-azure-conformance-ipv6
   decorate: true
+  decoration_config:
+    timeout: 5h
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -753,7 +768,6 @@ periodics:
       - --aksengine-download-url=https://github.com/aramase/aks-engine/blob/test-pkg/aks-engine-test.tar.gz?raw=true
       # Specific test args
       - --ginkgo-parallel=30
-      - --timeout=450m
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -399,6 +399,10 @@ periodics:
     preset-k8s-ssh: "true"
   extra_refs:
   - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.17
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes
     repo: cloud-provider-azure
     base_ref: master
     path_alias: sigs.k8s.io/cloud-provider-azure
@@ -727,6 +731,7 @@ periodics:
       - runner.sh
       - kubetest
       args:
+      # Generic e2e test args
       - --test
       - --up
       - --down

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -199,7 +199,7 @@ presubmits:
         - name: AZURE_STORAGE_DRIVER
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 periodics:
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-1-15
   decorate: true
   labels:
@@ -254,7 +254,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-vmss-1-15
   decorate: true
   labels:
@@ -309,7 +309,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-file-1-15
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -199,7 +199,7 @@ presubmits:
         - name: AZURE_STORAGE_DRIVER
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 periodics:
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-1-16
   decorate: true
   labels:
@@ -254,7 +254,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-vmss-1-16
   decorate: true
   labels:
@@ -309,7 +309,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-file-1-16
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -199,7 +199,7 @@ presubmits:
         - name: AZURE_STORAGE_DRIVER
           value: kubernetes.io/azure-file # In-tree Azure file storage class
 periodics:
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-1-17
   decorate: true
   labels:
@@ -254,7 +254,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-disk-vmss-1-17
   decorate: true
   labels:
@@ -309,7 +309,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test on a VMSS-based cluster with Azure Disk in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 4h
+- interval: 12h
   name: kubernetes-e2e-azure-file-1-17
   decorate: true
   labels:

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -1,43 +1,47 @@
 periodics:
 - interval: 6h
   name: ci-dualstack-azure-e2e-1-16
+  decorate: true
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-1.16
+      command:
+      - runner.sh
+      - kubetest
       args:
-      - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.16
-      - --root=/go/src
-      - --service-account=/etc/service-account/service-account.json
-      - --timeout=470
-      - --upload=gs://kubernetes-jenkins/logs/
-      - --scenario=kubernetes_e2e
-      - --
-      - --gce-ssh=
-      - --test=true
-      - --up=true
-      - --down=true
-      - --deployment=aksengine
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
       - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
       - --provider=skeleton
-      - --ginkgo-parallel=1
+      - --deployment=aksengine
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
-      - --aksengine-creds=$AZURE_CREDENTIALS
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.16
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
-      - --aksengine-deploy-custom-k8s=True
+      - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
-      - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
+      - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
       - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/dualstack/kubernetes.json
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz
-      - --timeout=450m
+      # Specific test args
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\]
+      - --ginkgo-parallel=1
+      - --timeout=450m
       securityContext:
         privileged: true
   annotations:
@@ -47,43 +51,47 @@ periodics:
     description: "Dual-stack e2e tests on a 1.16 Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 - interval: 6h
   name: ci-dualstack-azure-e2e-1-17
+  decorate: true
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.17
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-1.17
+      command:
+      - runner.sh
+      - kubetest
       args:
-      - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=release-1.17
-      - --root=/go/src
-      - --service-account=/etc/service-account/service-account.json
-      - --timeout=470
-      - --upload=gs://kubernetes-jenkins/logs/
-      - --scenario=kubernetes_e2e
-      - --
-      - --gce-ssh=
-      - --test=true
-      - --up=true
-      - --down=true
-      - --deployment=aksengine
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
       - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
       - --provider=skeleton
-      - --ginkgo-parallel=1
+      - --deployment=aksengine
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
-      - --aksengine-creds=$AZURE_CREDENTIALS
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.17
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
-      - --aksengine-deploy-custom-k8s=True
+      - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
-      - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
+      - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
       - --aksengine-template-url=https://gist.githubusercontent.com/aramase/21c3bdb44509c0f70f71389903d49c67/raw/1a9957626edc2b5c7913c741b9487fde123d0570/dualstack-prow.json
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz
-      - --timeout=450m
+      # Specific test args
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\]
+      - --ginkgo-parallel=1
+      - --timeout=450m
       securityContext:
         privileged: true
   annotations:
@@ -93,43 +101,47 @@ periodics:
     description: "Dual-stack e2e tests on a 1.17 Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 - interval: 6h
   name: ci-dualstack-azure-e2e-master
+  decorate: true
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-master
+      command:
+      - runner.sh
+      - kubetest
       args:
-      - --job=$(JOB_NAME)
-      - --repo=k8s.io/kubernetes=master
-      - --root=/go/src
-      - --service-account=/etc/service-account/service-account.json
-      - --timeout=470
-      - --upload=gs://kubernetes-jenkins/logs/
-      - --scenario=kubernetes_e2e
-      - --
-      - --gce-ssh=
-      - --test=true
-      - --up=true
-      - --down=true
-      - --deployment=aksengine
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
       - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
       - --provider=skeleton
-      - --ginkgo-parallel=1
+      - --deployment=aksengine
       - --aksengine-agentpoolcount=2
       - --aksengine-admin-username=azureuser
-      - --aksengine-creds=$AZURE_CREDENTIALS
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.17
       - --aksengine-mastervmsize=Standard_DS2_v2
       - --aksengine-agentvmsize=Standard_D4s_v3
-      - --aksengine-deploy-custom-k8s=True
+      - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
-      - --aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE
+      - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
       - --aksengine-template-url=https://gist.githubusercontent.com/aramase/21c3bdb44509c0f70f71389903d49c67/raw/1a9957626edc2b5c7913c741b9487fde123d0570/dualstack-prow.json
-      - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.0/aks-engine-v0.46.0-linux-amd64.tar.gz
-      - --timeout=450m
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      # Specific test args
       - --test_args=--ginkgo.focus=\[Feature:IPv6DualStackAlphaFeature\]
+      - --ginkgo-parallel=1
+      - --timeout=450m
       securityContext:
         privileged: true
   annotations:


### PR DESCRIPTION
- Checkout kubernetes repo for cloud-provider-azure-serial job
- Changed the period of in-tree azure disk/file e2e jobs from 4h to 12h. Those jobs don't need to be run this frequently.
- Upgraded azure dualstack jobs to pod utils

/assign @feiskyer @andyzhangx @aramase 