### PR TITLE
Azure: move Windows [Serial] & [Slow] test cases to separate serial jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -113,7 +113,7 @@ periodics:
     testgrid-tab-name: aks-engine-azure-windows-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
-- interval: 12h
+- interval: 8h
   name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows
   labels:
     preset-service-account: "true"
@@ -138,6 +138,7 @@ periodics:
       - "--deployment=aksengine"
       - "--provider=skeleton"
       - "--build=quick"
+      - "--ginkgo-parallel=4"
       - "--aksengine-admin-username=azureuser"
       - "--aksengine-admin-password=AdminPassw0rd"
       - "--aksengine-creds=$AZURE_CREDENTIALS"
@@ -150,7 +151,7 @@ periodics:
       - "--aksengine-win-binaries"
       - "--aksengine-deploy-custom-k8s"
       - "--aksengine-agentpoolcount=2"
-      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|GMSA"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|\\[Serial\\]|\\[Slow\\]|GMSA"
       - "--timeout=620m"
       securityContext:
         privileged: true
@@ -159,7 +160,54 @@ periodics:
     testgrid-tab-name: aks-engine-azure-1-14-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
-- interval: 12h
+- interval: 8h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-14-windows-serial-slow
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.14"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=650"
+      - "--scenario=kubernetes_e2e"
+      - --
+      - "--test=true"
+      - "--up=true"
+      - "--down=true"
+      - "--deployment=aksengine"
+      - "--provider=skeleton"
+      - "--build=quick"
+      - "--ginkgo-parallel=1"
+      - "--aksengine-admin-username=azureuser"
+      - "--aksengine-admin-password=AdminPassw0rd"
+      - "--aksengine-creds=$AZURE_CREDENTIALS"
+      # Note: Updating aks-engine version for 1.14 + Windows configs has caused issues in the past - update this config with caution!
+      - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.31.2/aks-engine-v0.31.2-linux-amd64.tar.gz"
+      - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
+      - "--aksengine-winZipBuildScript=$WIN_BUILD"
+      - "--aksengine-orchestratorRelease=1.14"
+      - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release.json"
+      - "--aksengine-win-binaries"
+      - "--aksengine-deploy-custom-k8s"
+      - "--aksengine-agentpoolcount=2"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=(\\[sig-windows\\]|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-autoscaling\\].\\[Feature:HPA\\]|\\[sig-apps\\].CronJob).*(\\[Serial\\]|\\[Slow\\])|(\\[Serial\\]|\\[Slow\\]).*(\\[Conformance\\]|\\[NodeConformance\\]) --ginkgo.skip=\\[LinuxOnly\\]|GMSA"
+      - "--timeout=620m"
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-tab-name: aks-engine-azure-1-14-windows-serial-slow
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Release tests for K8s 1.14 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
+- interval: 8h
   name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows
   labels:
     preset-service-account: "true"
@@ -184,6 +232,7 @@ periodics:
       - "--deployment=aksengine"
       - "--provider=skeleton"
       - "--build=quick"
+      - "--ginkgo-parallel=4"
       - "--aksengine-admin-username=azureuser"
       - "--aksengine-admin-password=AdminPassw0rd"
       - "--aksengine-creds=$AZURE_CREDENTIALS"
@@ -195,7 +244,7 @@ periodics:
       - "--aksengine-win-binaries"
       - "--aksengine-deploy-custom-k8s"
       - "--aksengine-agentpoolcount=2"
-      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|GMSA"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption --ginkgo.skip=\\[LinuxOnly\\]|\\[Serial\\]|\\[Slow\\]|GMSA"
       - "--timeout=620m"
       securityContext:
         privileged: true
@@ -204,8 +253,100 @@ periodics:
     testgrid-tab-name: aks-engine-azure-1-15-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
-- interval: 12h
+- interval: 8h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-15-windows-serial-slow
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-1.15
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.15"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=650"
+      - "--scenario=kubernetes_e2e"
+      - --
+      - "--test=true"
+      - "--up=true"
+      - "--down=true"
+      - "--deployment=aksengine"
+      - "--provider=skeleton"
+      - "--build=quick"
+      - "--ginkgo-parallel=1"
+      - "--aksengine-admin-username=azureuser"
+      - "--aksengine-admin-password=AdminPassw0rd"
+      - "--aksengine-creds=$AZURE_CREDENTIALS"
+      - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz"
+      - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
+      - "--aksengine-winZipBuildScript=$WIN_BUILD"
+      - "--aksengine-orchestratorRelease=1.15"
+      - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_15.json"
+      - "--aksengine-win-binaries"
+      - "--aksengine-deploy-custom-k8s"
+      - "--aksengine-agentpoolcount=2"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=(\\[sig-windows\\]|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-autoscaling\\].\\[Feature:HPA\\]|\\[sig-apps\\].CronJob).*(\\[Serial\\]|\\[Slow\\])|(\\[Serial\\]|\\[Slow\\]).*(\\[Conformance\\]|\\[NodeConformance\\]) --ginkgo.skip=\\[LinuxOnly\\]|GMSA"
+      - "--timeout=620m"
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-tab-name: aks-engine-azure-1-15-windows-serial-slow
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Release tests for K8s 1.15 on Clusters with Windows nodes provided by aks-engine on Azure cloud.
+- interval: 8h
   name: ci-kubernetes-e2e-aks-engine-azure-1-16-windows
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-1.16
+      args:
+      - "--job=$(JOB_NAME)"
+      - "--root=/go/src"
+      - "--repo=k8s.io/kubernetes=release-1.16"
+      - "--upload=gs://kubernetes-jenkins/logs/"
+      - "--timeout=650"
+      - "--scenario=kubernetes_e2e"
+      - --
+      - "--test=true"
+      - "--up=true"
+      - "--down=true"
+      - "--deployment=aksengine"
+      - "--provider=skeleton"
+      - "--build=quick"
+      - "--ginkgo-parallel=4"
+      - "--aksengine-admin-username=azureuser"
+      - "--aksengine-admin-password=AdminPassw0rd"
+      - "--aksengine-creds=$AZURE_CREDENTIALS"
+      - "--aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.46.3/aks-engine-v0.46.3-linux-amd64.tar.gz"
+      - "--aksengine-public-key=$AZURE_SSH_PUBLIC_KEY_FILE"
+      - "--aksengine-winZipBuildScript=$WIN_BUILD"
+      - "--aksengine-orchestratorRelease=1.16"
+      - "--aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_release_1_16.json"
+      - "--aksengine-win-binaries"
+      - "--aksengine-deploy-custom-k8s"
+      - "--aksengine-agentpoolcount=2"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-autoscaling\\].\\[Feature:HPA\\]  --ginkgo.skip=\\[LinuxOnly\\]|\\[Serial\\]|\\[Slow\\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application"
+      - "--timeout=620m"
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-windows, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
+    testgrid-tab-name: aks-engine-azure-1-16-windows
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
+- interval: 8h
+  name: ci-kubernetes-e2e-aks-engine-azure-1-16-windows-serial-slow
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -240,13 +381,13 @@ periodics:
       - "--aksengine-win-binaries"
       - "--aksengine-deploy-custom-k8s"
       - "--aksengine-agentpoolcount=2"
-      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=\\[Conformance\\]|\\[NodeConformance\\]|\\[sig-windows\\]|\\[sig-apps\\].CronJob|\\[sig-api-machinery\\].ResourceQuota|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-autoscaling\\].\\[Feature:HPA\\]  --ginkgo.skip=\\[LinuxOnly\\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application"
+      - "--test_args=--num-nodes=2 --node-os-distro=windows --ginkgo.focus=(\\[sig-windows\\]|\\[sig-scheduling\\].SchedulerPreemption|\\[sig-autoscaling\\].\\[Feature:HPA\\]|\\[sig-apps\\].CronJob).*(\\[Serial\\]|\\[Slow\\])|(\\[Serial\\]|\\[Slow\\]).*(\\[Conformance\\]|\\[NodeConformance\\]) --ginkgo.skip=\\[LinuxOnly\\]|GMSA|Guestbook.application.should.create.and.stop.a.working.application"
       - "--timeout=620m"
       securityContext:
         privileged: true
   annotations:
     testgrid-dashboards: sig-windows, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
-    testgrid-tab-name: aks-engine-azure-1-16-windows
+    testgrid-tab-name: aks-engine-azure-1-16-windows-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud"
 - interval: 8h
@@ -274,7 +415,7 @@ periodics:
       - "--deployment=aksengine"
       - "--provider=skeleton"
       - "--build=quick"
-      - "--ginkgo-parallel=6"
+      - "--ginkgo-parallel=4"
       - "--aksengine-orchestratorRelease=1.17"
       - "--aksengine-admin-username=azureuser"
       - "--aksengine-admin-password=AdminPassw0rd"


### PR DESCRIPTION
This PR extracts [Serial] & [Slow] test cases from

- https://testgrid.k8s.io/provider-azure-windows#aks-engine-azure-1-14-windows
- https://testgrid.k8s.io/provider-azure-windows#aks-engine-azure-1-15-windows
- https://testgrid.k8s.io/provider-azure-windows#aks-engine-azure-1-16-windows

and run them in separate jobs in an attempt to isolate them during the test run so that we can have a clearer test signal for Windows.

/assign @marosset @adelina-t