### PR TITLE
bump kubekins bazel version to match 0.25.2 used in build and test

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -21,11 +21,16 @@ presubmits:
       containers:
       - image: launcher.gcr.io/google/bazel:0.25.2
         command:
-        - bash
+        - ../test-infra/hack/bazel.sh
         args:
-        - -c
-        - |
-          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
+        - build
+        - --config=remote
+        - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
+        - --
+        - //...
+        - -//vendor/...
+        - -//build/...
+        - //build/release-tars
   - name: pull-kubernetes-bazel-test
     decorate: true
     always_run: true

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -38,7 +38,7 @@ substitutions:
   _GIT_TAG: '12345'
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
-  _OLD_BAZEL_VERSION: 0.23.2
+  _OLD_BAZEL_VERSION: 0.25.2
   _UPGRADE_DOCKER: 'false'
 options:
   substitution_option: ALLOW_LOOSE

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -11,7 +11,7 @@ variants:
     GO_VERSION: 1.13.8
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    OLD_BAZEL_VERSION: 0.25.2
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: 1.13.8


### PR DESCRIPTION
And a small cleanup of the job config for build to make the invocation consistent across the jobs.

/assign @fejta 
