### PR TITLE
Improve ghProxy docs and make Prow warn if ghproxy isn't being used.

### DIFF
--- a/ghproxy/README.md
+++ b/ghproxy/README.md
@@ -1,6 +1,34 @@
 # ghProxy
 
 ghProxy is a reverse proxy HTTP cache optimized for use with the GitHub API (https://api.github.com).
-It is essentially just a reverse proxy wrapper around [ghCache](/ghproxy/ghcache) with some additional prometheus instrumentation logic to monitor disk usage and push metrics to a prometheus push gateway.
+It is essentially just a reverse proxy wrapper around [ghCache](/ghproxy/ghcache) with Prometheus instrumentation to monitor disk usage.
 
-ghProxy is designed to reduce API token usage by allowing many components to share a single ghCache. Note that components must use the same API token to benefit from the cache and avoid clobbering existing cache entries for other tokens.
+ghProxy is designed to reduce API token usage by allowing many components to
+share a single ghCache. Note that components must use the same API token to
+benefit from the cache and avoid clobbering existing cache entries for other
+tokens.
+
+## with Prow
+
+While ghProxy can be used with any GitHub API client, it was designed for Prow.
+Prow's GitHub client request throttling is optimized for use with ghProxy and
+doesn't count requests that can be fulfilled with a cached response against the
+throttling limit.
+
+Many Prow features (and soon components) require ghProxy in order to avoid
+rapidly consuming the API rate limit. Direct your Prow components that use the
+GitHub API (anything that requires the GH token secret) to use ghProxy and fall
+back to using the upstream API by adding the following flags:
+
+```yaml
+--github-endpoint=http://ghproxy  # Replace this as needed to point to your ghProxy instance.
+--github-endpoint=https://api.github.com
+```
+
+## Deploying
+
+A new container image is automatically built and published to
+[gcr.io/k8s-prow/ghproxy](https://gcr.io/k8s-prow/ghproxy) whenever this
+directory is changed on the master branch. You can find a recent stable image
+tag and an example of how to deploy ghProxy to Kubernetes by checking out
+[Prow's ghProxy deployment](/prow/cluster/ghproxy.yaml).

--- a/ghproxy/ghcache/README.md
+++ b/ghproxy/ghcache/README.md
@@ -6,7 +6,8 @@ ghCache is an HTTP cache optimized for caching responses from the GitHub API (ht
 - Every cache hit is revalidated with a conditional HTTP request to GitHub regardless of cache entry freshness (TTL). The 'Cache-Control' header is ignored and overwritten to achieve this.
 - Concurrent requests for the same resource are coalesced and share a single request/response from GitHub instead of each request resulting in a corresponding upstream request and response.
 
-ghCache also provides prometheus instrumentation to expose cache activity and API token usage/savings.
+ghCache also provides prometheus instrumentation to expose cache activity,
+request duration, and API token usage/savings.
 
 ## Why?
 
@@ -14,4 +15,4 @@ The most important behavior of ghCache is the mandatory cache entry revalidation
 While this property would cause most API caches to use tokens excessively, in the case of GitHub, we can actually save API tokens. This is because conditional requests for unchanged resources don't cost any API tokens!!! See: https://developer.github.com/v3/#conditional-requests
 Free revalidation allows us to ensure that every request is satisfied with the most up to date resource without actually spending an API token unless the resource has been updated since we last checked it.
 
-Request coalescing is beneficial for use cases in which the same resource is requested multiple times in rapid succession. Normally these requests would each result in an upstream request to GitHub, potentially costing API tokens, but with request coalescing at most one token is used.
+Request coalescing is beneficial for use cases in which the same resource is requested multiple times in rapid succession. Normally these requests would each result in an upstream request to GitHub, potentially costing API tokens, but with request coalescing at most one token is used. This particularly helps when many handlers react to the same event like in Prow's [hook component](/prow/cmd/hook).

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -78,12 +78,16 @@ func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagS
 
 // Validate validates GitHub options.
 func (o *GitHubOptions) Validate(dryRun bool) error {
-	for _, uri := range o.endpoint.Strings() {
+	endpoints := o.endpoint.Strings()
+	for _, uri := range endpoints {
 		if uri == "" {
 			uri = github.DefaultAPIEndpoint
 		} else if _, err := url.ParseRequestURI(uri); err != nil {
 			return fmt.Errorf("invalid -github-endpoint URI: %q", uri)
 		}
+	}
+	if len(endpoints) == 1 && endpoints[0] == github.DefaultAPIEndpoint {
+		logrus.Error("It doesn't look like you are using ghproxy to cache API calls to GitHub! This has become a required component of Prow and other components will soon be allowed to add features that may rapidly consume API ratelimit without caching. Starting May 1, 2020 use Prow components without ghproxy at your own risk! https://github.com/kubernetes/test-infra/tree/master/ghproxy#ghproxy")
 	}
 
 	if o.graphqlEndpoint == "" {


### PR DESCRIPTION
The first commit adds ghProxy docs about how to use with Prow.

The second commit makes the GH client warn if it doesn't look like ghProxy is being used and sets an ultimatum of May 1, 2020 when Prow components may start assuming ghProxy is used. This assumption will let us avoid a lot of in-process caching which will simplify code.
Holding for approval from some other [Prow OWNERS](https://github.com/kubernetes/test-infra/blob/master/prow/OWNERS).
/hold 

/assign @fejta @stevekuznetsov @alvaroaleman @cblecker 