### PR TITLE
Remove --hyperkube and KUBE_BUILD_HYPERKUBE references

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -47,7 +47,6 @@ periodics:
       - --
       - --allow-dup
       - --extra-publish-file=k8s-master
-      - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
       # docker-in-docker needs privileged mode
       securityContext:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -144,7 +144,6 @@ periodics:
       - --
       - --allow-dup
       - --extra-publish-file=k8s-stable3
-      - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200302-ca9526d
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -144,7 +144,6 @@ periodics:
       - --
       - --allow-dup
       - --extra-publish-file=k8s-stable2
-      - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200302-ca9526d
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -179,7 +179,6 @@ periodics:
       - --
       - --allow-dup
       - --extra-publish-file=k8s-stable1
-      - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200302-ca9526d
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -182,7 +182,6 @@ periodics:
       - --
       - --allow-dup
       - --extra-publish-file=k8s-beta
-      - --hyperkube
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200302-ca9526d
       name: ""

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -118,8 +118,6 @@ periodics:
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
-      - name: KUBE_BUILD_HYPERKUBE
-        value: "n"
       - name: KUBE_BUILD_CONFORMANCE
         value: "n"
       securityContext:

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -52,8 +52,6 @@ periodics:
       env:
       - name: KUBE_BUILD_WITH_COVERAGE
         value: "true"
-      - name: KUBE_BUILD_HYPERKUBE
-        value: "n"
       - name: KUBE_BUILD_CONFORMANCE
         value: "n"
       securityContext:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -7,7 +7,7 @@ presubmits:
     skip_report: false
     max_concurrency: 8
     optional: true
-    run_if_changed: '(hyperkube|local-up-cluster)'
+    run_if_changed: 'local-up-cluster'
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"

--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -215,7 +215,6 @@ func (n localCluster) TestSetup() error {
 func (n localCluster) Down() error {
 	processes := []string{
 		"cloud-controller-manager",
-		"hyperkube", // remove hyperkube when it is removed from local-up-cluster.sh
 		"kube-controller-manager",
 		"kube-proxy",
 		"kube-scheduler",

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -120,8 +120,6 @@ def main(args):
         push_build_args.append('--bucket=%s' % args.release)
     if args.registry:
         push_build_args.append('--docker-registry=%s' % args.registry)
-    if args.hyperkube:
-        env['KUBE_BUILD_HYPERKUBE'] = 'y'
     if args.extra_publish_file:
         push_build_args.append('--extra-publish-file=%s' % args.extra_publish_file)
     if args.allow_dup:
@@ -159,8 +157,6 @@ if __name__ == '__main__':
         help='The release kind to push to GCS. Supported values are kubernetes or federation')
     PARSER.add_argument(
         '--registry', help='Push images to the specified docker registry')
-    PARSER.add_argument(
-        '--hyperkube', action='store_true', help='Build hyperkube image')
     PARSER.add_argument(
         '--extra-publish-file', help='Additional version file uploads to')
     PARSER.add_argument(


### PR DESCRIPTION
follow up from change in k/k where we removed hyperkube, we should fix
up the jobs and scripts to remove any references.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>