### PR TITLE
Add activate Kubespray yamllint CI job and use Kubespray image

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -4,12 +4,12 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kubespray
       testgrid-tab-name: yamllint
-    always_run: false
-    skip_report: true
+    always_run: true
+    skip_report: false
     decorate: true
     spec:
       containers:
-      - image: quay.io/kubermatic/yamllint:0.1
+      - image: quay.io/kubespray/kubespray:v2.12.5
         args:
         - yamllint
         - "--strict"


### PR DESCRIPTION
Now that `pull-kubespray-yamllint` job works (see https://github.com/kubernetes-sigs/kubespray/pull/5808#issuecomment-606955352), we can make it required for all PRs.

Moreover since kubermatic's image was using a different version of `yamllint` I'm switching to the docker image used by the current Kubespray CI (see https://github.com/kubernetes-sigs/kubespray/blob/master/.gitlab-ci.yml#L43-L44)