### PR TITLE
[Scalability] Update chaos monkey experiment related  tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -336,7 +336,7 @@ periodics:
 
   # Experimental job confirming that node killer works. Fork of ci-kubernetes-e2e-gci-gce-scalability.
   # To be removed after Chaos Monkey flags are enabled in ci-kubernetes-e2e-gci-gce-scalability
-- interval: 30m
+- interval: 6h
   name: ci-kubernetes-e2e-gci-gce-scalability-node-killer
   labels:
     preset-service-account: "true"
@@ -374,9 +374,7 @@ periodics:
           - --test-cmd-args=--prometheus-scrape-node-exporter
           - --test-cmd-args=--provider=gce
           - --test-cmd-args=--report-dir=/workspace/_artifacts
-          - --test-cmd-args=--testconfig=testing/density/config.yaml
           - --test-cmd-args=--testconfig=testing/load/config.yaml
-          - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
           - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
           - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
           - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -330,8 +330,6 @@ presubmits:
         - --test-cmd-args=--testconfig=testing/density/config.yaml
         - --test-cmd-args=--testconfig=testing/load/config.yaml
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-        - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
@@ -343,6 +341,58 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+
+  # clone of pull-perf-tests-clusterloader2 with enabled node killer and using only load test
+  - name: pull-perf-tests-clusterloader2-nodekiller-experimental
+    always_run: false
+    skip_report: false
+    max_concurrency: 1
+    branches:
+      - master
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-presubmits: "true"
+    spec:
+      containers:
+        - args:
+            - --root=/go/src
+            - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
+            - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --timeout=120
+            - --scenario=kubernetes_e2e
+            - --
+            - --cluster=
+            - --extract=ci/latest
+            - --gcp-nodes=100
+            - --gcp-project-type=scalability-presubmit-project
+            - --gcp-zone=us-east1-b
+            - --provider=gce
+            - --tear-down-previous
+            - --test=false
+            - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+            - --test-cmd-args=cluster-loader2
+            - --test-cmd-args=--nodes=100
+            - --test-cmd-args=--prometheus-scrape-node-exporter
+            - --test-cmd-args=--provider=gce
+            - --test-cmd-args=--report-dir=/workspace/_artifacts
+            - --test-cmd-args=--testconfig=testing/load/config.yaml
+            - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
+            - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+            - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
+            - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
+            - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+            - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+            - --test-cmd-name=ClusterLoaderV2
+            - --timeout=100m
+            - --use-logexporter
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200331-ccdcc25-master
+          resources:
+            requests:
+              memory: "6Gi"
 
   - name: pull-perf-tests-clusterloader2-kubemark
     always_run: false

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -562,6 +562,9 @@ dashboards:
   - name: pull-perf-tests-clusterloader2
     test_group_name: pull-perf-tests-clusterloader2
     base_options: width=10
+  - name: pull-perf-tests-clusterloader2-nodekiller-experimental
+    test_group_name: pull-perf-tests-clusterloader2-nodekiller-experimental
+    base_options: width=10
   - name: pull-perf-tests-clusterloader2-kubemark
     test_group_name: pull-perf-tests-clusterloader2-kubemark
     base_options: width=10

--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -630,6 +630,9 @@ test_groups:
 - name: pull-perf-tests-clusterloader2
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-perf-tests-clusterloader2
   days_of_results: 30
+- name: pull-perf-tests-clusterloader2-nodekiller-experimental
+  gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-perf-tests-clusterloader2-nodekiller-experimental
+  days_of_results: 30
 - name: pull-perf-tests-clusterloader2-kubemark
   gcs_prefix: kubernetes-jenkins/pr-logs/directory/pull-perf-tests-clusterloader2-kubemark
   days_of_results: 30


### PR DESCRIPTION
* Make experimental job run every 6h and only execute load test
* Add manually triggered presubmit to support contributor to Node Killer
* Remove flags enabling Chaos Monkey from presubmit job

/sig scalability
/assign @wojtek-t 
/assign @mm4tt 