### PR TITLE
Repoowners: Minimize global lock usage

### DIFF
--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"sync"
 	"testing"
 
 	"github.com/sirupsen/logrus"
@@ -185,7 +186,7 @@ func getTestClient(
 			return nil, nil, err
 		}
 	}
-	cache := make(map[string]cacheEntry)
+	cache := newCache()
 	if cacheOptions != nil {
 		var entry cacheEntry
 		entry.sha, err = localGit.RevParse("org", "repo", "HEAD")
@@ -244,7 +245,7 @@ labels:
 				return nil, nil, fmt.Errorf("cannot add commit: %v", err)
 			}
 		}
-		cache["org"+"/"+"repo:master"] = entry
+		cache.data["org"+"/"+"repo:master"] = entry
 		// mark this entry is cache
 		entry.owners.baseDir = "cache"
 	}
@@ -1384,4 +1385,17 @@ func TestTopLevelApprovers(t *testing.T) {
 	if !foundApprovers.Equal(sets.NewString(expectedApprovers...)) {
 		t.Errorf("Expected Owners: %v\tFound Owners: %v ", expectedApprovers, foundApprovers)
 	}
+}
+
+func TestCacheDoesntRace(t *testing.T) {
+	key := "key"
+	cache := newCache()
+
+	wg := &sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() { cache.setEntry(key, cacheEntry{}); wg.Done() }()
+	go func() { cache.getEntry(key); wg.Done() }()
+
+	wg.Wait()
 }


### PR DESCRIPTION
This PR minimizes the usage of the global lock in `repoowners` as much as possible, its not used at all anymore while doing api calls but just when accessing the cache map.

/assign @stevekuznetsov @cjwagner 