### PR TITLE
Skip some steps that make the azure kubemark test job fail unnecessarily.

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -759,7 +759,7 @@ periodics:
     testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-scalability, provider-azure-periodic
     testgrid-tab-name: ci-kubernetes-kubemark-100-azure-test
     testgrid-num-failures-to-alert: '1'
-    description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled. (test only)"
+    description: "Runs kubemark tests (100 nodes) with the Azure cloud provider enabled."
   labels:
     preset-service-account: "true"
     preset-azure-cred: "true"
@@ -781,7 +781,6 @@ periodics:
       - kubetest
       args:
       - --up
-      - --dump=$(ARTIFACTS)
       - --deployment=aksengine
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --build-with-kubemark=true

--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -127,7 +127,7 @@ func run(deploy deployer, o options) error {
 		}
 		// If node testing is enabled, check that the api is reachable before
 		// proceeding with further steps. This is accomplished by listing the nodes.
-		if !o.nodeTests {
+		if !o.nodeTests && !strings.EqualFold(string(o.build), "none") {
 			errs = util.AppendError(errs, control.XMLWrap(&suite, "Check APIReachability", func() error { return getKubectlVersion(deploy) }))
 			if dump != "" {
 				errs = util.AppendError(errs, control.XMLWrap(&suite, "list nodes", func() error {


### PR DESCRIPTION
Skip some steps that make the azure kubemark test job fail unnecessarily.

/kind bug
/area provider/azure