### PR TITLE
Jenkins controller: Use patch

### DIFF
--- a/prow/jenkins/BUILD.bazel
+++ b/prow/jenkins/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
     ],


### PR DESCRIPTION
When using crier, another actor is present in the system that may change
jobs, which results in update failures. We assume that the fields we
care about are different from the ones crier cares about.

Fixes https://github.com/openshift/release/issues/7679

/assign @petr-muller 