### PR TITLE
Fix cluster-api-do presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -9,9 +9,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
         command:
-        - make
-        args:
-        - test
+        - "./scripts/ci-test.sh"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: pr-test
@@ -24,9 +22,7 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
         command:
-        - make
-        args:
-        - manager
+        - "./scripts/ci-build.sh"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: pr-build


### PR DESCRIPTION
This PR updates `build` and `test` presubmit jobs to uses ci scripts instead of uses `make target` directly

/cc @xmudrii 