### PR TITLE
Revert "ci-k8sio-cip: run every hour"

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1110,7 +1110,7 @@ periodics:
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
 # ci-k8sio-cip runs daily, to make sure that the destination GCRs do not deviate
 # away from the intent of the manifest.
-- interval: 1h
+- interval: 4h
   cluster: test-infra-trusted
   max_concurrency: 1
   # This name is the "job name", passed in as "--job=NAME" for mkpj.


### PR DESCRIPTION
This reverts commit 5e5a1c082f7c3cef8d3d6416b4b3a0c7052e9cd4.

We are running into "unexpected response code 429; body: Quota Exceeded"
for the requests to read image tags from GCR. Instead of increasing the
timeout for this job alone, dial back the frequency. This is to make it
behave more politely to other jobs running on the same node that might
also have to read tags from GCR.