### PR TITLE
Make hold related commands only working for PR

### DIFF
--- a/prow/plugins/hold/hold.go
+++ b/prow/plugins/hold/hold.go
@@ -81,6 +81,9 @@ func handleGenericComment(pc plugins.Agent, e github.GenericCommentEvent) error 
 // a /hold directive, we want to add a label if one does not already exist.
 // If they add /hold cancel, we want to remove the label if it exists.
 func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, f hasLabelFunc) error {
+	if !e.IsPR {
+		return nil
+	}
 	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}

--- a/prow/plugins/hold/hold_test.go
+++ b/prow/plugins/hold/hold_test.go
@@ -34,6 +34,7 @@ func TestHandle(t *testing.T) {
 		hasLabel      bool
 		shouldLabel   bool
 		shouldUnlabel bool
+		isPR          bool
 	}{
 		{
 			name:          "nothing to do",
@@ -41,6 +42,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "quoted hold in a reply",
@@ -48,6 +50,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold",
@@ -55,6 +58,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   true,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold with reason",
@@ -62,6 +66,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   true,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold, Label already exists",
@@ -69,6 +74,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold with reason, Label already exists",
@@ -76,6 +82,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold cancel",
@@ -83,6 +90,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold cancel with whitespace",
@@ -90,6 +98,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,
+			isPR:          true,
 		},
 		{
 			name:          "requested hold cancel, Label already gone",
@@ -97,6 +106,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
 		},
 		{
 			name:          "requested unhold",
@@ -104,6 +114,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,
+			isPR:          true,
 		},
 		{
 			name:          "requested unhold with whitespace",
@@ -111,6 +122,7 @@ func TestHandle(t *testing.T) {
 			hasLabel:      true,
 			shouldLabel:   false,
 			shouldUnlabel: true,
+			isPR:          true,
 		},
 		{
 			name:          "requested unhold, Label already gone",
@@ -118,6 +130,23 @@ func TestHandle(t *testing.T) {
 			hasLabel:      false,
 			shouldLabel:   false,
 			shouldUnlabel: false,
+			isPR:          true,
+		},
+		{
+			name:          "requested hold for issues",
+			body:          "/hold",
+			hasLabel:      false,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+			isPR:          false,
+		},
+		{
+			name:          "requested unhold for issues",
+			body:          "/unhold",
+			hasLabel:      true,
+			shouldLabel:   false,
+			shouldUnlabel: false,
+			isPR:          false,
 		},
 	}
 
@@ -131,6 +160,7 @@ func TestHandle(t *testing.T) {
 			Body:   tc.body,
 			Number: 1,
 			Repo:   github.Repo{Owner: github.User{Login: "org"}, Name: "repo"},
+			IsPR:   tc.isPR,
 		}
 		hasLabel := func(label string, issueLabels []github.Label) bool {
 			return tc.hasLabel


### PR DESCRIPTION
Hold commands only take action when the target is a PR.

Fix #16666