### PR TITLE
Migrate scalability tests to use e2- machine family for nodes

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -871,6 +871,7 @@ presubmits:
         - --gcp-nodes=100
         - --gcp-project-type=scalability-presubmit-project
         - --gcp-zone=us-east1-b
+        - --gcp-node-size=e2-standard-2
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-100-performance
         - --tear-down-previous
@@ -921,7 +922,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -871,6 +871,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-nodes=100
+        - --gcp-node-size=e2-standard-2
         - --gcp-project-type=scalability-presubmit-project
         - --gcp-zone=us-east1-b
         - --provider=gce
@@ -931,7 +932,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -925,6 +925,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-nodes=100
+        - --gcp-node-size=e2-standard-2
         - --gcp-project-type=scalability-presubmit-project
         - --gcp-zone=us-east1-b
         - --provider=gce
@@ -986,7 +987,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-presubmit-project
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -218,7 +218,7 @@ periodics:
       - --extract=ci/latest-1.18
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -283,6 +283,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=100
+      - --gcp-node-size=e2-standard-2
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -111,7 +111,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-size=n1-standard-2
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-4
+      - --gcp-node-size=e2-standard-4
       - --gcp-nodes=4
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -177,7 +177,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project=k8s-jenkins-blocking-kubemark
       - --gcp-zone=us-central1-f
@@ -238,7 +238,7 @@ periodics:
       - --cluster=kubemark-5000
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=84
       - --gcp-project=kubemark-scalability-testing
       - --gcp-zone=us-east1-b
@@ -303,7 +303,7 @@ periodics:
       - --cluster=kubemark-100pods
       - --extract=ci/latest
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=9
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -72,6 +72,7 @@ periodics:
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest
       - --gcp-nodes=5000
+      - --gcp-node-size=e2-standard-2
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
       - --provider=gce
@@ -142,6 +143,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-nodes=100
+      - --gcp-node-size=e2-standard-2
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce


### PR DESCRIPTION
This PR migrates nodes in scalability tests to use e2- instance family.

This excludes:
* masters
* some experimental jobs
* presubmit jobs

/assign @wojtek-t 