### PR TITLE
Fix broken CI job - ci-kubernetes-e2e-gci-gce-ipvs

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -294,17 +294,20 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-e2e-containerd: "true"
+    preset-e2e-containerd-image-load: "true"
   spec:
     containers:
     - args:
+      - --repo=github.com/containerd/cri=master
       - --timeout=170
-      - --bare
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
       - --env=KUBE_PROXY_MODE=ipvs
+      - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
+      - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env
       - --extract=ci/latest
-      - --gcp-master-image=gci
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30


### PR DESCRIPTION
The CI job fails as the 3 worker nodes fail to come up. A quick look at
the kubelet logs show:
```
F0318 21:59:03.419573    3167 server.go:274] failed to run Kubelet: docker API version is older than 1.26.0
```
So essentially the image has a stale runtime.

We need to resurrect the broken CI job. the closest working CI job to
this one is "ci-containerd-e2e-ubuntu-gce". With the updates the
configure.sh from the `containerd/cri` updates the runtime before
installing kubernetes.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>