### PR TITLE
kubekins-e2e: set K8S_RELEASE as stable-1.18

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -15,7 +15,7 @@ variants:
   '1.18':
     CONFIG: '1.18'
     GO_VERSION: 1.13.8
-    K8S_RELEASE: latest-1.18
+    K8S_RELEASE: stable-1.18
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.17':


### PR DESCRIPTION
- set K8S_RELEASE as stable-1.18

/hold until 1.18.0 is out


/sig release
/area release-eng

cc: @kubernetes/release-engineering @kubernetes/sig-release-admins
/assign @spiffxp @cblecker @justaugustus 