### PR TITLE
Azure: add path_alias to windows presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -15,6 +15,7 @@ presubmits:
     decorate: true
     decoration_config:
       timeout: 5h
+    path_alias: k8s.io/kubernetes
     branches:
     - master
     labels:


### PR DESCRIPTION
Follow-up PR for https://github.com/kubernetes/test-infra/pull/16695. This PR adds a critical line `path_alias: k8s.io/kubernetes`, which checks out Kubernetes to `$(GOPATH)/src/k8s.io/kubernetes` instead of `$(GOPATH)/src/github.com/kubernetes/kubernetes`.