### PR TITLE
ci-k8sio-cip: rename k8s-artifacts-prod service account

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1153,8 +1153,8 @@ periodics:
     base_ref: master
   spec:
     # The k8s-artifacts-prod name was chosen in
-    # https://github.com/kubernetes/k8s.io/pull/655.
-    serviceAccountName: k8s-artifacts-prod
+    # https://github.com/kubernetes/k8s.io/pull/695.
+    serviceAccountName: k8s-infra-gcr-promoter
     containers:
     # TODO: Move the official cip image to a more serious location.
     #

--- a/prow/cluster/trusted_serviceaccounts.yaml
+++ b/prow/cluster/trusted_serviceaccounts.yaml
@@ -36,7 +36,7 @@ apiVersion: v1
 metadata:
   annotations:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com
-  name: k8s-artifacts-prod
+  name: k8s-infra-gcr-promoter
   namespace: test-pods
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above


### PR DESCRIPTION
This is a follow-up to https://github.com/kubernetes/k8s.io/pull/695,
which renamed the expected service account name.

/cc @fejta @thockin