### PR TITLE
Plank: Allow watching prowjobs

### DIFF
--- a/prow/cluster/plank_rbac.yaml
+++ b/prow/cluster/plank_rbac.yaml
@@ -18,6 +18,7 @@ rules:
       - get
       - create
       - list
+      - watch
       - update
       - patch
 ---


### PR DESCRIPTION
We missed that in https://github.com/kubernetes/test-infra/pull/16863

/assign @cjwagner @stevekuznetsov 