### PR TITLE
boskos/ranch: remove support for reading storage from file

### DIFF
--- a/boskos/cleaner/cleaner_test.go
+++ b/boskos/cleaner/cleaner_test.go
@@ -55,7 +55,7 @@ func createFakeBoskos(objects ...runtime.Object) (*ranch.Storage, boskosClient, 
 		obj.(metav1.Object).SetNamespace(testNS)
 	}
 	names := make(chan releasedResource, 100)
-	s, _ := ranch.NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(objects...), testNS, "")
+	s := ranch.NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(objects...), testNS)
 	r, _ := ranch.NewRanch("", s, testTTL)
 
 	return s, &fakeBoskos{ranch: r}, names

--- a/boskos/cmd/boskos/boskos.go
+++ b/boskos/cmd/boskos/boskos.go
@@ -50,7 +50,6 @@ var (
 	configPath                  = flag.String("config", "config.yaml", "Path to init resource file")
 	dynamicResourceUpdatePeriod = flag.Duration("dynamic-resource-update-period", defaultDynamicResourceUpdatePeriod,
 		"Period at which to update dynamic resources. Set to 0 to disable.")
-	storagePath       = flag.String("storage", "", "Path to persistent volume to load the state")
 	requestTTL        = flag.Duration("request-ttl", defaultRequestTTL, "request TTL before losing priority in the queue")
 	kubeClientOptions crds.KubernetesClientOptions
 	logLevel          = flag.String("log-level", "info", fmt.Sprintf("Log level is one of %v.", logrus.AllLevels))
@@ -96,10 +95,7 @@ func main() {
 		logrus.WithError(err).Fatal("unable to get client")
 	}
 
-	storage, err := ranch.NewStorage(interrupts.Context(), client, *namespace, *storagePath)
-	if err != nil {
-		logrus.WithError(err).Fatal("failed to create storage")
-	}
+	storage := ranch.NewStorage(interrupts.Context(), client, *namespace)
 
 	r, err := ranch.NewRanch(*configPath, storage, *requestTTL)
 	if err != nil {

--- a/boskos/cmd/cleaner/main.go
+++ b/boskos/cmd/cleaner/main.go
@@ -103,7 +103,7 @@ func v1Main(client *client.Client) {
 	if err != nil {
 		logrus.WithError(err).Fatal("failed to construct kube client")
 	}
-	st, _ := ranch.NewStorage(context.Background(), kubeClient, namespace, "")
+	st := ranch.NewStorage(context.Background(), kubeClient, namespace)
 
 	cleaner := cleaner.NewCleaner(cleanerCount, client, defaultBoskosRetryPeriod, st)
 

--- a/boskos/cmd/fake-mason/main.go
+++ b/boskos/cmd/fake-mason/main.go
@@ -74,7 +74,7 @@ func main() {
 		logrus.WithError(err).Fatal("failed to create kubeClient")
 	}
 
-	st, _ := ranch.NewStorage(context.Background(), kubeClient, *namespace, "")
+	st := ranch.NewStorage(context.Background(), kubeClient, *namespace)
 
 	flag.Parse()
 	logrus.SetFormatter(&logrus.JSONFormatter{})

--- a/boskos/mason/mason_test.go
+++ b/boskos/mason/mason_test.go
@@ -99,7 +99,7 @@ func (fc *fakeConfig) Construct(ctx context.Context, res common.Resource, typeTo
 func createFakeBoskos(tc testConfig) (*ranch.Storage, *Client, chan releasedResource) {
 	names := make(chan releasedResource, 100)
 	configNames := map[string]bool{}
-	s, _ := ranch.NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(), "test", "")
+	s := ranch.NewStorage(context.Background(), fakectrlruntimeclient.NewFakeClient(), "test")
 	r, _ := ranch.NewRanch("", s, testTTL)
 
 	for rtype, c := range tc {

--- a/boskos/ranch/ranch_test.go
+++ b/boskos/ranch/ranch_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"errors"
+
 	"github.com/go-test/deep"
 	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -76,7 +77,7 @@ func makeTestRanch(objects []runtime.Object) *Ranch {
 		obj.(metav1.Object).SetNamespace(testNS)
 	}
 	client := &onceConflictingClient{Client: fakectrlruntimeclient.NewFakeClient(objects...)}
-	s, _ := NewStorage(context.Background(), client, testNS, "")
+	s := NewStorage(context.Background(), client, testNS)
 	s.now = func() time.Time {
 		return fakeNow
 	}


### PR DESCRIPTION
I don't think anyone is using PVs for storage anymore (especially since we've now refactored things to rely heavily on the CRDs), so we can remove the code to support reading Boskos storage from disk.

/assign @alvaroaleman 