### PR TITLE
SDCICD-202. Point osde2e staging jobs at new default/next names.

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -34,21 +34,16 @@ test_groups:
   - configuration_value: upgrade-version
 
 # OpenShift Dedicated staging
-- name: osd-stage-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.2
+- name: osd-stage-default
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-default
   column_header:
   - configuration_value: cluster-version
-- name: osd-stage-4.3
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.3
+- name: osd-stage-next
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-next
   column_header:
   - configuration_value: cluster-version
-- name: osd-upgrade-stage-4.2-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.2-4.2
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osd-upgrade-stage-4.2-4.3
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-4.2-4.3
+- name: osd-upgrade-stage-default-next
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-default-next
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
@@ -216,9 +211,9 @@ dashboards:
 # OpenShift Dedicated staging dashboard
 - name: redhat-osd-stage
   dashboard_tab:
-  - name: osd-stage-4.2
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 staging cluster.
-    test_group_name: osd-stage-4.2
+  - name: osd-stage-default
+    description: Runs cluster acceptance tests on an OpenShift Dedicated staging cluster using the current default version.
+    test_group_name: osd-stage-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -236,9 +231,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-stage-4.3
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.3 staging cluster.
-    test_group_name: osd-stage-4.3
+  - name: osd-stage-next
+    description: Runs cluster acceptance tests on an OpenShift Dedicated staging cluster using the latest version.
+    test_group_name: osd-stage-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -256,29 +251,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-stage-4.2-4.2
-    description: Runs upgrade tests between OpenShift Dedicated 4.2 and 4.2 in staging.
-    test_group_name: osd-upgrade-stage-4.2-4.2
-    base_options: width=10
-    open_test_template: # The URL template to visit after clicking on a cell
-      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
-    file_bug_template: # The URL template to visit when filing a bug
-      url: https://github.com/openshift/osde2e/issues/new
-      options:
-        - key: title
-          value: 'E2E: <test-name>'
-        - key: body
-          value: <test-url>
-    open_bug_template: # The URL template to visit when visiting an associated bug
-      url: https://github.com/openshift/osde2e/issues/
-    results_url_template: # The URL template to visit after clicking
-      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
-    code_search_url_template: # The URL template to visit when searching for changelists
-      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-stage-4.2-4.3
-    description: Runs upgrade tests between OpenShift Dedicated 4.2 and 4.3 in staging.
-    test_group_name: osd-upgrade-stage-4.2-4.3
+  - name: osd-upgrade-stage-default-next
+    description: Runs upgrade tests between OpenShift Dedicated current default version and latest in staging.
+    test_group_name: osd-upgrade-stage-default-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>


### PR DESCRIPTION
The staging jobs are now pointed at default/next, mirroring the approach
taken by prod.