### PR TITLE
kops/gce: adds Firewall to the e2e skip list

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --kops-zones=us-central1-c
       - --provider=gce
       - --timeout=140m
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops


### PR DESCRIPTION
This addition to the skip list exclude only: https://github.com/kubernetes/kubernetes/blob/master/test/e2e/network/firewall.go#L50
I'm electing to exclude this test right now because it makes some IMO arbitrary assumptions about the way instances will be named. When they are not named in this way, this test falls apart. 

I think that checking for valid firewalls is reasonable, but right now we're being tested on naming conventions, not content. I'm interested in both improving kops/gce cluster hardening (and tests) and reviewing naming strategies for kops/gce. However, I think that at this time, it would be more beneficial to skip this one in the interest of getting a reasonable subset of tests running that can be promoted to presubmits and rely on the signals we get. 