### PR TITLE
plugins: use plugin-local github clients in owners client

### DIFF
--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -57,6 +57,10 @@ func (f *fakeOwnersClient) WithFields(fields logrus.Fields) repoowners.Interface
 	return f
 }
 
+func (f *fakeOwnersClient) WithGitHubClient(client github.Client) repoowners.Interface {
+	return f
+}
+
 type fakeRepoOwners struct {
 	approvers    map[string]sets.String
 	reviewers    map[string]sets.String

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -167,14 +167,15 @@ type Agent struct {
 func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientAgent *ClientAgent, metrics *Metrics, logger *logrus.Entry, plugin string) Agent {
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
+	gitHubClient := clientAgent.GitHubClient.WithFields(logger.Data).ForPlugin(plugin)
 	return Agent{
-		GitHubClient:              clientAgent.GitHubClient.WithFields(logger.Data).ForPlugin(plugin),
+		GitHubClient:              gitHubClient,
 		KubernetesClient:          clientAgent.KubernetesClient,
 		BuildClusterCoreV1Clients: clientAgent.BuildClusterCoreV1Clients,
 		ProwJobClient:             clientAgent.ProwJobClient,
 		GitClient:                 clientAgent.GitClient,
 		SlackClient:               clientAgent.SlackClient,
-		OwnersClient:              clientAgent.OwnersClient.WithFields(logger.Data),
+		OwnersClient:              clientAgent.OwnersClient.WithFields(logger.Data).WithGitHubClient(gitHubClient),
 		BugzillaClient:            clientAgent.BugzillaClient,
 		Metrics:                   metrics,
 		Config:                    prowConfig,

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -255,9 +255,9 @@ labels:
 	}
 	return &Client{
 			logger: logrus.WithField("client", "repoowners"),
+			ghc:    ghc,
 			delegate: &delegate{
 				git:   git,
-				ghc:   ghc,
 				cache: cache,
 
 				mdYAMLEnabled: func(org, repo string) bool {


### PR DESCRIPTION
The repo-owners client delegates some calls to GitHub when filling out
its central cache. We should allow for users to pass in context-local
GitHub clients so that these calls are appropriately labeled by the
plugins that make them. Support for a generic client is left intact in
case the owners client is somehow used outside of a plugin context.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>