### PR TITLE
Revert "Enable NodeKiller on ClusterLoader presubmits"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -342,8 +342,9 @@ presubmits:
         - --test-cmd-args=--testconfig=testing/density/config.yaml
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+        # TODO(jprzychodzen): Re-enable node_killer when flakiness fixed
+        #- - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
+        #- - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
         - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml


### PR DESCRIPTION
This reverts commit 53f19ac1b60b0a056afd47dae713aa49c6c31160.

Here is an example of PR when presubmit failed twice due to NK - https://github.com/kubernetes/perf-tests/pull/1126
An example presubmit run https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/perf-tests/1126/pull-perf-tests-clusterloader2/1240479871608557568/
In the above run, NK killed 6 nodes during density which in the end resulted in test timing out after 1h40min.

We should change the logic to not kill the nodes so many times.