### PR TITLE
Fix images/krte/variants.yaml symlink

### DIFF
--- a/images/krte/variants.yaml
+++ b/images/krte/variants.yaml
@@ -1,1 +1,1 @@
-images/kubekins-e2e/variants.yaml
+../kubekins-e2e/variants.yaml


### PR DESCRIPTION
No release-branch variants of the krte image have been built recently,
turns out this symlink was pointing to nothing

```
$ gcloud container images list-tags gcr.io/k8s-testimages/krte
DIGEST        TAGS                                                TIMESTAMP
a1d61daba1de  latest-master,v20200212-1f7b8ac-master              2020-02-12T13:35:02
622741bc9f0c  v20200205-602500d-master                            2020-02-05T10:59:48
de6deae10055  v20200123-dd36597-master                            2020-01-23T15:26:23
2ea4bff1bb8a  v20200107-164c5e8-master                            2020-01-07T13:23:47
```

ref: https://github.com/kubernetes/test-infra/issues/16700
introduced in: https://github.com/kubernetes/test-infra/pull/15610