### PR TITLE
ci-k8sio-cip: use k8s service account

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1152,6 +1152,9 @@ periodics:
     repo: k8s.io
     base_ref: master
   spec:
+    # The k8s-artifacts-prod name was chosen in
+    # https://github.com/kubernetes/k8s.io/pull/655.
+    serviceAccountName: k8s-artifacts-prod
     containers:
     # TODO: Move the official cip image to a more serious location.
     #

--- a/prow/cluster/trusted_serviceaccounts.yaml
+++ b/prow/cluster/trusted_serviceaccounts.yaml
@@ -31,12 +31,18 @@ metadata:
   name: deployer
   namespace: test-pods
 ---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-artifacts-prod
+  namespace: test-pods
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above
 # * Config service account on job
 # Do the same for the following:
 # k8s-artifacts-graveyard-service-account
 # k8s-artifacts-prod-bak-service-account
-# k8s-artifacts-prod-service-account
 # k8s-gcr-prod-service-account
 # service-account


### PR DESCRIPTION
This is a follow-up to https://github.com/kubernetes/k8s.io/pull/655 and
https://github.com/kubernetes/test-infra/pull/16883.

/cc @fejta @thockin 

Aside: I think the KSA name "k8s-artifacts-prod" is bad (too generic) and should be changed in the future, but let's do that later when we need to disambiguate.