### PR TITLE
Respect do-not-merge/contains-merge-commits label

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -440,6 +440,7 @@ tide:
     missingLabels:
     - do-not-merge
     - do-not-merge/blocked-paths
+    - do-not-merge/contains-merge-commits
     - do-not-merge/hold
     - do-not-merge/invalid-commit-message
     - do-not-merge/invalid-owners-file
@@ -456,6 +457,7 @@ tide:
     - do-not-merge
     - do-not-merge/blocked-paths
     - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
     - do-not-merge/hold
     - do-not-merge/invalid-commit-message
     - do-not-merge/invalid-owners-file


### PR DESCRIPTION
This label is set by the mergecommitblocker plugin, currently enabled
for:

- kubernetes/kubernetes
- kubernetes/release
- kubernetes/sig-release

But tide wasn't setup to block merges on the presence of this label.

Have tide respect it in the query for all kubernetes orgs, and the
query for k/k

/sig testing
/sig release
/sig contributor-experience

/cc @nikhita @cblecker @justaugustus

Notice for this change was given back in May 2019, do we need another
lazy consensus period, or just a followup notice?
- ref: https://groups.google.com/forum/#!msg/kubernetes-dev/x88DyA-CfOI/puGgMGMpBgAJ
- ref: https://github.com/kubernetes/test-infra/pull/12783