### PR TITLE
Sync kind release-blocking job with merge-blocking for master

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -1,35 +1,44 @@
 periodics:
-- interval: 20m
+- interval: 1h
   name: ci-kubernetes-kind-e2e-parallel
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-testing-kind
     testgrid-tab-name: kind-master-parallel
-    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes master cluster created with sigs.k8s.io/kind
+    description: Uses kubetest to run e2e tests against a latest kubernetes master cluster created with sigs.k8s.io/kind
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-num-columns-recent: '6'
   labels:
-    preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-master
+    - image: gcr.io/k8s-testimages/krte:v20200212-1f7b8ac-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      # TODO(https://github.com/kubernetes-sigs/kind/issues/1392) use community-owned bucket instead
+      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
       env:
-      # skip serial tests and run with --ginkgo-parallel
-      - name: "PARALLEL"
+      - name: FOCUS
+        value: "."
+      # TODO(bentheelder): reduce the skip list further
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+      - name: PARALLEL
         value: "true"
-      args:
-      - "--job=$(JOB_NAME)"
-      - "--root=/go/src"
-      - "--repo=k8s.io/kubernetes=master"
-      - "--repo=sigs.k8s.io/kind=master"
-      - "--service-account=/etc/service-account/service-account.json"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--scenario=execute"
-      - "--"
-      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      - name: BUILD_TYPE
+        value: bazel
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -40,43 +49,52 @@ periodics:
           memory: "9000Mi"
           # during the tests more like 3-20m is used
           cpu: 2000m
-- interval: 20m
+- interval: 1h
   name: ci-kubernetes-kind-ipv6-e2e-parallel
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-testing-kind
     testgrid-tab-name: kind-ipv6-master-parallel
-    description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
+    description: Uses kubetest to run e2e tests against a latest kubernetes master IPv6 cluster created with sigs.k8s.io/kind
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-num-columns-recent: '6'
   labels:
-    preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
     preset-bazel-remote-cache-enabled: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 60m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-master
+    - image: gcr.io/k8s-testimages/krte:v20200212-1f7b8ac-master
+      command:
+      - wrapper.sh
+      - bash
+      - -c
+      # TODO(https://github.com/kubernetes-sigs/kind/issues/1392) use community-owned bucket instead
+      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
       env:
       # enable IPV6 in bootstrap image
-      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+      - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"
       # tell kind CI script to use ipv6
-      - name: "IP_FAMILY"
+      - name: IP_FAMILY
         value: "ipv6"
-      # skip serial tests and run with --ginkgo-parallel
-      - name: "PARALLEL"
+      - name: FOCUS
+        value: "."
+      # TODO(bentheelder): reduce the skip list further
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|ReplicationController.light.Should.scale.from.1.pod.to.2.pods|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+      - name: PARALLEL
         value: "true"
-      args:
-      - "--job=$(JOB_NAME)"
-      - "--root=/go/src"
-      - "--repo=k8s.io/kubernetes=master"
-      - "--repo=sigs.k8s.io/kind=master"
-      - "--service-account=/etc/service-account/service-account.json"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--scenario=execute"
-      - "--"
-      - "./../../sigs.k8s.io/kind/hack/ci/e2e.sh"
+      - name: BUILD_TYPE
+        value: bazel
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
The changes are based on the pull-kubernetes-e2e-kind and ci-kubernetes-conformance-ga-only jobs

These include:
- moving from deprecated bootstrap.py to decorated pod-utils job
- using krte instead of kubekins as the image
- using the focus/skip list that runs more than conformance tests
- bumping the interval up to 1h based on the additional runtime seen
  in presubmits

ref: https://github.com/kubernetes/test-infra/issues/16700

/cc @alejandrox1 @droslean @justaugustus @BenTheElder 