### PR TITLE
Enable timeout for SSH-ing to non-logexported nodes

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -59,6 +59,12 @@ presets:
   # Dump full systemd journal on master and nodes.
   - name: LOG_DUMP_SYSTEMD_JOURNAL
     value: "true"
+  # Timeout for the log dumping over SSH. Relevant only if fallback to SSH log dumping takes place
+  # e.g. when logexporter daemonset fails for some reason.
+  # We deliberately cap it at 1h to avoid spending too much time (e.g. over 5h for 5k node cluster)
+  # on dumping logs that in most cases we won't need anyway.
+  - name: LOG_DUMP_SSH_TIMEOUT_SECONDS
+    value: 3600
   # Use private clusters for scalability tests - https://github.com/kubernetes/kubernetes/issues/76374
   - name: KUBE_GCE_PRIVATE_CLUSTER
     value: "true"
@@ -147,6 +153,12 @@ presets:
   # Dump clusterloader prober's log files
   - name: LOG_DUMP_EXTRA_FILES
     value: "cl2-*"
+  # Timeout for the log dumping over SSH. Relevant only if fallback to SSH log dumping takes place
+  # e.g. when logexporter daemonset fails for some reason.
+  # We deliberately cap it at 1h to avoid spending too much time (e.g. over 5h for 5k node cluster)
+  # on dumping logs that in most cases we won't need anyway.
+  - name: LOG_DUMP_SSH_TIMEOUT_SECONDS
+    value: 3600
   # Keep all logrotated files (not just 5 latest which is a default)
   - name: LOGROTATE_FILES_MAX_COUNT
     value: 1000


### PR DESCRIPTION
Add `LOG_DUMP_SSH_TIMEOUT_SECONDS` environment variable to `preset-e2e-scalability-common` and `preset-e2e-kubemark-common` presets in SIG scalability test jobs.

This change uses the mechanism merged to kubernetes/kubernetes repo in [this](https://github.com/kubernetes/kubernetes/pull/89825) PR.

/sig scalability