### PR TITLE
Add a version package, populate it and use it

### DIFF
--- a/boskos/aws-janitor/BUILD.bazel
+++ b/boskos/aws-janitor/BUILD.bazel
@@ -19,8 +19,10 @@ go_library(
     ],
 )
 
+NAME = "aws-janitor"
+
 go_binary(
-    name = "aws-janitor",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -28,6 +30,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@gcloud-go//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/boskos/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
+++ b/boskos/aws-janitor/cmd/aws-janitor-boskos/BUILD.bazel
@@ -2,8 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "aws-janitor-boskos"
+
 go_binary(
-    name = "aws-janitor-boskos",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -11,6 +13,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@gcloud-go//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/boskos/cmd/boskos/BUILD.bazel
+++ b/boskos/cmd/boskos/BUILD.bazel
@@ -1,8 +1,10 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "boskos"
+
 go_binary(
-    name = "boskos",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -10,6 +12,7 @@ go_binary(
 
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/boskos/cmd/boskos/boskos.go
+++ b/boskos/cmd/boskos/boskos.go
@@ -68,7 +68,7 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("boskos")
+	logrusutil.ComponentInit()
 	kubeClientOptions.AddFlags(flag.CommandLine)
 	flag.Parse()
 	level, err := logrus.ParseLevel(*logLevel)

--- a/boskos/cmd/cleaner/BUILD.bazel
+++ b/boskos/cmd/cleaner/BUILD.bazel
@@ -23,13 +23,16 @@ go_library(
     ],
 )
 
+NAME = "cleaner"
+
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "cleaner",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/boskos/cmd/cleaner/main.go
+++ b/boskos/cmd/cleaner/main.go
@@ -71,7 +71,7 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("boskos-cleaner")
+	logrusutil.ComponentInit()
 	flag.Parse()
 	kubeClientOptions.Validate()
 

--- a/boskos/cmd/cli/BUILD.bazel
+++ b/boskos/cmd/cli/BUILD.bazel
@@ -13,14 +13,17 @@ go_library(
     ],
 )
 
+NAME = "boskosctl"
+
 prow_image(
     name = "image",
     base = "@boskosctl-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "boskosctl",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/boskos/cmd/fake-mason/BUILD.bazel
+++ b/boskos/cmd/fake-mason/BUILD.bazel
@@ -17,13 +17,16 @@ go_library(
     ],
 )
 
+NAME = "fake-mason"
+
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "fake-mason",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/boskos/cmd/janitor/BUILD.bazel
+++ b/boskos/cmd/janitor/BUILD.bazel
@@ -10,8 +10,10 @@ load(
     "go_test",
 )
 
+NAME = "janitor"
+
 go_binary(
-    name = "janitor",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )
@@ -49,6 +51,7 @@ container_image(
 prow_image(
     name = "image",
     base = ":janitor_image",
+    component = NAME,
     # the entrypoint must be sh
     # https://github.com/kubernetes/test-infra/issues/5877
     entrypoint = [

--- a/boskos/cmd/metrics/BUILD.bazel
+++ b/boskos/cmd/metrics/BUILD.bazel
@@ -10,8 +10,10 @@ load(
     "go_library",
 )
 
+NAME = "metrics"
+
 go_binary(
-    name = "metrics",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )
@@ -34,6 +36,7 @@ go_library(
 
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/boskos/cmd/metrics/metrics.go
+++ b/boskos/cmd/metrics/metrics.go
@@ -55,7 +55,8 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("boskos-metrics")
+	logrusutil.ComponentInit()
+
 	flag.Parse()
 	boskos, err := client.NewClient("Metrics", boskosURL, username, passwordFile)
 	if err != nil {

--- a/boskos/cmd/reaper/BUILD.bazel
+++ b/boskos/cmd/reaper/BUILD.bazel
@@ -3,8 +3,10 @@ package(default_visibility = ["//visibility:public"])
 load("//prow:def.bzl", "prow_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+NAME = "reaper"
+
 go_binary(
-    name = "reaper",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )
@@ -22,6 +24,7 @@ go_library(
 
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/experiment/resultstore/BUILD.bazel
+++ b/experiment/resultstore/BUILD.bazel
@@ -1,7 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image", "prow_push")
 
-prow_image(name = "image")
+NAME = "resultstore"
+
+prow_image(
+    name = "image",
+    component = NAME,
+)
 
 prow_push(
     name = "push",
@@ -37,7 +42,7 @@ go_library(
 )
 
 go_binary(
-    name = "resultstore",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/experiment/resultstore/main.go
+++ b/experiment/resultstore/main.go
@@ -106,7 +106,7 @@ func parseOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("storeship")
+	logrusutil.ComponentInit()
 
 	opt := parseOptions()
 	for {

--- a/experiment/tracer/main.go
+++ b/experiment/tracer/main.go
@@ -73,7 +73,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("tracer")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -3,8 +3,10 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//prow:def.bzl", "prow_image", "prow_push")
 
+NAME = "ghproxy"
+
 go_binary(
-    name = "ghproxy",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -21,6 +23,7 @@ prow_push(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -125,7 +125,7 @@ func flagOptions() *options {
 }
 
 func main() {
-	logrusutil.ComponentInit("ghproxy")
+	logrusutil.ComponentInit()
 
 	o := flagOptions()
 	flag.Parse()

--- a/greenhouse/BUILD.bazel
+++ b/greenhouse/BUILD.bazel
@@ -21,8 +21,10 @@ go_library(
     ],
 )
 
+NAME = "greenhouse"
+
 go_binary(
-    name = "greenhouse",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -49,6 +51,7 @@ filegroup(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/greenhouse/main.go
+++ b/greenhouse/main.go
@@ -64,7 +64,7 @@ var diskCheckInterval = flag.Duration("disk-check-interval", time.Second*10,
 var promMetrics *prometheusMetrics
 
 func init() {
-	logrusutil.ComponentInit("greenhouse")
+	logrusutil.ComponentInit()
 
 	logrus.SetOutput(os.Stdout)
 	promMetrics = initMetrics()

--- a/label_sync/BUILD.bazel
+++ b/label_sync/BUILD.bazel
@@ -12,9 +12,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+NAME = "label_sync"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -28,7 +31,7 @@ prow_push(
 )
 
 go_binary(
-    name = "label_sync",
+    name = NAME,
     embed = [":go_default_library"],
 )
 

--- a/label_sync/main.go
+++ b/label_sync/main.go
@@ -680,7 +680,7 @@ func newClient(tokenPath string, tokens, tokenBurst int, dryRun bool, graphqlEnd
 // It took about 10 minutes to process all my 8 repos with all wanted "kubernetes" labels (70+)
 // Next run takes about 22 seconds to check if all labels are correct on all repos
 func main() {
-	logrusutil.ComponentInit("label_sync")
+	logrusutil.ComponentInit()
 
 	flag.Parse()
 	if *debug {

--- a/maintenance/migratestatus/migratestatus.go
+++ b/maintenance/migratestatus/migratestatus.go
@@ -115,7 +115,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("migratestatus")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -154,6 +154,7 @@ filegroup(
         "//prow/statusreconciler:all-srcs",
         "//prow/test:all-srcs",
         "//prow/tide:all-srcs",
+        "//prow/version:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/prow/cmd/admission/BUILD.bazel
+++ b/prow/cmd/admission/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "admission"
+
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -31,7 +34,7 @@ go_library(
 )
 
 go_binary(
-    name = "admission",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -57,7 +57,7 @@ func (o *options) parse(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("admission")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/branchprotector/BUILD.bazel
+++ b/prow/cmd/branchprotector/BUILD.bazel
@@ -13,9 +13,12 @@ k8s_object(
     template = ":oneshot-job.yaml",
 )
 
+NAME = "branchprotector"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     directory = "/",
     files = [":branchprotector"],
     visibility = ["//visibility:public"],
@@ -72,7 +75,7 @@ filegroup(
 )
 
 go_binary(
-    name = "branchprotector",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/prow/cmd/branchprotector/protect.go
+++ b/prow/cmd/branchprotector/protect.go
@@ -100,7 +100,7 @@ func (e *Errors) add(err error) {
 }
 
 func main() {
-	logrusutil.ComponentInit("branchprotector")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -52,16 +52,19 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
+NAME = "checkconfig"
+
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     directory = "/",
     files = [":checkconfig"],
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "checkconfig",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -185,7 +185,7 @@ func (o *options) gatherOptions(flag *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("checkconfig")
+	logrusutil.ComponentInit()
 
 	o, err := parseOptions()
 	if err != nil {

--- a/prow/cmd/clonerefs/BUILD.bazel
+++ b/prow/cmd/clonerefs/BUILD.bazel
@@ -14,8 +14,10 @@ go_library(
     ],
 )
 
+NAME = "clonerefs"
+
 go_binary(
-    name = "clonerefs",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -24,6 +26,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     files = [
         "github_known_hosts",
         "ssh_config",

--- a/prow/cmd/clonerefs/main.go
+++ b/prow/cmd/clonerefs/main.go
@@ -25,7 +25,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("clonerefs")
+	logrusutil.ComponentInit()
 
 	o := &clonerefs.Options{}
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/config-bootstrapper/BUILD.bazel
+++ b/prow/cmd/config-bootstrapper/BUILD.bazel
@@ -35,14 +35,17 @@ filegroup(
     tags = ["automanaged"],
 )
 
+NAME = "config-bootstrapper"
+
 go_binary(
-    name = "config-bootstrapper",
+    name = NAME,
     embed = [":go_default_library"],
 )
 
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     directory = "/",
     files = [":config-bootstrapper"],
     visibility = ["//visibility:public"],

--- a/prow/cmd/config-bootstrapper/main.go
+++ b/prow/cmd/config-bootstrapper/main.go
@@ -146,7 +146,7 @@ func run(sourcePaths []string, defaultNamespace string, configUpdater plugins.Co
 }
 
 func main() {
-	logrusutil.ComponentInit("config-bootstrapper")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -31,8 +31,10 @@ go_library(
     ],
 )
 
+NAME = "crier"
+
 go_binary(
-    name = "crier",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -40,6 +42,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -170,7 +170,7 @@ func parseOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("crier")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -22,9 +22,12 @@ container_image(
     ],
 )
 
+NAME = "deck"
+
 prow_image(
     name = "image",
     base = ":spyglass-lenses",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -40,7 +43,7 @@ container_image(
 )
 
 go_binary(
-    name = "deck",
+    name = NAME,
     data = [
         ":templates",
         "//prow/cmd/deck/static",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -259,7 +259,7 @@ func v(fragment string, children ...simplifypath.Node) simplifypath.Node {
 }
 
 func main() {
-	logrusutil.ComponentInit("deck")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/entrypoint/BUILD.bazel
+++ b/prow/cmd/entrypoint/BUILD.bazel
@@ -14,8 +14,10 @@ go_library(
     ],
 )
 
+NAME = "entrypoint"
+
 go_binary(
-    name = "entrypoint",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -24,6 +26,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     symlinks = {"/entrypoint": "/app/prow/cmd/entrypoint/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/entrypoint/main.go
+++ b/prow/cmd/entrypoint/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("entrypoint")
+	logrusutil.ComponentInit()
 
 	o := entrypoint.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/exporter/BUILD.bazel
+++ b/prow/cmd/exporter/BUILD.bazel
@@ -4,9 +4,12 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
+NAME = "exporter"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -37,7 +40,7 @@ go_library(
 )
 
 go_binary(
-    name = "exporter",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/exporter/main.go
+++ b/prow/cmd/exporter/main.go
@@ -68,7 +68,7 @@ func mustRegister(component string, lister lister) *prometheus.Registry {
 }
 
 func main() {
-	logrusutil.ComponentInit("exporter")
+	logrusutil.ComponentInit()
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")

--- a/prow/cmd/gcsupload/BUILD.bazel
+++ b/prow/cmd/gcsupload/BUILD.bazel
@@ -16,14 +16,17 @@ go_library(
     ],
 )
 
+NAME = "gcsupload"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "gcsupload",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/prow/cmd/gcsupload/main.go
+++ b/prow/cmd/gcsupload/main.go
@@ -29,7 +29,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("gcsupload")
+	logrusutil.ComponentInit()
 
 	o := gcsupload.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -21,8 +21,10 @@ go_library(
     ],
 )
 
+NAME = "gerrit"
+
 go_binary(
-    name = "gerrit",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -44,6 +46,7 @@ filegroup(
 
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -230,7 +230,7 @@ func (st *syncTime) Update(newState client.LastSyncState) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("gerrit")
+	logrusutil.ComponentInit()
 
 	defer interrupts.WaitForGracefulShutdown()
 

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "hook"
+
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "hook",
+    name = NAME,
     data = [
         "//config/prow:configs",
     ],

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -92,7 +92,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
-	logrusutil.ComponentInit("hook")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "horologium"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "horologium",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -72,7 +72,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("horologium")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/initupload/BUILD.bazel
+++ b/prow/cmd/initupload/BUILD.bazel
@@ -14,8 +14,10 @@ go_library(
     ],
 )
 
+NAME = "initupload"
+
 go_binary(
-    name = "initupload",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -24,6 +26,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     symlinks = {"/initupload": "/app/prow/cmd/initupload/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/initupload/main.go
+++ b/prow/cmd/initupload/main.go
@@ -30,7 +30,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("initupload")
+	logrusutil.ComponentInit()
 
 	o := initupload.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/jenkins-operator/BUILD.bazel
+++ b/prow/cmd/jenkins-operator/BUILD.bazel
@@ -5,9 +5,12 @@ licenses(["notice"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "jenkins-operator"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -48,7 +51,7 @@ filegroup(
 )
 
 go_binary(
-    name = "jenkins-operator",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     race = "off",

--- a/prow/cmd/jenkins-operator/main.go
+++ b/prow/cmd/jenkins-operator/main.go
@@ -124,7 +124,7 @@ func gatherOptions() options {
 }
 
 func main() {
-	logrusutil.ComponentInit("jenkins-operator")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/mkpj/BUILD.bazel
+++ b/prow/cmd/mkpj/BUILD.bazel
@@ -8,8 +8,11 @@ load(
 )
 load("//prow:def.bzl", "prow_image")
 
+NAME = "mkpj"
+
 prow_image(
     name = "image",
+    component = NAME,
     directory = "/",
     files = [":mkpj"],
     visibility = ["//visibility:public"],
@@ -56,6 +59,6 @@ go_test(
 )
 
 go_binary(
-    name = "mkpj",
+    name = NAME,
     embed = [":go_default_library"],
 )

--- a/prow/cmd/mkpod/BUILD.bazel
+++ b/prow/cmd/mkpod/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "mkpod"
+
 prow_image(
     name = "image",
+    component = NAME,
     directory = "/",
     files = [":mkpod"],
     visibility = ["//visibility:public"],
@@ -24,7 +27,7 @@ go_library(
 )
 
 go_binary(
-    name = "mkpod",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -22,8 +22,10 @@ go_library(
     ],
 )
 
+NAME = "peribolos"
+
 go_binary(
-    name = "peribolos",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -124,6 +126,7 @@ k8s_objects(
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     directory = "/",
     files = [":peribolos"],
     visibility = ["//visibility:public"],

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -147,7 +147,7 @@ func (o *options) parseArgs(flags *flag.FlagSet, args []string) error {
 }
 
 func main() {
-	logrusutil.ComponentInit("peribolos")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/pipeline/BUILD.bazel
+++ b/prow/cmd/pipeline/BUILD.bazel
@@ -1,8 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "pipeline"
+
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -52,7 +55,7 @@ go_library(
 )
 
 go_binary(
-    name = "pipeline",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -110,7 +110,7 @@ func newPipelineConfig(cfg rest.Config, stop <-chan struct{}) (*pipelineConfig, 
 }
 
 func main() {
-	logrusutil.ComponentInit("pipeline")
+	logrusutil.ComponentInit()
 
 	o := parseOptions()
 

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "plank"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "plank",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -85,7 +85,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("plank")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/sidecar/BUILD.bazel
+++ b/prow/cmd/sidecar/BUILD.bazel
@@ -14,8 +14,10 @@ go_library(
     ],
 )
 
+NAME = "sidecar"
+
 go_binary(
-    name = "sidecar",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],
@@ -24,6 +26,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     symlinks = {"/sidecar": "/app/prow/cmd/sidecar/app.binary"},
     visibility = ["//visibility:public"],
 )

--- a/prow/cmd/sidecar/main.go
+++ b/prow/cmd/sidecar/main.go
@@ -27,7 +27,7 @@ import (
 )
 
 func main() {
-	logrusutil.ComponentInit("sidecar")
+	logrusutil.ComponentInit()
 
 	o := sidecar.NewOptions()
 	if err := options.Load(o); err != nil {

--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "sinker"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "sinker",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -89,7 +89,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("sinker")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:]...)
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/status-reconciler/BUILD.bazel
+++ b/prow/cmd/status-reconciler/BUILD.bazel
@@ -3,13 +3,16 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "status-reconciler"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
 )
 
 go_binary(
-    name = "status-reconciler",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -110,7 +110,7 @@ func (o *options) Validate() error {
 }
 
 func main() {
-	logrusutil.ComponentInit("status-reconciler")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/cmd/sub/BUILD.bazel
+++ b/prow/cmd/sub/BUILD.bazel
@@ -21,8 +21,10 @@ go_library(
     ],
 )
 
+NAME = "sub"
+
 go_binary(
-    name = "sub",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -30,6 +32,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/prow/cmd/sub/main.go
+++ b/prow/cmd/sub/main.go
@@ -86,7 +86,7 @@ func init() {
 }
 
 func main() {
-	logrusutil.ComponentInit("pubsub-subscriber")
+	logrusutil.ComponentInit()
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(flagOptions.configPath, flagOptions.jobConfigPath); err != nil {

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -1,9 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "tide"
+
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -30,7 +33,7 @@ go_library(
 )
 
 go_binary(
-    name = "tide",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -116,7 +116,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func main() {
-	logrusutil.ComponentInit("tide")
+	logrusutil.ComponentInit()
 
 	defer interrupts.WaitForGracefulShutdown()
 

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "tot"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "tot",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -270,7 +270,7 @@ func (f fallbackHandler) getURL(jobName string) string {
 }
 
 func main() {
-	logrusutil.ComponentInit("tot")
+	logrusutil.ComponentInit()
 
 	o := gatherOptions()
 	if err := o.Validate(); err != nil {

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -37,6 +37,7 @@ def prow_image(
         goarch = "amd64",
         goos = "linux",
         pure = "on",
+        x_defs = {"k8s.io/test-infra/prow/version.Name": name},
     )
 
     container_image(

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -25,6 +25,7 @@ load(
 
 ## prow_image is a macro for creating :app and :image targets
 def prow_image(
+        component,
         name,  # use "image"
         base = None,
         stamp = True,  # stamp by default, but allow overrides
@@ -37,7 +38,7 @@ def prow_image(
         goarch = "amd64",
         goos = "linux",
         pure = "on",
-        x_defs = {"k8s.io/test-infra/prow/version.Name": name},
+        x_defs = {"k8s.io/test-infra/prow/version.Name": component},
     )
 
     container_image(

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -24,14 +24,17 @@ go_library(
     ],
 )
 
+NAME = "cherrypicker"
+
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "cherrypicker",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -2,8 +2,11 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "needs-rebase"
+
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
@@ -27,7 +30,7 @@ go_library(
 )
 
 go_binary(
-    name = "needs-rebase",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
     visibility = ["//visibility:public"],

--- a/prow/external-plugins/refresh/BUILD.bazel
+++ b/prow/external-plugins/refresh/BUILD.bazel
@@ -26,14 +26,17 @@ go_library(
     ],
 )
 
+NAME = "refresh"
+
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 
 go_binary(
-    name = "refresh",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     deps = [
         "//ghproxy/ghcache:go_default_library",
         "//prow/errorutil:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -37,8 +37,10 @@ import (
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
+
 	"k8s.io/test-infra/ghproxy/ghcache"
 	"k8s.io/test-infra/prow/errorutil"
+	"k8s.io/test-infra/prow/version"
 )
 
 type timeClient interface {
@@ -247,14 +249,15 @@ type delegate struct {
 	maxSleepTime  time.Duration
 	initialDelay  time.Duration
 
-	gqlc     gqlClient
-	client   httpClient
-	bases    []string
-	dry      bool
-	fake     bool
-	throttle throttler
-	getToken func() []byte
-	censor   func([]byte) []byte
+	userAgent string
+	gqlc      gqlClient
+	client    httpClient
+	bases     []string
+	dry       bool
+	fake      bool
+	throttle  throttler
+	getToken  func() []byte
+	censor    func([]byte) []byte
 
 	mut      sync.Mutex // protects botName and email
 	userData *User
@@ -434,7 +437,8 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 	return &client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		delegate: &delegate{
-			time: &standardTime{},
+			time:      &standardTime{},
+			userAgent: version.UserAgent(),
 			gqlc: githubql.NewEnterpriseClient(
 				graphqlEndpoint,
 				&http.Client{
@@ -471,7 +475,8 @@ func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, cen
 	return &client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		delegate: &delegate{
-			time: &standardTime{},
+			time:      &standardTime{},
+			userAgent: version.UserAgent(),
 			gqlc: githubql.NewEnterpriseClient(
 				graphqlEndpoint,
 				&http.Client{
@@ -750,6 +755,9 @@ func (c *client) doRequest(method, path, accept string, body interface{}) (*http
 		req.Header.Add("Accept", "application/vnd.github.v3+json")
 	} else {
 		req.Header.Add("Accept", accept)
+	}
+	if c.userAgent != "" {
+		req.Header.Add("User-Agent", c.userAgent)
 	}
 	// Disable keep-alive so that we don't get flakes when GitHub closes the
 	// connection prematurely.

--- a/prow/logrusutil/BUILD.bazel
+++ b/prow/logrusutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/logrusutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/version:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -22,8 +22,9 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/version"
 )
 
 // DefaultFieldsFormatter wraps another logrus.Formatter, injecting
@@ -49,11 +50,11 @@ func Init(formatter *DefaultFieldsFormatter) {
 }
 
 // ComponentInit is a syntax sugar for easier Init
-func ComponentInit(component string) {
+func ComponentInit() {
 	Init(
 		&DefaultFieldsFormatter{
 			PrintLineNumber: true,
-			DefaultFields:   logrus.Fields{"component": component},
+			DefaultFields:   logrus.Fields{"component": version.Name},
 		},
 	)
 }

--- a/prow/version/BUILD.bazel
+++ b/prow/version/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "k8s.io/test-infra/prow/version",
+    visibility = ["//visibility:public"],
+    x_defs = {"Version": "{DOCKER_TAG}"},
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/version/doc.go
+++ b/prow/version/doc.go
@@ -1,0 +1,13 @@
+// version holds variables that identify a Prow binary's name and version
+package version
+
+var (
+	// Name is the colloquial identifier for the compiled component
+	Name = "unset"
+	// Version is a concatenation of the commit SHA and date for the build
+	Version = "0"
+)
+
+func UserAgent() string {
+	return Name + "/" + Version
+}

--- a/prow/version/doc.go
+++ b/prow/version/doc.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 // version holds variables that identify a Prow binary's name and version
 package version
 

--- a/robots/commenter/BUILD.bazel
+++ b/robots/commenter/BUILD.bazel
@@ -3,14 +3,17 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image", "prow_push")
 
+NAME = "commenter"
+
 go_binary(
-    name = "commenter",
+    name = NAME,
     embed = [":go_default_library"],
 )
 
 prow_image(
     name = "image",
     base = "@alpine-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/robots/issue-creator/BUILD.bazel
+++ b/robots/issue-creator/BUILD.bazel
@@ -1,14 +1,17 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("//prow:def.bzl", "prow_image", "prow_push")
 
+NAME = "issue-creator"
+
 go_binary(
-    name = "issue-creator",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
 
 prow_image(
     name = "image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/robots/pr-creator/BUILD.bazel
+++ b/robots/pr-creator/BUILD.bazel
@@ -14,8 +14,10 @@ go_library(
     ],
 )
 
+NAME = "pr-creator"
+
 go_binary(
-    name = "pr-creator",
+    name = NAME,
     embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )
@@ -23,6 +25,7 @@ go_binary(
 prow_image(
     name = "image",
     base = "@git-base//image",
+    component = NAME,
     visibility = ["//visibility:public"],
 )
 

--- a/robots/pr-labeler/BUILD.bazel
+++ b/robots/pr-labeler/BUILD.bazel
@@ -12,7 +12,12 @@ prow_push(
     },
 )
 
-prow_image(name = "image")
+NAME = "pr-labeler"
+
+prow_image(
+    name = "image",
+    component = NAME,
+)
 
 go_library(
     name = "go_default_library",
@@ -41,6 +46,6 @@ filegroup(
 
 # Delete after gazelle stops forcing its creation
 go_binary(
-    name = "pr-labeler",
+    name = NAME,
     embed = [":go_default_library"],
 )

--- a/testgrid/cmd/configurator/BUILD.bazel
+++ b/testgrid/cmd/configurator/BUILD.bazel
@@ -3,13 +3,18 @@ package(default_visibility = ["//visibility:public"])
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("//prow:def.bzl", "prow_image")
 
+NAME = "configurator"
+
 go_binary(
-    name = "configurator",
+    name = NAME,
     embed = [":go_default_library"],
     pure = "on",
 )
 
-prow_image(name = "image")
+prow_image(
+    name = "image",
+    component = NAME,
+)
 
 go_test(
     name = "go_default_test",


### PR DESCRIPTION
The last commit was generated with:

```py
#!/usr/bin/env python

import sys

out = []
imageIndex = 0
goBinaryIndex = 0
declaration = ""
with open(sys.argv[1]) as f:
	for i, line in enumerate(f):
		out.append(line)
		if "prow_image(" in line:
			imageIndex = i
			out.append("    component = NAME,\n")

		if "go_binary(" in line:
			goBinaryIndex = i

		if i == goBinaryIndex + 1 and "name" in line:
			# ex. "    name = "deck","
			component = line.split("\"")[1]
			out = out[:-1] # undo the name declaration in go_binary
			declaration = "NAME = \"{}\"\n".format(component) # declare the shared var
			out.append("    name = NAME,\n") # rewrite the name declaration to use it

		if imageIndex != 0 and declaration != "":
			# we need to insert at the earliest declaration that will use it
			insertIndex = imageIndex
			if goBinaryIndex < insertIndex:
				insertIndex = goBinaryIndex
			out.insert(insertIndex, declaration)
			declaration = ""

with open(sys.argv[1], 'w') as f:
    for line in out:
    	f.write(line)


# manually edit:
# experiment/resultstore/BUILD.bazel (prow_image was not indented)
# prow/cmd/peribolos/BUILD.bazel (e2e images don't need rename)
# robots/pr-labeler/BUILD.bazel (prow_image was not indented)
```


/assign @ixdy @fejta @cjwagner @alvaroaleman 