### PR TITLE
cert-manager: add ci-cert-manager-e2e-v1-17 to testgrid

### DIFF
--- a/config/testgrids/cert-manager/jetstack-cert-manager-master.yaml
+++ b/config/testgrids/cert-manager/jetstack-cert-manager-master.yaml
@@ -161,6 +161,26 @@ dashboards:
     results_url_template:
       url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
     test_group_name: ci-cert-manager-e2e-v1-16
+  - base_options: width=10
+    code_search_path: https://github.com/jetstack/cert-manager/search
+    code_search_url_template:
+      url: https://github.com/jetstack/cert-manager/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: title
+        value: 'E2E: <test-name>'
+      - key: body
+        value: <test-url>
+      url: https://github.com/jetstack/cert-manager/issues/new
+    name: cert-manager-master-e2e-v1-17
+    description: End-to-end tests using Kubernetes 1.17
+    open_bug_template:
+      url: https://github.com/jetstack/cert-manager/issues/
+    open_test_template:
+      url: https://prow.build-infra.jetstack.net/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.build-infra.jetstack.net/job-history/<gcs_prefix>
+    test_group_name: ci-cert-manager-e2e-v1-17
 
 # These are periodic jobs that target the master branch of cert-manager
 test_groups:
@@ -180,3 +200,5 @@ test_groups:
   name: ci-cert-manager-e2e-v1-15
 - gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-16
   name: ci-cert-manager-e2e-v1-16
+- gcs_prefix: jetstack-logs/logs/ci-cert-manager-e2e-v1-17
+  name: ci-cert-manager-e2e-v1-17


### PR DESCRIPTION
Adds the Kubernetes v1.17 periodic job to the cert-manager 'master' testgrid dashboard 😄 
