### PR TITLE
Revert "Migrate and/or prepare to migrate cip jobs to workload-identity"

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -45,7 +45,7 @@ presubmits:
       volumes:
       - name: creds
         secret:
-          secretName: k8s-gcr-backup-test-prod-bak-service-account # TODO(fejta): https://github.com/kubernetes/k8s.io/issues/597
+          secretName: k8s-gcr-backup-test-prod-bak-service-account
   kubernetes-sigs/k8s-container-image-promoter:
   # Run promoter e2e tests.
   - name: pull-cip-e2e
@@ -73,7 +73,7 @@ presubmits:
       volumes:
       - name: k8s-cip-test-prod-service-account-creds
         secret:
-          secretName: k8s-cip-test-prod-service-account # TODO(fejta): https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/180
+          secretName: k8s-cip-test-prod-service-account
     annotations:
       testgrid-dashboards: sig-release-misc
   - name: pull-cip-auditor-e2e
@@ -101,7 +101,7 @@ presubmits:
       volumes:
       - name: k8s-gcr-audit-test-prod-service-account-creds
         secret:
-          secretName: k8s-gcr-audit-test-prod-service-account # TODO(fejta): https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/180
+          secretName: k8s-gcr-audit-test-prod-service-account
     annotations:
       testgrid-dashboards: sig-release-misc
   # Build all binaries and also run unit tests.

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -746,7 +746,17 @@ postsubmits:
         - cip
         args:
         - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
         - -dry-run=false
+        - -use-service-account
+        volumeMounts:
+        - name: k8s-artifacts-prod-service-account-creds
+          mountPath: /etc/k8s-artifacts-prod-service-account
+          readOnly: true
+      volumes:
+      - name: k8s-artifacts-prod-service-account-creds
+        secret:
+          secretName: k8s-artifacts-prod-service-account
     annotations:
       testgrid-dashboards: sig-release-misc
   kubernetes/community:
@@ -1130,7 +1140,17 @@ periodics:
       - cip
       args:
       - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+      - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
       - -dry-run=false
+      - -use-service-account
+      volumeMounts:
+      - name: k8s-artifacts-prod-service-account-creds
+        mountPath: /etc/k8s-artifacts-prod-service-account
+        readOnly: true
+    volumes:
+    - name: k8s-artifacts-prod-service-account-creds
+      secret:
+        secretName: k8s-artifacts-prod-service-account
   annotations:
     testgrid-dashboards: sig-release-misc
 # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
@@ -1163,7 +1183,7 @@ periodics:
     volumes:
     - name: k8s-artifacts-prod-bak-service-account-creds
       secret:
-        secretName: k8s-artifacts-prod-bak-service-account # TODO(fejta): https://github.com/kubernetes/k8s.io/issues/597
+        secretName: k8s-artifacts-prod-bak-service-account
   annotations:
     testgrid-dashboards: sig-release-misc
     # TODO: enable alerting once the job has stabilized


### PR DESCRIPTION
This reverts commit d2a6eb3d4ed7dbec8302200a11a98d76ea940687.

/assign @listx @ncdc 

Probably an easy fix but let's wait until after code freeze to switch back