### PR TITLE
fix transfigure diff logic

### DIFF
--- a/testgrid/cmd/transfigure/transfigure.sh
+++ b/testgrid/cmd/transfigure/transfigure.sh
@@ -69,12 +69,12 @@ main() {
     --output "${testgrid_dir}/${testgrid_subdir}/gen-config.yaml"
 
 
-  if [[ $(git diff --exit-code) -eq 0 ]]; then
+  git add --all
+
+  if git diff --cached --quiet --exit-code; then
     echo "Transfigure did not change anything. Aborting no-op bump"
     exit 0
   fi
-
-  git add --all
 
   echo "Running kubernetes/test-infra tests..."
   bazel test //config/tests/...


### PR DESCRIPTION
The change in https://github.com/kubernetes/test-infra/pull/16692 broken the transfigure job in **Istio**. This change will also check diff on _untracked_ files. 

https://github.com/istio/test-infra/pull/2472#issuecomment-596802353

https://storage.googleapis.com/istio-prow/pr-logs/pull/istio_test-infra/2472/pull-test-infra-check-testgrid-config/674/build-log.txt

```console
cat: '': No such file or directory
Using user from GitHub: 
cat: '': No such file or directory
Using email from GitHub: 
Ensuring kubernetes/test-infra repo
Cloning into 'test-infra'...
Created temporary repository
Checking out transfigure-branch
Switched to a new branch 'transfigure-branch'
Generating testgrid yaml
/transfigure.sh: line 72: diff: unbound variable
Cleaning temporary repository at /home/prow/go/src/github.com/istio/test-infra/test-infra
```