### PR TITLE
backfill missing reviewers from approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- fejta # lead
+- spiffxp # lead
+- stevekuznetsov # lead
+- test-infra-oncall # oncall
 approvers:
 - fejta # lead
 - spiffxp # lead

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -205,3 +205,13 @@ aliases:
     - frapposelli
 ## END CUSTOM CONTENT
 
+  # copied from sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
+  cluster-api-admins:
+    - detiber
+    - justinsb
+    - davidewatson
+    - vincepri
+  cluster-api-vsphere-maintainers:
+    - frapposelli
+    - yastij
+    - randomvariable

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -96,7 +96,6 @@ aliases:
     - spiffxp
     - stevekuznetsov
   sig-ui-leads:
-    - danielromlein
     - floreks
     - jeefy
     - maciaszczykm
@@ -123,7 +122,6 @@ aliases:
     - cantbewong
     - cindyxing
     - dejanb
-    - ptone
   wg-k8s-infra-leads:
     - bartsmykla
     - dims

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,7 +8,200 @@ aliases:
   - Katharine
   - michelle192837
 
+  # copied from git.k8s.io/community/OWNERS_ALIASES
+  sig-api-machinery-leads:
+    - deads2k
+    - fedebongio
+    - lavalamp
+  sig-apps-leads:
+    - janetkuo
+    - kow3ns
+    - mattfarina
+    - prydonius
+  sig-architecture-leads:
+    - derekwaynecarr
+    - dims
+    - johnbelamaric
+  sig-auth-leads:
+    - deads2k
+    - enj
+    - liggitt
+    - mikedanese
+    - tallclair
+  sig-autoscaling-leads:
+    - mwielgus
+  sig-cli-leads:
+    - pwittrock
+    - seans3
+    - soltysh
+  sig-cloud-provider-leads:
+    - andrewsykim
+    - cheftako
+  sig-cluster-lifecycle-leads:
+    - fabriziopandini
+    - justinsb
+    - neolit123
+    - timothysc
+  sig-contributor-experience-leads:
+    - Phillels
+    - cblecker
+    - mrbobbytables
+    - nikhita
+  sig-docs-leads:
+    - jimangel
+    - kbarnard10
+    - kbhawkey
+    - sftim
+    - zacharysarah
+  sig-instrumentation-leads:
+    - brancz
+    - ehashman
+    - logicalhan
+  sig-multicluster-leads:
+    - pmorie
+    - quinton-hoole
+  sig-network-leads:
+    - caseydavenport
+    - dcbw
+    - thockin
+  sig-node-leads:
+    - dchen1107
+    - derekwaynecarr
+  sig-pm-leads:
+    - calebamiles
+    - jdumars
+    - justaugustus
+    - lachie83
+  sig-release-leads:
+    - calebamiles
+    - justaugustus
+    - tpepper
   sig-scalability-leads:
-  - mm4tt
-  - shyamjvs
-  - wojtek-t
+    - mm4tt
+    - shyamjvs
+    - wojtek-t
+  sig-scheduling-leads:
+    - Huang-Wei
+    - ahg-g
+  sig-service-catalog-leads:
+    - jberkhahn
+    - mszostok
+  sig-storage-leads:
+    - jsafrane
+    - msau42
+    - saad-ali
+    - xing-yang
+  sig-testing-leads:
+    - fejta
+    - spiffxp
+    - stevekuznetsov
+  sig-ui-leads:
+    - danielromlein
+    - floreks
+    - jeefy
+    - maciaszczykm
+  sig-usability-leads:
+    - Rajakavitha1
+    - hpandeycodeit
+    - tashimi
+    - vllry
+  sig-windows-leads:
+    - benmoss
+    - ddebroy
+    - marosset
+    - michmike
+  wg-apply-leads:
+    - lavalamp
+  wg-component-standard-leads:
+    - mtaufen
+    - stealthybox
+    - sttts
+  wg-data-protection-leads:
+    - xing-yang
+    - yuxiangqian
+  wg-iot-edge-leads:
+    - cantbewong
+    - cindyxing
+    - dejanb
+    - ptone
+  wg-k8s-infra-leads:
+    - bartsmykla
+    - dims
+    - spiffxp
+  wg-lts-leads:
+    - imkin
+    - quinton-hoole
+    - tpepper
+    - youngnick
+  wg-machine-learning-leads:
+    - k82cn
+    - kow3ns
+    - vishh
+  wg-multitenancy-leads:
+    - srampal
+    - tashimi
+  wg-policy-leads:
+    - ericavonb
+    - hannibalhuang
+  wg-resource-management-leads:
+    - derekwaynecarr
+    - vishh
+  wg-security-audit-leads:
+    - aasmall
+    - cji
+    - jaybeale
+    - joelsmith
+  ug-big-data-leads:
+    - erikerlandson
+    - foxish
+    - liyinan926
+  ug-vmware-users-leads:
+    - brysonshepherd
+    - cantbewong
+    - mylesagray
+    - phenixblue
+  committee-code-of-conduct:
+    - AevaOnline
+    - Bradamant3
+    - carolynvs
+    - jdumars
+    - tashimi
+  committee-product-security:
+    - cjcullen
+    - joelsmith
+    - jonpulsifer
+    - liggitt
+    - lukehinds
+    - philips
+    - tallclair
+  committee-steering:
+    - cblecker
+    - derekwaynecarr
+    - dims
+    - nikhita
+    - parispittman
+    - spiffxp
+    - timothysc
+## BEGIN CUSTOM CONTENT
+  provider-aws:
+    - d-nishi
+    - justinsb
+    - kris-nova
+  provider-azure:
+    - craiglpeters
+    - justaugustus
+    - feiskyer
+    - khenidak
+  provider-gcp:
+    - abgworrall
+  provider-ibmcloud:
+    - spzala
+  provider-openstack:
+    - chrigl
+    - lingxiankong
+    - ramineni
+  provider-vmware:
+    - cantbewong
+    - frapposelli
+## END CUSTOM CONTENT
+

--- a/boskos/aws-janitor/OWNERS
+++ b/boskos/aws-janitor/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- liztio
+- justinsb
+- detiber
 approvers:
 - liztio
 - justinsb

--- a/config/OWNERS
+++ b/config/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cblecker
+- krzyzacy
+- spiffxp
+- wojtek-t
+- chases2
 approvers:
 - cblecker
 - krzyzacy

--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/OWNERS
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- nikhiljindal
 approvers:
 - nikhiljindal

--- a/config/jobs/apache-spark-on-k8s/spark-integration/OWNERS
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- foxish
 approvers:
 - foxish

--- a/config/jobs/bazelbuild/rules_k8s/OWNERS
+++ b/config/jobs/bazelbuild/rules_k8s/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- fejta
 approvers:
 - fejta

--- a/config/jobs/cadvisor/OWNERS
+++ b/config/jobs/cadvisor/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- dashpole
 approvers:
 - dashpole

--- a/config/jobs/containerd/cri/OWNERS
+++ b/config/jobs/containerd/cri/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- yujuhong
+- Random-Liu
+- dchen1107
 approvers:
 - yujuhong
 - Random-Liu

--- a/config/jobs/gke/containerd/OWNERS
+++ b/config/jobs/gke/containerd/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Random-Liu
+- yujuhong
 approvers:
 - Random-Liu
 - yujuhong

--- a/config/jobs/helm/charts/OWNERS
+++ b/config/jobs/helm/charts/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- foxish
+- mattfarina
+- prydonius
+- unguiculus
+- viglesiasce
 approvers:
 - foxish
 - mattfarina

--- a/config/jobs/kubeflow/OWNERS
+++ b/config/jobs/kubeflow/OWNERS
@@ -1,14 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- abhi-g
 - jlewi
-- kunmingg
-- lluunn
-- richardsliu
+- clarketm
 approvers:
-- abhi-g
 - jlewi
-- kunmingg
-- lluunn
-- richardsliu
+- clarketm

--- a/config/jobs/kubeflow/OWNERS
+++ b/config/jobs/kubeflow/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- abhi-g
+- jlewi
+- kunmingg
+- lluunn
+- richardsliu
 approvers:
 - abhi-g
 - jlewi

--- a/config/jobs/kubernetes-csi/OWNERS
+++ b/config/jobs/kubernetes-csi/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- msau42
+- saad-ali
 approvers:
 - msau42
 - saad-ali

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- fredkan
+- xianlubird
+- haoshuwei
 approvers:
 - fredkan
 - xianlubird

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/OWNERS
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+  - cheftako
+  - mcrute
+  - anfernee
+  - andrewsykim
 approvers:
   - cheftako
   - mcrute

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bigkraig
+- M00nF1sh
+- gyuho
 approvers:
 - bigkraig
 - M00nF1sh

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- leakingtapan
+- gyuho
+- bertinatto
 approvers:
 - leakingtapan
 - gyuho

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- leakingtapan
+- gyuho
+- bertinatto
+- wongma7
 approvers:
 - leakingtapan
 - gyuho

--- a/config/jobs/kubernetes-sigs/aws-encryption-provider/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-encryption-provider/OWNERS
@@ -1,3 +1,8 @@
+reviewers:
+- micahhausler
+- sethpollack
+- justinsb
+- gyuho
 approvers:
 - micahhausler
 - sethpollack

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- leakingtapan
+- gyuho
+- bertinatto
+- wongma7
 approvers:
 - leakingtapan
 - gyuho

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andyzhangx
+- feiskyer
+- chewong
 approvers:
 - andyzhangx
 - feiskyer

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andyzhangx
+- feiskyer
+- chewong
 approvers:
 - andyzhangx
 - feiskyer

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andyzhangx
+- feiskyer
+- chewong
 approvers:
 - andyzhangx
 - feiskyer

--- a/config/jobs/kubernetes-sigs/cli-utils/OWNERS
+++ b/config/jobs/kubernetes-sigs/cli-utils/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- liujingfang1
+- monopole
+- mortent
+- pwittrock
+- seans3
 approvers:
 - liujingfang1
 - monopole

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/OWNERS
@@ -1,5 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andyzhangx
+- brendandburns
+- feiskyer
+- justaugustus
+- karataliu
+- khenidak
+- chewong
 approvers:
 - andyzhangx
 - brendandburns

--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/OWNERS
@@ -1,4 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+- chuckha
+- detiber
+- justinsb
+- vincepri
 approvers:
 - chuckha
 - detiber

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/OWNERS
@@ -1,5 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- chuckha
+- davidewatson
+- detiber
+- d-nishi
+- enxebre
+- ingvagabund
+- kris-nova
+- luxas
+- randomvariable
+- timothysc
+- vincepri
 approvers:
 - chuckha
 - davidewatson

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- xmudrii
 approvers:
 - xmudrii

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/OWNERS
@@ -1,4 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+- chuckha
+- detiber
+- justinsb
+- vincepri
 approvers:
 - chuckha
 - detiber

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- detiber
+- maisem
+- krousey
+- justinsb
+- vincepri
 approvers:
 - detiber
 - maisem

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- gyliu513
+- jichenjc
+- morvencao
+- xunpan
 approvers:
 - gyliu513
 - jichenjc

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-ibmcloud/OWNERS
@@ -3,10 +3,10 @@
 reviwers:
 - gyliu513
 - jichenjc
-- morvencao
-- xunpan
+# - morvencao # TODO: kubernetes-sigs member, must join kubernetes org
+# - xunpan # TODO: kubernetes-sigs member, must join kubernetes org
 approvers:
 - gyliu513
 - jichenjc
-- morvencao
-- xunpan
+# - morvencao # TODO: kubernetes-sigs member, must join kubernetes org
+# - xunpan # TODO: kubernetes-sigs member, must join kubernetes org

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- flaper87
+- Lion-Wei
+- chaosaffe
+- m1093782566
+- dims
 approvers:
 - flaper87
 - Lion-Wei

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+  - sig-cluster-lifecycle-leads
+  - sig-vmware-leads
+  - cluster-api-admins
+  - cluster-api-vsphere-maintainers
+  - figo
+  - akutz
 approvers:
   - sig-cluster-lifecycle-leads
   - sig-vmware-leads

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/OWNERS
@@ -2,14 +2,14 @@
 
 reviwers:
   - sig-cluster-lifecycle-leads
-  - sig-vmware-leads
+  - provider-vmware
   - cluster-api-admins
   - cluster-api-vsphere-maintainers
   - figo
   - akutz
 approvers:
   - sig-cluster-lifecycle-leads
-  - sig-vmware-leads
+  - provider-vmware
   - cluster-api-admins
   - cluster-api-vsphere-maintainers
   - figo

--- a/config/jobs/kubernetes-sigs/cluster-api/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- davidewatson
+- detiber
+- justinsb
+- luxas
+- timothysc
+- vincepri
 approvers:
 - davidewatson
 - detiber

--- a/config/jobs/kubernetes-sigs/controller-runtime/OWNERS
+++ b/config/jobs/kubernetes-sigs/controller-runtime/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+reviewers:
+  - directxman12
+  - pwittrock
 approvers:
   - directxman12
   - pwittrock

--- a/config/jobs/kubernetes-sigs/etcdadm/OWNERS
+++ b/config/jobs/kubernetes-sigs/etcdadm/OWNERS
@@ -1,4 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
+reviewers:
+- dlipovetsky
+- justinsb
 approvers:
 - dlipovetsky
 - justinsb

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- davidz627
+- msau42
+- saad-ali
 approvers:
 - davidz627
 - msau42

--- a/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/gcp-filestore-csi-driver/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- davidz627
+- msau42
+- saad-ali
 approvers:
 - davidz627
 - msau42

--- a/config/jobs/kubernetes-sigs/kind/OWNERS
+++ b/config/jobs/kubernetes-sigs/kind/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bentheelder
+- munnerz
+- neolit123
 approvers:
 - bentheelder
 - munnerz

--- a/config/jobs/kubernetes-sigs/kube-batch/OWNERS
+++ b/config/jobs/kubernetes-sigs/kube-batch/OWNERS
@@ -2,11 +2,11 @@
 
 reviewers:
 - k82cn
-- animeshsingh
+# - animeshsingh # TODO: kubernetes-sigs member, must join kubernetes org
 - hex108
 - hzxuzhonghu
 approvers:
 - k82cn
-- animeshsingh
+# - animeshsingh # TODO: kubernetes-sigs member, must join kubernetes org
 - hex108
 - hzxuzhonghu

--- a/config/jobs/kubernetes-sigs/kube-batch/OWNERS
+++ b/config/jobs/kubernetes-sigs/kube-batch/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- k82cn
+- animeshsingh
+- hex108
+- hzxuzhonghu
 approvers:
 - k82cn
 - animeshsingh

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/OWNERS
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- caesarxuchao
+- deads2k
+- lavalamp
 approvers:
 - caesarxuchao
 - deads2k

--- a/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
@@ -1,4 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
+reviwers:
+  - directxman12
+  - mengqiy
+  - pwittrock
 approvers:
   - directxman12
   - mengqiy

--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -1,5 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- ant31
+- mattymo
+- atoms
+- chadswen
+- mirwan
+- riverzhang
+- verwilst
+- woopstar
 approvers:
 - ant31
 - mattymo

--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -7,7 +7,6 @@ reviewers:
 - chadswen
 - mirwan
 - riverzhang
-- verwilst
 - woopstar
 approvers:
 - ant31
@@ -16,5 +15,4 @@ approvers:
 - chadswen
 - mirwan
 - riverzhang
-- verwilst
 - woopstar

--- a/config/jobs/kubernetes-sigs/kustomize/OWNERS
+++ b/config/jobs/kubernetes-sigs/kustomize/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- liujingfang1
+- monopole
+- mortent
+- pwittrock
+- seans3
 approvers:
 - liujingfang1
 - monopole

--- a/config/jobs/kubernetes-sigs/poseidon/OWNERS
+++ b/config/jobs/kubernetes-sigs/poseidon/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- ICGog
+- ms705
+- shivramsrivastava
+- m1093782566
 approvers:
 - ICGog
 - ms705

--- a/config/jobs/kubernetes-sigs/poseidon/OWNERS
+++ b/config/jobs/kubernetes-sigs/poseidon/OWNERS
@@ -1,12 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviwers:
-- ICGog
-- ms705
-- shivramsrivastava
 - m1093782566
+- sig-scheduling-leads
 approvers:
-- ICGog
-- ms705
-- shivramsrivastava
 - m1093782566
+- sig-scheduling-leads

--- a/config/jobs/kubernetes-sigs/release-notes/OWNERS
+++ b/config/jobs/kubernetes-sigs/release-notes/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+  - jeefy
+  - marpaia
+  - onyiny-ang
+  - sig-release-leads
 approvers:
   - jeefy
   - marpaia

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- aramase
+- ritazh
 approvers:
 - aramase
 - ritazh

--- a/config/jobs/kubernetes-sigs/service-apis/OWNERS
+++ b/config/jobs/kubernetes-sigs/service-apis/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bowei
+- thockin
 approvers:
 - bowei
 - thockin

--- a/config/jobs/kubernetes-sigs/service-catalog/OWNERS
+++ b/config/jobs/kubernetes-sigs/service-catalog/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- jberkhahn
+- MHBauer
+- mszostok
 approvers:
 - jberkhahn
 - MHBauer

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+  - msau42
+  - saad-ali
+  - wongma7
+  - jsafrane
+  - dhirajh
+  - cofyc
 approvers:
   - msau42
   - saad-ali

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/OWNERS
@@ -5,12 +5,10 @@ reviewers:
   - saad-ali
   - wongma7
   - jsafrane
-  - dhirajh
   - cofyc
 approvers:
   - msau42
   - saad-ali
   - wongma7
   - jsafrane
-  - dhirajh
   - cofyc

--- a/config/jobs/kubernetes-sigs/sig-windows/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-windows/OWNERS
@@ -1,5 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- adelina-t
+- andyzhangx
+- bclau
+- benmoss
+- chewong
+- feiskyer
+- marosset
+- PatrickLang
 approvers:
 - adelina-t
 - andyzhangx

--- a/config/jobs/kubernetes-sigs/sig-windows/OWNERS
+++ b/config/jobs/kubernetes-sigs/sig-windows/OWNERS
@@ -3,7 +3,7 @@
 reviewers:
 - adelina-t
 - andyzhangx
-- bclau
+- claudiubelu
 - benmoss
 - chewong
 - feiskyer
@@ -12,7 +12,7 @@ reviewers:
 approvers:
 - adelina-t
 - andyzhangx
-- bclau
+- claudiubelu
 - benmoss
 - chewong
 - feiskyer

--- a/config/jobs/kubernetes-sigs/slack-infra/OWNERS
+++ b/config/jobs/kubernetes-sigs/slack-infra/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
+- jeefy
 approvers:
 - Katharine
 - jeefy

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/OWNERS
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- lavalamp
+- apelisse
+- jennybuckley
 approvers:
 - lavalamp
 - apelisse

--- a/config/jobs/kubernetes-sigs/testing_frameworks/OWNERS
+++ b/config/jobs/kubernetes-sigs/testing_frameworks/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- apelisse
+- hoegaarden
+- totherme
 approvers:
 - apelisse
 - hoegaarden

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- akutz
+- codenrhoden
+- dvonthenen
+- figo
+- frapposelli
 approvers:
 - akutz
 - codenrhoden

--- a/config/jobs/kubernetes/client-go/OWNERS
+++ b/config/jobs/kubernetes/client-go/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- sttts
+- nikhita
 approvers:
 - sttts
 - nikhita

--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- aoxn
+- cheyang
+- xlgao-zju
 approvers:
 - aoxn
 - cheyang

--- a/config/jobs/kubernetes/cloud-provider-aws/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-aws/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mcrute
 approvers:
 - mcrute

--- a/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
@@ -3,8 +3,6 @@
 reviewers:
 - awly
 - mikedanese
-- calebmiles
 approvers:
 - awly
 - mikedanese
-- calebmiles

--- a/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- awly
+- mikedanese
+- calebmiles
 approvers:
 - awly
 - mikedanese

--- a/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- dims
 approvers:
 - dims

--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -1,5 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- abrarshivani
+- baludontu
+- divyenpatel
+- imkin
+- kerneltime
+- luomiao
+- frapposelli
+- dougm
+- figo
+- akutz
+- yastij
 approvers:
 - abrarshivani
 - baludontu

--- a/config/jobs/kubernetes/cluster-registry/OWNERS
+++ b/config/jobs/kubernetes/cluster-registry/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- font
+- madhusudancs
+- perotinus
+- pmorie
 approvers:
 - font
 - madhusudancs

--- a/config/jobs/kubernetes/community/OWNERS
+++ b/config/jobs/kubernetes/community/OWNERS
@@ -1,5 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- calebamiles
+- castrojo
+- cblecker
+- grodrigues3
+- idvoretskyi
+- jdumars
+- parispittman
 approvers:
 - calebamiles
 - castrojo

--- a/config/jobs/kubernetes/generated/OWNERS
+++ b/config/jobs/kubernetes/generated/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- justaugustus
+- Katharine
+- krzyzacy
+- yguo0905
 approvers:
 - justaugustus
 - Katharine

--- a/config/jobs/kubernetes/node-problem-detector/OWNERS
+++ b/config/jobs/kubernetes/node-problem-detector/OWNERS
@@ -1,3 +1,8 @@
+reviewers:
+  - wangzhen127
+  - Random-Liu
+  - andyxning
+  - dchen1107
 approvers:
   - wangzhen127
   - Random-Liu

--- a/config/jobs/kubernetes/org/OWNERS
+++ b/config/jobs/kubernetes/org/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- calebamiles
+- cblecker
+- fejta
+- grodrigues3
+- idvoretskyi
+- spiffxp
 approvers:
 - calebamiles
 - cblecker

--- a/config/jobs/kubernetes/publishing-bot/OWNERS
+++ b/config/jobs/kubernetes/publishing-bot/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- caesarxuchao
+- mfojtik
+- nikhita
+- sttts
 approvers:
 - caesarxuchao
 - mfojtik

--- a/config/jobs/kubernetes/repo-infra/OWNERS
+++ b/config/jobs/kubernetes/repo-infra/OWNERS
@@ -1,3 +1,8 @@
+reviwers:
+- BenTheElder
+- clarketm
+- fejta
+- mikedanese
 approvers:
 - BenTheElder
 - clarketm

--- a/config/jobs/kubernetes/sig-api-machinery/OWNERS
+++ b/config/jobs/kubernetes/sig-api-machinery/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- lavalamp
+- deads2k
 approvers:
 - lavalamp
 - deads2k

--- a/config/jobs/kubernetes/sig-apps/OWNERS
+++ b/config/jobs/kubernetes/sig-apps/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mattfarina
+- prydonius
+- kow3ns
 approvers:
 - mattfarina
 - prydonius

--- a/config/jobs/kubernetes/sig-autoscaling/OWNERS
+++ b/config/jobs/kubernetes/sig-autoscaling/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mwielgus
+- maciekpytel
+- bskiba
 approvers:
 - mwielgus
 - maciekpytel

--- a/config/jobs/kubernetes/sig-cli/OWNERS
+++ b/config/jobs/kubernetes/sig-cli/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- AdoHe
+- pwittrock
+- soltysh
 approvers:
 - AdoHe
 - pwittrock

--- a/config/jobs/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andrewsykim
+- cheftako
+- hogepodge
+- justaugustus
 approvers:
 - andrewsykim
 - cheftako

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- chrislovecnm
+- justinsb
+- shyamjvs
 approvers:
 - chrislovecnm
 - justinsb

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -1,5 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andyzhangx
+- brendandburns
+- feiskyer
+- justaugustus
+- karataliu
+- khenidak
+- chewong
 approvers:
 - andyzhangx
 - brendandburns

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- jiayingz
+- mindprince
+- vishh
+- yguo0905
 approvers:
 - jiayingz
 - mindprince

--- a/config/jobs/kubernetes/sig-instrumentation/OWNERS
+++ b/config/jobs/kubernetes/sig-instrumentation/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- piosz
+- brancz
 approvers:
 - piosz
 - brancz

--- a/config/jobs/kubernetes/sig-network/OWNERS
+++ b/config/jobs/kubernetes/sig-network/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- aojea
+- bowei
+- cadmuxe
+- jingax10
+- mrhohn
+- rramkumar1
 approvers:
 - aojea
 - bowei

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- yujuhong
+- Random-Liu
+- dchen1107
 approvers:
 - yujuhong
 - Random-Liu

--- a/config/jobs/kubernetes/sig-pm/OWNERS
+++ b/config/jobs/kubernetes/sig-pm/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+  - calebamiles # SIG PM Chair
+  - idvoretskyi # SIG PM Chair
+  - jdumars # SIG PM Chair
+  - justaugustus # SIG PM Chair
 approvers:
   - calebamiles # SIG PM Chair
   - idvoretskyi # SIG PM Chair

--- a/config/jobs/kubernetes/sig-release/cip/OWNERS
+++ b/config/jobs/kubernetes/sig-release/cip/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- dims
+- hh
+- listx
+- tpepper
 approvers:
 - dims
 - hh

--- a/config/jobs/kubernetes/sig-scalability/OWNERS
+++ b/config/jobs/kubernetes/sig-scalability/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mborsz
+- mm4tt
+- shyamjvs
+- wojtek-t
+
 approvers:
 - mborsz
 - mm4tt

--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bsalamat
+- k82cn
 approvers:
 - bsalamat
 - k82cn

--- a/config/jobs/kubernetes/sig-storage/OWNERS
+++ b/config/jobs/kubernetes/sig-storage/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- saad-ali
+- msau42
 approvers:
 - saad-ali
 - msau42

--- a/config/jobs/kubernetes/sig-windows/OWNERS
+++ b/config/jobs/kubernetes/sig-windows/OWNERS
@@ -1,3 +1,10 @@
+reviewers:
+- pjh
+- PatrickLang
+- michmike
+- benmoss
+- ddebroy
+- yliaog
 approvers:
 - pjh
 - PatrickLang

--- a/config/jobs/kubernetes/system-validators/OWNERS
+++ b/config/jobs/kubernetes/system-validators/OWNERS
@@ -1,6 +1,13 @@
 # See the OWNERS file documentation:
 #  https://github.com/kubernetes/community/blob/master/contributors/devel/owners.md
 
+reviewers:
+- timothysc
+- fabriziopandini
+- neolit123
+- rosti
+- ereslibre
+- yastij
 approvers:
 - timothysc
 - fabriziopandini

--- a/config/jobs/kubernetes/wg-k8s-infra/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cblecker
+- dims
+- spiffxp
 approvers:
 - cblecker
 - dims

--- a/config/jobs/tensorflow/minigo/OWNERS
+++ b/config/jobs/tensorflow/minigo/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- Kashomon
 approvers:
 - cjwagner
 - Kashomon

--- a/config/testgrids/OWNERS
+++ b/config/testgrids/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
-
+reviewers:
+- michelle192837
+- spiffxp
+- wojtek-t
+- shyamjvs
+- chases2
 approvers:
 - michelle192837
 - spiffxp

--- a/config/testgrids/conformance/OWNERS
+++ b/config/testgrids/conformance/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- spiffxp
+- timothysc
 approvers:
 - spiffxp
 - timothysc

--- a/config/testgrids/conformance/kind/OWNERS
+++ b/config/testgrids/conformance/kind/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bentheelder
+- munnerz
+- neolit123
 approvers:
 - bentheelder
 - munnerz

--- a/config/testgrids/kubeflow/OWNERS
+++ b/config/testgrids/kubeflow/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- jlewi
 approvers:
 - jlewi

--- a/config/testgrids/kubernetes/sig-api-machinery/OWNERS
+++ b/config/testgrids/kubernetes/sig-api-machinery/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- lavalamp
+- deads2k
 approvers:
 - lavalamp
 - deads2k

--- a/config/testgrids/kubernetes/sig-apps/OWNERS
+++ b/config/testgrids/kubernetes/sig-apps/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mattfarina
+- prydonius
+- kow3ns
 approvers:
 - mattfarina
 - prydonius

--- a/config/testgrids/kubernetes/sig-autoscaling/OWNERS
+++ b/config/testgrids/kubernetes/sig-autoscaling/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- mwielgus
+- maciekpytel
+- bskiba
 approvers:
 - mwielgus
 - maciekpytel

--- a/config/testgrids/kubernetes/sig-cli/OWNERS
+++ b/config/testgrids/kubernetes/sig-cli/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- AdoHe
+- pwittrock
+- soltysh
 approvers:
 - AdoHe
 - pwittrock

--- a/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- andrewsykim
+- cheftako
+- hogepodge
+- justaugustus
 approvers:
 - andrewsykim
 - cheftako

--- a/config/testgrids/kubernetes/sig-cloud-provider/aws/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/aws/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- chrislovecnm
+- justinsb
+- shyamjvs
 approvers:
 - chrislovecnm
 - justinsb

--- a/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/azure/OWNERS
@@ -1,5 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- andyzhangx
+- brendandburns
+- feiskyer
+- justaugustus
+- karataliu
+- khenidak
 approvers:
 - andyzhangx
 - brendandburns

--- a/config/testgrids/kubernetes/sig-contribex/OWNERS
+++ b/config/testgrids/kubernetes/sig-contribex/OWNERS
@@ -1,5 +1,13 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- calebamiles
+- castrojo
+- cblecker
+- grodrigues3
+- idvoretskyi
+- jdumars
+- parispittman
 approvers:
 - calebamiles
 - castrojo

--- a/config/testgrids/kubernetes/sig-instrumentation/OWNERS
+++ b/config/testgrids/kubernetes/sig-instrumentation/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- piosz
+- brancz
 approvers:
 - piosz
 - brancz

--- a/config/testgrids/kubernetes/sig-network/OWNERS
+++ b/config/testgrids/kubernetes/sig-network/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- bowei
+- rramkumar1
+- mrhohn
 approvers:
 - bowei
 - rramkumar1

--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- yujuhong
+- Random-Liu
+- dchen1107
 approvers:
 - yujuhong
 - Random-Liu

--- a/config/testgrids/kubernetes/sig-scalability/OWNERS
+++ b/config/testgrids/kubernetes/sig-scalability/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mborsz
+- mm4tt
+- shyamjvs
+- wojtek-t
 approvers:
 - mborsz
 - mm4tt

--- a/config/testgrids/kubernetes/sig-scheduling/OWNERS
+++ b/config/testgrids/kubernetes/sig-scheduling/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bsalamat
+- k82cn
 approvers:
 - bsalamat
 - k82cn

--- a/config/testgrids/kubernetes/sig-storage/OWNERS
+++ b/config/testgrids/kubernetes/sig-storage/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- saad-ali
+- msau42
 approvers:
 - saad-ali
 - msau42

--- a/config/testgrids/kubernetes/sig-testing/OWNERS
+++ b/config/testgrids/kubernetes/sig-testing/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- test-infra-oncall # oncall
+- fejta # lead
+- spiffxp # lead
+- stevekuznetsov # lead
 approvers:
 - test-infra-oncall # oncall
 - fejta # lead

--- a/config/testgrids/kubernetes/wg-multi-tenancy/OWNERS
+++ b/config/testgrids/kubernetes/wg-multi-tenancy/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- rjbez17
+- srampal
+- tashimi
 approvers:
 - rjbez17
 - srampal

--- a/config/testgrids/kyma/OWNERS
+++ b/config/testgrids/kyma/OWNERS
@@ -1,3 +1,7 @@
+reviewers:
+- tehcyx
+- mszostok
+- piotrmiskiewicz
 approvers:
 - tehcyx
 - mszostok

--- a/config/testgrids/openshift/OWNERS
+++ b/config/testgrids/openshift/OWNERS
@@ -1,3 +1,12 @@
+reviewers:
+- stevekuznetsov
+- smarterclayton
+- droslean
+- hongkailiu
+- petr-muller
+- bparees
+- jeefy
+- jeremyeder
 approvers:
 - stevekuznetsov
 - smarterclayton

--- a/docs/OWNERS
+++ b/docs/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cblecker
+- mithrav
+- spiffxp
 approvers:
 - cblecker
 - mithrav

--- a/experiment/logviewer/OWNERS
+++ b/experiment/logviewer/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mborsz
 approvers:
 - mborsz

--- a/experiment/manual-trigger/OWNERS
+++ b/experiment/manual-trigger/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov

--- a/experiment/resultstore/OWNERS
+++ b/experiment/resultstore/OWNERS
@@ -1,2 +1,4 @@
+reviewers:
+- fejta
 approvers:
 - fejta

--- a/experiment/slack-oncall-updater/OWNERS
+++ b/experiment/slack-oncall-updater/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
 approvers:
 - Katharine

--- a/gencred/OWNERS
+++ b/gencred/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- clarketm
+- fejta
 approvers:
 - clarketm
 - fejta

--- a/ghproxy/OWNERS
+++ b/ghproxy/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+  - cjwagner
 approvers:
   - cjwagner
 labels:

--- a/gopherage/OWNERS
+++ b/gopherage/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
+- spiffxp
 approvers:
 - Katharine
 - spiffxp

--- a/greenhouse/OWNERS
+++ b/greenhouse/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- amwat
+- BenTheElder
+- ixdy
 approvers:
 - amwat
 - BenTheElder

--- a/gubernator/OWNERS
+++ b/gubernator/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- ibzib
+- Katharine
+- rmmh
+- stevekuznetsov
 approvers:
 - ibzib
 - Katharine

--- a/jenkins/OWNERS
+++ b/jenkins/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- cjwagner
+- fejta
+- krzyzacy
 approvers:
 - cjwagner
 - fejta

--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -1,5 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Random-Liu
+- yguo0905
+- yujuhong
+- tallclair
+- derekwaynecarr
+- ConnorDoyle
+- klueska
+- dchen1107
 approvers:
 - Random-Liu
 - yguo0905

--- a/kettle/OWNERS
+++ b/kettle/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
+- spiffxp
 approvers:
 - Katharine
 - spiffxp

--- a/kubetest/OWNERS
+++ b/kubetest/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- krzyzacy
+- shyamjvs
+- wojtek-t # For European timezone emergencies.
+- feiskyer
 approvers:
 - krzyzacy
 - shyamjvs

--- a/kubetest2/OWNERS
+++ b/kubetest2/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- BenTheElder
+- krzyzacy
 approvers:
 - BenTheElder
 - krzyzacy

--- a/label_sync/OWNERS
+++ b/label_sync/OWNERS
@@ -6,6 +6,10 @@ filters:
       - cblecker
       - spiffxp
       - fejta
+    reviewers:
+      - cblecker
+      - spiffxp
+      - fejta
     labels:
       - area/label_sync
   "labels\\.yaml":

--- a/logexporter/OWNERS
+++ b/logexporter/OWNERS
@@ -1,5 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- mborsz
+- shyamjvs
+- wojtek-t
+- sig-scalability-leads
 approvers:
 - mborsz
 - shyamjvs

--- a/metrics/OWNERS
+++ b/metrics/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- spiffxp
 approvers:
 - cjwagner
 - spiffxp

--- a/pkg/benchmarkjunit/OWNERS
+++ b/pkg/benchmarkjunit/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- fejta
 approvers:
 - cjwagner
 - fejta

--- a/pkg/genyaml/OWNERS
+++ b/pkg/genyaml/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- clarketm
 approvers:
 - clarketm

--- a/planter/OWNERS
+++ b/planter/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- BenTheElder
+- ixdy
 approvers:
 - BenTheElder
 - ixdy

--- a/prow/bugzilla/OWNERS
+++ b/prow/bugzilla/OWNERS
@@ -1,3 +1,7 @@
+reviewers:
+- stevekuznetsov
+- petr-muller
+- bbguimaraes
 approvers:
 - stevekuznetsov
 - petr-muller

--- a/prow/bugzilla/OWNERS
+++ b/prow/bugzilla/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
 - stevekuznetsov
 - petr-muller
-- bbguimaraes
 approvers:
 - stevekuznetsov
 - petr-muller
-- bbguimaraes

--- a/prow/clonerefs/OWNERS
+++ b/prow/clonerefs/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cluster/OWNERS
+++ b/prow/cluster/OWNERS
@@ -2,6 +2,13 @@
 
 labels:
 - area/prow/bump
+reviewers:
+- amwat
+- cjwagner
+- fejta
+- ixdy
+- katharine
+- krzyzacy
 approvers:
 - amwat
 - cjwagner

--- a/prow/cluster/monitoring/OWNERS
+++ b/prow/cluster/monitoring/OWNERS
@@ -1,3 +1,8 @@
+reviewers:
+  - cblecker
+  - cjwagner
+  - hongkailiu
+  - stevekuznetsov
 approvers:
   - cblecker
   - cjwagner

--- a/prow/cmd/autobump/OWNERS
+++ b/prow/cmd/autobump/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
 approvers:
 - cjwagner

--- a/prow/cmd/checkconfig/OWNERS
+++ b/prow/cmd/checkconfig/OWNERS
@@ -5,3 +5,5 @@ approvers:
 - cjwagner
 reviewers:
 - chases2
+- stevekuznetsov
+- cjwagner

--- a/prow/cmd/clonerefs/OWNERS
+++ b/prow/cmd/clonerefs/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/config-bootstrapper/OWNERS
+++ b/prow/cmd/config-bootstrapper/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/deck/OWNERS
+++ b/prow/cmd/deck/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+ - Katharine
 approvers:
  - Katharine
 labels:

--- a/prow/cmd/entrypoint/OWNERS
+++ b/prow/cmd/entrypoint/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/gcsupload/OWNERS
+++ b/prow/cmd/gcsupload/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/gerrit/OWNERS
+++ b/prow/cmd/gerrit/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- amwat
+- krzyzacy
 approvers:
 - amwat
 - krzyzacy

--- a/prow/cmd/initupload/OWNERS
+++ b/prow/cmd/initupload/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/mkpod/OWNERS
+++ b/prow/cmd/mkpod/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviwers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/sidecar/OWNERS
+++ b/prow/cmd/sidecar/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/cmd/status-reconciler/OWNERS
+++ b/prow/cmd/status-reconciler/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/crier/OWNERS
+++ b/prow/crier/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- krzyzacy
+- katharine
 approvers:
 - krzyzacy
 - katharine

--- a/prow/entrypoint/OWNERS
+++ b/prow/entrypoint/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/external-plugins/cherrypicker/OWNERS
+++ b/prow/external-plugins/cherrypicker/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- kargakis
+- stevekuznetsov
 approvers:
 - kargakis
 - stevekuznetsov

--- a/prow/external-plugins/refresh/OWNERS
+++ b/prow/external-plugins/refresh/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov

--- a/prow/gcsupload/OWNERS
+++ b/prow/gcsupload/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/gerrit/OWNERS
+++ b/prow/gerrit/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- fejta
+- Katharine
 approvers:
 - fejta
 - Katharine

--- a/prow/initupload/OWNERS
+++ b/prow/initupload/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/plugins/bugzilla/OWNERS
+++ b/prow/plugins/bugzilla/OWNERS
@@ -1,3 +1,7 @@
+reviewers:
+- stevekuznetsov
+- petr-muller
+- bbguimaraes
 approvers:
 - stevekuznetsov
 - petr-muller

--- a/prow/plugins/bugzilla/OWNERS
+++ b/prow/plugins/bugzilla/OWNERS
@@ -1,8 +1,6 @@
 reviewers:
 - stevekuznetsov
 - petr-muller
-- bbguimaraes
 approvers:
 - stevekuznetsov
 - petr-muller
-- bbguimaraes

--- a/prow/pod-utils/OWNERS
+++ b/prow/pod-utils/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- stevekuznetsov
 approvers:
 - cjwagner
 - stevekuznetsov

--- a/prow/sidecar/OWNERS
+++ b/prow/sidecar/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/prow/spyglass/OWNERS
+++ b/prow/spyglass/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- paulangton
+- Katharine
 approvers:
 - paulangton
 - Katharine

--- a/prow/statusreconciler/OWNERS
+++ b/prow/statusreconciler/OWNERS
@@ -1,5 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- stevekuznetsov
 approvers:
 - stevekuznetsov
 labels:

--- a/robots/OWNERS
+++ b/robots/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- fejta
+- stevekuznetsov
 approvers:
 - cjwagner
 - fejta

--- a/robots/coverage/OWNERS
+++ b/robots/coverage/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
 approvers:
 - Katharine

--- a/scenarios/OWNERS
+++ b/scenarios/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- fejta
+- krzyzacy
 approvers:
 - cjwagner
 - fejta

--- a/testgrid/OWNERS
+++ b/testgrid/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- michelle192837
+- spiffxp
+- wojtek-t
+- shyamjvs
+- chases2
 approvers:
 - michelle192837
 - spiffxp

--- a/triage/OWNERS
+++ b/triage/OWNERS
@@ -1,5 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- Katharine
+- spiffxp
 approvers:
 - Katharine
 - spiffxp

--- a/velodrome/OWNERS
+++ b/velodrome/OWNERS
@@ -1,5 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- cjwagner
+- krzyzacy
+- spiffxp
 approvers:
 - cjwagner
 - krzyzacy


### PR DESCRIPTION
add owners to reviewers in any OWNERS file without a reviewers entry

mitigates https://github.com/kubernetes/test-infra/issues/16793

**NOTE**: This PR does NOT attempt to correct the OWNERS files in any other way, this change was plenty large enough. Any approvers / reviewers that should be changed should be done in a different PR, this PR is purely copying approves into reviewers where no reviewers exist so we will assign leave reviewers with context on changes instead of always assigning top level OWNERS.

This has been especially bad for `config/` where prowjob directories have intended leaf owners, but they nearly all have `approvers` only so those people do not in fact wind up CCed on those PRs, instead some of the root OWNERS are reviewing all job PRs which is not sustainable.