### PR TITLE
Make Plank use a caching PJ client.

### DIFF
--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -34,7 +34,7 @@ go_library(
         "//prow/plank:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/manager:go_default_library",
     ],
 )
 


### PR DESCRIPTION
We're seeing some issues with the API server taking too long to list PJs this is a mitigation for the most critical components.
/assign @chases2 @Katharine @stevekuznetsov 

I couldn't figure out what the default value of the timeout is from the docs and gave up trying to find it in the code.