### PR TITLE
schedulerf_perf: constrain compute resources

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -410,6 +410,15 @@ periodics:
       # even on very powerful machines
       - name: BENCHTIME
         value: 1ns
+      # We need to constraint compute resources so all the tests
+      # finish approximately at the same time. More compute power
+      # can increase scheduling throughput and make consequent results
+      # incomparable.
+      resources:
+        requests:
+          cpu: 4
+        limits:
+          cpu: 4
 
 - name: ci-benchmark-kube-dns-master
   interval: 2h


### PR DESCRIPTION
We need to constraint compute resources so all the tests
finish approximatelly at the same time. More compute power
can increase scheduling throughput and make consequent results
incomparable.

All test containers run by scheduler_perf jenkins job set memory resource request to "1Gi". Not sure what's the right request for cpu so setting it to 4 cores for now to see how it will behave.

CC @ahg-g @liu-cong