### PR TITLE
Use correct target for verify-deps

### DIFF
--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -23,4 +23,4 @@ if ! command -v bazel &>/dev/null; then
 fi
 
 set -o xtrace
-bazel test --test_output=streamed //hack:verify-deps
+bazel test --test_output=streamed @io_k8s_repo_infra//hack:verify-deps


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/16296

This is passing https://testgrid.k8s.io/sig-testing-misc#post-bazel&include-filter-by-regex=verify-deps just the wrong target in the bash script

/assign @matthyx 