### PR TITLE
Branchprotector: modernize parameters

### DIFF
--- a/prow/cmd/branchprotector/README.md
+++ b/prow/cmd/branchprotector/README.md
@@ -70,6 +70,9 @@ branch-protection:
       # this is the foo org policy
       protect: true  # enable protection
       enforce_admins: true  # rules apply to admins
+      required_linear_history: true  # enforces a linear commit Git history
+      allow_force_pushes: true  # permits force pushes to the protected branch
+      allow_deletions: true  # allows deletion of the protected branch
       required_pull_request_reviews:
         dismiss_stale_reviews: false # automatically dismiss old reviews
         dismissal_restrictions: # allow review dismissals

--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -1030,6 +1030,126 @@ branch-protection:
 				},
 			},
 		},
+		{
+			name:     "require linear history",
+			branches: []string{"cfgdef/repo1=master", "cfgdef/repo1=branch", "cfgdef/repo2=master"},
+			config: `
+branch-protection:
+  protect: true
+  required_linear_history: true
+  orgs:
+    cfgdef:
+`,
+			expected: []requirements{
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:         &no,
+						RequiredLinearHistory: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:         &no,
+						RequiredLinearHistory: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo2",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:         &no,
+						RequiredLinearHistory: true,
+					},
+				},
+			},
+		},
+		{
+			name:     "allow force pushes",
+			branches: []string{"cfgdef/repo1=master", "cfgdef/repo1=branch", "cfgdef/repo2=master"},
+			config: `
+branch-protection:
+  protect: true
+  allow_force_pushes: true
+  orgs:
+    cfgdef:
+`,
+			expected: []requirements{
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:    &no,
+						AllowForcePushes: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:    &no,
+						AllowForcePushes: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo2",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:    &no,
+						AllowForcePushes: true,
+					},
+				},
+			},
+		},
+		{
+			name:     "allow deletions",
+			branches: []string{"cfgdef/repo1=master", "cfgdef/repo1=branch", "cfgdef/repo2=master"},
+			config: `
+branch-protection:
+  protect: true
+  allow_deletions: true
+  orgs:
+    cfgdef:
+`,
+			expected: []requirements{
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:  &no,
+						AllowDeletions: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo1",
+					Branch: "branch",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:  &no,
+						AllowDeletions: true,
+					},
+				},
+				{
+					Org:    "cfgdef",
+					Repo:   "repo2",
+					Branch: "master",
+					Request: &github.BranchProtectionRequest{
+						EnforceAdmins:  &no,
+						AllowDeletions: true,
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {

--- a/prow/cmd/branchprotector/request.go
+++ b/prow/cmd/branchprotector/request.go
@@ -31,6 +31,9 @@ func makeRequest(policy branchprotection.Policy) github.BranchProtectionRequest 
 		RequiredPullRequestReviews: makeReviews(policy.RequiredPullRequestReviews),
 		RequiredStatusChecks:       makeChecks(policy.RequiredStatusChecks),
 		Restrictions:               makeRestrictions(policy.Restrictions),
+		RequiredLinearHistory:      makeBool(policy.RequiredLinearHistory),
+		AllowForcePushes:           makeBool(policy.AllowForcePushes),
+		AllowDeletions:             makeBool(policy.AllowDeletions),
 	}
 
 }

--- a/prow/config/branch_protection.go
+++ b/prow/config/branch_protection.go
@@ -38,13 +38,20 @@ type Policy struct {
 	Restrictions *Restrictions `json:"restrictions,omitempty"`
 	// RequiredPullRequestReviews specifies github approval/review criteria.
 	RequiredPullRequestReviews *ReviewPolicy `json:"required_pull_request_reviews,omitempty"`
+	// RequiredLinearHistory enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
+	RequiredLinearHistory *bool `json:"required_linear_history,omitempty"`
+	// AllowForcePushes permits force pushes to the protected branch by anyone with write access to the repository.
+	AllowForcePushes *bool `json:"allow_force_pushes,omitempty"`
+	// AllowDeletions allows deletion of the protected branch by anyone with write access to the repository.
+	AllowDeletions *bool `json:"allow_deletions,omitempty"`
 	// Exclude specifies a set of regular expressions which identify branches
 	// that should be excluded from the protection policy
 	Exclude []string `json:"exclude,omitempty"`
 }
 
 func (p Policy) defined() bool {
-	return p.Protect != nil || p.RequiredStatusChecks != nil || p.Admins != nil || p.Restrictions != nil || p.RequiredPullRequestReviews != nil
+	return p.Protect != nil || p.RequiredStatusChecks != nil || p.Admins != nil || p.Restrictions != nil || p.RequiredPullRequestReviews != nil ||
+		p.RequiredLinearHistory != nil || p.AllowForcePushes != nil || p.AllowDeletions != nil
 }
 
 // ContextPolicy configures required github contexts.
@@ -154,6 +161,9 @@ func (p Policy) Apply(child Policy) Policy {
 		Protect:                    selectBool(p.Protect, child.Protect),
 		RequiredStatusChecks:       mergeContextPolicy(p.RequiredStatusChecks, child.RequiredStatusChecks),
 		Admins:                     selectBool(p.Admins, child.Admins),
+		RequiredLinearHistory:      selectBool(p.RequiredLinearHistory, child.RequiredLinearHistory),
+		AllowForcePushes:           selectBool(p.AllowForcePushes, child.AllowForcePushes),
+		AllowDeletions:             selectBool(p.AllowDeletions, child.AllowDeletions),
 		Restrictions:               mergeRestrictions(p.Restrictions, child.Restrictions),
 		RequiredPullRequestReviews: mergeReviewPolicy(p.RequiredPullRequestReviews, child.RequiredPullRequestReviews),
 		Exclude:                    unionStrings(p.Exclude, child.Exclude),

--- a/prow/config/branch_protection_test.go
+++ b/prow/config/branch_protection_test.go
@@ -180,11 +180,17 @@ func TestApply(test *testing.T) {
 				Protect: &t,
 			},
 			child: Policy{
-				Admins: &f,
+				Admins:                &f,
+				RequiredLinearHistory: &t,
+				AllowForcePushes:      &t,
+				AllowDeletions:        &t,
 			},
 			expected: Policy{
-				Protect: &t,
-				Admins:  &f,
+				Protect:               &t,
+				Admins:                &f,
+				RequiredLinearHistory: &t,
+				AllowForcePushes:      &t,
+				AllowDeletions:        &t,
 			},
 		},
 		{

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -535,6 +535,9 @@ type BranchProtectionRequest struct {
 	EnforceAdmins              *bool                              `json:"enforce_admins"`
 	RequiredPullRequestReviews *RequiredPullRequestReviewsRequest `json:"required_pull_request_reviews"`
 	Restrictions               *RestrictionsRequest               `json:"restrictions"`
+	RequiredLinearHistory      bool                               `json:"required_linear_history"`
+	AllowForcePushes           bool                               `json:"allow_force_pushes"`
+	AllowDeletions             bool                               `json:"allow_deletions"`
 }
 
 func (r BranchProtectionRequest) String() string {


### PR DESCRIPTION
Branchprotector: add support for new GitHub API [parameter](https://developer.github.com/v3/repos/branches/#update-branch-protection):

fix https://github.com/kubernetes/test-infra/issues/16077

Name | Type | Description
-- | -- | --
required_linear_history | boolean | Enforces a linear commit Git history, which prevents anyone from pushing merge commits to a branch.
allow_force_pushes | boolean | Permits force pushes to the protected branch by anyone with write access to the repository. 
allow_deletions | boolean | Allows deletion of the protected branch by anyone with write access to the repository. 



