### PR TITLE
[Kubeflow pipelines] Update KFP prow config

### DIFF
--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -278,7 +278,30 @@ postsubmits:
         - "7200"
     annotations:
       testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/pipeline.
+      description: Postsubmit component tests for kubeflow/pipeline.
+  - name: kubeflow-pipeline-postsubmit-integration-test
+      branches:
+        - ^master$
+      decorate: true
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+              command:
+                - ./test/presubmit-tests-with-pipeline-deployment.sh
+              args:
+                - --workflow_file
+                - sample_test.yaml
+                - --test_result_folder
+                - sample_test
+                - --timeout
+                - "3600"
+                - --is_integration_test
+                - true
+      annotations:
+        testgrid-dashboards: sig-big-data
+        description: Postsubmit integration tests for kubeflow/pipeline.
   - name: kubeflow-pipeline-postsubmit-mkp-component-test
     branches:
     - ^master$

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -281,24 +281,24 @@ postsubmits:
       description: Postsubmit component tests for kubeflow/pipeline.
   - name: kubeflow-pipeline-postsubmit-integration-test
     branches:
-      - ^master$
+    - ^master$
     decorate: true
     labels:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
-            command:
-              - ./test/presubmit-tests-with-pipeline-deployment.sh
-            args:
-              - --workflow_file
-              - sample_test.yaml
-              - --test_result_folder
-              - sample_test
-              - --timeout
-              - "3600"
-              - --is_integration_test
-              - true
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - sample_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "3600"
+        - --is_integration_test
+        - true
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit integration tests for kubeflow/pipeline.

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -298,7 +298,7 @@ postsubmits:
         - --timeout
         - "3600"
         - --is_integration_test
-        - true
+        - "true"
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit integration tests for kubeflow/pipeline.

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -280,28 +280,28 @@ postsubmits:
       testgrid-dashboards: sig-big-data
       description: Postsubmit component tests for kubeflow/pipeline.
   - name: kubeflow-pipeline-postsubmit-integration-test
-      branches:
-        - ^master$
-      decorate: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
-              command:
-                - ./test/presubmit-tests-with-pipeline-deployment.sh
-              args:
-                - --workflow_file
-                - sample_test.yaml
-                - --test_result_folder
-                - sample_test
-                - --timeout
-                - "3600"
-                - --is_integration_test
-                - true
-      annotations:
-        testgrid-dashboards: sig-big-data
-        description: Postsubmit integration tests for kubeflow/pipeline.
+    branches:
+      - ^master$
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+            command:
+              - ./test/presubmit-tests-with-pipeline-deployment.sh
+            args:
+              - --workflow_file
+              - sample_test.yaml
+              - --test_result_folder
+              - sample_test
+              - --timeout
+              - "3600"
+              - --is_integration_test
+              - true
+    annotations:
+      testgrid-dashboards: sig-big-data
+      description: Postsubmit integration tests for kubeflow/pipeline.
   - name: kubeflow-pipeline-postsubmit-mkp-component-test
     branches:
     - ^master$

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -380,7 +380,7 @@ presubmits:
         - --timeout
         - "3600"
         - --is_integration_test
-        - true
+        - "true"
   - name: kubeflow-pipeline-upgrade-test
     always_run: true
     decorate: true

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -362,6 +362,25 @@ presubmits:
         - sample_test
         - --timeout
         - "3600"
+  - name: kubeflow-pipeline-integration-test
+      always_run: false
+      decorate: true
+      labels:
+        preset-service-account: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+            command:
+              - ./test/presubmit-tests-with-pipeline-deployment.sh
+            args:
+              - --workflow_file
+              - sample_test.yaml
+              - --test_result_folder
+              - sample_test
+              - --timeout
+              - "3600"
+              - --is_integration_test
+              - true
   - name: kubeflow-pipeline-upgrade-test
     always_run: true
     decorate: true

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -363,24 +363,24 @@ presubmits:
         - --timeout
         - "3600"
   - name: kubeflow-pipeline-integration-test
-      always_run: false
-      decorate: true
-      labels:
-        preset-service-account: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
-            command:
-              - ./test/presubmit-tests-with-pipeline-deployment.sh
-            args:
-              - --workflow_file
-              - sample_test.yaml
-              - --test_result_folder
-              - sample_test
-              - --timeout
-              - "3600"
-              - --is_integration_test
-              - true
+    always_run: false
+    decorate: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+          command:
+            - ./test/presubmit-tests-with-pipeline-deployment.sh
+          args:
+            - --workflow_file
+            - sample_test.yaml
+            - --test_result_folder
+            - sample_test
+            - --timeout
+            - "3600"
+            - --is_integration_test
+            - true
   - name: kubeflow-pipeline-upgrade-test
     always_run: true
     decorate: true

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -369,18 +369,18 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
-          command:
-            - ./test/presubmit-tests-with-pipeline-deployment.sh
-          args:
-            - --workflow_file
-            - sample_test.yaml
-            - --test_result_folder
-            - sample_test
-            - --timeout
-            - "3600"
-            - --is_integration_test
-            - true
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200314-a0cadb9-master
+        command:
+        - ./test/presubmit-tests-with-pipeline-deployment.sh
+        args:
+        - --workflow_file
+        - sample_test.yaml
+        - --test_result_folder
+        - sample_test
+        - --timeout
+        - "3600"
+        - --is_integration_test
+        - true
   - name: kubeflow-pipeline-upgrade-test
     always_run: true
     decorate: true


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3256

Context: we wish to separate integration test (which invokes other GCP services) out from previous presubmit sample tests, to reduce the test time and flakiness. Thanks.