### PR TITLE
add node problem detector to image pushing

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
+++ b/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
@@ -1,0 +1,32 @@
+postsubmits:
+  # this is the github repo we'll build from; this block needs to be repeated for each repo.
+  kubernetes/node-problem-detector:
+    - name: node-problem-detector-push-images
+      cluster: test-infra-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-node-node-problem-detector
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200213-0032cdb
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-npd
+              - --scratch-bucket=gs://k8s-staging-npd-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-service-account


### PR DESCRIPTION
This is an effort to support multi arch image for npd, the build is run via qemu register, thus the `test-infra-trusted` cluster

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>