### PR TITLE
prow: label prowjob metrics with cluster

### DIFF
--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -57,10 +57,11 @@ type jobLabel struct {
 	org          string
 	repo         string
 	baseRef      string
+	cluster      string
 }
 
 func (jl *jobLabel) values() []string {
-	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.state, jl.org, jl.repo, jl.baseRef}
+	return []string{jl.jobNamespace, jl.jobName, jl.jobType, jl.state, jl.org, jl.repo, jl.baseRef, jl.cluster}
 }
 
 func init() {
@@ -78,7 +79,7 @@ func getJobLabelMap(pjs []prowapi.ProwJob) map[jobLabel]float64 {
 }
 
 func getJobLabel(pj prowapi.ProwJob) jobLabel {
-	jl := jobLabel{jobNamespace: pj.Namespace, jobName: pj.Spec.Job, jobType: string(pj.Spec.Type), state: string(pj.Status.State)}
+	jl := jobLabel{jobNamespace: pj.Namespace, jobName: pj.Spec.Job, jobType: string(pj.Spec.Type), state: string(pj.Status.State), cluster: pj.Spec.Cluster}
 
 	if pj.Spec.Refs != nil {
 		jl.org = pj.Spec.Refs.Org


### PR DESCRIPTION
It is important to be able to query for trends between build clusters or
to ask "is this specific build cluster healthy?".

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/cc @cjwagner 
/assign @alvaroaleman 