### PR TITLE
 add dashboard for metrics-server ci and add serathius as OWNER

### DIFF
--- a/config/testgrids/kubernetes/sig-instrumentation/OWNERS
+++ b/config/testgrids/kubernetes/sig-instrumentation/OWNERS
@@ -3,6 +3,8 @@
 reviewers:
 - piosz
 - brancz
+- serathius
 approvers:
 - piosz
 - brancz
+- serathius

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -3,6 +3,7 @@ dashboard_groups:
   dashboard_names:
   - sig-instrumentation-tests
   - sig-instrumentation-image-pushes
+  - sig-instrumentation-metrics-server
 
 dashboards:
 - name: sig-instrumentation-tests
@@ -72,3 +73,4 @@ dashboards:
       base_options: include-filter-by-regex=sig-instrumentation
       description: sig-instrumentation gke stackdriver logging e2e tests for 1.13 branch with Ubuntu
 - name: sig-instrumentation-image-pushes
+- name: sig-instrumentation-metrics-server


### PR DESCRIPTION

Preparing to migrate metrics-server ci to Prow. https://github.com/kubernetes-sigs/metrics-server/issues/483
Adding dashboard for presubmit test results.

/cc @brancz