### PR TITLE
ci-k8sio-backup: reduce frequency from 1h to 12h

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1155,7 +1155,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-misc
 # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
-- interval: 1h
+- interval: 12h
   cluster: test-infra-trusted
   max_concurrency: 1
   name: ci-k8sio-backup


### PR DESCRIPTION
This is because we are running into quota exceeded errors. [1]

[1]: https://github.com/kubernetes/kubernetes/issues/88802