### PR TITLE
Set CONCURRENT_SERVICE_SYNCS to 5 in gce 5k correctness tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -20,6 +20,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --cluster=gce-scale-cluster
+      - --env=CONCURRENT_SERVICE_SYNCS=5
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
       - --extract=ci/latest
       - --gcp-master-image=gci


### PR DESCRIPTION
The default value is 1 which is disappointingly low, especially in context of the correctness test where we have many networking operations executed in parallel. 
I tested this change on 5k node correctness tests with NetLB tests re-enabled (see https://github.com/kubernetes/kubernetes/pull/89421) and it resulted in quite nice speed up. The last run of “regular” correctness tests took ~3h (https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/1246769907454971907) vs the manual run with CONCURRENT_SERVICE_SYNCS=5 and extra netLB tests took only ~2.5h.

We should consider changing this default in k/k, but let’s first change it here and allow it to soak a bit.