### PR TITLE
Azure: start using spot VMSS instances

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -599,6 +599,9 @@ func (c *Cluster) populateAPIModelTemplate() error {
 		if err := c.populateAzureCloudConfig(isVMSS); err != nil {
 			return err
 		}
+		if isVMSS {
+			v.Properties.AgentPoolProfiles[0].ScalesetPriority = "Spot"
+		}
 	}
 
 	apiModel, _ := json.MarshalIndent(v, "", "    ")

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -183,6 +183,7 @@ type AgentPoolProfile struct {
 	Extensions             []map[string]string `json:"extensions,omitempty"`
 	OSDiskSizeGB           int                 `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	EnableVMSSNodePublicIP bool                `json:"enableVMSSNodePublicIP,omitempty"`
+	ScalesetPriority       string              `json:"scalesetPriority,omitempty"`
 }
 
 type AzureClient struct {


### PR DESCRIPTION
Start using spot VMSS instances to save compute cost.

/assign @feiskyer 