### PR TITLE
Add aojea as sig-network jobs approver

### DIFF
--- a/config/jobs/kubernetes/sig-network/OWNERS
+++ b/config/jobs/kubernetes/sig-network/OWNERS
@@ -1,8 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- aojea
 - bowei
 - cadmuxe
 - jingax10
-- rramkumar1
 - mrhohn
+- rramkumar1


### PR DESCRIPTION
Test infra is an area I use to frequent :-) and this will allow us to cover EU hours too.

I sorted the list alphabetically too