### PR TITLE
Enable Chaos Monkey for ClusterLoader2 presubmit

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -341,9 +341,8 @@ presubmits:
         - --test-cmd-args=--testconfig=testing/density/config.yaml
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-        # TODO(jprzychodzen): Re-enable node_killer when flakiness fixed
-        #- - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-        #- - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
+        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
         - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml


### PR DESCRIPTION
Chaos Monkey already runs for an experimental jobs and tests are green. Enabling for presubmit job to prevent breaking Node Killer with ClusterLoader2 changes.

* [Testgrid](https://testgrid.k8s.io/sig-scalability-experiments#gce-cos-master-scalability-100-nodekiller)

/sig scalability

Ref. kubernetes/kubernetes#89051
/assign @mm4tt 
