### PR TITLE
Fix the load test definition

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -423,8 +423,8 @@ periodics:
       - --test-cmd-args=--provider=gce
       - --test-cmd-args=--report-dir=/logs/artifacts
       - --test-cmd-args=--enable-prometheus-server=true
-      - --test-cmd-args=--testconfig=testing/node-throughput/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/node-throughput/windows_override.yaml
+      - --test-cmd-args=--testconfig=testing/windows-tests/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/windows-tests/windows_override.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=300m
 


### PR DESCRIPTION
As we removed the windows configs under `node-throughput` folder, so need to update it to `windows-tests` folder