### PR TITLE
Sinker: Do not error if pod is already gone

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -418,14 +418,7 @@ func (c *controller) clean() {
 				continue
 			}
 
-			// Delete old finished or orphan pods. Don't quit if we fail to delete one.
-			if err := client.Delete(pod.ObjectMeta.Name, &metav1.DeleteOptions{}); err == nil {
-				log.WithFields(logrus.Fields{"pod": pod.ObjectMeta.Name, "reason": reason}).Info("Deleted old completed pod.")
-				metrics.podsRemoved[reason]++
-			} else {
-				log.WithField("pod", pod.ObjectMeta.Name).WithError(err).Error("Error deleting pod.")
-				metrics.podRemovalErrors[string(k8serrors.ReasonForError(err))]++
-			}
+			c.deletePod(log, pod.Name, reason, client, &metrics)
 		}
 	}
 
@@ -446,4 +439,16 @@ func (c *controller) clean() {
 		sinkerMetrics.prowJobsCleaningErrors.WithLabelValues(k).Set(float64(v))
 	}
 	c.logger.Info("Sinker reconciliation complete.")
+}
+
+func (c *controller) deletePod(log *logrus.Entry, name, reason string, client podInterface, m *sinkerReconciliationMetrics) {
+	// Delete old finished or orphan pods. Don't quit if we fail to delete one.
+	if err := client.Delete(name, &metav1.DeleteOptions{}); err == nil {
+		log.WithFields(logrus.Fields{"pod": name, "reason": reason}).Info("Deleted old completed pod.")
+		m.podsRemoved[reason]++
+	} else if !k8serrors.IsNotFound(err) {
+		log.WithField("pod", name).WithError(err).Error("Error deleting pod.")
+		m.podRemovalErrors[string(k8serrors.ReasonForError(err))]++
+	}
+
 }

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -807,3 +807,16 @@ func TestFlags(t *testing.T) {
 		})
 	}
 }
+
+func TestDeletePodToleratesNotFound(t *testing.T) {
+	client := corev1fake.NewSimpleClientset().CoreV1().Pods("default")
+	m := &sinkerReconciliationMetrics{}
+	c := &controller{}
+	l := logrus.NewEntry(logrus.New())
+
+	c.deletePod(l, "i-do-not-exist", "reason", client, m)
+
+	if n := len(m.podRemovalErrors); n != 0 {
+		t.Errorf("Expected no pod removal errors, got %v", m.podRemovalErrors)
+	}
+}


### PR DESCRIPTION
Avoids the occasional `{ "level": "error", "component": "sinker", "cluster": 2.0, "pod": "f3dbea95-6222-11ea-84b0-0a58ac109efa", "file": "prow/cmd/sinker/main.go:426", "error": "pods "f3dbea95-6222-11ea-84b0-0a58ac109efa" not found", "func": "main.(*controller).clean", "msg": "Error deleting pod." }`