### PR TITLE
add postsubmit job and move dashboard to sig-auth

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -17,7 +17,7 @@ presubmits:
         - make
         - test-style
     annotations:
-      testgrid-dashboards: presubmits-secrets-store-csi-driver, provider-azure-presubmit
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-lint
       description: "Run linting rules for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -40,7 +40,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: presubmits-secrets-store-csi-driver, provider-azure-presubmit
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-unit
       description: "Run unit tests for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -63,7 +63,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: presubmits-secrets-store-csi-driver, provider-azure-presubmit
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-sanity
       description: "Run sanity tests for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
@@ -95,7 +95,42 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: presubmits-secrets-store-csi-driver, provider-azure-presubmit
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver, provider-azure-presubmit
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-vault
       description: "Run e2e test with vault provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
+
+postsubmits:
+  kubernetes-sigs/secrets-store-csi-driver:
+  - name: secrets-store-csi-driver-e2e-vault-postsubmit
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200306-3e08456-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
+          make e2e-bootstrap &&
+          export KUBECONFIG=$(kind get kubeconfig-path) &&
+          make e2e-vault
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-tab-name: secrets-store-csi-driver-e2e-vault-postsubmit
+      description: "Run e2e test with vault provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -379,28 +379,31 @@ dashboards:
     test_group_name: ci-kubernetes-node-kubelet-serial
     base_options: include-filter-by-regex=GPU|DevicePlugin
 
-- name: sig-auth
+- name: sig-auth-gce
   dashboard_tab:
   - name: gce
     test_group_name: ci-kubernetes-e2e-gci-gce
     base_options: include-filter-by-regex=sig-auth
     description: apps gce e2e tests for master branch
-  - name: gke
-    test_group_name: ci-kubernetes-e2e-gci-gke
-    base_options: include-filter-by-regex=sig-auth
-    description: apps gke e2e tests for master branch
   - name: gce-slow
     test_group_name: ci-kubernetes-e2e-gci-gce-slow
     base_options: include-filter-by-regex=sig-auth
     description: apps gce slow e2e tests for master branch
-  - name: gke-slow
-    test_group_name: ci-kubernetes-e2e-gci-gke-slow
-    base_options: include-filter-by-regex=sig-auth
-    description: apps gke slow e2e tests for master branch
   - name: gce-serial
     test_group_name: ci-kubernetes-e2e-gci-gce-serial
     base_options: include-filter-by-regex=sig-auth
     description: apps gce serial e2e tests for master branch
+
+- name: sig-auth-gke
+  dashboard_tab:
+  - name: gke
+    test_group_name: ci-kubernetes-e2e-gci-gke
+    base_options: include-filter-by-regex=sig-auth
+    description: apps gke e2e tests for master branch
+  - name: gke-slow
+    test_group_name: ci-kubernetes-e2e-gci-gke-slow
+    base_options: include-filter-by-regex=sig-auth
+    description: apps gke slow e2e tests for master branch
   - name: gke-serial
     test_group_name: ci-kubernetes-e2e-gci-gke-serial
     base_options: include-filter-by-regex=sig-auth
@@ -410,7 +413,7 @@ dashboards:
 - name: presubmits-cloud-provider-alibaba
 - name: presubmits-alibaba-cloud-csi-driver
 - name: sig-multicluster-kubemci
-- name: presubmits-secrets-store-csi-driver
+- name: sig-auth-secrets-store-csi-driver
 
 - name: presubmits-kubernetes-blocking
   dashboard_tab:
@@ -644,7 +647,6 @@ dashboard_groups:
   - presubmits-misc
   - presubmits-cloud-provider-alibaba
   - presubmits-alibaba-cloud-csi-driver
-  - presubmits-secrets-store-csi-driver
 
 - name: sig-multicluster
   dashboard_names:
@@ -659,3 +661,9 @@ dashboard_groups:
   - vmware-conformance
   - vmware-conformance-cloud-provider
   - vmware-cluster-api-provider-vsphere
+
+- name: sig-auth
+  dashboard_names:
+  - sig-auth-gce
+  - sig-auth-gke
+  - sig-auth-secrets-store-csi-driver


### PR DESCRIPTION
- `secrets-store-csi-driver` was sponsored by sig-auth for the move to kubernetes-sigs. So changing the sig-auth dashboard to make it a dashboard group and adding the new dashboard.
- Adds a postsubmit e2e job for the driver