### PR TITLE
prow command to list possible tests on PR

### DIFF
--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -31,7 +31,23 @@ import (
 	"k8s.io/test-infra/prow/plugins"
 )
 
-var testHelpRe = regexp.MustCompile(`(?m)^/test\s*\?\s*$`)
+var (
+	testHelpRe          = regexp.MustCompile(`(?m)^/test\s*\?\s*$`)
+	emptyTestRe         = regexp.MustCompile(`(?m)^/test\s*$`)
+	retestWithTargetRe  = regexp.MustCompile(`(?m)^/retest\s+\S+$`)
+	testWithAnyTargetRe = regexp.MustCompile(`(?m)^/test\s+\S+$`)
+
+	testWithoutTargetNote = "The `/test` command needs one or more targets.\n"
+	retestWithTargetNote  = "The `/retest` command does not accept any targets.\n"
+	targetNotFoundNote    = "The specified target(s) for `/test` were not found.\n"
+)
+
+func mayNeedHelpComment(body string) bool {
+	return emptyTestRe.MatchString(body) ||
+		retestWithTargetRe.MatchString(body) ||
+		testWithAnyTargetRe.MatchString(body) ||
+		testHelpRe.MatchString(body)
+}
 
 func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCommentEvent) error {
 	org := gc.Repo.Owner.Login
@@ -62,7 +78,7 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	if !pjutil.RetestRe.MatchString(gc.Body) &&
 		!pjutil.OkToTestRe.MatchString(gc.Body) &&
 		!pjutil.TestAllRe.MatchString(gc.Body) &&
-		!testHelpRe.MatchString(gc.Body) {
+		!mayNeedHelpComment(gc.Body) {
 		matched := false
 		for _, presubmit := range presubmits {
 			matched = matched || presubmit.TriggerMatches(gc.Body)
@@ -95,31 +111,6 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 		}
 	}
 
-	pr, err := refGetter.PullRequest()
-	if err != nil {
-		return err
-	}
-
-	// Process "help" comments
-	if testHelpRe.MatchString(gc.Body) {
-		branch := pr.Base.Ref
-		available, err := availablePresubmits(c.GitHubClient, gc.Body, org, repo, branch, pr.Number, presubmits, c.Logger)
-		if err != nil {
-			return err
-		}
-		var resp string
-		if len(available) > 0 {
-			var listBuilder strings.Builder
-			for _, name := range available {
-				listBuilder.WriteString(fmt.Sprintf("\n* `%s`", name))
-			}
-			resp = fmt.Sprintf("The following commands are available to trigger jobs:%s\n\nUse `/test all` to run all jobs.", listBuilder.String())
-		} else {
-			resp = fmt.Sprintf("No presubmit jobs available for %s/%s@%s", org, repo, branch)
-		}
-		return c.GitHubClient.CreateComment(org, repo, number, plugins.FormatResponseRaw(gc.Body, gc.HTMLURL, gc.User.Login, resp))
-	}
-
 	// At this point we can trust the PR, so we eventually update labels.
 	// Ensure we have labels before test, because TrustedPullRequest() won't be called
 	// when commentAuthor is trusted.
@@ -141,6 +132,10 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 		}
 	}
 
+	pr, err := refGetter.PullRequest()
+	if err != nil {
+		return err
+	}
 	baseSHA, err := refGetter.BaseSHA()
 	if err != nil {
 		return err
@@ -149,6 +144,9 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	toTest, toSkip, err := FilterPresubmits(HonorOkToTest(trigger), c.GitHubClient, gc.Body, pr, presubmits, c.Logger)
 	if err != nil {
 		return err
+	}
+	if needsHelp, note := shouldRespondWithHelp(gc.Body, len(toTest)+len(toSkip)); needsHelp {
+		return addHelpComment(c.GitHubClient, gc.Body, org, repo, pr.Base.Ref, pr.Number, presubmits, gc.HTMLURL, commentAuthor, note, c.Logger)
 	}
 	return RunAndSkipJobs(c, pr, baseSHA, toTest, toSkip, gc.GUID, *trigger.ElideSkippedContexts)
 }
@@ -227,4 +225,38 @@ func getContexts(combinedStatus *github.CombinedStatus) (sets.String, sets.Strin
 		}
 	}
 	return failedContexts, allContexts
+}
+
+func addHelpComment(githubClient githubClient, body, org, repo, branch string, number int, presubmits []config.Presubmit, HTMLURL, user, note string, logger *logrus.Entry) error {
+	available, err := availablePresubmits(githubClient, body, org, repo, branch, number, presubmits, logger)
+	if err != nil {
+		return err
+	}
+	var resp string
+	if len(available) > 0 {
+		var listBuilder strings.Builder
+		for _, name := range available {
+			listBuilder.WriteString(fmt.Sprintf("\n* `%s`", name))
+		}
+		resp = fmt.Sprintf("%sThe following commands are available to trigger jobs:%s\n\nUse `/test all` to run all jobs.",
+			note, listBuilder.String())
+	} else {
+		resp = fmt.Sprintf("No presubmit jobs available for %s/%s@%s", org, repo, branch)
+	}
+	return githubClient.CreateComment(org, repo, number, plugins.FormatResponseRaw(body, HTMLURL, user, resp))
+}
+
+func shouldRespondWithHelp(body string, toRunOrSkip int) (bool, string) {
+	switch {
+	case testHelpRe.MatchString(body):
+		return true, ""
+	case emptyTestRe.MatchString(body):
+		return true, testWithoutTargetNote
+	case retestWithTargetRe.MatchString(body):
+		return true, retestWithTargetNote
+	case toRunOrSkip == 0 && testWithAnyTargetRe.MatchString(body):
+		return true, targetNotFoundNote
+	default:
+		return false, ""
+	}
 }

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -69,6 +69,7 @@ type testcase struct {
 func TestHandleGenericComment(t *testing.T) {
 	truth := true
 	var lies bool
+	helpComment := "The following commands are available to trigger jobs:\n* `/test job`\n* `/test jib`\n\nUse `/test all` to run all jobs."
 	var testcases = []testcase{
 		{
 			name: "Not a PR.",
@@ -821,7 +822,7 @@ func TestHandleGenericComment(t *testing.T) {
 			Body:         "/test ?",
 			State:        "open",
 			IsPR:         true,
-			AddedComment: "@trusted-member: The following commands are available to trigger jobs:\n* `/test job`\n* `/test jib`\n\nUse `/test all` to run all jobs.",
+			AddedComment: helpComment,
 		},
 		{
 			name:   `help command "/test ?" uses RerunCommand field of presubmits`,
@@ -853,8 +854,31 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-
 			AddedComment: "@trusted-member: The following commands are available to trigger jobs:\n* `/rerun_command`\n* `/command_foo`\n\nUse `/test all` to run all jobs.",
+		},
+		{
+			name:         "/test with no target results in a help message",
+			Author:       "trusted-member",
+			Body:         "/test",
+			State:        "open",
+			IsPR:         true,
+			AddedComment: testWithoutTargetNote + helpComment,
+		},
+		{
+			name:         "/retest with trailing words results in a help message",
+			Author:       "trusted-member",
+			Body:         "/retest FOO",
+			State:        "open",
+			IsPR:         true,
+			AddedComment: retestWithTargetNote + helpComment,
+		},
+		{
+			name:         "/test with unknown target results in a help message",
+			Author:       "trusted-member",
+			Body:         "/test FOO",
+			State:        "open",
+			IsPR:         true,
+			AddedComment: targetNotFoundNote + helpComment,
 		},
 	}
 	for _, tc := range testcases {

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -858,121 +858,123 @@ func TestHandleGenericComment(t *testing.T) {
 		},
 	}
 	for _, tc := range testcases {
-		if tc.Branch == "" {
-			tc.Branch = "master"
-		}
-		g := &fakegithub.FakeClient{
-			CreatedStatuses: map[string][]github.Status{},
-			IssueComments:   map[int][]github.IssueComment{},
-			OrgMembers:      map[string][]string{"org": {"trusted-member"}},
-			PullRequests: map[int]*github.PullRequest{
-				0: {
-					User:   github.User{Login: tc.PRAuthor},
-					Number: 0,
-					Head: github.PullRequestBranch{
-						SHA: "cafe",
-					},
-					Base: github.PullRequestBranch{
-						Ref: tc.Branch,
-						Repo: github.Repo{
-							Owner: github.User{Login: "org"},
-							Name:  "repo",
-						},
-					},
-				},
-			},
-			IssueLabelsExisting: tc.IssueLabels,
-			PullRequestChanges:  map[int][]github.PullRequestChange{0: {{Filename: "CHANGED"}}},
-			CombinedStatuses: map[string]*github.CombinedStatus{
-				"cafe": {
-					Statuses: []github.Status{
-						{State: github.StatusPending, Context: "pull-job"},
-						{State: github.StatusFailure, Context: "pull-jib"},
-						{State: github.StatusSuccess, Context: "pull-jub"},
-					},
-				},
-			},
-			Collaborators: []string{"k8s-ci-robot"},
-		}
-		fakeConfig := &config.Config{ProwConfig: config.ProwConfig{ProwJobNamespace: "prowjobs"}}
-		fakeProwJobClient := fake.NewSimpleClientset()
-		c := Client{
-			GitHubClient:  g,
-			ProwJobClient: fakeProwJobClient.ProwV1().ProwJobs(fakeConfig.ProwJobNamespace),
-			Config:        fakeConfig,
-			Logger:        logrus.WithField("plugin", PluginName),
-			GitClient:     nil,
-		}
-		presubmits := tc.Presubmits
-		if presubmits == nil {
-			presubmits = map[string][]config.Presubmit{
-				"org/repo": {
-					{
-						JobBase: config.JobBase{
-							Name: "job",
-						},
-						AlwaysRun: true,
-						Reporter: config.Reporter{
-							Context: "pull-job",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
-						RerunCommand: `/test job`,
-						Brancher:     config.Brancher{Branches: []string{"master"}},
-					},
-					{
-						JobBase: config.JobBase{
-							Name: "jib",
-						},
-						AlwaysRun: false,
-						Reporter: config.Reporter{
-							Context: "pull-jib",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
-						RerunCommand: `/test jib`,
-					},
-				},
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.Branch == "" {
+				tc.Branch = "master"
 			}
-		}
-		if err := c.Config.SetPresubmits(presubmits); err != nil {
-			t.Fatalf("%s: failed to set presubmits: %v", tc.name, err)
-		}
+			g := &fakegithub.FakeClient{
+				CreatedStatuses: map[string][]github.Status{},
+				IssueComments:   map[int][]github.IssueComment{},
+				OrgMembers:      map[string][]string{"org": {"trusted-member"}},
+				PullRequests: map[int]*github.PullRequest{
+					0: {
+						User:   github.User{Login: tc.PRAuthor},
+						Number: 0,
+						Head: github.PullRequestBranch{
+							SHA: "cafe",
+						},
+						Base: github.PullRequestBranch{
+							Ref: tc.Branch,
+							Repo: github.Repo{
+								Owner: github.User{Login: "org"},
+								Name:  "repo",
+							},
+						},
+					},
+				},
+				IssueLabelsExisting: tc.IssueLabels,
+				PullRequestChanges:  map[int][]github.PullRequestChange{0: {{Filename: "CHANGED"}}},
+				CombinedStatuses: map[string]*github.CombinedStatus{
+					"cafe": {
+						Statuses: []github.Status{
+							{State: github.StatusPending, Context: "pull-job"},
+							{State: github.StatusFailure, Context: "pull-jib"},
+							{State: github.StatusSuccess, Context: "pull-jub"},
+						},
+					},
+				},
+				Collaborators: []string{"k8s-ci-robot"},
+			}
+			fakeConfig := &config.Config{ProwConfig: config.ProwConfig{ProwJobNamespace: "prowjobs"}}
+			fakeProwJobClient := fake.NewSimpleClientset()
+			c := Client{
+				GitHubClient:  g,
+				ProwJobClient: fakeProwJobClient.ProwV1().ProwJobs(fakeConfig.ProwJobNamespace),
+				Config:        fakeConfig,
+				Logger:        logrus.WithField("plugin", PluginName),
+				GitClient:     nil,
+			}
+			presubmits := tc.Presubmits
+			if presubmits == nil {
+				presubmits = map[string][]config.Presubmit{
+					"org/repo": {
+						{
+							JobBase: config.JobBase{
+								Name: "job",
+							},
+							AlwaysRun: true,
+							Reporter: config.Reporter{
+								Context: "pull-job",
+							},
+							Trigger:      `(?m)^/test (?:.*? )?job(?: .*?)?$`,
+							RerunCommand: `/test job`,
+							Brancher:     config.Brancher{Branches: []string{"master"}},
+						},
+						{
+							JobBase: config.JobBase{
+								Name: "jib",
+							},
+							AlwaysRun: false,
+							Reporter: config.Reporter{
+								Context: "pull-jib",
+							},
+							Trigger:      `(?m)^/test (?:.*? )?jib(?: .*?)?$`,
+							RerunCommand: `/test jib`,
+						},
+					},
+				}
+			}
+			if err := c.Config.SetPresubmits(presubmits); err != nil {
+				t.Fatalf("%s: failed to set presubmits: %v", tc.name, err)
+			}
 
-		event := github.GenericCommentEvent{
-			Action: github.GenericCommentActionCreated,
-			Repo: github.Repo{
-				Owner:    github.User{Login: "org"},
-				Name:     "repo",
-				FullName: "org/repo",
-			},
-			Body:        tc.Body,
-			User:        github.User{Login: tc.Author},
-			IssueAuthor: github.User{Login: tc.PRAuthor},
-			IssueState:  tc.State,
-			IsPR:        tc.IsPR,
-		}
+			event := github.GenericCommentEvent{
+				Action: github.GenericCommentActionCreated,
+				Repo: github.Repo{
+					Owner:    github.User{Login: "org"},
+					Name:     "repo",
+					FullName: "org/repo",
+				},
+				Body:        tc.Body,
+				User:        github.User{Login: tc.Author},
+				IssueAuthor: github.User{Login: tc.PRAuthor},
+				IssueState:  tc.State,
+				IsPR:        tc.IsPR,
+			}
 
-		trigger := plugins.Trigger{
-			IgnoreOkToTest:       tc.IgnoreOkToTest,
-			ElideSkippedContexts: tc.ElideSkippedContexts,
-		}
-		trigger.SetDefaults()
+			trigger := plugins.Trigger{
+				IgnoreOkToTest:       tc.IgnoreOkToTest,
+				ElideSkippedContexts: tc.ElideSkippedContexts,
+			}
+			trigger.SetDefaults()
 
-		log.Printf("running case %s", tc.name)
-		// In some cases handleGenericComment can be called twice for the same event.
-		// For instance on Issue/PR creation and modification.
-		// Let's call it twice to ensure idempotency.
-		if err := handleGenericComment(c, trigger, event); err != nil {
-			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
-		}
-		validate(tc.name, fakeProwJobClient.Fake.Actions(), g, tc, t)
-		if err := handleGenericComment(c, trigger, event); err != nil {
-			t.Fatalf("%s: didn't expect error: %s", tc.name, err)
-		}
-		validate(tc.name, fakeProwJobClient.Fake.Actions(), g, tc, t)
+			log.Printf("running case %s", tc.name)
+			// In some cases handleGenericComment can be called twice for the same event.
+			// For instance on Issue/PR creation and modification.
+			// Let's call it twice to ensure idempotency.
+			if err := handleGenericComment(c, trigger, event); err != nil {
+				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
+			}
+			validate(t, fakeProwJobClient.Fake.Actions(), g, tc)
+			if err := handleGenericComment(c, trigger, event); err != nil {
+				t.Fatalf("%s: didn't expect error: %s", tc.name, err)
+			}
+			validate(t, fakeProwJobClient.Fake.Actions(), g, tc)
+		})
 	}
 }
 
-func validate(name string, actions []clienttesting.Action, g *fakegithub.FakeClient, tc testcase, t *testing.T) {
+func validate(t *testing.T, actions []clienttesting.Action, g *fakegithub.FakeClient, tc testcase) {
 	startedContexts := sets.NewString()
 	for _, action := range actions {
 		switch action := action.(type) {
@@ -988,26 +990,26 @@ func validate(name string, actions []clienttesting.Action, g *fakegithub.FakeCli
 		t.Errorf("Not built but should have: %+v", tc)
 	}
 	if tc.StartsExactly != "" && (startedContexts.Len() != 1 || !startedContexts.Has(tc.StartsExactly)) {
-		t.Errorf("Didn't build expected context %v, instead built %v", tc.StartsExactly, startedContexts)
+		t.Errorf("didn't build expected context %v, instead built %v", tc.StartsExactly, startedContexts)
 	}
 	if tc.ShouldReport && len(g.CreatedStatuses) == 0 {
-		t.Errorf("%s: Expected report to github", name)
+		t.Error("expected report to github")
 	} else if !tc.ShouldReport && len(g.CreatedStatuses) > 0 {
-		t.Errorf("%s: Expected no reports to github, but got %d: %v", name, len(g.CreatedStatuses), g.CreatedStatuses)
+		t.Errorf("expected no reports to github, but got %d: %v", len(g.CreatedStatuses), g.CreatedStatuses)
 	}
 	if !reflect.DeepEqual(g.IssueLabelsAdded, tc.AddedLabels) {
-		t.Errorf("%s: expected %q to be added, got %q", name, tc.AddedLabels, g.IssueLabelsAdded)
+		t.Errorf("expected %q to be added, got %q", tc.AddedLabels, g.IssueLabelsAdded)
 	}
 	if !reflect.DeepEqual(g.IssueLabelsRemoved, tc.RemovedLabels) {
-		t.Errorf("%s: expected %q to be removed, got %q", name, tc.RemovedLabels, g.IssueLabelsRemoved)
+		t.Errorf("expected %q to be removed, got %q", tc.RemovedLabels, g.IssueLabelsRemoved)
 	}
 	if tc.AddedComment != "" {
 		if len(g.IssueComments[0]) == 0 {
-			t.Errorf("%s: expected the comments to contain %s, got no comments", name, tc.AddedComment)
+			t.Errorf("expected the comments to contain %s, got no comments", tc.AddedComment)
 		}
 		for _, c := range g.IssueComments[0] {
 			if !strings.Contains(c.Body, tc.AddedComment) {
-				t.Errorf("%s: expected the comment to contain %s, got %s", name, tc.AddedComment, c.Body)
+				t.Errorf("expected the comment to contain %s, got %s", tc.AddedComment, c.Body)
 			}
 		}
 	}

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -68,8 +68,8 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Examples:    []string{"/ok-to-test"},
 	})
 	pluginHelp.AddCommand(pluginhelp.Command{
-		Usage:       "/test (<job name>|all)",
-		Description: "Manually starts a/all test job(s).",
+		Usage:       "/test [<job name>|all]",
+		Description: "Manually starts a/all test job(s). Lists all possible job(s) when no jobs/an invalid job are specified.",
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
 		Examples:    []string{"/test all", "/test pull-bazel-test"},
@@ -80,6 +80,13 @@ func helpProvider(config *plugins.Configuration, enabledRepos []config.OrgRepo) 
 		Featured:    true,
 		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
 		Examples:    []string{"/retest"},
+	})
+	pluginHelp.AddCommand(pluginhelp.Command{
+		Usage:       "/test ?",
+		Description: "List available test job(s) for a trusted PR.",
+		Featured:    true,
+		WhoCanUse:   "Anyone can trigger this command on a trusted PR.",
+		Examples:    []string{"/test ?"},
 	})
 	return pluginHelp, nil
 }


### PR DESCRIPTION
The command `/test ?` or `/test -ls` results in a response comment from the `trigger` plugin listing all available tests for a PR. Closes #16765