### PR TITLE
Prowjob CRD: Do not require completion time for aborted state

### DIFF
--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -45,7 +45,6 @@ spec:
                   - "success"
                   - "failure"
                   - "error"
-                  - "aborted"
           - required:
             - completionTime
   additionalPrinterColumns:

--- a/prow/cluster/starter.yaml
+++ b/prow/cluster/starter.yaml
@@ -75,7 +75,6 @@ spec:
                   - "success"
                   - "failure"
                   - "error"
-                  - "aborted"
           - required:
             - completionTime
   additionalPrinterColumns:


### PR DESCRIPTION
Required because since https://github.com/kubernetes/test-infra/pull/16973 we let hook set jobs to `aborted` and then the controllers react to that. It is important that the completionTimestamp remains unset, because thats how the controllers determine that they have to stop the test payload.

/assign @stevekuznetsov 