### PR TITLE
Prow job yaml for kubernetes-sigs/scheduler-plugins

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/OWNERS
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- ahg-g
+- Huang-Wei

--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
@@ -1,0 +1,36 @@
+# sigs.k8s.io/scheduler-plugins presubmits
+presubmits:
+  kubernetes-sigs/scheduler-plugins:
+  - name: pull-scheduler-plugins-verify-gofmt
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - verify-gofmt
+  - name: pull-scheduler-plugins-unit-test
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - unit-test
+  - name: pull-scheduler-plugins-integration-test
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - integration-test

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -354,6 +354,7 @@ var noPresubmitsInTestgridPrefixes = []string{
 	"kubernetes-sigs/gcp-filestore-csi-driver",
 	"kubernetes-sigs/kind",
 	"kubernetes-sigs/kubebuilder-declarative-pattern",
+	"kubernetes-sigs/scheduler-plugins",
 	"kubernetes-sigs/service-catalog",
 	"kubernetes-sigs/sig-storage-local-static-provisioner",
 	"kubernetes-sigs/slack-infra",


### PR DESCRIPTION
This PR adds the prow job yaml for repo kubernetes-sigs/scheduler-plugins.

BTW: I've tested it locally following the [guide](https://github.com/kubernetes/test-infra/blob/master/prow/build_test_update.md#running-a-prowjob-locally).

```
wei.huang1@wei-mbp:/tmp/disks|⇒  pwd
/tmp/disks
wei.huang1@wei-mbp:/tmp/disks|⇒  ll
total 0
drwxr-xr-x 4 wei.huang1 128 Mar 31 22:55 config
drwxr-xr-x 2 wei.huang1  64 Mar 31 18:09 kind-node
drwxr-xr-x 3 wei.huang1  96 Mar 31 23:02 prowjob-out
```

/sig scheduling