### PR TITLE
Provider/Azure: Skipping building k8s binary in azure kubemark test.

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -1145,7 +1145,7 @@ func (c *Cluster) Build(b buildStrategy) error {
 		if c.customKubeBinaryURL, err = c.uploadToAzureStorage(newK8sNodeTarball); err != nil {
 			return err
 		}
-	} else if !*testCcm && !*testAzureDiskCSIDriver && !*testAzureFileCSIDriver && !*testBlobfuseCSIDriver {
+	} else if !*testCcm && !*testAzureDiskCSIDriver && !*testAzureFileCSIDriver && !*testBlobfuseCSIDriver && !strings.EqualFold(string(b), "none") {
 		// Only build the required components to run upstream e2e tests
 		for _, component := range []string{"WHAT='test/e2e/e2e.test'", "WHAT=cmd/kubectl", "ginkgo"} {
 			cmd := exec.Command("make", component)


### PR DESCRIPTION
Skipping building k8s binary in azure kubemark test.

/area provider/azure