### PR TITLE
Add a bazelbuild 2.2.0 image variant

### DIFF
--- a/images/bazelbuild/variants.yaml
+++ b/images/bazelbuild/variants.yaml
@@ -1,4 +1,6 @@
 variants:
+  2.2.0:
+    BAZEL_VERSION: 2.2.0
   2.1.0:
     BAZEL_VERSION: 2.1.0
   2.0.0:


### PR DESCRIPTION
As mentioned in [#sig-testing](https://kubernetes.slack.com/archives/C09QZ4DQB/p1586050607083300), I'd like to add a 2.2.0 variant of the [k8s.gcr.io/k8s-testimages/bazelbuild](https://console.cloud.google.com/gcr/images/k8s-testimages/GLOBAL/bazelbuild?gcrImageListsize=30) image to use in image pushing jobs that with the same bazel version as k/k 1.19.