### PR TITLE
ci-k8sio-cip: do not use secret

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1143,17 +1143,8 @@ periodics:
       - cip
       args:
       - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-      - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
       - -dry-run=false
-      - -use-service-account
-      volumeMounts:
-      - name: k8s-artifacts-prod-service-account-creds
-        mountPath: /etc/k8s-artifacts-prod-service-account
-        readOnly: true
-    volumes:
-    - name: k8s-artifacts-prod-service-account-creds
-      secret:
-        secretName: k8s-artifacts-prod-service-account
+      - -use-service-account # @listx: deprecated; remove after verifying Workload Identity makes this obsolete
   annotations:
     testgrid-dashboards: sig-release-releng-blocking
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io


### PR DESCRIPTION
Ever since https://github.com/kubernetes/k8s.io/pull/655, this job
should already run with an authenticated GCP SA (before the job's code
even runs). This means there is no need to use the keyfile to
authenticate (again), as it is redundant.

We still keep the `-use-service-account` flag for now because the
promoter currently still tries to extract OAUTH tokens as the GCP
account at the very beginning of its run. It's a nice sanity check.

Once we confirm that the OAUTH tokens do still get populated in the
business logic of the job, we don't need to keep this flag any more
because the GCRs that the promoter deals with today are all public (the
promoter was designed to deal with private repos), and so the very
first "read GCR" API calls do not need the OAUTH tokens for just reading
the repos. That takes care of the GCR read API calls.

As for the GCR write calls, the gcrane.Copy() method that perform the
GCR writes do their own authentication dance, but that is separate and
automatic as long as the GCP account is authenticated before that
function call.

This is why the `-use-service-account` flag is marked for future
deprecation in this commit.