### PR TITLE
Add decorate to pull-kubespray-yamllint job

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -6,6 +6,7 @@ presubmits:
       testgrid-tab-name: yamllint
     always_run: false
     skip_report: true
+    decorate: true
     spec:
       containers:
       - image: quay.io/kubermatic/yamllint:0.1


### PR DESCRIPTION
After adding the job in #16869 @spiffxp found that the `decorate: true` was missing.

See https://github.com/kubernetes-sigs/kubespray/pull/5808#issuecomment-606193815