### PR TITLE
Sanitize GIT TAG

### DIFF
--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -25,6 +25,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -51,8 +52,13 @@ func getVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	validTagRegexp, err := regexp.Compile("[^-_.a-zA-Z0-9]+")
+	if err != nil {
+		return "", err
+	}
+	sanitizedOutput := validTagRegexp.ReplaceAllString(string(output), "")
 	t := time.Now().Format("20060102")
-	return fmt.Sprintf("v%s-%s", t, strings.TrimSpace(string(output))), nil
+	return fmt.Sprintf("v%s-%s", t, sanitizedOutput), nil
 }
 
 func (o *options) validateConfigDir() error {


### PR DESCRIPTION
This was previously discussed on [slack](https://kubernetes.slack.com/archives/CCK68P2Q2/p1582317814225200?thread_ts=1582310313.224300&cid=CCK68P2Q2). apiserver-network-proxy has a golang submodule that requires a git tag with a slash (/) character (https://github.com/kubernetes-sigs/apiserver-network-proxy/tags). This is invalid for docker's specification of a [tag](https://docs.docker.com/engine/reference/commandline/tag/)

> A tag name must be valid ASCII and may contain lowercase and uppercase letters, digits, underscores, periods and dashes. A tag name may not start with a period or a dash and may contain a maximum of 128 characters.

This PR sanitizes the git tag to remove invalid characters before being used as a docker tag.

/cc @caesarxuchao 
/assign @Katharine 