### PR TITLE
Update cache gerrit cookie more frequently.

### DIFF
--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -1,7 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- amwat
-- krzyzacy
+- fejta
+- Katharine
 labels:
 - area/prow/gerrit

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -164,7 +164,7 @@ func NewClient(instances map[string][]string) (*Client, error) {
 func auth(c *Client, cookiefilePath string) {
 	logrus.Info("Starting auth loop...")
 	var previousToken string
-	wait := 10 * time.Minute
+	wait := time.Minute
 	for {
 		raw, err := ioutil.ReadFile(cookiefilePath)
 		if err != nil {


### PR DESCRIPTION
When using workload identity to authenticate with the metadata server,
the metadata server returns the same (internally cached) access token
until shortly before the token's expiration. This is most likely to
reduce load on the token issuing servers and/or metadata server.

Updating grandmatriarch to bake cookies every minute when not using
a secret credentials file. This should be fast enough to push the new
token before the previous one's expiration.

Also, update gerrit to check for a new token every minute. There is already
logic to only push the new token if it differs from the last one, and updating
the token involves a relatively cheap operation (reading a small file).

Also:
* update OWNERS to fejta and Katharine instead of amit/sen
* will work on a more precise fix after this

/assign @Katharine @cjwagner 
/cc @krzyzacy @amwat 