### PR TITLE
releng: Update variants (kubekins, krte) to use go1.13.9

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,26 +1,26 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.13.8
+    GO_VERSION: 1.13.9
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.13.8
+    GO_VERSION: 1.13.9
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: 1.13.8
+    GO_VERSION: 1.13.9
     K8S_RELEASE: stable-1.18
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
-    GO_VERSION: 1.13.8
+    GO_VERSION: 1.13.9
     K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
(Part of the quarterly Golang updates: https://github.com/kubernetes/release/issues/1134)

/hold until:
- [x] Kubernetes v1.18.0 has been released
- [x] after the following PRs have merged:
  - [x] `master`: https://github.com/kubernetes/kubernetes/pull/89275
  - [x] 1.18: https://github.com/kubernetes/kubernetes/pull/89398
  - [x] 1.17: https://github.com/kubernetes/kubernetes/pull/89399
  - [ ] ~1.16: https://github.com/kubernetes/kubernetes/pull/89400~
        Dropped the 1.16 bump since the PR is still in test. Will do this one in a follow-up PR.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>