### PR TITLE
Add Kubespray yamllint CI job

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -5,11 +5,7 @@ approvers:
 - mattymo
 - atoms
 - chadswen
-- rsmitty
-- bogdando
-- bradbeam
-- woopstar
+- mirwan
 - riverzhang
-- holser
-- smana
 - verwilst
+- woopstar

--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -1,0 +1,15 @@
+presubmits:
+  kubernetes-sigs/kubespray:
+  - name: pull-kubespray-yamllint
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-kubespray
+      testgrid-tab-name: yamllint
+    always_run: false
+    skip_report: true
+    spec:
+      containers:
+      - image: quay.io/kubermatic/yamllint:0.1
+        args:
+        - yamllint
+        - "--strict"
+        - .

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -18,6 +18,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-etcdadm
     - sig-cluster-lifecycle-image-pushes
     - sig-cluster-lifecycle-system-validators
+    - sig-cluster-lifecycle-kubespray
 
 dashboards:
 - name: sig-cluster-lifecycle-all
@@ -46,6 +47,7 @@ dashboards:
 - name: sig-cluster-lifecycle-etcdadm
 - name: sig-cluster-lifecycle-image-pushes
 - name: sig-cluster-lifecycle-system-validators
+- name: sig-cluster-lifecycle-kubespray
 
 test_groups:
 # @luxas' multiarch e2e results


### PR DESCRIPTION
Adding a simple CI job for Kubespray on Prow.

Update OWNERS based on latest https://github.com/kubernetes-sigs/kubespray/blob/master/OWNERS_ALIASES in kubespray, minus myself and @lucckysb whoa re not members of the kubernetes org (see https://github.com/kubernetes/test-infra/pull/16869#issuecomment-601672819)

After I got stuck with #12565 I'm taking another shot at this, following the documentation in [config/jobs/README.md](https://github.com/kubernetes/test-infra/blob/master/config/jobs/README.md#adding-or-updating-jobs)