### PR TITLE
Allow Overriding Default Token Settings - BranchProtector

### DIFF
--- a/prow/cmd/branchprotector/protect_test.go
+++ b/prow/cmd/branchprotector/protect_test.go
@@ -61,6 +61,15 @@ func TestOptions_Validate(t *testing.T) {
 			},
 			expectedErr: false,
 		},
+		{
+			name: "override default tokens allowed",
+			opt: options{
+				config:     "dummy",
+				tokens:     5000,
+				tokenBurst: 200,
+			},
+			expectedErr: false,
+		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
/kind feature

This PR adds flags to branchprotector to allow overriding the default token and token burst values.