### PR TITLE
Migrate to rerun_auth_configs

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -62,8 +62,9 @@ deck:
   hidden_repos:
   - kubernetes-security
   google_analytics: UA-82843984-5
-  rerun_auth_config:
-    github_team_ids:
+  rerun_auth_configs:
+    '*':
+      github_team_ids:
       - 2009231 # test-infra-admins
 
 prowjob_namespace: default


### PR DESCRIPTION
Migrate to `rerun_auth_configs`. Afterwards, repo owners to tune perms as desired.