### PR TITLE
Removing gce-windows-2019-1.18 job from 1.18 release informing dashboard

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -463,7 +463,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.18-informing
+    testgrid-dashboards: google-windows, sig-windows
     testgrid-tab-name: gce-windows-2019-1.18
   decorate: true
   extra_refs:


### PR DESCRIPTION
Removing gce-windows-2019-1.18 job from 1.18 release informing dashboard.

This job is currently giving a noisy signal due to issues with 1909 windows test images and  those issues are not considered release blocking.