### PR TITLE
[Scalability][Experimental tests] Remove Chaos Monkey

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -169,7 +169,6 @@ periodics:
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
@@ -225,7 +224,6 @@ periodics:
           - --test-cmd-args=--provider=gce
           - --test-cmd-args=--report-dir=/workspace/_artifacts
           - --test-cmd-args=--testconfig=testing/load/experimental-config.yaml
-          - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
@@ -284,7 +282,6 @@ periodics:
           - --test-cmd-args=--provider=gce
           - --test-cmd-args=--report-dir=/workspace/_artifacts
           - --test-cmd-args=--testconfig=testing/load/experimental-config.yaml
-          - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
@@ -347,7 +344,6 @@ periodics:
           - --test-cmd-args=--testconfig=testing/density/config.yaml
           - --test-cmd-args=--testconfig=testing/load/config.yaml
           - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-          - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
           - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml


### PR DESCRIPTION
Chaos Monkey stretches experiments too much. It should be disabled until K8s will be able to survive this.

/sig scalability
