### PR TITLE
Kops - update jobs from using ci/latest to release/latest-1.18

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -15,7 +15,9 @@ periodics:
       args:
       - --cluster=e2e-kops-gce-latest.k8s.local
       - --deployment=kops
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel=30
       - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -18,7 +18,9 @@ periodics:
       - --cluster=e2e-kops-aws-channelalpha.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-args=--channel=alpha
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -50,7 +52,9 @@ periodics:
       - --cluster=e2e-kops-aws-ha-uswest2.k8s.local
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel=10
       - --kops-args=--master-count=3
       - --kops-nodes=6
@@ -84,9 +88,9 @@ periodics:
       - --cluster=e2e-kops-aws-containerd.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --extract=release/latest
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-args=--container-runtime=containerd --networking=calico --image=136693071363/debian-10-amd64-20200210-166
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -118,7 +122,9 @@ periodics:
       args:
       - --cluster=e2e-kops-aws-coredns.test-cncf-aws.k8s.io
       - --deployment=kops
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-overrides=spec.kubeDNS.provider=CoreDNS
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -151,7 +157,9 @@ periodics:
       args:
       - --cluster=e2e-kops-aws-launchtemplates.test-cncf-aws.k8s.io
       - --deployment=kops
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-feature-flags=EnableLaunchTemplates
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -184,7 +192,9 @@ periodics:
       - --cluster=e2e-kops-aws-newrunner.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -215,7 +225,9 @@ periodics:
       - --cluster=e2e-kops-aws-updown.test-cncf-aws.k8s.io
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
-      - --extract=ci/latest
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/latest-1.18
       - --ginkgo-parallel
       - --kops-publish=gs://kops-ci/bin/latest-ci-updown-green.txt
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci.txt


### PR DESCRIPTION
Kops is failing with k8s 1.19 because of the removal of basic auth support from kube-apiserver.
[Until we get that fixed](https://github.com/kubernetes/kops/pull/8783) i'm updating the jobs to use the latest 1.18 release so that we can have clearer signal while we prepare for the kops 1.17 release.