### PR TITLE
jobs: move gce-cos-master-reboot to release-master-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -571,9 +571,11 @@ periodics:
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200311-1e25827-master
   annotations:
-    testgrid-dashboards: sig-release-master-informing, google-gce
+    testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-reboot
     description: Uses kubetest to run a subset of e2e tests (+Feature:Reboot) against a cluster created with cluster/kube-up.sh
+    testgrid-alert-email: gke-node-experience-team+alerts@google.com
+    testgrid-num-failures-to-alert: '6'
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial


### PR DESCRIPTION
The release branch equivalent is present in all other release-blocking
dashboards, eg:
- https://testgrid.k8s.io/sig-release-1.18-blocking#gce-cos-k8sbeta-reboot
- https://testgrid.k8s.io/sig-release-1.17-blocking#gce-cos-k8sstable1-reboot
- https://testgrid.k8s.io/sig-release-1.16-blocking#gce-cos-k8sstable2-reboot
- https://testgrid.k8s.io/sig-release-1.15-blocking#gce-cos-k8sstable3-reboot

ref: https://github.com/kubernetes/test-infra/issues/9363