### PR TITLE
Remove unnecessary prefix from oauth volume/volumemount

### DIFF
--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -257,9 +257,8 @@ func tmpVolume(name string) (coreapi.Volume, coreapi.VolumeMount) {
 }
 
 func oauthVolume(secret, key string) (coreapi.Volume, coreapi.VolumeMount) {
-	name := strings.Join([]string{"oauth-secret", secret}, "-")
 	return coreapi.Volume{
-			Name: name,
+			Name: secret,
 			VolumeSource: coreapi.VolumeSource{
 				Secret: &coreapi.SecretVolumeSource{
 					SecretName: secret,
@@ -270,7 +269,7 @@ func oauthVolume(secret, key string) (coreapi.Volume, coreapi.VolumeMount) {
 				},
 			},
 		}, coreapi.VolumeMount{
-			Name:      name,
+			Name:      secret,
 			MountPath: "/secrets/oauth",
 			ReadOnly:  true,
 		}

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -362,12 +362,12 @@ func TestCloneRefs(t *testing.T) {
 					OauthTokenFile: "/secrets/oauth/oauth-token",
 				}),
 				VolumeMounts: []coreapi.VolumeMount{logMount, codeMount,
-					{Name: "oauth-secret-oauth-secret", ReadOnly: true, MountPath: "/secrets/oauth"}, tmpMount,
+					{Name: "oauth-secret", ReadOnly: true, MountPath: "/secrets/oauth"}, tmpMount,
 				},
 			},
 			volumes: []coreapi.Volume{
 				{
-					Name: "oauth-secret-oauth-secret",
+					Name: "oauth-secret",
 					VolumeSource: coreapi.VolumeSource{
 						Secret: &coreapi.SecretVolumeSource{
 							SecretName: "oauth-secret",


### PR DESCRIPTION
If the secret name is long already, by adding another 12 characters as a prefix will cause errors like 
```console
Invalid value: "more-than-63-chars-secret-name" must be no more than 63 characters
```