### PR TITLE
Add a verify-build job to scheduler-plugins presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/scheduler-plugins/scheduler-plugins-presubmits.yaml
@@ -12,6 +12,17 @@ presubmits:
         - make
         args:
         - verify-gofmt
+  - name: pull-scheduler-plugins-verify-build
+    decorate: true
+    path_alias: sigs.k8s.io/scheduler-plugins
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - build
   - name: pull-scheduler-plugins-unit-test
     decorate: true
     path_alias: sigs.k8s.io/scheduler-plugins


### PR DESCRIPTION
Add a job to ensure `go build <cmd>` works in k-sigs/scheduler-plugins repo.

/sig scheduling