### PR TITLE
prow/cmd/horologium: log when job is skipped

### DIFF
--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -163,6 +163,13 @@ func sync(prowJobClient prowJobClient, cfg *config.Config, cr cronClient, now ti
 				if _, err := prowJobClient.Create(&prowJob); err != nil {
 					errs = append(errs, err)
 				}
+			} else {
+				logger.WithFields(logrus.Fields{
+					"previous-found": previousFound,
+					"should-trigger": shouldTrigger,
+					"name":           p.Name,
+					"job":            p.JobBase.Name,
+				}).Info("skipping cron periodic")
 			}
 		}
 	}


### PR DESCRIPTION
Add more debugging logs to see why the job is being skipped.

I've seen a case, where a periodic job is not being triggered
while the deck (dashboard) reports the last run was success.

e.g. An hourly periodic job is being reported "Duration=6h40m...",
when the actual complete duration was <2h. So, the latest job
was complete in time, but horologium somehow never reported this
as complete. As a result, this hourly job is never triggered for
the last 6-hour.
