### PR TITLE
Revert/remove clap clap functionality in assign plugin

### DIFF
--- a/prow/plugins/assign/assign.go
+++ b/prow/plugins/assign/assign.go
@@ -34,7 +34,7 @@ const pluginName = "assign"
 var (
 	assignRe = regexp.MustCompile(`(?mi)^/(un)?assign(( @?[-\w]+?)*)\s*$`)
 	// CCRegexp parses and validates /cc commands, also used by blunderbuss
-	CCRegexp = regexp.MustCompile(`(?mi)^/(un)?(?:cc|👏[\x{1f3fb}-\x{1f3ff}]?👏[\x{1f3fb}-\x{1f3ff}]?)(( +@?[-/\w]+?)*)\s*$`)
+	CCRegexp = regexp.MustCompile(`(?mi)^/(un)?cc(( +@?[-/\w]+?)*)\s*$`)
 )
 
 func init() {

--- a/prow/plugins/assign/assign_test.go
+++ b/prow/plugins/assign/assign_test.go
@@ -295,18 +295,6 @@ func TestAssignAndReview(t *testing.T) {
 			requested: []string{"cjwagner"},
 		},
 		{
-			name:      "clap clap works too",
-			body:      "/👏👏 @cjwagner ",
-			commenter: "rando",
-			requested: []string{"cjwagner"},
-		},
-		{
-			name:      "clap clap with skin tone works too",
-			body:      "/👏🏽👏🏽 @cjwagner ",
-			commenter: "rando",
-			requested: []string{"cjwagner"},
-		},
-		{
 			name:        "multi commands",
 			body:        "/cc @cjwagner\n/uncc @spxtr",
 			commenter:   "rando",


### PR DESCRIPTION
This functionality is problematic on a number of levels and shouldn't have been approved.

First, it's weird, undocumented behaviour. If someone is not in the joke, it will be confusing as to why emoji are triggering a review request. There is nothing in the plugin's documentation or help page saying that this is an option.

Second, it's an easter egg in a core command. It's not an optional plugin that can be turned on or off.. most prow users use the assign plugin, and there is no flag or option to disable this undocumented behaviour.

Third, this messes with [devstats](https://github.com/cncf/devstats/blob/dc4f67ac9db47600ce444da4d024c294a4e85e7e/metrics/kubernetes/bot_commands.sql#L9) where we collect data on bot commands that are issued.

And lastly, it's non-inclusive. Beyond the issues raised in the first point that it's in undocumented inside joke, it also uses emojis in a command which messes with screen readers and other accessibility bits. It's just (unfortunately) not really a great idea from a contributor experience standpoint. I'm happy to see that are tests for skin colours, but unfortunately that's not enough.

To be clear: I like memes and jokes, and feel there is room for fun. Great examples of this are the dog/cat/pony/goose plugins (they have full help documentation, are optional, and don't mess with the actual PR workflow). Unfortunately, these inclusivity considerations are important, and any changes to prow that impact that contributor experience need to be run through sig-contribex.

FYI @kubernetes/sig-contributor-experience @kubernetes/sig-testing @kubernetes/test-infra-maintainers

This reverts commit 46626dea0bee533ddec96ee1f6e39a93bd9308ec, reversing
changes made to fd45432efbe1eecb848d9a87127a61db4f2eeee3.