### PR TITLE
kubetest: allow passing env var from GKE create command

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -309,7 +309,9 @@ func (g *gkeDeployer) Up() error {
 
 	def := g.shape[defaultPool]
 	args := make([]string, len(g.createCommand))
-	copy(args, g.createCommand)
+	for i := range args {
+		args[i] = os.ExpandEnv(g.createCommand[i])
+	}
 	args = append(args,
 		"--project="+g.project,
 		g.location,


### PR DESCRIPTION
**Background**:
We need to use `kubetest` to create GKE clusters with Workload Identity being enabled,  and the `gcloud` command is:
```
gcloud beta container clusters create [cluster-name] \
  --release-channel regular \
  --workload-pool=[project-id].svc.id.goog
```
See more details in https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_workload_identity_on_a_new_cluster.

The command requires the project_id, which we cannot provide directly as we also use `kubetest` to acquire the project from `boskos`. 

**Proposed solution**:
Since `kubetest` will set the `PROJECT` env var after acquiring the project from `boskos`, we can pass `${PROJECT}` as part of the GKE creation command to correctly set `workload-pool`. One place we need to change is expanding the env var in the GKE creation command, and it won't impact the existing functionalities.