### PR TITLE
s3: refactor gcs-upload and enable s3 support for gcsupload, sidecar & initupload

### DIFF
--- a/pkg/io/BUILD.bazel
+++ b/pkg/io/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["opener.go"],
+    srcs = [
+        "opener.go",
+        "option.go",
+    ],
     importpath = "k8s.io/test-infra/pkg/io",
     visibility = ["//visibility:public"],
     deps = [
@@ -12,6 +15,7 @@ go_library(
         "@com_google_cloud_go//storage:go_default_library",
         "@dev_gocloud//blob:go_default_library",
         "@dev_gocloud//gcerrors:go_default_library",
+        "@org_golang_google_api//googleapi:go_default_library",
         "@org_golang_google_api//option:go_default_library",
     ],
 )

--- a/pkg/io/option.go
+++ b/pkg/io/option.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package io
+
+import (
+	"cloud.google.com/go/storage"
+	"gocloud.dev/blob"
+	"google.golang.org/api/googleapi"
+)
+
+// WriterOptions are options for the opener Writer method
+type WriterOptions struct {
+	BufferSize      *int64
+	ContentEncoding *string
+	ContentType     *string
+	Metadata        map[string]string
+}
+
+// Apply applies the WriterOptions to storage.Writer and blob.WriterOptions
+// Both arguments are allowed to be nil.
+func (wo WriterOptions) Apply(writer *storage.Writer, o *blob.WriterOptions) {
+	if writer != nil {
+		if wo.BufferSize != nil {
+			if *wo.BufferSize < googleapi.DefaultUploadChunkSize {
+				writer.ChunkSize = int(*wo.BufferSize)
+			}
+		}
+		if wo.ContentEncoding != nil {
+			writer.ObjectAttrs.ContentEncoding = *wo.ContentEncoding
+		}
+		if wo.ContentType != nil {
+			writer.ObjectAttrs.ContentType = *wo.ContentType
+		}
+		if wo.Metadata != nil {
+			writer.ObjectAttrs.Metadata = wo.Metadata
+		}
+	}
+
+	if o == nil {
+		return
+	}
+
+	if wo.BufferSize != nil {
+		o.BufferSize = int(*wo.BufferSize)
+	}
+	if wo.ContentEncoding != nil {
+		o.ContentEncoding = *wo.ContentEncoding
+	}
+	if wo.ContentType != nil {
+		o.ContentType = *wo.ContentType
+	}
+	if wo.Metadata != nil {
+		o.Metadata = wo.Metadata
+	}
+}

--- a/pkg/io/providers/BUILD.bazel
+++ b/pkg/io/providers/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@dev_gocloud//blob:go_default_library",
+        "@dev_gocloud//blob/memblob:go_default_library",
         "@dev_gocloud//blob/s3blob:go_default_library",
     ],
 )

--- a/pkg/io/providers/providers.go
+++ b/pkg/io/providers/providers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"gocloud.dev/blob"
+	_ "gocloud.dev/blob/memblob"
 	"gocloud.dev/blob/s3blob"
 )
 

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -40,7 +40,7 @@ func (o fakeOpener) Reader(ctx context.Context, path string) (io.ReadCloser, err
 	return nil, storage.ErrObjectNotExist
 }
 
-func (o fakeOpener) Writer(ctx context.Context, path string) (io.WriteCloser, error) {
+func (o fakeOpener) Writer(ctx context.Context, path string, _ ...io.WriterOptions) (io.WriteCloser, error) {
 	return nil, errors.New("do not call Writer")
 }
 

--- a/prow/flagutil/storage.go
+++ b/prow/flagutil/storage.go
@@ -25,10 +25,13 @@ import (
 )
 
 type StorageClientOptions struct {
-	// GCSCredentialsFile is used for reading/writing from/to GCS.
+	// GCSCredentialsFile is used for reading/writing to GCS block storage.
+	// It's optional, if you want to write to local paths or GCS credentials auto-discovery is used.
+	// If set, this file is used to read/write to gs:// paths
+	// If not, credential auto-discovery is used
 	GCSCredentialsFile string
-	// S3CredentialsFile string is used for reading/writing to s3 block storage.
-	// If you want to write to local paths, this parameter is optional.
+	// S3CredentialsFile is used for reading/writing to s3 block storage.
+	// It's optional, if you want to write to local paths or S3 credentials auto-discovery is used.
 	// If set, this file is used to read/write to s3:// paths
 	// If not, go cloud credential auto-discovery is used
 	// For more details see the pkg/io/providers pkg.

--- a/prow/gcsupload/BUILD.bazel
+++ b/prow/gcsupload/BUILD.bazel
@@ -16,8 +16,6 @@ go_library(
         "//prow/pod-utils/gcs:go_default_library",
         "@com_github_googlecloudplatform_testgrid//util/gcs:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_google_cloud_go//storage:go_default_library",
-        "@org_golang_google_api//option:go_default_library",
     ],
 )
 

--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -36,7 +36,7 @@ func NewOptions() *Options {
 }
 
 // Options exposes the configuration necessary
-// for defining where in GCS an upload will land.
+// for defining where in storage an upload will land.
 type Options struct {
 	// Items are files or directories to upload.
 	Items []string `json:"items,omitempty"`
@@ -46,10 +46,19 @@ type Options struct {
 
 	*prowapi.GCSConfiguration
 
-	// GcsCredentialsFile is the path to the JSON
-	// credentials for pushing to GCS.
+	// GcsCredentialsFile is used for reading/writing to GCS block storage.
+	// It's optional, if you want to write to local paths or GCS credentials auto-discovery is used.
+	// If set, this file is used to read/write to gs:// paths
+	// If not, credential auto-discovery is used
 	GcsCredentialsFile string `json:"gcs_credentials_file,omitempty"`
-	DryRun             bool   `json:"dry_run"`
+	// S3CredentialsFile is used for reading/writing to s3 block storage.
+	// It's optional, if you want to write to local paths or S3 credentials auto-discovery is used.
+	// If set, this file is used to read/write to s3:// paths
+	// If not, go cloud credential auto-discovery is used
+	// For more details see the pkg/io/providers pkg.
+	S3CredentialsFile string `json:"s3_credentials_file,omitempty"`
+
+	DryRun bool `json:"dry_run"`
 
 	// mediaTypes holds additional extension media types to add to Go's
 	// builtin's and the local system's defaults.  Values are
@@ -79,8 +88,8 @@ func (o *Options) Validate() error {
 			return errors.New("GCS upload was requested no GCS bucket was provided")
 		}
 
-		if o.GcsCredentialsFile == "" {
-			return errors.New("GCS upload was requested but no GCS credentials file was provided")
+		if o.GcsCredentialsFile == "" && o.S3CredentialsFile == "" {
+			return errors.New("blob storage upload was requested but neither GCS nor S3 credentials file was provided")
 		}
 	}
 
@@ -127,6 +136,7 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 
 	fs.Var(&o.gcsPath, "gcs-path", "GCS path to upload into")
 	fs.StringVar(&o.GcsCredentialsFile, "gcs-credentials-file", "", "file where Google Cloud authentication credentials are stored")
+	fs.StringVar(&o.S3CredentialsFile, "s3-credentials-file", "", "file where the S3 credentials are stored")
 	fs.BoolVar(&o.DryRun, "dry-run", true, "do not interact with GCS")
 
 	fs.Var(&o.mediaTypes, "media-type", "Optional comma-delimited set of extension media types.  Each entry is colon-delimited {extension}:{media-type}, for example, log:text/plain.")

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -102,7 +102,7 @@ func (o Options) Run() error {
 	uploadTargets["started.json"] = gcs.DataUpload(bytes.NewReader(startedData))
 
 	if err := o.Options.Run(spec, uploadTargets); err != nil {
-		return fmt.Errorf("failed to upload to GCS: %v", err)
+		return fmt.Errorf("failed to upload to blob storage: %v", err)
 	}
 
 	if failed {
@@ -112,7 +112,7 @@ func (o Options) Run() error {
 	return nil
 }
 
-// processCloneLog checks if clone operation successed or failed for a ref
+// processCloneLog checks if clone operation succeeded or failed for a ref
 // and upload clone logs as build log upon failures.
 // returns: bool - clone status
 //          []Record - containing final SHA on successful clones

--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -11,13 +11,15 @@ go_library(
     importpath = "k8s.io/test-infra/prow/pod-utils/gcs",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
-        "@org_golang_google_api//googleapi:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
     ],
 )
 
@@ -44,9 +46,10 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
-        "@com_google_cloud_go//storage:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/prow/pod-utils/gcs/doc.go
+++ b/prow/pod-utils/gcs/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // Package gcs handles uploading files and raw data
-// to GCS and determines where in the GCS
+// to blob storage and determines where in the GCS
 // bucket data should go given a specific
 // job specification
 package gcs

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -20,9 +20,10 @@ import (
 	"mime"
 	"strings"
 
-	"cloud.google.com/go/storage"
-
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
+
+	"k8s.io/test-infra/pkg/io"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // TODO(fejta): migrate usage off type alias.
@@ -33,8 +34,8 @@ type Started = metadata.Started
 // Finished holds finished.json data
 type Finished = metadata.Finished
 
-// AttributesFromFileName guesses file attributes from the filename
-// and returns the attributes and a simplifed filename.  For example,
+// WriterOptionsFromFileName guesses file attributes from the filename
+// and returns the writerOptions and a simplified filename.  For example,
 // build-log.txt.gz would be:
 //
 //   Content-Type: text/plain; charset=utf-8
@@ -42,8 +43,8 @@ type Finished = metadata.Finished
 //
 // and the simplified filename would be build-log.txt (excluding the
 // content encoding extension).
-func AttributesFromFileName(filename string) (string, *storage.ObjectAttrs) {
-	attrs := &storage.ObjectAttrs{}
+func WriterOptionsFromFileName(filename string) (string, *io.WriterOptions) {
+	attrs := &io.WriterOptions{}
 	segments := strings.Split(filename, ".")
 	index := len(segments) - 1
 	segment := segments[index]
@@ -51,10 +52,10 @@ func AttributesFromFileName(filename string) (string, *storage.ObjectAttrs) {
 	// https://www.iana.org/assignments/http-parameters/http-parameters.xhtml#content-coding
 	switch segment {
 	case "gz", "gzip":
-		attrs.ContentEncoding = "gzip"
+		attrs.ContentEncoding = utilpointer.StringPtr("gzip")
 	}
 
-	if attrs.ContentEncoding != "" {
+	if attrs.ContentEncoding != nil {
 		if index == 0 {
 			segment = ""
 		} else {
@@ -67,13 +68,13 @@ func AttributesFromFileName(filename string) (string, *storage.ObjectAttrs) {
 	if segment != "" {
 		mediaType := mime.TypeByExtension("." + segment)
 		if mediaType != "" {
-			attrs.ContentType = mediaType
+			attrs.ContentType = utilpointer.StringPtr(mediaType)
 		}
 	}
 
-	if attrs.ContentType == "" && attrs.ContentEncoding == "gzip" {
-		attrs.ContentType = "application/gzip"
-		attrs.ContentEncoding = ""
+	if attrs.ContentType == nil && attrs.ContentEncoding != nil && *attrs.ContentEncoding == "gzip" {
+		attrs.ContentType = utilpointer.StringPtr("application/gzip")
+		attrs.ContentEncoding = nil
 	}
 
 	return filename, attrs

--- a/prow/pod-utils/gcs/metadata_test.go
+++ b/prow/pod-utils/gcs/metadata_test.go
@@ -21,110 +21,112 @@ import (
 	"reflect"
 	"testing"
 
-	"cloud.google.com/go/storage"
+	utilpointer "k8s.io/utils/pointer"
+
+	"k8s.io/test-infra/pkg/io"
 )
 
-func TestAttrsFromFileName(t *testing.T) {
+func TestWriterOptionsFromFileName(t *testing.T) {
 	mime.AddExtensionType(".log", "text/plain")
 
 	testCases := []struct {
 		name             string
 		filename         string
 		expectedFileName string
-		expectedAttrs    *storage.ObjectAttrs
+		expectedAttrs    *io.WriterOptions
 	}{
 		{
 			name:             "txt",
 			filename:         "build-log.txt",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "text/plain; charset=utf-8",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
 		{
 			name:             "txt.gz",
 			filename:         "build-log.txt.gz",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentEncoding: "gzip",
-				ContentType:     "text/plain; charset=utf-8",
+			expectedAttrs: &io.WriterOptions{
+				ContentEncoding: utilpointer.StringPtr("gzip"),
+				ContentType:     utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
 		{
 			name:             "txt.gzip",
 			filename:         "build-log.txt.gzip",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentEncoding: "gzip",
-				ContentType:     "text/plain; charset=utf-8",
+			expectedAttrs: &io.WriterOptions{
+				ContentEncoding: utilpointer.StringPtr("gzip"),
+				ContentType:     utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
 		{
 			name:             "bare gz",
 			filename:         "gz",
 			expectedFileName: "gz",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "application/gzip",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
 		{
 			name:             "gz",
 			filename:         "build-log.gz",
 			expectedFileName: "build-log",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "application/gzip",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
 		{
 			name:             "gzip",
 			filename:         "build-log.gzip",
 			expectedFileName: "build-log",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "application/gzip",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
 		{
 			name:             "json",
 			filename:         "events.json",
 			expectedFileName: "events.json",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "application/json",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("application/json"),
 			},
 		},
 		{
 			name:             "json.gz",
 			filename:         "events.json.gz",
 			expectedFileName: "events.json",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentEncoding: "gzip",
-				ContentType:     "application/json",
+			expectedAttrs: &io.WriterOptions{
+				ContentEncoding: utilpointer.StringPtr("gzip"),
+				ContentType:     utilpointer.StringPtr("application/json"),
 			},
 		},
 		{
 			name:             "log",
 			filename:         "journal.log",
 			expectedFileName: "journal.log",
-			expectedAttrs: &storage.ObjectAttrs{
-				ContentType: "text/plain; charset=utf-8",
+			expectedAttrs: &io.WriterOptions{
+				ContentType: utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
 		{
 			name:             "empty",
 			filename:         "",
 			expectedFileName: "",
-			expectedAttrs:    &storage.ObjectAttrs{},
+			expectedAttrs:    &io.WriterOptions{},
 		},
 		{
 			name:             "dot",
 			filename:         ".",
 			expectedFileName: ".",
-			expectedAttrs:    &storage.ObjectAttrs{},
+			expectedAttrs:    &io.WriterOptions{},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			actualFileName, actualAttrs := AttributesFromFileName(test.filename)
+			actualFileName, actualAttrs := WriterOptionsFromFileName(test.filename)
 
 			if actualFileName != test.expectedFileName {
 				t.Errorf("expected file name %q but got %q", test.expectedFileName, actualFileName)

--- a/prow/pod-utils/gcs/upload_test.go
+++ b/prow/pod-utils/gcs/upload_test.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"sync"
 	"testing"
-
-	"cloud.google.com/go/storage"
 )
 
 func TestUploadToGcs(t *testing.T) {
@@ -87,7 +85,7 @@ func TestUploadToGcs(t *testing.T) {
 			targets[fmt.Sprintf("fail-%d", i)] = fail
 		}
 
-		err := Upload(&storage.BucketHandle{}, targets)
+		err := Upload("", "", "", targets)
 		if err != nil && !testCase.expectedErr {
 			t.Errorf("%s: expected no error but got %v", testCase.name, err)
 		}

--- a/prow/sidecar/BUILD.bazel
+++ b/prow/sidecar/BUILD.bazel
@@ -35,10 +35,15 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["run_test.go"],
+    srcs = [
+        "options_test.go",
+        "run_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/entrypoint:go_default_library",
+        "//prow/gcsupload:go_default_library",
         "//prow/pod-utils/wrapper:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",

--- a/prow/statusreconciler/status_test.go
+++ b/prow/statusreconciler/status_test.go
@@ -38,7 +38,7 @@ func (t *testOpener) Reader(ctx context.Context, path string) (io.ReadCloser, er
 	return os.Open(path)
 }
 
-func (t *testOpener) Writer(ctx context.Context, path string) (io.WriteCloser, error) {
+func (t *testOpener) Writer(ctx context.Context, path string, _ ...io.WriterOptions) (io.WriteCloser, error) {
 	return os.Create(path)
 }
 

--- a/prow/tide/history/BUILD.bazel
+++ b/prow/tide/history/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
     srcs = ["history_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/io:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",

--- a/prow/tide/history/history_test.go
+++ b/prow/tide/history/history_test.go
@@ -29,6 +29,7 @@ import (
 	"cloud.google.com/go/storage"
 	"k8s.io/apimachinery/pkg/util/diff"
 
+	pkgio "k8s.io/test-infra/pkg/io"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
@@ -147,7 +148,7 @@ func (t *testOpener) Reader(ctx context.Context, path string) (io.ReadCloser, er
 	return t, nil
 }
 
-func (t *testOpener) Writer(ctx context.Context, path string) (io.WriteCloser, error) {
+func (t *testOpener) Writer(ctx context.Context, path string, _ ...pkgio.WriterOptions) (io.WriteCloser, error) {
 	if path != fakePath {
 		return nil, fmt.Errorf("path %q != expected %q", path, fakePath)
 	}


### PR DESCRIPTION
Goal of this PR is to leverage the new s3-enabled opener package for gcsupload, sidecar & initupload which is the next step to implement https://github.com/kubernetes/test-infra/issues/11260.
The initial commit on this PR is just one of the variants how this can be achieved. Imho we should first get consensus on some of the following issues:

* Refactoring of `gcs.Upload` (and also FileUpload, DataUpload, ..)
    * Implementation options:
        * Move implementation from gcs to opener package
        * Keep implementation in gcs package (replace gcsObjectWriter through something generic which uses the opener)
        * Create a new package which replaces gcs (e.g. blobstorage) and leverages opener
    * Considerations:
        * How invasive is the change
        * In which variants would we hide it behind a feature gate
    * Notes:
        * gcs currently exposes *storage.ObjectAttrs. I guess we also don't want to expose *blob.ObjectAttrs
            * So we need our own struct which hides both implementations?

* Changes to `DecorationConfig`
    * In all variants: add `s3_credentials_secret` field similar to `gcs_credentials_secret`
    * Options regarding GcsConfiguration:s3_credentials_secrets3_credentials_secret
        * extending GcsConfiguration
        * create new BlobStorageConfiguration and deprecate GcsConfiguration 
    * Options regarding GcsConfiguration fields:
        * keeping the bucket field and changing the behaviour:
            * use the protocol the bucket starts with, e.g. s3://prow-artifacts => s3
            * defaulting to file if it starts with /
            * defaulting to gs:// if no prefix is discovered 
        * deprecating the bucket and similar fields and adding a path field 
            * path field can now be something like:
                * gs://prow-artifacts
                * /local/path/to/files
                * s3://prow-artifacts/some/deep/folder/structure
    * Notes:
        * this has impact on how the decoration config is propagated to / parsed by the test pods

* What about the gcsupload binary:
  * extend (and possibly rename it) to support other storage provider
  * create a new blobstorageupload binary   
 
* Notes about the current implementation on this PR:
    * Moved implementation from gcs to opener package
    * Extended GcsConfiguration to avoid introducing a new struct and the corresponding migration efforts for setting / parsing both

Please ignore some details in the current implementation for now like the path handling in gcsupload/run.go. I would like to get 
consensus on the major issues so I can then refactor it further on the basis of the current implementation. 
