### PR TITLE
Azure: ignore BlobHasBeenModified error when uploading to Azure Storage

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -956,13 +956,18 @@ func (c *Cluster) uploadToAzureStorage(filePath string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to open file %v . Error %v", filePath, err)
 	}
+	defer file.Close()
+
 	blobURL := containerURL.NewBlockBlobURL(filepath.Base(file.Name()))
-	_, err1 := azblob.UploadFileToBlockBlob(context.Background(), file, blobURL, azblob.UploadToBlockBlobOptions{})
-	file.Close()
-	if err1 != nil {
-		return "", err1
-	}
 	blobURLString := blobURL.URL()
+	if _, err = azblob.UploadFileToBlockBlob(context.Background(), file, blobURL, azblob.UploadToBlockBlobOptions{}); err != nil {
+		// 'BlobHasBeenModified' conflict happens when two concurrent jobs are trying to upload files with the same name
+		// Simply ignore the error and return the blob URL since at least one job will successfully upload the file to Azure storage
+		if strings.Contains(err.Error(), "BlobHasBeenModified") {
+			return blobURLString.String(), nil
+		}
+		return "", err
+	}
 	log.Printf("Uploaded %s to %s", filePath, blobURLString.String())
 	return blobURLString.String(), nil
 }


### PR DESCRIPTION
'BlobHasBeenModified' conflict happens when two concurrent jobs are trying to upload files with the same name. We simply need to ignore the error and return the blob URL since at least one job will successfully upload the file to Azure storage

Fixed the following error:
```
2020/03/21 13:50:51 main.go:316: Something went wrong: failed to acquire k8s binaries: -> github.com/Azure/azure-storage-blob-go/azblob.newStorageError, /go/pkg/mod/github.com/!azure/azure-storage-blob-go@v0.8.0/azblob/zc_storage_error.go:42
===== RESPONSE ERROR (ServiceCode=BlobHasBeenModified) =====
Description=The request failed due to a concurrent modification on the blob.
RequestId:b36a8022-f01e-009e-4a87-ff8851000000
Time:2020-03-21T13:50:43.3823102Z, Details: 
   Code: BlobHasBeenModified
   PUT https://k8sprowstorage.blob.core.windows.net/mystoragecontainer/kubernetes-node-linux-amd64-v1.19.0-alpha.0-988-g479b7e7918b.tar.gz?timeout=61
   Authorization: REDACTED
   Content-Length: [147648972]
   User-Agent: [Azure-Storage/0.7 (go1.13.8; linux)]
   X-Ms-Blob-Cache-Control: []
   X-Ms-Blob-Content-Disposition: []
   X-Ms-Blob-Content-Encoding: []
   X-Ms-Blob-Content-Language: []
   X-Ms-Blob-Content-Type: []
   X-Ms-Blob-Type: [BlockBlob]
   X-Ms-Client-Request-Id: [752630c4-09f1-4f7c-65d2-27ed39a67f04]
   X-Ms-Date: [Sat, 21 Mar 2020 13:50:40 GMT]
   X-Ms-Version: [2018-11-09]
   --------------------------------------------------------------------------------
   RESPONSE Status: 409 The request failed due to a concurrent modification on the blob.
   Content-Length: [252]
   Content-Type: [application/xml]
   Date: [Sat, 21 Mar 2020 13:50:43 GMT]
   Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
   X-Ms-Error-Code: [BlobHasBeenModified]
   X-Ms-Request-Id: [b36a8022-f01e-009e-4a87-ff8851000000]
   X-Ms-Version: [2018-11-09]
```

/assign @feiskyer 