### PR TITLE
releng: Update 1.16 variant (kubekins, krte) to use go1.13.9

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -26,7 +26,7 @@ variants:
     OLD_BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.13.8
+    GO_VERSION: 1.13.9
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/16921 adding the 1.16 bump now that the branch has been [updated to 1.13.9](https://github.com/kubernetes/kubernetes/pull/89400).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @Katharine @spiffxp 
cc: @kubernetes/release-engineering 

ref: https://github.com/kubernetes/release/issues/1134