### PR TITLE
releng: Add blocking, presubmit dashboards and add alerts for image promoter

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
@@ -1,11 +1,11 @@
 postsubmits:
-  # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/k8s-container-image-promoter:
     - name: cip-postsubmit-push-to-staging
       cluster: test-infra-trusted
       annotations:
-        # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-release-releng-blocking
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
       decorate: true
       branches:
         - ^master$
@@ -16,7 +16,6 @@ postsubmits:
             command:
               - /run.sh
             args:
-              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
               - --project=k8s-staging-artifact-promoter
               - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
               - --env-passthrough=PULL_BASE_REF

--- a/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
@@ -5,7 +5,7 @@ postsubmits:
       cluster: test-infra-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
-        testgrid-dashboards: sig-release-misc
+        testgrid-dashboards: sig-release-releng-blocking
       decorate: true
       branches:
         - ^master$

--- a/config/jobs/image-pushing/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/k8s-staging-releng.yaml
@@ -74,7 +74,7 @@ postsubmits:
     - name: post-release-push-image-k8s-cloud-builder
       cluster: test-infra-trusted
       annotations:
-        testgrid-dashboards: sig-release-image-pushes, sig-release-master-informing
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
       run_if_changed: '^images\/'
@@ -100,7 +100,7 @@ postsubmits:
     - name: post-release-push-image-releng-ci-bazel
       cluster: test-infra-trusted
       annotations:
-        testgrid-dashboards: sig-release-image-pushes, sig-release-master-informing
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
       run_if_changed: '^images\/'
@@ -126,7 +126,7 @@ postsubmits:
     - name: post-release-push-image-kubepkg
       cluster: test-infra-trusted
       annotations:
-        testgrid-dashboards: sig-release-image-pushes, sig-release-master-informing
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
       branches:

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -463,7 +463,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-release-misc
+    testgrid-dashboards: sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-build
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
 postsubmits:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -34,7 +34,7 @@ presubmits:
           requests:
             memory: "6Gi"
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-cluster-up
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
@@ -56,7 +56,7 @@ presubmits:
         - test
         - //...
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-test
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
@@ -66,7 +66,7 @@ periodics:
   interval: 6h
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
-    testgrid-dashboards: sig-release-master-informing
+    testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-packages-debs
   decorate: true
   extra_refs:
@@ -88,7 +88,7 @@ periodics:
   interval: 6h
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
-    testgrid-dashboards: sig-release-master-informing
+    testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-packages-rpms
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -75,7 +75,7 @@ presubmits:
         secret:
           secretName: k8s-cip-test-prod-service-account
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits
   - name: pull-cip-auditor-e2e
     decorate: true
     path_alias: "sigs.k8s.io/k8s-container-image-promoter"
@@ -103,7 +103,7 @@ presubmits:
         secret:
           secretName: k8s-gcr-audit-test-prod-service-account
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits
   # Build all binaries and also run unit tests.
   - name: pull-cip-unit-tests
     decorate: true
@@ -120,7 +120,7 @@ presubmits:
         args:
         - "test-ci"
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits
   # Run linter.
   - name: pull-cip-lint
     decorate: true
@@ -137,4 +137,4 @@ presubmits:
         args:
         - "lint-ci"
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-presubmits

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -120,7 +120,7 @@ periodics:
       - 2241179 # release-managers
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
-    testgrid-dashboards: sig-release-master-informing
+    testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-debs
 
 - interval: 4h
@@ -143,5 +143,5 @@ periodics:
       - 2241179 # release-managers
   annotations:
     testgrid-alert-email: release-managers@kubernetes.io
-    testgrid-dashboards: sig-release-master-informing
+    testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-rpms

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -759,6 +759,8 @@ postsubmits:
           secretName: k8s-artifacts-prod-service-account
     annotations:
       testgrid-dashboards: sig-release-releng-blocking
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
   kubernetes/community:
   - name: post-community-tempelis-apply
     cluster: test-infra-trusted
@@ -1154,6 +1156,8 @@ periodics:
         secretName: k8s-artifacts-prod-service-account
   annotations:
     testgrid-dashboards: sig-release-releng-blocking
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-num-failures-to-alert: '1'
 # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
 - interval: 12h
   cluster: test-infra-trusted
@@ -1187,6 +1191,5 @@ periodics:
         secretName: k8s-artifacts-prod-bak-service-account
   annotations:
     testgrid-dashboards: sig-release-releng-blocking
-    # TODO: enable alerting once the job has stabilized
-    # testgrid-alert-email: k8s-infra-alerts@kubernetes.io
-    # testgrid-num-failures-to-alert: '1'
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -758,7 +758,7 @@ postsubmits:
         secret:
           secretName: k8s-artifacts-prod-service-account
     annotations:
-      testgrid-dashboards: sig-release-misc
+      testgrid-dashboards: sig-release-releng-blocking
   kubernetes/community:
   - name: post-community-tempelis-apply
     cluster: test-infra-trusted
@@ -1153,7 +1153,7 @@ periodics:
       secret:
         secretName: k8s-artifacts-prod-service-account
   annotations:
-    testgrid-dashboards: sig-release-misc
+    testgrid-dashboards: sig-release-releng-blocking
 # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
 - interval: 12h
   cluster: test-infra-trusted
@@ -1186,7 +1186,7 @@ periodics:
       secret:
         secretName: k8s-artifacts-prod-bak-service-account
   annotations:
-    testgrid-dashboards: sig-release-misc
+    testgrid-dashboards: sig-release-releng-blocking
     # TODO: enable alerting once the job has stabilized
     # testgrid-alert-email: k8s-infra-alerts@kubernetes.io
     # testgrid-num-failures-to-alert: '1'

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -13,9 +13,10 @@ dashboard_groups:
   - sig-release-1.16-informing
   - sig-release-1.15-blocking
   - sig-release-1.15-informing
+  - sig-release-releng-blocking
   - sig-release-releng-informing
+  - sig-release-releng-presubmits
   - sig-release-image-pushes
-  - sig-release-misc
   - sig-release-publishing-bot
   - sig-release-release-notes-presubmits
   - sig-release-prototype-master-blocking
@@ -27,6 +28,10 @@ dashboard_groups:
 dashboards:
 - name: sig-release-master-blocking
 - name: sig-release-master-informing
+  dashboard_tab:
+  - name: Conformance - OpenStack
+    test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
+    description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
 - name: sig-release-1.18-blocking
 - name: sig-release-1.18-informing
 - name: sig-release-1.17-blocking
@@ -35,13 +40,10 @@ dashboards:
 - name: sig-release-1.16-informing
 - name: sig-release-1.15-blocking
 - name: sig-release-1.15-informing
+- name: sig-release-releng-blocking
 - name: sig-release-releng-informing
-  dashboard_tab:
-  - name: Conformance - OpenStack
-    test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
-    description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
+- name: sig-release-releng-presubmits
 - name: sig-release-image-pushes
-- name: sig-release-misc
 - name: sig-release-publishing-bot
 - name: sig-release-release-notes-presubmits
   dashboard_tab:


### PR DESCRIPTION
- Add new dashboards (`sig-release-releng-{blocking,presubmits}`)
- Remove `sig-release-misc` dashboard
- Configure alert emails and options for container image promoter jobs