### PR TITLE
Revert "Azure: start using spot VMSS instances"

### DIFF
--- a/kubetest/azure.go
+++ b/kubetest/azure.go
@@ -599,9 +599,6 @@ func (c *Cluster) populateAPIModelTemplate() error {
 		if err := c.populateAzureCloudConfig(isVMSS); err != nil {
 			return err
 		}
-		if isVMSS {
-			v.Properties.AgentPoolProfiles[0].ScalesetPriority = "Spot"
-		}
 	}
 
 	apiModel, _ := json.MarshalIndent(v, "", "    ")

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -183,7 +183,6 @@ type AgentPoolProfile struct {
 	Extensions             []map[string]string `json:"extensions,omitempty"`
 	OSDiskSizeGB           int                 `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	EnableVMSSNodePublicIP bool                `json:"enableVMSSNodePublicIP,omitempty"`
-	ScalesetPriority       string              `json:"scalesetPriority,omitempty"`
 }
 
 type AzureClient struct {


### PR DESCRIPTION
Reverts kubernetes/test-infra#16854

There is only 10 spot core per region and a quota increase isn't possible at the moment.

/assign @feiskyer 