### PR TITLE
kubeadm/windows: increase test timeout to 180m

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -1,11 +1,11 @@
 periodics:
 - name: kubeadm-windows-gcp-k8s-stable
-  interval: 2h
+  interval: 180m
   labels:
     preset-service-account: "true"
   decorate: true
   decoration_config:
-    timeout: 2h
+    timeout: 180m
   extra_refs:
   - org: kubernetes-sigs
     repo: sig-windows-tools


### PR DESCRIPTION
/priority important-soon
/kind cleanup
/assign @benmoss 

looks like more than 2h are needed for Serial-mode based on the latest runs:
https://k8s-testgrid.appspot.com/sig-windows#kubeadm-windows-gcp-k8s-stable