### PR TITLE
Group sig-instrumentation dashboards

### DIFF
--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -1,3 +1,9 @@
+dashboard_groups:
+- name: sig-instrumentation
+  dashboard_names:
+  - sig-instrumentation-tests
+  - sig-instrumentation-image-pushes
+
 dashboards:
 - name: sig-instrumentation-tests
   dashboard_tab:


### PR DESCRIPTION
SIGs/WGs should have one top-level dashboard group, I swear this used to be enforced by tests