### PR TITLE
Add GA-only conformance job to master-blocking testgrid

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -271,6 +271,7 @@ periodics:
   annotations:
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-stale-results-hours: '48'
-    testgrid-dashboards: conformance-all, conformance-kind, sig-testing-kind
+    testgrid-dashboards: sig-release-master-blocking, conformance-all, conformance-kind, sig-testing-kind
     testgrid-tab-name: conformance-ga-only
-    testgrid-alert-email: liggitt@google.com
+    testgrid-alert-email: "kubernetes-release-team@googlegroups.com, kubernetes-sig-architecture@googlegroups.com"
+    description: "OWNER: sig-architecture (conformance); conformance tests run against a master kind cluster with only GA APIs and features enabled"

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -471,13 +471,13 @@ func TestReleaseBlockingJobsMustHaveTestgridDescriptions(t *testing.T) {
 					t.Logf("NOTICE: %v: - Must have a description that starts with OWNER: ", intro)
 				}
 				if dashboardtab.AlertOptions == nil {
-					t.Logf("NOTICE: %v: - Must have alert_options", intro)
+					t.Logf("NOTICE: %v: - Must have alert_options (ensure informing dashboard is listed first in testgrid-dashboards)", intro)
 				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
 					t.Logf("NOTICE: %v: - Must have alert_options.alert_mail_to_addresses", intro)
 				}
 			} else {
 				if dashboardtab.AlertOptions == nil {
-					t.Errorf("%v: - Must have alert_options", intro)
+					t.Errorf("%v: - Must have alert_options (ensure blocking dashboard is listed first in testgrid-dashboards)", intro)
 				} else if dashboardtab.AlertOptions.AlertMailToAddresses == "" {
 					t.Errorf("%v: - Must have alert_options.alert_mail_to_addresses", intro)
 				}


### PR DESCRIPTION
Part of https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/20191023-conformance-without-beta.md

The periodic GA-only conformance job ensures that no new beta APIs or features are introduced as requirements to pass conformance tests. In the four days this job has existed, it has already caught one breaking change.

@kubernetes/sig-release 
for ack of addition to release-blocking dashboard

@kubernetes/sig-architecture-pr-reviews 
for surfacing of conformance results as part of release criteria
