### PR TITLE
Fix scalability release branch jobs (take 2)

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -947,7 +947,7 @@ presubmits:
         - --root=/go/src
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=release-1.16
+        - --repo=k8s.io/perf-tests=release-1.15
         - --repo=k8s.io/release
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-jenkins/pr-logs

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -965,6 +965,12 @@ presubmits:
         - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -235,6 +235,12 @@ periodics:
       # TODO(oxddr): re-enable this once we understand impact on https://github.com/kubernetes/kubernetes/issues/89051
       # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
       # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
@@ -294,6 +300,11 @@ periodics:
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
       - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
@@ -1009,6 +1020,12 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
@@ -1069,6 +1086,11 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1189,7 +1189,7 @@ presubmits:
       - args:
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=master
+        - --repo=k8s.io/perf-tests=release-1.18
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=120
@@ -1249,7 +1249,7 @@ presubmits:
         - --root=/go/src
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=master
+        - --repo=k8s.io/perf-tests=release-1.18
         - --repo=k8s.io/release
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-jenkins/pr-logs

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -236,6 +236,11 @@ periodics:
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
       - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
@@ -295,6 +300,12 @@ periodics:
       # TODO(oxddr): re-enable this once we understand impact on https://github.com/kubernetes/kubernetes/issues/89051
       # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
       # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
@@ -1205,6 +1216,12 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
         - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
@@ -1265,6 +1282,11 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
+        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m


### PR DESCRIPTION
This is take 2 of https://github.com/kubernetes/test-infra/pull/17086

In my haste to grep at the problem I missed the fact that k8s.io/perf-tests itself has release branches (ref: https://github.com/kubernetes/test-infra/pull/17086#issuecomment-608600996)

It turns out there is a presubmit in 1.15 using the `release-1.16` branch, and both presubmits in 1.18 are using the `master` branch.  I reverted the previous change and corrected the branches.

/assign @wojtek-t @mm4tt 