### PR TITLE
jobs: give ci-kubernetes-verify job more cpu

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -397,7 +397,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "4"
+          cpu: "6"
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -404,7 +404,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "4"
+          cpu: "6"
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -458,7 +458,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "4"
+          cpu: "6"
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -461,7 +461,7 @@ periodics:
       name: ""
       resources:
         requests:
-          cpu: "4"
+          cpu: "6"
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -215,4 +215,4 @@ periodics:
         privileged: true
       resources:
         requests:
-          cpu: 4
+          cpu: 6


### PR DESCRIPTION
it's hitting its timeout more frequently across all release branches,
this may prevent it from getting scheduled next to noisy neighbors

ref: https://github.com/kubernetes/kubernetes/issues/89052
/shrug