### PR TITLE
use 2.2.0 transition image for bazel tests

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -19,7 +19,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.25.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         command:
         - bash
         args:
@@ -45,7 +45,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.25.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -139,7 +139,7 @@ postsubmits:
     - release-\d+.\d+ # per-release job
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.25.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -171,7 +171,7 @@ postsubmits:
     - release-\d+.\d+ # per-release job
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.25.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -248,7 +248,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel
+    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       imagePullPolicy: Always
       command:
       - bash
@@ -290,7 +290,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:0.25.2
+    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       command:
       - ../test-infra/hack/bazel.sh
       args:
@@ -322,7 +322,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel
+    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       command:
       - ../test-infra/hack/bazel.sh
       args:


### PR DESCRIPTION
Tests pass on 2.2.0:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/83821/pull-kubernetes-bazel-build-canary/1242293481200685058
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/83821/pull-kubernetes-bazel-test-canary/1242293481200685057

Tests pass on 0.23.2:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/89407/pull-kubernetes-bazel-build-canary/1242298514772332544
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/89407/pull-kubernetes-bazel-test-canary/1242301535199694848

/assign @fejta 