### PR TITLE
Switch SIG Docs merge method from squash to merge (default)

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -490,7 +490,6 @@ tide:
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
     kubernetes/kube-deploy: squash
-    kubernetes/website: squash
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
By removing the custom prow config to squash commits, SIG Docs will begin using the default prow merge method ([merge](https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#general-configuration)).

Early on, `squash` was used for SIG Docs as it was easier to revert / fix commits. However, today we find it to be problematic in the release cycle as the release lead needs to change the label to `merge` to resolve conflicts.

As a result, @kubernetes/sig-docs-en-reviews and @kubernetes/sig-docs-en-owners will need to be more strict around squashing commits before merging.

This is the first step of a larger effort to simplify the docs release process.

/cc @kubernetes/sig-docs-zh-reviews @kubernetes/sig-docs-ko-reviews @kubernetes/sig-docs-de-reviews @kubernetes/sig-docs-es-reviews @kubernetes/sig-docs-pt-reviews @kubernetes/sig-docs-id-reviews @kubernetes/sig-docs-ru-reviews @kubernetes/sig-docs-pl-reviews @kubernetes/sig-docs-vi-reviews
/cc @zacharysarah @kbarnard10 @sftim @kbhawkey

/hold

(for discussion if needed) 
