### PR TITLE
tide: skip unknown context in kubernetes-sigs/cluster-api-provider-openstack

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -506,6 +506,10 @@ tide:
           dashboard:
             skip-unknown-contexts: true
             from-branch-protection: true
+      kubernetes-sigs:
+        repos:
+          cluster-api-provider-openstack:
+            skip-unknown-contexts: true
   batch_size_limit:
     "kubernetes/kubernetes": 15
 


### PR DESCRIPTION
This change makes it possible to merge PRs in kubernetes-sigs/cluster-api-provider-openstack even though OpenLab/Zuul jobs failed.

All Prow jobs will still be mandatory