### PR TITLE
Update cluster-api-provider-digitalocean OWNERS

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/OWNERS
@@ -1,6 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviwers:
+- cpanato
+- MorrisLaw
+- prksu
 - xmudrii
 approvers:
+- cpanato
+- MorrisLaw
+- prksu
 - xmudrii


### PR DESCRIPTION
This PR updates the OWNERS file for the `cluster-api-provider-digitalocean` jobs. The file is updated to match the maintainers listed in [the repository OWNERS file](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/blob/master/OWNERS_ALIASES).

/hold
until https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/146 is not merged