### PR TITLE
Provider/Azure: Expose the logs of azure kubemark testing scripts.

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -1050,7 +1050,8 @@ func (c *Cluster) Up() error {
 			"--clusterloader2-bin-url", *clusterLoader2BinURL,
 			"--kubemark-size", *kubemarkSize,
 			"--location", *kubemarkLocation)
-		if err := cmd.Run(); err != nil {
+
+		if err := control.FinishRunning(cmd); err != nil {
 			return fmt.Errorf("failed to build up kubemark environment: %v", err)
 		}
 


### PR DESCRIPTION
We need to expose the logs of the kubemark testing scripts to figure out what's going run within.

/area provider/azure