### PR TITLE
Remove nikhita as approver for cluster-api-do jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -3,5 +3,4 @@
 approvers:
 - andrewsykim
 - alvaroaleman
-- nikhita
 - xmudrii


### PR DESCRIPTION
Ref: https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/141

I don't have the bandwidth for reviews right now.

/cc @xmudrii 
