### PR TITLE
Allow report templates to be configured as per org or repo.

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -100,19 +100,18 @@ func TestReportTemplate(t *testing.T) {
 	}
 	for _, tc := range testcases {
 		var b bytes.Buffer
-		if err := c.Plank.ReportTemplate.Execute(&b, &prowapi.ProwJob{
-			Spec: prowapi.ProwJobSpec{
-				Refs: &prowapi.Refs{
-					Org:  tc.org,
-					Repo: tc.repo,
-					Pulls: []prowapi.Pull{
-						{
-							Number: tc.number,
-						},
-					},
+		refs := &prowapi.Refs{
+			Org:  tc.org,
+			Repo: tc.repo,
+			Pulls: []prowapi.Pull{
+				{
+					Number: tc.number,
 				},
 			},
-		}); err != nil {
+		}
+
+		reportTemplate := c.Plank.ReportTemplateForRepo(refs)
+		if err := reportTemplate.Execute(&b, &prowapi.ProwJob{Spec: prowapi.ProwJobSpec{Refs: refs}}); err != nil {
 			t.Errorf("Error executing template: %v", err)
 			continue
 		}

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -1,9 +1,13 @@
 # Announcements
 
 New features added to each component:
+ - *March 25, 2020* Added a `report_templates` option to the Plank config that allows
+    to specify different report templates for each organization or a specific repository.
+    The `report_template` option is deprecated and it will be removed on *September 2020*
+    which is going to be replaced with the `*` value in `report_templates`.
  - *January 03, 2020* Added a `pr_status_base_urls` option to the Tide config
    that allows to specify different tide's URL for each organization or a specific repository.
-   The `pr_status_base_url` will be deprecated on *June 2020* and it will be replaces with the
+   The `pr_status_base_url` will be deprecated on *June 2020* and it will be replaced with the
    `*` value in `pr_status_base_urls`.
  - *November 05, 2019* The `config-updater` plugin supports update configs on build clusters
     by using [`clusters`](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/updateconfig#usage).

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -26,7 +26,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/github/report"
@@ -147,7 +147,7 @@ func (c *Client) Report(pj *v1.ProwJob) ([]*v1.ProwJob, error) {
 	}
 
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter
-	return []*v1.ProwJob{pj}, report.Report(c.gc, c.config().Plank.ReportTemplate, *pj, c.config().GitHubReporter.JobTypesToReport)
+	return []*v1.ProwJob{pj}, report.Report(c.gc, c.config().Plank.ReportTemplateForRepo(pj.Spec.Refs), *pj, c.config().GitHubReporter.JobTypesToReport)
 }
 
 func lockKeyForPJ(pj *v1.ProwJob) (*simplePull, error) {

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -167,7 +167,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 	}
 
 	jenkinsConfig := s.configAgent.Config().JenkinsOperators
-	kubeReport := s.configAgent.Config().Plank.ReportTemplate
+	kubeReport := s.configAgent.Config().Plank.ReportTemplateForRepo(&prowapi.Refs{Org: org, Repo: repo})
 	reportTypes := s.configAgent.Config().GitHubReporter.JobTypesToReport
 	for _, pj := range pjutil.GetLatestProwJobs(presubmits, prowapi.PresubmitJob) {
 		var reportTemplate *template.Template
@@ -192,7 +192,7 @@ func (s *server) handleIssueComment(l *logrus.Entry, ic github.IssueCommentEvent
 func (s *server) reportForProwJob(pj prowapi.ProwJob, configs []config.JenkinsOperator) *template.Template {
 	for _, cfg := range configs {
 		if cfg.LabelSelector.Matches(labels.Set(pj.Labels)) {
-			return cfg.ReportTemplate
+			return cfg.ReportTemplateForRepo(pj.Spec.Refs)
 		}
 	}
 	return nil

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -222,9 +222,10 @@ func (c *Controller) Sync() error {
 
 	var reportErrs []error
 	if !c.skipReport {
-		reportTemplate := c.config().ReportTemplate
 		reportTypes := c.cfg().GitHubReporter.JobTypesToReport
+		jConfig := c.config()
 		for report := range reportCh {
+			reportTemplate := jConfig.ReportTemplateForRepo(report.Spec.Refs)
 			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -294,9 +294,9 @@ func (c *Controller) Sync() error {
 
 	var reportErrs []error
 	if !c.skipReport {
-		reportTemplate := c.config().Plank.ReportTemplate
 		reportTypes := c.config().GitHubReporter.JobTypesToReport
 		for report := range reportCh {
+			reportTemplate := c.config().Plank.ReportTemplateForRepo(report.Spec.Refs)
 			if err := reportlib.Report(c.ghc, reportTemplate, report, reportTypes); err != nil {
 				reportErrs = append(reportErrs, err)
 				c.log.WithFields(pjutil.ProwJobFields(&report)).WithError(err).Warn("Failed to report ProwJob status")


### PR DESCRIPTION
Adds a new field `report_templates` that allows having different report templates for each organization or repository.

Since the same logic has already been used for `pr_status_base_urls` and `default_decoration_configs`, so it makes sense to have different values in the report template configuration.

/cc @stevekuznetsov @alvaroaleman @petr-muller 