### PR TITLE
Remove andrewsykim from owners

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -1,5 +1,4 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- andrewsykim
 - xmudrii


### PR DESCRIPTION
@andrewsykim doesn't have the capacity to be active here and decided to step down as a maintainer.

/assign @andrewsykim 
/hold
until https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/143 is not merged