### PR TITLE
ci-k8sio-backup: remove job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1158,38 +1158,3 @@ periodics:
     testgrid-dashboards: sig-release-releng-blocking
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
     testgrid-num-failures-to-alert: '1'
-# TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
-- interval: 12h
-  cluster: test-infra-trusted
-  max_concurrency: 1
-  name: ci-k8sio-backup
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: k8s.io
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200318-68cca07-1.17
-      command:
-      - infra/gcp/backup_tools/backup.sh
-      env:
-      # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
-      # here anyway in case the underlying image changes (the backup.sh script
-      # needs it to be defined).
-      - name: GOPATH
-        value: /go
-      - name: GOOGLE_APPLICATION_CREDENTIALS
-        value: /etc/k8s-artifacts-prod-bak-service-account/service-account.json
-      volumeMounts:
-      - name: k8s-artifacts-prod-bak-service-account-creds
-        mountPath: /etc/k8s-artifacts-prod-bak-service-account
-        readOnly: true
-    volumes:
-    - name: k8s-artifacts-prod-bak-service-account-creds
-      secret:
-        secretName: k8s-artifacts-prod-bak-service-account
-  annotations:
-    testgrid-dashboards: sig-release-releng-blocking
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
-    testgrid-num-failures-to-alert: '1'


### PR DESCRIPTION
The backup job is exceeding GCR quota limits. Remove temporarily while
we figure out a fix within the next 2 weeks before the Vanity Domain
Flip [1] happens.

[1]: https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/Vanity-Domain-Flip.md

/cc @spiffxp @stp-ip @BenTheElder @bartsmykla 