### PR TITLE
Make storage migrator tests required

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -3,8 +3,6 @@ presubmits:
   - name: pull-kube-storage-version-migrator-disruptive
     decorate: true
     always_run: true
-    # TODO: remove this when the test is stable
-    optional: true
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -46,8 +46,6 @@ presubmits:
   - name: pull-kube-storage-version-migrator-fully-automated-e2e
     decorate: true
     always_run: true
-    # TODO: remove this when the test is stable
-    optional: true
     labels:
       preset-service-account: "true"
       preset-k8s-ssh: "true"


### PR DESCRIPTION
cc @sanchezl 

The tests are fixed by https://github.com/kubernetes-sigs/kube-storage-version-migrator/pull/58.