### PR TITLE
Remove references to prowjobs/status subresource

### DIFF
--- a/prow/cluster/pipeline_rbac.yaml
+++ b/prow/cluster/pipeline_rbac.yaml
@@ -27,7 +27,6 @@ rules:
   - prow.k8s.io
   resources:
   - prowjobs
-  - prowjobs/status
   verbs:
   - get
   - list

--- a/prow/cmd/pipeline/dev.yaml
+++ b/prow/cmd/pipeline/dev.yaml
@@ -54,7 +54,6 @@ rules:
   - prow.k8s.io
   resources:
   - prowjobs
-  - prowjobs/status
   verbs:
   - get
   - list


### PR DESCRIPTION
We do not activate the status subresource in our CRD definitions, nor do
we have any code that interacts with it.