### PR TITLE
Azure: point csi-driver repo to master branch

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.15-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.15-windows.yaml
@@ -15,9 +15,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
@@ -72,9 +72,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azurefile-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
@@ -15,9 +15,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
@@ -72,9 +72,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azurefile-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
@@ -15,9 +15,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
@@ -72,9 +72,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azurefile-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -15,9 +15,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
@@ -73,9 +73,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azurefile-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
@@ -133,9 +133,9 @@ periodics:
     repo: kubernetes
     base_ref: release-1.18
     path_alias: k8s.io/kubernetes
-  - org: chewong # TODO(chewong): Change to kubernetes-sigs
+  - org: kubernetes-sigs
     repo: azuredisk-csi-driver
-    base_ref: windows-e2e # TODO(chewong): Change to master
+    base_ref: master
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
@@ -195,9 +195,9 @@ periodics:
     repo: kubernetes
     base_ref: release-1.18
     path_alias: k8s.io/kubernetes
-  - org: chewong # TODO(chewong): Change to kubernetes-sigs
+  - org: kubernetes-sigs
     repo: azurefile-csi-driver
-    base_ref: windows-e2e # TODO(chewong): Change to master
+    base_ref: master
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -83,9 +83,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azuredisk-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
@@ -145,9 +145,9 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
-    - org: chewong # TODO(chewong): Change to kubernetes-sigs
+    - org: kubernetes-sigs
       repo: azurefile-csi-driver
-      base_ref: windows-e2e # TODO(chewong): Change to master
+      base_ref: master
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:


### PR DESCRIPTION
With https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/320 and https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/215 merged, we should point the csi-driver repo back to the master branch.

/assign @marosset 