### PR TITLE
Change merge-method of cluster-api-provider-openstack to default (=me…

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -482,7 +482,6 @@ tide:
     kubernetes-client/gen: squash
     kubernetes-sigs/cluster-api-provider-digitalocean: squash
     kubernetes-sigs/cluster-api-provider-ibmcloud: squash
-    kubernetes-sigs/cluster-api-provider-openstack: squash
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
     kubernetes-sigs/kubespray: squash


### PR DESCRIPTION
…rge)

Changed to the default which is merge so we can you the CAPI release-notes tool which 
depends on merge commits