### PR TITLE
post-k8sio-cip: use workload identity

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -765,23 +765,15 @@ postsubmits:
     branches:
     - ^master$
     spec:
+      serviceAccountName: k8s-infra-gcr-promoter
       containers:
       - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200328-v2.3.1-172-gfeb5dc0
         command:
         - cip
         args:
         - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        - -key-files=/etc/k8s-artifacts-prod-service-account/service-account.json
         - -dry-run=false
         - -use-service-account
-        volumeMounts:
-        - name: k8s-artifacts-prod-service-account-creds
-          mountPath: /etc/k8s-artifacts-prod-service-account
-          readOnly: true
-      volumes:
-      - name: k8s-artifacts-prod-service-account-creds
-        secret:
-          secretName: k8s-artifacts-prod-service-account
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io


### PR DESCRIPTION
For added context, the ci-k8sio-cip job was the first to use WI for
purposes of the promoter, and the rest of this commit message chronicles
some proof as to the fact that the promoter (cip binary) can work with
WI.

Chronologically, #16948 happened last Wednesday (2020-03-25), which turned on the
first use of the `k8s-infra-gcr-promoter` KSA. The next change after
this was #17026 (2020-03-30), which bumped the promoter to fix a bug
where the promoter was constantly (always) promoting the same set of
images during each ci-k8sio-cip run [1].

The key thing to note here is that essentially between 2020-03-25 and
2020-03-30 (after KSA, but before promoter bump), the ci-k8sio-cip job
continued to promote a small subset of images redundantly in each run.
Thanks to this happy accident, we have proof that the promoter can
function with just workload identity, as in this run from 2020-03-28 [2]
(reproduced below in part):

    *looking at "/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io"
    Built:   2020-03-05 02:06:38+0000
    Version: v2.3.1-117-gd677a55
    Commit:  d677a55
    I0328 06:31:50.022670      13 cip.go:274] ********** START **********
    I0328 06:31:50.103698      13 inventory.go:1916] reading this reg:{eu.gcr.io/k8s-artifacts-prod/apparmor-loader k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.com  false}
    I0328 06:31:50.104044      13 inventory.go:1916] reading this reg:{gcr.io/k8s-staging-cluster-api-azure/cluster-api-azure-controller   true}
    ...
    (skipped)
    ...
    I0328 06:32:28.076560      13 inventory.go:1854] ---------- BEGIN PROMOTION ----------
    I0328 06:32:29.934607      13 inventory.go:1626] Request {0 gcr.io/google-containers us.gcr.io/k8s-artifacts-prod k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.   com metrics-server-s390x metrics-server-s390x sha256:27c8aad4faf3c0372783fd1d57c03dde5271382323cc46fa53e9726b2bf7d1ab  v0.3.4}: OK
    I0328 06:32:30.438615      13 inventory.go:1626] Request {0 gcr.io/google-containers eu.gcr.io/k8s-artifacts-prod k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.   com kube-state-metrics-amd64 kube-state-metrics-amd64 sha256:3babef61933269555dd5bb313d78661049a354710f4aa01e4172d85cc55ffe62  v1.7.2}: OK
    I0328 06:32:30.544805      13 inventory.go:1626] Request {0 gcr.io/google-containers eu.gcr.io/k8s-artifacts-prod k8s-infra-gcr-promoter@k8s-artifacts-prod.iam.gserviceaccount.   com kube-state-metrics-arm64 kube-state-metrics-arm64 sha256:f00386b017a0230dc9803e72a34ed315339aa9513a0d18de1c6522a547cb449f  v1.9.0}: OK
    ...

Notice the version `v2.3.1-117-gd677a55` which was pushed up before the
bump to `v2.3.1-172-gfeb5dc0` in #17026, and the timestamp "0328" which
denotes the the 28th of March.

[1]: https://github.com/kubernetes-sigs/k8s-container-image-promoter/commit/3d2cef326d6c29f4e5f52cccac7bfc9d49f84a84
[2]: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-k8sio-cip/1243787652998631424.