### PR TITLE
deck: use prow/github instead of go-github in oauth handlers

### DIFF
--- a/prow/cmd/deck/BUILD.bazel
+++ b/prow/cmd/deck/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
         "//prow/tide:go_default_library",
         "//prow/tide/history:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
-        "@com_github_google_go_github//github:go_default_library",
         "@com_github_gorilla_sessions//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
     importpath = "k8s.io/test-infra/prow/flagutil",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ghclient:go_default_library",
         "//pkg/io:go_default_library",
         "//prow/bugzilla:go_default_library",
         "//prow/client/clientset/versioned:go_default_library",
@@ -25,14 +24,12 @@ go_library(
         "//prow/git:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
-        "//prow/githuboauth:go_default_library",
         "//prow/kube:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
     ],
 )
 

--- a/prow/flagutil/git.go
+++ b/prow/flagutil/git.go
@@ -36,7 +36,7 @@ type GitOptions struct {
 
 // AddFlags injects Git options into the given FlagSet.
 func (o *GitOptions) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&o.host, "git-host", "github.com", "Host to contact for git operations.")
+	fs.StringVar(&o.host, "git-host", "github.com", "host to contact for git operations.")
 	fs.StringVar(&o.user, "git-user", "", "User for git commits, optional. Can be derived from GitHub credentials.")
 	fs.StringVar(&o.email, "git-email", "", "Email for git commits, optional. Can be derived from GitHub credentials.")
 	fs.StringVar(&o.tokenPath, "git-token-path", "", "Path to the file containing the git token for HTTPS operations, optional. Can be derived from GitHub credentials.")

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -24,18 +24,14 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/oauth2"
-
-	"k8s.io/test-infra/pkg/ghclient"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
-	"k8s.io/test-infra/prow/githuboauth"
 )
 
 // GitHubOptions holds options for interacting with GitHub.
 type GitHubOptions struct {
-	host                string
+	Host                string
 	endpoint            Strings
 	graphqlEndpoint     string
 	TokenPath           string
@@ -45,7 +41,7 @@ type GitHubOptions struct {
 // NewGitHubOptions creates a GitHubOptions with default values.
 func NewGitHubOptions() *GitHubOptions {
 	return &GitHubOptions{
-		host:            github.DefaultHost,
+		Host:            github.DefaultHost,
 		endpoint:        NewStrings(github.DefaultAPIEndpoint),
 		graphqlEndpoint: github.DefaultAPIEndpoint,
 	}
@@ -64,7 +60,7 @@ func (o *GitHubOptions) AddFlagsWithoutDefaultGitHubTokenPath(fs *flag.FlagSet) 
 }
 
 func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagSet) {
-	fs.StringVar(&o.host, "github-host", github.DefaultHost, "GitHub's default host (may differ for enterprise)")
+	fs.StringVar(&o.Host, "github-host", github.DefaultHost, "GitHub's default host (may differ for enterprise)")
 	o.endpoint = NewStrings(github.DefaultAPIEndpoint)
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.graphqlEndpoint, "github-graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub GraphQL API endpoint (may differ for enterprise).")
@@ -148,7 +144,7 @@ func (o *GitHubOptions) GitHubClientWithAccessToken(token string) github.Client 
 
 // GitClient returns a Git client.
 func (o *GitHubOptions) GitClient(secretAgent *secret.Agent, dryRun bool) (client *git.Client, err error) {
-	client, err = git.NewClientWithHost(o.host)
+	client, err = git.NewClientWithHost(o.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -174,18 +170,4 @@ func (o *GitHubOptions) GitClient(secretAgent *secret.Agent, dryRun bool) (clien
 	client.SetCredentials(botName, secretAgent.GetTokenGenerator(o.TokenPath))
 
 	return client, nil
-}
-
-// GitHubOAuthClient returns an oauth client.
-func (o *GitHubOptions) GitHubOAuthClient(oauthConfig *oauth2.Config) githuboauth.OAuthClient {
-	oauthConfig.Endpoint = oauth2.Endpoint{
-		AuthURL:  fmt.Sprintf("https://%s/login/oauth/authorize", o.host),
-		TokenURL: fmt.Sprintf("https://%s/login/oauth/access_token", o.host),
-	}
-	return githuboauth.NewClient(oauthConfig)
-}
-
-// GetGitHubClient returns a github client wrapper.
-func (o *GitHubOptions) GetGitHubClient(accessToken string, dryRun bool) githuboauth.GitHubClientWrapper {
-	return ghclient.NewClientWithEndpoint(o.endpoint.Strings()[0], accessToken, dryRun)
 }

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -232,14 +232,15 @@ type Client interface {
 
 	WithFields(fields logrus.Fields) Client
 	ForPlugin(plugin string) Client
+	ForSubcomponent(subcomponent string) Client
 }
 
 // client interacts with the github api.
 type client struct {
 	// If logger is non-nil, log all method calls with it.
 	logger *logrus.Entry
-	// plugin is used to add more identification to the user-agent header
-	plugin string
+	// identifier is used to add more identification to the user-agent header
+	identifier string
 	*delegate
 }
 
@@ -268,16 +269,26 @@ type delegate struct {
 // ForPlugin clones the client, keeping the underlying delegate the same but adding
 // a plugin identifier and log field
 func (c *client) ForPlugin(plugin string) Client {
+	return c.forKeyValue("plugin", plugin)
+}
+
+// ForSubcomponent clones the client, keeping the underlying delegate the same but adding
+// an identifier and log field
+func (c *client) ForSubcomponent(subcomponent string) Client {
+	return c.forKeyValue("subcomponent", subcomponent)
+}
+
+func (c *client) forKeyValue(key, value string) Client {
 	return &client{
-		plugin:   plugin,
-		logger:   c.logger.WithField("plugin", plugin),
-		delegate: c.delegate,
+		identifier: value,
+		logger:     c.logger.WithField(key, value),
+		delegate:   c.delegate,
 	}
 }
 
 func (c *client) userAgent() string {
-	if c.plugin != "" {
-		return version.UserAgentWithIdentifier(c.plugin)
+	if c.identifier != "" {
+		return version.UserAgentWithIdentifier(c.identifier)
 	}
 	return version.UserAgent()
 }

--- a/prow/githuboauth/BUILD.bazel
+++ b/prow/githuboauth/BUILD.bazel
@@ -6,7 +6,8 @@ go_library(
     importpath = "k8s.io/test-infra/prow/githuboauth",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_github_google_go_github//github:go_default_library",
+        "//prow/flagutil:go_default_library",
+        "//prow/github:go_default_library",
         "@com_github_gorilla_sessions//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@org_golang_x_net//context:go_default_library",
@@ -34,7 +35,6 @@ go_test(
     srcs = ["githuboauth_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "@com_github_google_go_github//github:go_default_library",
         "@com_github_gorilla_securecookie//:go_default_library",
         "@com_github_gorilla_sessions//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",


### PR DESCRIPTION
There was no real reason to be using the older, separate client in
deck's handlers and it meant that new tooling to track client usage in
logs and metrics was not supported for these calls.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @cjwagner @alvaroaleman 