### PR TITLE
aws-janitor - Only pass the LaunchTemplateName to DeleteLaunchTemplate

### DIFF
--- a/boskos/aws-janitor/resources/launch_templates.go
+++ b/boskos/aws-janitor/resources/launch_templates.go
@@ -57,8 +57,7 @@ func (LaunchTemplates) MarkAndSweep(sess *session.Session, acct string, region s
 
 	for _, lt := range toDelete {
 		deleteReq := &ec2.DeleteLaunchTemplateInput{
-			LaunchTemplateId:   aws.String(lt.ID),
-			LaunchTemplateName: aws.String(lt.Name),
+			LaunchTemplateId: aws.String(lt.ID),
 		}
 
 		if _, err := svc.DeleteLaunchTemplate(deleteReq); err != nil {


### PR DESCRIPTION
Followup to #16794

Fixes the error seen [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/maintenance-ci-aws-janitor/1241059387938705410). According to the [docs](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DeleteLaunchTemplate.html) you can either provide the ID or Name but not both.