### PR TITLE
GCSUpload: Properly handle errors with concurrency settings

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -586,6 +586,9 @@ func (g *GCSConfiguration) Validate() error {
 	if g.PathStrategy != PathStrategyExplicit && (g.DefaultOrg == "" || g.DefaultRepo == "") {
 		return fmt.Errorf("default org and repo must be provided for GCS strategy %q", g.PathStrategy)
 	}
+	if g.MaxConcurrency < 1 {
+		return fmt.Errorf("max_concurrency must be > 0, was %d", g.MaxConcurrency)
+	}
 	return nil
 }
 

--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -116,7 +116,7 @@ func (o *Options) Complete(args []string) {
 	}
 	o.mediaTypes = flagutil.NewStrings()
 
-	if o.GCSConfiguration.MaxConcurrency == 0 {
+	if o.GCSConfiguration.MaxConcurrency < 1 {
 		o.GCSConfiguration.MaxConcurrency = int64(4 * runtime.NumCPU())
 	}
 }

--- a/prow/gcsupload/options_test.go
+++ b/prow/gcsupload/options_test.go
@@ -33,7 +33,8 @@ func TestOptions_Validate(t *testing.T) {
 			input: Options{
 				DryRun: true,
 				GCSConfiguration: &prowapi.GCSConfiguration{
-					PathStrategy: prowapi.PathStrategyExplicit,
+					PathStrategy:   prowapi.PathStrategyExplicit,
+					MaxConcurrency: 1,
 				},
 			},
 			expectedErr: false,
@@ -44,11 +45,24 @@ func TestOptions_Validate(t *testing.T) {
 				DryRun:             false,
 				GcsCredentialsFile: "secrets",
 				GCSConfiguration: &prowapi.GCSConfiguration{
+					Bucket:         "seal",
+					PathStrategy:   prowapi.PathStrategyExplicit,
+					MaxConcurrency: 1,
+				},
+			},
+			expectedErr: false,
+		},
+		{
+			name: "missing max concurrency",
+			input: Options{
+				DryRun:             false,
+				GcsCredentialsFile: "secrets",
+				GCSConfiguration: &prowapi.GCSConfiguration{
 					Bucket:       "seal",
 					PathStrategy: prowapi.PathStrategyExplicit,
 				},
 			},
-			expectedErr: false,
+			expectedErr: true,
 		},
 		{
 			name: "push to GCS, missing bucket",
@@ -56,7 +70,8 @@ func TestOptions_Validate(t *testing.T) {
 				DryRun:             false,
 				GcsCredentialsFile: "secrets",
 				GCSConfiguration: &prowapi.GCSConfiguration{
-					PathStrategy: prowapi.PathStrategyExplicit,
+					PathStrategy:   prowapi.PathStrategyExplicit,
+					MaxConcurrency: 1,
 				},
 			},
 			expectedErr: true,
@@ -66,8 +81,9 @@ func TestOptions_Validate(t *testing.T) {
 			input: Options{
 				DryRun: false,
 				GCSConfiguration: &prowapi.GCSConfiguration{
-					Bucket:       "seal",
-					PathStrategy: prowapi.PathStrategyExplicit,
+					Bucket:         "seal",
+					PathStrategy:   prowapi.PathStrategyExplicit,
+					MaxConcurrency: 1,
 				},
 			},
 			expectedErr: true,
@@ -157,9 +173,10 @@ func TestValidatePathOptions(t *testing.T) {
 		o := Options{
 			DryRun: true,
 			GCSConfiguration: &prowapi.GCSConfiguration{
-				PathStrategy: testCase.strategy,
-				DefaultOrg:   testCase.org,
-				DefaultRepo:  testCase.repo,
+				PathStrategy:   testCase.strategy,
+				DefaultOrg:     testCase.org,
+				DefaultRepo:    testCase.repo,
+				MaxConcurrency: 1,
 			},
 		}
 		err := o.Validate()


### PR DESCRIPTION
#12940 apparently introduced some issue wrt to the concurrency handling, `inituploads` just blocks forever with no output. This PR adds makes sure the defaulting works and adds validation.

cc @stevekuznetsov 