### PR TITLE
Delete gce-ssh flag for azure kubemark test.

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -776,8 +776,8 @@ periodics:
       - runner.sh
       - kubetest
       args:
-      - --gce-ssh=
-      - --up=true
+      - --up
+      - --dump=$(ARTIFACTS)
       - --deployment=aksengine
       - --aksengine-creds=$AZURE_CREDENTIALS
       - --build-with-kubemark=true


### PR DESCRIPTION
Delete gce-ssh flag for azure kubemark test because it's not compatible with pod-utility.

/kind bug
/area provider/azure