### PR TITLE
ghproxy: record the user agent on cache response metrics

### DIFF
--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -129,7 +129,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}()
 
-	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path)
+	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"))
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
 	}

--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -19,6 +19,7 @@ package ghmetrics
 import (
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -64,7 +65,7 @@ var cacheCounter = prometheus.NewCounterVec(
 		Name: "ghcache_responses",
 		Help: "How many cache responses of each cache response mode there are.",
 	},
-	[]string{"mode", "path"},
+	[]string{"mode", "path", "user_agent"},
 )
 
 // timeoutDuration provides the 'github_request_timeouts' histogram that keeps
@@ -127,7 +128,7 @@ func CollectGitHubTokenMetrics(tokenHash, apiVersion string, headers http.Header
 // CollectGitHubRequestMetrics publishes the number of requests by API path to
 // `github_requests` on prometheus.
 func CollectGitHubRequestMetrics(tokenHash, path, statusCode, userAgent string, roundTripTime float64) {
-	ghRequestDurationHistVec.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "status": statusCode, "user_agent": userAgent}).Observe(roundTripTime)
+	ghRequestDurationHistVec.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "status": statusCode, "user_agent": userAgentWithoutVersion(userAgent)}).Observe(roundTripTime)
 }
 
 // timestampStringToTime takes a unix timestamp and returns a `time.Time`
@@ -140,13 +141,21 @@ func timestampStringToTime(tstamp string) time.Time {
 	return time.Unix(timestamp, 0)
 }
 
+// userAgentWithouVersion formats a user agent without the version to reduce label cardinality
+func userAgentWithoutVersion(userAgent string) string {
+	if !strings.Contains(userAgent, "/") {
+		return userAgent
+	}
+	return strings.SplitN(userAgent, "/", 2)[0]
+}
+
 // CollectCacheRequestMetrics records a cache outcome for a specific path
-func CollectCacheRequestMetrics(mode, path string) {
-	cacheCounter.With(prometheus.Labels{"mode": mode, "path": simplifier.Simplify(path)}).Inc()
+func CollectCacheRequestMetrics(mode, path, userAgent string) {
+	cacheCounter.With(prometheus.Labels{"mode": mode, "path": simplifier.Simplify(path), "user_agent": userAgentWithoutVersion(userAgent)}).Inc()
 }
 
 // CollectRequestTimeoutMetrics publishes the duration of timed-out requests by
 // API path to 'github_request_timeouts' on prometheus.
 func CollectRequestTimeoutMetrics(tokenHash, path, userAgent string, reqStartTime, responseTime time.Time) {
-	timeoutDuration.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "user_agent": userAgent}).Observe(float64(responseTime.Sub(reqStartTime).Seconds()))
+	timeoutDuration.With(prometheus.Labels{"token_hash": tokenHash, "path": simplifier.Simplify(path), "user_agent": userAgentWithoutVersion(userAgent)}).Observe(float64(responseTime.Sub(reqStartTime).Seconds()))
 }

--- a/ghproxy/ghmetrics/ghpath_test.go
+++ b/ghproxy/ghmetrics/ghpath_test.go
@@ -329,3 +329,33 @@ func Test_GetSimplifiedPathNotifications(t *testing.T) {
 		})
 	}
 }
+
+func TestUserAgentWithoutVersion(t *testing.T) {
+	tests := []struct {
+		name, in, out string
+	}{
+		{
+			name: "normal user agent gets split",
+			in:   "hook.config-updater/v20200314-12f848798",
+			out:  "hook.config-updater",
+		},
+		{
+			name: "user agent without version does not split",
+			in:   "some-custom-thing",
+			out:  "some-custom-thing",
+		},
+		{
+			name: "malformed user agent returns something sensible",
+			in:   "some/custom/thing",
+			out:  "some",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if actual, expected := userAgentWithoutVersion(test.in), test.out; actual != expected {
+				t.Errorf("%s: expected %s, got %s", test.name, expected, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Often it is not enough to see which user agent is making requests to
GitHub through the cache, as those requests may be cached and not
responsible for token exhaustion. It is therefore necessary to be able
to track cache responses by user agent.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @alvaroaleman 