### PR TITLE
Azure: Install Azure CLI

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -263,7 +263,7 @@ periodics:
       - --aksengine-deploy-custom-k8s
       - --aksengine-location=westus2
       - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
-      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/autoscaler-virtual-kubelet.json
+      - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/cloud-provider-azure/master/tests/k8s-azure/manifest/linux-autoscaler.json
       - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.48.0/aks-engine-v0.48.0-linux-amd64.tar.gz
       # Specific test args
       - --test-ccm

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -416,7 +416,28 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 		return nil, err
 	}
 
+	if err := c.installAzureCLI(); err != nil {
+		return nil, err
+	}
+
 	return &c, nil
+}
+
+func (c *Cluster) installAzureCLI() error {
+	if err := control.FinishRunning(exec.Command("pip", "install", "azure-cli")); err != nil {
+		return err
+	}
+
+	cmd := exec.Command("az", "login", "--service-principal",
+		fmt.Sprintf("-u=%s", c.credentials.ClientID),
+		fmt.Sprintf("-p=%s", c.credentials.ClientSecret),
+		fmt.Sprintf("-t=%s", c.credentials.TenantID))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed az login with error: %v", err)
+	}
+
+	log.Println("az login success.")
+	return nil
 }
 
 func getAKSDeploymentMethod(k8sRelease string) aksDeploymentMethod {

--- a/kubetest/azure_helpers.go
+++ b/kubetest/azure_helpers.go
@@ -94,6 +94,8 @@ type WindowsProfile struct {
 	WindowsSku            string `json:"WindowsSku"`
 	WindowsDockerVersion  string `json:"windowsDockerVersion"`
 	SSHEnabled            bool   `json:"sshEnabled,omitempty"`
+	EnableCSIProxy        bool   `json:"enableCSIProxy,omitempty"`
+	CSIProxyURL           string `json:"csiProxyURL,omitempty"`
 }
 
 // KubernetesContainerSpec defines configuration for a container spec


### PR DESCRIPTION
[`az acr build`](https://docs.microsoft.com/en-us/cli/azure/acr?view=azure-cli-latest#az-acr-build) will allow us to build and push Windows containers in a Linux environment (prow) ([example](https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/334#issuecomment-605082289)). Installing Azure CLI will be the first step in enabling CSI driver e2e test on Windows clusters. 

/cc @aramase @andyzhangx @ZeroMagic 
/assign @feiskyer