### PR TITLE
pull-k8sio-backup: use workload identity

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -26,6 +26,7 @@ presubmits:
     branches:
     - ^master$
     spec:
+      serviceAccountName: k8s-infra-gcr-promoter-test
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200329-0d2a077-1.17
         command:
@@ -36,16 +37,6 @@ presubmits:
         # script needs it to be defined).
         - name: GOPATH
           value: /go
-        - name: GOOGLE_APPLICATION_CREDENTIALS
-          value: /creds/service-account.json
-        volumeMounts:
-        - name: creds
-          mountPath: /creds
-          readOnly: true
-      volumes:
-      - name: creds
-        secret:
-          secretName: k8s-gcr-backup-test-prod-bak-service-account
   kubernetes-sigs/k8s-container-image-promoter:
   # Run promoter e2e tests.
   - name: pull-cip-e2e

--- a/prow/cluster/build_serviceaccounts.yaml
+++ b/prow/cluster/build_serviceaccounts.yaml
@@ -13,6 +13,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    # Used by container image promotor backup test job (pull-k8sio-backup)
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-gcr-backup-test-prod-bak.iam.gserviceaccount.com
+  name: k8s-infra-gcr-promoter-test
+  namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     # Used by Kops testing jobs
     iam.gke.io/gcp-service-account: pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
   name: k8s-kops-test


### PR DESCRIPTION
The sister PR from the GCP SA side is
https://github.com/kubernetes/k8s.io/pull/710.