### PR TITLE
Publishing several arm64 ci test results into upstream

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -613,6 +613,8 @@ test_groups:
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-integration
 - name: arm64-conformance-stable
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-stable
+- name: arm64-nodeconformance
+  gcs_prefix: k8s-conformance-arm/logs/ci-k8s-nodeconformance-arm64
 - name: arm64-conformance-aws-cluster
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-aws-cluster
 - name: arm64-conformance-aws-cluster-1-13-2

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -605,6 +605,8 @@ test_groups:
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-kind-arm64
 - name: arm64-conformance-containerd
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-containerd
+- name: arm64-conformance-flannel-network
+  gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-flannel
 - name: arm64-integration
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-integration
 - name: arm64-conformance-stable

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -607,6 +607,8 @@ test_groups:
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-containerd
 - name: arm64-conformance-flannel-network
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-flannel
+- name: arm64-conformance-calico-network
+  gcs_prefix: k8s-conformance-arm/logs/ci-k8s-conformance-arm64-calico
 - name: arm64-integration
   gcs_prefix: k8s-conformance-arm/logs/ci-k8s-integration
 - name: arm64-conformance-stable

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -64,6 +64,9 @@ dashboards:
     - name: conformance-flannel
       test_group_name: arm64-conformance-flannel-network
       description: Runs conformance test by using kubetest against latest version of kubernetes on arm64 with flannel network
+    - name: conformance-calico
+      test_group_name: arm64-conformance-calico-network
+      description: Runs conformance test by using kubetest against latest version of kubernetes on arm64 with calico network
     - name: kind, master (dev, ARM64)
       description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster on ARM64 platform
       test_group_name: arm64-kind-master

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -76,6 +76,9 @@ dashboards:
     - name: integration-tests
       test_group_name: arm64-integration
       description: Integration test results for Arm64
+    - name: nodeconformance
+      test_group_name: arm64-nodeconformance
+      description: Runs NodeConformance test by using kubetest against latest version of kubernetes on arm64
 
   #Docker node conformance dashboard
 - name: sig-node-docker

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -61,6 +61,9 @@ dashboards:
     - name: conformance
       test_group_name: arm64-conformance
       description: Runs conformance test by using kubetest against latest version of kubernetes on arm64
+    - name: conformance-flannel
+      test_group_name: arm64-conformance-flannel-network
+      description: Runs conformance test by using kubetest against latest version of kubernetes on arm64 with flannel network
     - name: kind, master (dev, ARM64)
       description: Runs conformance tests using kubetest against latest kubernetes master with a kubernetes-in-docker cluster on ARM64 platform
       test_group_name: arm64-kind-master


### PR DESCRIPTION
Publish following test result on ARM64:
- k8s conformance test under flannel network
- k8s conformance test under calico network
- k8s NodeConformance test