### PR TITLE
E2e test for cli-utils

### DIFF
--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -20,3 +20,26 @@ presubmits:
       testgrid-dashboards: sig-cli-misc
       testgrid-tab-name: cli-utils-presubmit-master
       description: cli-utils presubmit tests on master branch
+  - name: cli-utils-presubmit-master-e2e
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/cli-utils
+    branches:
+    - ^master$
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200312-a0f211f-master
+        command:
+        - runner.sh
+        - make
+        - prow-presubmit-check-e2e
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cli-misc
+      testgrid-tab-name: cli-utils-presubmit-master-e2e
+      description: cli-utils presubmit e2e tests on master branch


### PR DESCRIPTION
Adds an additional presubmit job for the sigs.k8s.io/cli-utils repo. This job will run e2e tests using kind.

@monopole @seans3 