### PR TITLE
Allow image push for k8s dns images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dns.yaml
@@ -1,0 +1,32 @@
+postsubmits:
+  # this is the github repo we'll build from; this block needs to be repeated for each repo.
+  kubernetes/dns:
+    - name: dns-push-images
+      cluster: test-infra-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-network-dns
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200213-0032cdb
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-dns
+              - --scratch-bucket=gs://k8s-staging-dns-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
+            env:
+              - name: GOOGLE_APPLICATION_CREDENTIALS
+                value: /creds/service-account.json
+            volumeMounts:
+              - name: creds
+                mountPath: /creds
+        volumes:
+          - name: creds
+            secret:
+              secretName: deployer-service-account

--- a/config/jobs/image-pushing/k8s-staging-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dns.yaml
@@ -10,6 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
+        serviceAccountName: deployer # TODO(fejta): use pusher
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200213-0032cdb
             command:
@@ -20,13 +21,3 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-dns-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /creds/service-account.json
-            volumeMounts:
-              - name: creds
-                mountPath: /creds
-        volumes:
-          - name: creds
-            secret:
-              secretName: deployer-service-account

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -2,6 +2,7 @@ dashboard_groups:
 - name: sig-network
   dashboard_names:
     - sig-network-dualstack-azure-e2e
+    - sig-network-dns
     - sig-network-external-dns
     - sig-network-gce
     - sig-network-gke
@@ -11,6 +12,7 @@ dashboard_groups:
     - sig-network-service-apis
 
 dashboards:
+- name: sig-network-dns
 - name: sig-network-dualstack-azure-e2e
 - name: sig-network-external-dns
 - name: sig-network-gce


### PR DESCRIPTION
This includes kube-dns and node-cache images.
The cloudbuild file is being added in https://github.com/kubernetes/dns/pull/364

@MrHohn @rramkumar1 @listx 