### PR TITLE
capz: Remove soggiest from OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/OWNERS
@@ -9,7 +9,6 @@ approvers:
 - justaugustus
 - karataliu
 - khenidak
-- soggiest
 reviewers:
 - juan-lee
 - serbrech


### PR DESCRIPTION
Wrapping up @soggiest's offboarding from capz.
ref: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/387

Signed-off-by: Stephen Augustus <saugustus@vmware.com>