### PR TITLE
GHE support for clonerefs

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -96,10 +96,10 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 	} else {
 		// try to parse the host from the repoLink URL
 		u, err := url.Parse(refs.RepoLink)
-		if err != nil {
-			clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
-		} else {
+		if err == nil && u.Host != "" {
 			clonePath = fmt.Sprintf("%s/%s/%s", u.Host, refs.Org, refs.Repo)
+		} else {
+			clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 		}
 	}
 	return path.Join(baseDir, "src", clonePath)
@@ -117,11 +117,10 @@ func gitCtxForRefs(refs prowapi.Refs, baseDir string, env []string, oauthToken s
 	// try to parse the host from the repoLink URL
 	var repositoryURI string
 	u, err := url.Parse(refs.RepoLink)
-	if err != nil {
-		repositoryURI = fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
-
-	} else {
+	if err == nil && u.Host != "" {
 		repositoryURI = fmt.Sprintf("https://%s/%s/%s.git", u.Host, refs.Org, refs.Repo)
+	} else {
+		repositoryURI = fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
 	}
 	g := gitCtx{
 		cloneDir:      PathForRefs(baseDir, refs),

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -43,8 +43,9 @@ func TestPathForRefs(t *testing.T) {
 		{
 			name: "default generated",
 			refs: prowapi.Refs{
-				Org:  "org",
-				Repo: "repo",
+				Org:      "org",
+				Repo:     "repo",
+				RepoLink: "https://github.com/org/repo",
 			},
 			expected: "base/src/github.com/org/repo",
 		},

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -43,6 +43,14 @@ func TestPathForRefs(t *testing.T) {
 		{
 			name: "default generated",
 			refs: prowapi.Refs{
+				Org:  "org",
+				Repo: "repo",
+			},
+			expected: "base/src/github.com/org/repo",
+		},
+		{
+			name: "default generated with repo link",
+			refs: prowapi.Refs{
 				Org:      "org",
 				Repo:     "repo",
 				RepoLink: "https://github.com/org/repo",


### PR DESCRIPTION
clonerefs currently always hardcodes github.com. This PR fixes that by parsing the RepoLink 
(which is e.g.: `https://github.com/kubernetes/test-infra`) and uses the Host of the URL instead.