### PR TITLE
Fix for ci-kubernetes-e2e-gci-gce-ipvs

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -308,8 +308,6 @@ periodics:
       - --gcp-node-image=ubuntu
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=ubuntu-gke-1604-lts
-      - --image-project=ubuntu-os-gke-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m


### PR DESCRIPTION
the ipvs job should use the same images as the other jobs. Currently
this job fails because the runtime version required by kubelet is very
old.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>