### PR TITLE
SDCICD-241 / Refresh OSD Testgrid Dashboards

### DIFF
--- a/config/testgrids/openshift/dedicated.yaml
+++ b/config/testgrids/openshift/dedicated.yaml
@@ -1,75 +1,130 @@
 test_groups:
-# OpenShift Dedicated integration
-- name: osd-int-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2
+# OpenShift Dedicated AWS integration
+- name: osde2e-int-aws-e2e-osd-default-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-osd-default-nightly
   column_header:
   - configuration_value: cluster-version
-- name: osd-int-4.3
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.3
+- name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-osd-default-plus-one-nightly
   column_header:
   - configuration_value: cluster-version
-- name: osd-int-4.4
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.4
+- name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-osd-default-plus-two-nightly
   column_header:
   - configuration_value: cluster-version
-- name: osd-upgrade-int-4.2-4.2
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2-4.2
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osd-upgrade-int-4.2-4.3
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.2-4.3
+- name: osde2e-int-aws-e2e-upgrade-to-osd-default-plus-one-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-upgrade-to-osd-default-plus-one-nightly
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
-- name: osd-upgrade-int-4.3-4.3
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.3-4.3
-  column_header:
-  - configuration_value: cluster-version
-  - configuration_value: upgrade-version
-- name: osd-upgrade-int-4.3-4.4
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-int-4.3-4.4
+- name: osde2e-int-aws-e2e-upgrade-to-osd-default-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-aws-e2e-upgrade-to-osd-default-nightly
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
 
-# OpenShift Dedicated staging
-- name: osd-stage-default
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-default
+# OpenShift Dedicated GCP integration
+- name: osde2e-int-gcp-osd-default-plus-one-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-osd-default-plus-one-nightly
   column_header:
   - configuration_value: cluster-version
-- name: osd-stage-next
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-next
+- name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-osd-default-plus-two-nightly
   column_header:
   - configuration_value: cluster-version
-- name: osd-upgrade-stage-default-next
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-stage-default-next
+- name: osde2e-int-gcp-e2e-upgrade-to-osd-default-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-upgrade-to-osd-default-nightly
+  column_header:
+  - configuration_value: cluster-version
+  - configuration_value: upgrade-version
+- name: osde2e-int-gcp-e2e-upgrade-to-osd-default-plus-one-nightly
+  gcs_prefix: origin-ci-test/logs/osde2e-int-gcp-e2e-upgrade-to-osd-default-plus-one-nightly
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
 
-# OpenShift Dedicated production
-- name: osd-prod-default
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-default
+
+# OpenShift Dedicated AWS staging
+- name: osde2e-stage-aws-e2e-default
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-default
   column_header:
   - configuration_value: cluster-version
-- name: osd-prod-next
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-next
+- name: osde2e-stage-aws-e2e-next
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-next
   column_header:
   - configuration_value: cluster-version
-- name: osd-upgrade-prod-default-next
-  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-osde2e-master-e2e-prod-default-next
+- name: osde2e-stage-aws-e2e-oldest-imageset
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-oldest-imageset
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-stage-aws-e2e-middle-imageset
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-middle-imageset
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-stage-aws-e2e-upgrade-default-next-z
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-upgrade-default-next-z
+  column_header:
+  - configuration_value: cluster-version
+  - configuration_value: upgrade-version
+- name: osde2e-stage-aws-e2e-upgrade-default-next
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-aws-e2e-upgrade-default-next
+  column_header:
+  - configuration_value: cluster-version
+  - configuration_value: upgrade-version
+
+# OpenShift Dedicated GCP staging
+- name: osde2e-stage-gcp-e2e-next
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-next
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-stage-gcp-e2e-default
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-default
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-stage-gcp-e2e-upgrade-default-next
+  gcs_prefix: origin-ci-test/logs/osde2e-stage-gcp-e2e-upgrade-default-next
+  column_header:
+  - configuration_value: cluster-version
+  - configuration_value: upgrade-version
+
+# OpenShift Dedicated AWS production
+- name: osde2e-prod-aws-e2e-default
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-default
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-e2e-next
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-next
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-informing-default
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-informing-default
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-informing-next
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-informing-next
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-e2e-oldest-imageset
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-oldest-imageset
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-e2e-middle-imageset	
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-middle-imageset	
+  column_header:
+  - configuration_value: cluster-version
+- name: osde2e-prod-aws-e2e-upgrade-default-next
+  gcs_prefix: origin-ci-test/logs/osde2e-prod-aws-e2e-upgrade-default-next
   column_header:
   - configuration_value: cluster-version
   - configuration_value: upgrade-version
 
 dashboards:
-# OpenShift Dedicated integration dashboard
-- name: redhat-osd-int
+- name: redhat-osde2e-int-gcp
   dashboard_tab:
-  - name: osd-int-4.2
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.2 integration cluster.
-    test_group_name: osd-int-4.2
+# OpenShift Dedicated GCP integration dashboard
+  - name: osde2e-int-gcp-e2e-upgrade-to-osd-default-nightly
+    description: Runs upgrade e2e tests on a cluster in GCP going from Prod default to next z-nightly
+    test_group_name: osde2e-int-gcp-e2e-upgrade-to-osd-default-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -87,9 +142,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-int-4.3
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.3 integration cluster.
-    test_group_name: osd-int-4.3
+  - name: osde2e-int-gcp-e2e-upgrade-to-osd-default-plus-one-nightly
+    description: Runs upgrade e2e tests on a cluster in GCP going from Prod default to next y-nightly
+    test_group_name: osde2e-int-gcp-e2e-upgrade-to-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -107,9 +162,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-int-4.4
-    description: Runs cluster acceptance tests on an OpenShift Dedicated 4.4 integration cluster.
-    test_group_name: osd-int-4.4
+  - name: osde2e-int-gcp-osd-default-plus-one-nightly
+    description: Runs e2e tests on a cluster in GCP using prod y+1 nightly
+    test_group_name: osde2e-int-gcp-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -127,9 +182,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.2-4.2
-    description: Runs upgrade tests between OpenShift Dedicated 4.2 and 4.2 in integration.
-    test_group_name: osd-upgrade-int-4.2-4.2
+  - name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
+    description: Runs e2e tests on a cluster in GCP using prod y+2 nightly
+    test_group_name: osde2e-int-gcp-e2e-osd-default-plus-two-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -147,9 +202,12 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.2-4.3
-    description: Runs upgrade tests between OpenShift Dedicated 4.2 and 4.3 in integration.
-    test_group_name: osd-upgrade-int-4.2-4.3
+- name: redhat-osde2e-int-aws
+  dashboard_tab:
+# OpenShift Dedicated AWS integration dashboard
+  - name: osde2e-int-aws-e2e-upgrade-to-osd-default-plus-one-nightly
+    description: Runs upgrade e2e tests on a cluster in AWS going from Prod default to y+1 nightly
+    test_group_name: osde2e-int-aws-e2e-upgrade-to-osd-default-plus-one-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -167,9 +225,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.3-4.3
-    description: Runs upgrade tests between OpenShift Dedicated 4.3 and 4.3 in integration.
-    test_group_name: osd-upgrade-int-4.3-4.3
+  - name: osde2e-int-aws-e2e-upgrade-to-osd-default-nightly
+    description: Runs upgrade e2e tests on a cluster in AWS going from Prod default to same y-nightly
+    test_group_name: osde2e-int-aws-e2e-upgrade-to-osd-default-nightly
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -187,9 +245,235 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-int-4.3-4.4
-    description: Runs upgrade tests between OpenShift Dedicated 4.3 and 4.4 in integration.
-    test_group_name: osd-upgrade-int-4.3-4.4
+  - name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
+    description: Runs e2e tests on a cluster in AWS using prod y+1 nightly
+    test_group_name: osde2e-int-aws-e2e-osd-default-plus-one-nightly
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-int-aws-e2e-osd-default-nightly
+    description: Runs e2e tests on a cluster in AWS using default-z nightly version
+    test_group_name: osde2e-int-aws-e2e-osd-default-nightly
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
+    description: Runs e2e tests on a cluster in AWS using prod y+2 nightly
+    test_group_name: osde2e-int-aws-e2e-osd-default-plus-two-nightly
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+- name: redhat-osde2e-stage-gcp
+  dashboard_tab:
+# OpenShift Dedicated GCP stage dashboard
+  - name: osde2e-stage-gcp-e2e-upgrade-default-next
+    description: Runs upgrade e2e tests on a cluster in GCP going from default to next available Y-stream
+    test_group_name: osde2e-stage-gcp-e2e-upgrade-default-next
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-gcp-e2e-next
+    description: Runs e2e tests on a cluster in GCP using the next available version
+    test_group_name: osde2e-stage-gcp-e2e-next
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-gcp-e2e-default
+    description: Runs e2e tests on a cluster in GCP using the default version
+    test_group_name: osde2e-stage-gcp-e2e-default
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+- name: redhat-osde2e-stage-aws
+  dashboard_tab:
+# OpenShift Dedicated AWS stage dashboard
+  - name: osde2e-stage-aws-e2e-upgrade-default-next
+    description: Runs upgrade e2e tests on a cluster in AWS going from default to next available Y-stream
+    test_group_name: osde2e-stage-aws-e2e-upgrade-default-next
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-aws-e2e-next
+    description: Runs e2e tests on a cluster in AWS using the next available version
+    test_group_name: osde2e-stage-aws-e2e-next
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-aws-e2e-default
+    description: Runs e2e tests on a cluster in AWS using the default version
+    test_group_name: osde2e-stage-aws-e2e-default
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-aws-e2e-oldest-imageset
+    description: Runs e2e tests on a cluster in AWS using the oldest available version
+    test_group_name: osde2e-stage-aws-e2e-oldest-imageset
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-aws-e2e-middle-imageset
+    description: Runs e2e tests on a cluster in AWS using the middle-most available version
+    test_group_name: osde2e-stage-aws-e2e-middle-imageset
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-stage-aws-e2e-upgrade-default-next-z
+    description: Runs e2e upgrade tests on a cluster in AWS using the default version upgrading to the latest available z-stream version
+    test_group_name: osde2e-stage-aws-e2e-upgrade-default-next-z
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -208,12 +492,12 @@ dashboards:
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
 
-# OpenShift Dedicated staging dashboard
-- name: redhat-osd-stage
+- name: redhat-osde2e-prod-aws
   dashboard_tab:
-  - name: osd-stage-default
-    description: Runs cluster acceptance tests on an OpenShift Dedicated staging cluster using the current default version.
-    test_group_name: osd-stage-default
+# OpenShift Dedicated AWS prod dashboard
+  - name: osde2e-prod-aws-e2e-upgrade-default-next
+    description: Runs upgrade e2e tests on a cluster in AWS going from default to next available Y-stream
+    test_group_name: osde2e-prod-aws-e2e-upgrade-default-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -231,9 +515,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-stage-next
-    description: Runs cluster acceptance tests on an OpenShift Dedicated staging cluster using the latest version.
-    test_group_name: osd-stage-next
+  - name: osde2e-prod-aws-e2e-next
+    description: Runs e2e tests on a cluster in AWS using the next available version
+    test_group_name: osde2e-prod-aws-e2e-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -251,9 +535,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-stage-default-next
-    description: Runs upgrade tests between OpenShift Dedicated current default version and latest in staging.
-    test_group_name: osd-upgrade-stage-default-next
+  - name: osde2e-prod-aws-e2e-default
+    description: Runs e2e tests on a cluster in AWS using the default version
+    test_group_name: osde2e-prod-aws-e2e-default
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -271,13 +555,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-
-# OpenShift Dedicated production dashboard
-- name: redhat-osd-prod
-  dashboard_tab:
-  - name: osd-prod-default
-    description: Runs cluster acceptance tests on an OpenShift Dedicated production cluster using the current default version.
-    test_group_name: osd-prod-default
+  - name: osde2e-prod-aws-e2e-oldest-imageset
+    description: Runs e2e tests on a cluster in AWS using the oldest available version
+    test_group_name: osde2e-prod-aws-e2e-oldest-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -295,9 +575,9 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-prod-next
-    description: Runs cluster acceptance tests on an OpenShift Dedicated production cluster using the latest version.
-    test_group_name: osd-prod-next
+  - name: osde2e-prod-aws-e2e-middle-imageset
+    description: Runs e2e tests on a cluster in AWS using the middle-most available version
+    test_group_name: osde2e-prod-aws-e2e-middle-imageset
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
@@ -315,9 +595,29 @@ dashboards:
     code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
     code_search_url_template: # The URL template to visit when searching for changelists
       url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
-  - name: osd-upgrade-prod-default-next
-    description: Runs upgrade tests between OpenShift Dedicated current default version and latest in production.
-    test_group_name: osd-upgrade-prod-default-next
+  - name: osde2e-prod-aws-informing-default
+    description: Runs e2e informing tests on a cluster in AWS using the default version
+    test_group_name: osde2e-prod-aws-informing-default
+    base_options: width=10
+    open_test_template: # The URL template to visit after clicking on a cell
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    file_bug_template: # The URL template to visit when filing a bug
+      url: https://github.com/openshift/osde2e/issues/new
+      options:
+        - key: title
+          value: 'E2E: <test-name>'
+        - key: body
+          value: <test-url>
+    open_bug_template: # The URL template to visit when visiting an associated bug
+      url: https://github.com/openshift/osde2e/issues/
+    results_url_template: # The URL template to visit after clicking
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    code_search_path: github.com/openshift/osde2e/search # URL for regression search links.
+    code_search_url_template: # The URL template to visit when searching for changelists
+      url: https://github.com/openshift/osde2e/compare/<start-custom-0>...<end-custom-0>
+  - name: osde2e-prod-aws-informing-next
+    description: Runs e2e informing tests on a cluster in AWS using the next available version
+    test_group_name: osde2e-prod-aws-informing-next
     base_options: width=10
     open_test_template: # The URL template to visit after clicking on a cell
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>

--- a/config/testgrids/openshift/groups.yaml
+++ b/config/testgrids/openshift/groups.yaml
@@ -18,7 +18,9 @@ dashboard_groups:
   - redhat-openshift-okd-release-4.4-informing
   - redhat-openshift-okd-release-4.5-informing
   - redhat-openshift-okd-release-4.6-informing
-  - redhat-osd-int
-  - redhat-osd-prod
-  - redhat-osd-stage
+  - redhat-osde2e-int-gcp
+  - redhat-osde2e-int-aws
+  - redhat-osde2e-stage-gcp
+  - redhat-osde2e-stage-aws
+  - redhat-osde2e-prod-aws
   name: redhat


### PR DESCRIPTION
The OSD-related testgrid dashboards have gotten stale and there are several new jobs to track. 

This PR updates testgrid to directly reflect all the jobs currently running. 