### PR TITLE
Rename 'pull-kubernetes-e2e-gce-canary' and enable as non-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -60,15 +60,17 @@ presubmits:
           requests:
             memory: "6Gi"
 
-  - name: pull-kubernetes-e2e-gce-canary
-    always_run: false
-    skip_report: true
+  - name: pull-kubernetes-e2e-gce-canary-no-bazel
+    always_run: true
+    optional: true
     skip_branches:
     - release-\d+\.\d+ # per-release image
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, release-managers@kubernetes.io
+      testgrid-dashboards: sig-release-master-informing, sig-testing-canaries
       testgrid-num-failures-to-alert: "10"
     labels:
       preset-dind-enabled: "true"
@@ -96,7 +98,7 @@ presubmits:
         # Panic if anything mutates a shared informer cache
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --runtime-config=batch/v2alpha1=true
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary-no-bazel
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200320-57aed89-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -804,7 +804,7 @@ presubmits:
       preset-pull-kubernetes-e2e: "true"
       preset-pull-kubernetes-e2e-gce: "true"
       preset-service-account: "true"
-    name: pull-kubernetes-e2e-gce-canary
+    name: pull-kubernetes-e2e-gce-canary-no-bazel
     skip_report: true
     spec:
       containers:
@@ -825,7 +825,7 @@ presubmits:
         - --provider=gce
         - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
         - --runtime-config=batch/v2alpha1=true
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary-no-bazel
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -464,8 +464,8 @@ dashboards:
   - name: pull-kubernetes-e2e-gce-rbe
     test_group_name: pull-kubernetes-e2e-gce-rbe
     base_options: width=10
-  - name: pull-kubernetes-e2e-gce-canary
-    test_group_name: pull-kubernetes-e2e-gce-canary
+  - name: pull-kubernetes-e2e-gce-canary-no-bazel
+    test_group_name: pull-kubernetes-e2e-gce-canary-no-bazel
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-ubuntu
     test_group_name: pull-kubernetes-e2e-gce-ubuntu


### PR DESCRIPTION
- s/`pull-kubernetes-e2e-gce-canary`/`pull-kubernetes-e2e-gce-canary-no-bazel`

  So we actually know in the job name that it's running e2e-gce without
  bazel, specifically with the '--build=quick' flag.

- Set to always run
- Make non-blocking
- Add to `sig-release-master-informing` and `sig-testing-canaries`
- Add alert emails

---

Follow-up to @BenTheElder's review [here](https://github.com/kubernetes/test-infra/pull/16073#discussion_r374298253):

>  always_run: false + skip_report will mean when you /test pull-kubernetes-e2e-gce-canary you need to go track down the results yourself /shrug

ref: https://github.com/kubernetes/kubernetes/issues/88553, https://github.com/kubernetes/kubernetes/pull/89275, https://github.com/kubernetes/test-infra/pull/16073, https://github.com/kubernetes/kubernetes/issues/87441