### PR TITLE
Make Tide validate the requested merge method against the allowed methods.

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -68,6 +68,8 @@ type statusController struct {
 	ghc      githubClient
 	gc       git.ClientFactory
 
+	mergeChecker *mergeChecker
+
 	// newPoolPending is a size 1 chan that signals that the main Tide loop has
 	// updated the 'poolPRs' field with a freshly updated pool.
 	newPoolPending chan bool
@@ -248,8 +250,10 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 func (sc *statusController) expectedStatus(log *logrus.Entry, queryMap *config.QueryMap, pr *PullRequest, pool map[string]PullRequest, ccg contextCheckerGetter, blocks blockers.Blockers, baseSHA string) (string, string, error) {
 	repo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
 
-	if pr.Mergeable == githubql.MergeableStateConflicting {
-		return github.StatusError, fmt.Sprintf(statusNotInPool, " PR has merge conflicts."), nil
+	if reason, err := sc.mergeChecker.isAllowed(pr); err != nil {
+		return "", "", fmt.Errorf("error checking if merge is allowed: %v", err)
+	} else if reason != "" {
+		return github.StatusError, fmt.Sprintf(statusNotInPool, " "+reason), nil
 	}
 
 	cc, err := ccg()
@@ -317,11 +321,11 @@ func retestingStatus(retested []string) string {
 // targetURL determines the URL used for more details in the status
 // context on GitHub. If no PR dashboard is configured, we will use
 // the administrative Prow overview.
-func targetURL(c config.Getter, pr *PullRequest, log *logrus.Entry) string {
+func targetURL(c *config.Config, pr *PullRequest, log *logrus.Entry) string {
 	var link string
-	if tideURL := c().Tide.TargetURL; tideURL != "" {
+	if tideURL := c.Tide.TargetURL; tideURL != "" {
 		link = tideURL
-	} else if baseURL := c().Tide.GetPRStatusBaseURL(config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}); baseURL != "" {
+	} else if baseURL := c.Tide.GetPRStatusBaseURL(config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}); baseURL != "" {
 		parseURL, err := url.Parse(baseURL)
 		if err != nil {
 			log.WithError(err).Error("Failed to parse PR status base URL")
@@ -337,9 +341,10 @@ func targetURL(c config.Getter, pr *PullRequest, log *logrus.Entry) string {
 }
 
 func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullRequest, blocks blockers.Blockers, baseSHAs map[string]string, requiredContexts map[string][]string) {
+	c := sc.config()
 	// queryMap caches which queries match a repo.
 	// Make a new one each sync loop as queries will change.
-	queryMap := sc.config().Tide.Queries.QueryMap()
+	queryMap := c.Tide.Queries.QueryMap()
 	processed := sets.NewString()
 
 	process := func(pr *PullRequest) {
@@ -359,7 +364,7 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 		baseSHA := baseSHAs[poolKey(org, repo, branch)]
 		baseSHAGetter := newBaseSHAGetter(baseSHAs, sc.ghc, org, repo, branch)
 
-		cr := contextCheckerGetterFactory(sc.config(), sc.gc, org, repo, branch, baseSHAGetter, headSHA, requiredContexts[prKey(pr)])
+		cr := contextCheckerGetterFactory(c, sc.gc, org, repo, branch, baseSHAGetter, headSHA, requiredContexts[prKey(pr)])
 
 		wantState, wantDesc, err := sc.expectedStatus(log, queryMap, pr, pool, cr, blocks, baseSHA)
 		if err != nil {
@@ -388,7 +393,7 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 					Context:     statusContext,
 					State:       wantState,
 					Description: wantDesc,
-					TargetURL:   targetURL(sc.config, pr, log),
+					TargetURL:   targetURL(c, pr, log),
 				}); err != nil {
 				log.WithError(err).Errorf(
 					"Failed to set status context from %q to %q.",

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -56,6 +56,7 @@ type githubClient interface {
 	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
 	GetPullRequestChanges(org, repo string, number int) ([]github.PullRequestChange, error)
 	GetRef(string, string, string) (string, error)
+	GetRepo(owner, name string) (github.FullRepo, error)
 	Merge(string, string, int, github.MergeDetails) error
 	Query(context.Context, interface{}, map[string]interface{}) error
 }
@@ -84,6 +85,8 @@ type Controller struct {
 	// changedFiles caches the names of files changed by PRs.
 	// Cache entries expire if they are not used during a sync loop.
 	changedFiles *changedFilesAgent
+
+	mergeChecker *mergeChecker
 
 	History *history.History
 }
@@ -232,17 +235,18 @@ func NewController(ghcSync, ghcStatus github.Client, mgr manager, cfg config.Get
 	if err != nil {
 		return nil, fmt.Errorf("error initializing history client from %q: %v", historyURI, err)
 	}
+	mergeChecker := newMergeChecker(cfg, ghcSync)
 
-	sc, err := newStatusController(logger, ghcStatus, mgr, gc, cfg, opener, statusURI)
+	sc, err := newStatusController(logger, ghcStatus, mgr, gc, cfg, opener, statusURI, mergeChecker)
 	if err != nil {
 		return nil, err
 	}
 	go sc.run()
 
-	return newSyncController(logger, ghcSync, mgr, cfg, gc, sc, hist)
+	return newSyncController(logger, ghcSync, mgr, cfg, gc, sc, hist, mergeChecker)
 }
 
-func newStatusController(logger *logrus.Entry, ghc githubClient, mgr manager, gc git.ClientFactory, cfg config.Getter, opener io.Opener, statusURI string) (*statusController, error) {
+func newStatusController(logger *logrus.Entry, ghc githubClient, mgr manager, gc git.ClientFactory, cfg config.Getter, opener io.Opener, statusURI string, mergeChecker *mergeChecker) (*statusController, error) {
 	if err := mgr.GetFieldIndexer().IndexField(&prowapi.ProwJob{}, indexNamePassingJobs, indexFuncPassingJobs); err != nil {
 		return nil, fmt.Errorf("failed to add index for passing jobs to cache: %v", err)
 	}
@@ -252,6 +256,7 @@ func newStatusController(logger *logrus.Entry, ghc githubClient, mgr manager, gc
 		ghc:            ghc,
 		gc:             gc,
 		config:         cfg,
+		mergeChecker:   mergeChecker,
 		newPoolPending: make(chan bool, 1),
 		shutDown:       make(chan bool),
 		opener:         opener,
@@ -267,6 +272,7 @@ func newSyncController(
 	gc git.ClientFactory,
 	sc *statusController,
 	hist *history.History,
+	mergeChecker *mergeChecker,
 ) (*Controller, error) {
 	if err := mgr.GetFieldIndexer().IndexField(
 		&prowapi.ProwJob{},
@@ -287,7 +293,8 @@ func newSyncController(
 			ghc:             ghcSync,
 			nextChangeCache: make(map[changeCacheKey][]string),
 		},
-		History: hist,
+		mergeChecker: mergeChecker,
+		History:      hist,
 	}, nil
 }
 
@@ -384,7 +391,7 @@ func (c *Controller) Sync() error {
 	if err != nil {
 		return err
 	}
-	filteredPools := c.filterSubpools(c.config().Tide.MaxGoroutines, rawPools)
+	filteredPools := c.filterSubpools(c.mergeChecker.isAllowed, rawPools)
 
 	// Notify statusController about the new pool.
 	c.sc.Lock()
@@ -467,12 +474,12 @@ func subpoolsInParallel(goroutines int, sps map[string]*subpool, process func(*s
 // filterSubpools filters non-pool PRs out of the initially identified subpools,
 // deleting any pools that become empty.
 // See filterSubpool for filtering details.
-func (c *Controller) filterSubpools(goroutines int, raw map[string]*subpool) map[string]*subpool {
+func (c *Controller) filterSubpools(mergeAllowed func(*PullRequest) (string, error), raw map[string]*subpool) map[string]*subpool {
 	filtered := make(map[string]*subpool)
 	var lock sync.Mutex
 
 	subpoolsInParallel(
-		goroutines,
+		c.config().Tide.MaxGoroutines,
 		raw,
 		func(sp *subpool) {
 			if err := c.initSubpoolData(sp); err != nil {
@@ -480,7 +487,7 @@ func (c *Controller) filterSubpools(goroutines int, raw map[string]*subpool) map
 				return
 			}
 			key := poolKey(sp.org, sp.repo, sp.branch)
-			if spFiltered := filterSubpool(c.ghc, sp); spFiltered != nil {
+			if spFiltered := filterSubpool(c.ghc, mergeAllowed, sp); spFiltered != nil {
 				sp.log.WithField("key", key).WithField("pool", spFiltered).Debug("filtered sub-pool")
 
 				lock.Lock()
@@ -514,10 +521,10 @@ func (c *Controller) initSubpoolData(sp *subpool) error {
 // filtered subpool.
 // If the subpool becomes empty 'nil' is returned to indicate that the subpool
 // should be deleted.
-func filterSubpool(ghc githubClient, sp *subpool) *subpool {
+func filterSubpool(ghc githubClient, mergeAllowed func(*PullRequest) (string, error), sp *subpool) *subpool {
 	var toKeep []PullRequest
 	for _, pr := range sp.prs {
-		if !filterPR(ghc, sp, &pr) {
+		if !filterPR(ghc, mergeAllowed, sp, &pr) {
 			toKeep = append(toKeep, pr)
 		}
 	}
@@ -530,20 +537,24 @@ func filterSubpool(ghc githubClient, sp *subpool) *subpool {
 
 // filterPR indicates if a PR should be filtered out of the subpool.
 // Specifically we filter out PRs that:
-// - Have known merge conflicts.
+// - Have known merge conflicts or invalid merge method.
 // - Have failing or missing status contexts.
 // - Have pending required status contexts that are not associated with a
 //   ProwJob. (This ensures that the 'tide' context indicates that the pending
 //   status is preventing merge. Required ProwJob statuses are allowed to be
 //   'pending' because this prevents kicking PRs from the pool when Tide is
 //   retesting them.)
-func filterPR(ghc githubClient, sp *subpool, pr *PullRequest) bool {
+func filterPR(ghc githubClient, mergeAllowed func(*PullRequest) (string, error), sp *subpool, pr *PullRequest) bool {
 	log := sp.log.WithFields(pr.logFields())
 	// Skip PRs that are known to be unmergeable.
-	if pr.Mergeable == githubql.MergeableStateConflicting {
-		log.Debug("filtering out PR as it is unmergeable")
+	if reason, err := mergeAllowed(pr); err != nil {
+		log.WithError(err).Error("Error checking PR mergeability.")
+		return true
+	} else if reason != "" {
+		log.WithField("reason", reason).Debug("filtering out PR as it is not mergeable")
 		return true
 	}
+
 	// Filter out PRs with unsuccessful contexts unless the only unsuccessful
 	// contexts are pending required prowjobs.
 	contexts, err := headContexts(log, ghc, pr)
@@ -571,6 +582,86 @@ func filterPR(ghc githubClient, sp *subpool, pr *PullRequest) bool {
 	}
 
 	return false
+}
+
+// mergeChecker provides a function to check if a PR can be merged with
+// the requested method and does not have a merge conflict.
+// It caches results and should be cleared periodically with clearCache()
+type mergeChecker struct {
+	config config.Getter
+	ghc    githubClient
+
+	sync.Mutex
+	cache map[config.OrgRepo]map[github.PullRequestMergeType]bool
+}
+
+func newMergeChecker(cfg config.Getter, ghc githubClient) *mergeChecker {
+	m := &mergeChecker{
+		config: cfg,
+		ghc:    ghc,
+		cache:  map[config.OrgRepo]map[github.PullRequestMergeType]bool{},
+	}
+
+	go m.clearCache()
+	return m
+}
+
+func (m *mergeChecker) clearCache() {
+	// Only do this once per token reset since it could be a bit expensive for
+	// Tide instances that handle hundreds of repos.
+	ticker := time.NewTicker(time.Hour)
+	for {
+		<-ticker.C
+		m.Lock()
+		m.cache = make(map[config.OrgRepo]map[github.PullRequestMergeType]bool)
+		m.Unlock()
+	}
+}
+
+func (m *mergeChecker) repoMethods(orgRepo config.OrgRepo) (map[github.PullRequestMergeType]bool, error) {
+	m.Lock()
+	defer m.Unlock()
+
+	repoMethods, ok := m.cache[orgRepo]
+	if !ok {
+		fullRepo, err := m.ghc.GetRepo(orgRepo.Org, orgRepo.Repo)
+		if err != nil {
+			return nil, err
+		}
+		repoMethods = map[github.PullRequestMergeType]bool{
+			github.MergeMerge:  fullRepo.AllowMergeCommit,
+			github.MergeSquash: fullRepo.AllowSquashMerge,
+			github.MergeRebase: fullRepo.AllowRebaseMerge,
+		}
+		m.cache[orgRepo] = repoMethods
+	}
+	return repoMethods, nil
+}
+
+// isAllowed checks if a PR does not have merge conflicts and requests an
+// allowed merge method. If there is no error it returns a string explanation if
+// not allowed or "" if allowed.
+func (m *mergeChecker) isAllowed(pr *PullRequest) (string, error) {
+	if pr.Mergeable == githubql.MergeableStateConflicting {
+		return "PR has a merge conflict.", nil
+	}
+	mergeMethod, err := prMergeMethod(m.config().Tide, pr)
+	if err != nil {
+		// This should be impossible.
+		return "", fmt.Errorf("Programmer error! Failed to determine a merge method: %v", err)
+	}
+	orgRepo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
+	repoMethods, err := m.repoMethods(orgRepo)
+	if err != nil {
+		return "", fmt.Errorf("error getting repo data: %v", err)
+	}
+	if allowed, exists := repoMethods[mergeMethod]; !exists {
+		// Should be impossible as well.
+		return "", fmt.Errorf("Programmer error! PR requested the unrecognized merge type %q", mergeMethod)
+	} else if !allowed {
+		return fmt.Sprintf("Merge type %q disallowed by repo settings", mergeMethod), nil
+	}
+	return "", nil
 }
 
 func baseSHAMap(subpoolMap map[string]*subpool) map[string]string {
@@ -904,27 +995,6 @@ func (c *Controller) pickBatch(sp subpool, cc map[int]contextChecker) ([]PullReq
 	return res, presubmits, nil
 }
 
-func checkMergeLabels(pr PullRequest, squash, rebase, merge string, method github.PullRequestMergeType) (github.PullRequestMergeType, error) {
-	labelCount := 0
-	for _, prlabel := range pr.Labels.Nodes {
-		switch string(prlabel.Name) {
-		case squash:
-			method = github.MergeSquash
-			labelCount++
-		case rebase:
-			method = github.MergeRebase
-			labelCount++
-		case merge:
-			method = github.MergeMerge
-			labelCount++
-		}
-		if labelCount > 1 {
-			return "", fmt.Errorf("conflicting merge method override labels")
-		}
-	}
-	return method, nil
-}
-
 func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitTemplate, pr PullRequest, mergeMethod github.PullRequestMergeType) github.MergeDetails {
 	ghMergeDetails := github.MergeDetails{
 		SHA:         string(pr.HeadRefOID),
@@ -954,6 +1024,36 @@ func (c *Controller) prepareMergeDetails(commitTemplates config.TideMergeCommitT
 	return ghMergeDetails
 }
 
+func prMergeMethod(c config.Tide, pr *PullRequest) (github.PullRequestMergeType, error) {
+	repo := config.OrgRepo{Org: string(pr.Repository.Owner.Login), Repo: string(pr.Repository.Name)}
+	method := c.MergeMethod(repo)
+	squashLabel := c.SquashLabel
+	rebaseLabel := c.RebaseLabel
+	mergeLabel := c.MergeLabel
+	if squashLabel != "" || rebaseLabel != "" || mergeLabel != "" {
+		labelCount := 0
+		for _, prlabel := range pr.Labels.Nodes {
+			switch string(prlabel.Name) {
+			case "":
+				continue
+			case squashLabel:
+				method = github.MergeSquash
+				labelCount++
+			case rebaseLabel:
+				method = github.MergeRebase
+				labelCount++
+			case mergeLabel:
+				method = github.MergeMerge
+				labelCount++
+			}
+			if labelCount > 1 {
+				return "", fmt.Errorf("conflicting merge method override labels")
+			}
+		}
+	}
+	return method, nil
+}
+
 func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 	var merged, failed []int
 	defer func() {
@@ -965,25 +1065,18 @@ func (c *Controller) mergePRs(sp subpool, prs []PullRequest) error {
 
 	var errs []error
 	log := sp.log.WithField("merge-targets", prNumbers(prs))
+	tideConfig := c.config().Tide
 	for i, pr := range prs {
 		log := log.WithFields(pr.logFields())
-		repo := config.OrgRepo{Org: sp.org, Repo: sp.repo}
-		mergeMethod := c.config().Tide.MergeMethod(repo)
-		commitTemplates := c.config().Tide.MergeCommitTemplate(repo)
-		squashLabel := c.config().Tide.SquashLabel
-		rebaseLabel := c.config().Tide.RebaseLabel
-		mergeLabel := c.config().Tide.MergeLabel
-		if squashLabel != "" || rebaseLabel != "" || mergeLabel != "" {
-			var err error
-			mergeMethod, err = checkMergeLabels(pr, squashLabel, rebaseLabel, mergeLabel, mergeMethod)
-			if err != nil {
-				log.WithError(err).Error("Merge failed.")
-				errs = append(errs, err)
-				failed = append(failed, int(pr.Number))
-				continue
-			}
+		mergeMethod, err := prMergeMethod(tideConfig, &pr)
+		if err != nil {
+			log.WithError(err).Error("Failed to determine merge method.")
+			errs = append(errs, err)
+			failed = append(failed, int(pr.Number))
+			continue
 		}
 
+		commitTemplates := tideConfig.MergeCommitTemplate(config.OrgRepo{Org: sp.org, Repo: sp.repo})
 		keepTrying, err := tryMerge(func() error {
 			ghMergeDetails := c.prepareMergeDetails(commitTemplates, pr, mergeMethod)
 			return c.ghc.Merge(sp.org, sp.repo, int(pr.Number), ghMergeDetails)
@@ -1581,10 +1674,11 @@ type searchQuery struct {
 
 func (pr *PullRequest) logFields() logrus.Fields {
 	return logrus.Fields{
-		"org":  string(pr.Repository.Owner.Login),
-		"repo": string(pr.Repository.Name),
-		"pr":   int(pr.Number),
-		"sha":  string(pr.HeadRefOID),
+		"org":    string(pr.Repository.Owner.Login),
+		"repo":   string(pr.Repository.Name),
+		"pr":     int(pr.Number),
+		"branch": string(pr.BaseRef.Name),
+		"sha":    string(pr.HeadRefOID),
 	}
 }
 


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/issues/16159
unblocks: https://github.com/kubernetes/test-infra/pull/16160
PRs that request or configure an invalid merge method for the repo:
- Are filtered from pool so we don’t try to batch or retest them
- Are given a status context that indicates the conflict

The set of valid method per repo is cached and shared between status and sync controllers. The cache is reset once per token reset period to pick up changes to GH settings. (If we want this to be faster for instances that have ghproxy we can make the reset period configurable, but I don't think it matters much since these settings should rarely change for a repo, if ever.)
/cc @alvaroaleman @stevekuznetsov @fejta 