### PR TITLE
Add CAPO conformance tests to CAPO testgrid

### DIFF
--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -40,6 +40,9 @@ dashboards:
 - name: sig-cluster-lifecycle-cluster-api-provider-ibmcloud
 - name: sig-cluster-lifecycle-cluster-api-provider-vsphere
 - name: sig-cluster-lifecycle-cluster-api-provider-openstack
+  dashboard_tab:
+    - name: capo-conformance-stable-k8s-master
+      test_group_name: ci-cluster-api-provider-openstack-make-conformance-stable-k8s-ci-artifacts
 - name: sig-cluster-lifecycle-cluster-api-bootstrap-provider-kubeadm
 - name: sig-cluster-lifecycle-cluster-api-provider-docker
 - name: sig-cluster-lifecycle-kops
@@ -57,3 +60,5 @@ test_groups:
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm64
 - name: periodic-multi-platform-kubeadm-packet-arm64
   gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-packet-arm64
+- name: ci-cluster-api-provider-openstack-make-conformance-stable-k8s-ci-artifacts
+  gcs_prefix: k8s-conform-capi-openstack/periodic-logs/ci-cluster-api-provider-openstack-stable-acceptance-test-master


### PR DESCRIPTION
See: https://github.com/kubernetes/sig-release/issues/829

Logs from: https://console.cloud.google.com/storage/browser/k8s-conform-capi-openstack/ should be used