### PR TITLE
Kops/gce: promote gce-latest to optional presubmit

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -1,94 +1,60 @@
 periodics:
-- interval: 30m
+- interval: 3h
+  name: e2e-kops-gce-channelalpha
   labels:
+    preset-service-account: "true"
     preset-k8s-ssh: "true"
-  name: e2e-kops-gce-latest
   decorate: true
   decoration_config:
     timeout: 140m
   spec:
-    serviceAccountName: k8s-kops-test
     containers:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-gce-latest.k8s.local
+      - --cluster=e2e-kops-gce-channelalpha.k8s.local
       - --deployment=kops
       - --extract=ci/latest
       - --ginkgo-parallel=30
-      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
+      - --kops-args=--channel=alpha
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
       - --kops-zones=us-central1-c
       - --provider=gce
-      - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200312-a0f211f-master
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-gce-channelalpha
+
+- interval: 1h
+  name: e2e-kops-gce-ha
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-gce-ha.k8s.local
+      - --deployment=kops
+      - --extract=ci/latest
+      - --ginkgo-parallel=30
+      - --kops-args=--master-count=3
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
+      - --kops-zones=us-central1-c,us-central1-a,us-central1-f
+      - --provider=gce
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-ha
-
-
-# TODO(geojaz): These tests haven't worked for like months,
-# taking it one at a time till we get back online.
-
-# - interval: 1h
-#   name: e2e-kops-gce-channelalpha
-#   labels:
-#     preset-service-account: "true"
-#     preset-k8s-ssh: "true"
-#   decorate: true
-#   decoration_config:
-#     timeout: 140m
-#   spec:
-#     containers:
-#     - command:
-#       - runner.sh
-#       - /workspace/scenarios/kubernetes_e2e.py
-#       args:
-#       - --cluster=e2e-kops-gce-channelalpha.k8s.local
-#       - --deployment=kops
-#       - --extract=ci/latest
-#       - --ginkgo-parallel=30
-#       - --kops-args=--channel=alpha
-#       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-#       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
-#       - --kops-zones=us-central1-c
-#       - --provider=gce
-#       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-#       - --timeout=120m
-#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200312-a0f211f-master
-#   annotations:
-#     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-#     testgrid-tab-name: kops-gce-channelalpha
-
-# - interval: 30m
-#   name: e2e-kops-gce-ha
-#   labels:
-#     preset-service-account: "true"
-#     preset-k8s-ssh: "true"
-#   decorate: true
-#   decoration_config:
-#     timeout: 140m
-#   spec:
-#     containers:
-#     - command:
-#       - runner.sh
-#       - /workspace/scenarios/kubernetes_e2e.py
-#       args:
-#       - --cluster=e2e-kops-gce-ha.k8s.local
-#       - --deployment=kops
-#       - --extract=ci/latest
-#       - --ginkgo-parallel=30
-#       - --kops-args=--master-count=3
-#       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-#       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
-#       - --kops-zones=us-central1-c
-#       - --provider=gce
-#       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-#       - --timeout=120m
-#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200312-a0f211f-master
-#   annotations:
-#     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-#     testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/kops/kops-presubmits-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-gce.yaml
@@ -1,0 +1,36 @@
+presubmits:
+  kubernetes/kops:
+  - name: pull-kops-e2e-kops-gce-latest
+    branches:
+    - master
+    always_run: true
+    decorate: true
+    decoration_config:
+      timeout: 140m
+    skip_report: false
+    optional: true     # Start seeing test results on PRs, but it's ok to merge w/out green
+    path_alias: k8s.io/kops
+    labels:
+      preset-k8s-ssh: "true"
+    spec:
+      serviceAccountName: k8s-kops-test
+      containers:
+      - command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --cluster=e2e-kops-gce-latest.k8s.local
+        - --deployment=kops
+        - --extract=ci/latest
+        - --ginkgo-parallel=30
+        - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
+        - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+        - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+        - --kops-zones=us-central1-c
+        - --provider=gce
+        - --timeout=120m
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+        image: gcr.io/k8s-testimages/kubekins-e2e:latest
+    annotations:
+      testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+      testgrid-tab-name: kops-gce-latest


### PR DESCRIPTION
Promotes kops-gce-latest to presubmit so we can start to use the signal.
Also turns other kops/gce e2e on and adjusts various args. 