### PR TITLE
Use release/stable for Kops master pre-submit e2e

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -82,9 +82,9 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable.txt
         - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-        - --extract=release/latest
+        - --extract=release/stable
         - --ginkgo-parallel
         - --kops-build
         - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64


### PR DESCRIPTION
Kops pre-submit e2e is failing because of https://github.com/kubernetes/kops/pull/8783. Until it is merged we need to use the release/stable marker.

/cc @rifelpet 