### PR TITLE
Add managed webhook/HMAC config and associated validation.

### DIFF
--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/config",
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/errorutil:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2672,7 +2672,41 @@ func TestSlackReporterValidation(t *testing.T) {
 		})
 	}
 }
+func TestManagedHmacEntityValidation(t *testing.T) {
+	testCases := []struct {
+		name       string
+		prowConfig Config
+		shouldFail bool
+	}{
+		{
+			name:       "Missing managed HmacEntities",
+			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: nil}},
+			shouldFail: false,
+		},
+		{
+			name: "Config with all valid dates",
+			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: map[string]ManagedWebhookInfo{"foo/bar": {TokenCreatedAfter: time.Now()},
+				"foo/baz": {TokenCreatedAfter: time.Now()}}}},
+			shouldFail: false,
+		},
+		{
+			name: "Config with one invalid dates",
+			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: map[string]ManagedWebhookInfo{"foo/bar": {TokenCreatedAfter: time.Now()},
+				"foo/baz": {TokenCreatedAfter: time.Now().Add(time.Hour)}}}},
+			shouldFail: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
 
+			err := tc.prowConfig.validateComponentConfig()
+			if tc.shouldFail != (err != nil) {
+				t.Errorf("%s: Unexpected outcome. Error expected %v, Error found %s", tc.name, tc.shouldFail, err)
+			}
+
+		})
+	}
+}
 func TestValidateTriggering(t *testing.T) {
 	testCases := []struct {
 		name        string


### PR DESCRIPTION
Design doc https://docs.google.com/document/d/1we2DgZd42U0PRhB-XsvP2FJjLHX5dzJPEbXC6gqWkn0/edit#  

This is part 1 of the change which would allow us to have a declarative file which tracks which org/repo are using private hmac tokens for github integrations.