### PR TITLE
Create launcher.gcr.io/google/bazel:2.2.0-from-0.25.2

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -265,6 +265,31 @@ postsubmits:
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion
+  - name: post-test-infra-push-bazel
+    cluster: test-infra-trusted
+    run_if_changed: '^images/bazel/'
+    annotations:
+      testgrid-dashboards: "sig-testing-images"
+      testgrid-tab-name: "bazel"
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: builds and pushes launcher.gcr.io/google/bazel, adding support for a second version
+    decorate: true
+    branches:
+    - master
+    spec:
+      serviceAccountName: deployer # TODO(fejta): should be pusher
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200211-v0.4-10-g26b1b47
+        command:
+        - images/builder/ci-runner.sh
+        args:
+        - --scratch-bucket=gs://k8s-testimages-scratch
+        - --project=k8s-testimages
+        - images/bazel/
+        env:
+        - name: USE_BAZEL_VERSION
+          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bazelbuild
     cluster: test-infra-trusted
     run_if_changed: '^images/bazelbuild/'

--- a/images/bazel/Dockerfile
+++ b/images/bazel/Dockerfile
@@ -1,0 +1,29 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Includes git, gcloud, and bazel.
+ARG NEW_VERSION
+ARG OLD_VERSION
+FROM launcher.gcr.io/google/bazel:${OLD_VERSION} as old
+FROM launcher.gcr.io/google/bazel:${NEW_VERSION}
+
+# add env we can debug with the image name:tag
+ARG IMAGE_ARG
+ENV IMAGE=${IMAGE_ARG}
+
+#RUN cd $(dirname $(realpath $(which bazel))) \
+#    && curl -LO https://releases.bazel.build/${OLD_VERSION}/release/bazel-${OLD_VERSION}-linux-x86_64 \
+#    && chmod +x bazel-${OLD_VERSION}-linux-x86_64
+COPY --from=old \
+  /usr/local/lib/bazel/bin/bazel-real /usr/local/lib/bazel/bin/bazel-${OLD_VERSION}

--- a/images/bazel/Makefile
+++ b/images/bazel/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2016 The Kubernetes Authors.
+# Copyright 2020 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 push-prod:
-	bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch --build-dir=. images/bazelbuild
+	bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch images/bazel
 
 push:
-	bazel run //images/builder -- --allow-dirty --build-dir=. images/bazelbuild
+	bazel run //images/builder -- --allow-dirty images/bazel
 
 .PHONY: push push-prod

--- a/images/bazel/cloudbuild.yaml
+++ b/images/bazel/cloudbuild.yaml
@@ -1,0 +1,18 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION',
+            '--build-arg', 'NEW_VERSION=$_NEW_VERSION',
+            '--build-arg', 'OLD_VERSION=$_OLD_VERSION',
+            '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION',
+            '.' ]
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION']
+substitutions:
+  _GIT_TAG: '12345'
+  _NEW_VERSION: something
+  _OLD_VERSION: something
+options:
+  substitution_option: ALLOW_LOOSE
+images:
+  - 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION'
+  - 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION'

--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -1,0 +1,4 @@
+variants:
+  2.2.0-from-0.25.2:
+    NEW_VERSION: 2.2.0
+    OLD_VERSION: 0.25.2


### PR DESCRIPTION
/assign @mikedanese @Katharine 

This will create a `gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.25.2` that has both `2.2.0` and `0.25.2` installed, selectable in a PR via the `.bazelversion` file.

