### PR TITLE
jobs: add sig/ labels to OWNERS for kubernetes/ jobs

### DIFF
--- a/config/jobs/kubernetes/client-go/OWNERS
+++ b/config/jobs/kubernetes/client-go/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 approvers:
 - sttts
 - nikhita
+labels:
+- sig/apimachinery

--- a/config/jobs/kubernetes/cloud-provider-alibaba-cloud/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-alibaba-cloud/OWNERS
@@ -8,3 +8,5 @@ approvers:
 - aoxn
 - cheyang
 - xlgao-zju
+labels:
+- sig/cloud-provider

--- a/config/jobs/kubernetes/cloud-provider-aws/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-aws/OWNERS
@@ -4,3 +4,6 @@ reviewers:
 - mcrute
 approvers:
 - mcrute
+labels:
+- sig/cloud-provider
+- area/provider/aws

--- a/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-gcp/OWNERS
@@ -6,3 +6,6 @@ reviewers:
 approvers:
 - awly
 - mikedanese
+labels:
+- sig/cloud-provider
+- area/provider/aws

--- a/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-openstack/OWNERS
@@ -4,3 +4,6 @@ reviewers:
 - dims
 approvers:
 - dims
+labels:
+- sig/cloud-provider
+- area/provider/openstack

--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -24,3 +24,6 @@ approvers:
 - figo
 - akutz
 - yastij
+labels:
+- sig/cloud-provider
+- area/provider/vmware

--- a/config/jobs/kubernetes/cluster-registry/OWNERS
+++ b/config/jobs/kubernetes/cluster-registry/OWNERS
@@ -10,3 +10,5 @@ approvers:
 - madhusudancs
 - perotinus
 - pmorie
+labels:
+- sig/multicluster

--- a/config/jobs/kubernetes/community/OWNERS
+++ b/config/jobs/kubernetes/community/OWNERS
@@ -16,3 +16,5 @@ approvers:
 - idvoretskyi
 - jdumars
 - parispittman
+labels:
+- sig/contributor-experience

--- a/config/jobs/kubernetes/kops/OWNERS
+++ b/config/jobs/kubernetes/kops/OWNERS
@@ -15,3 +15,5 @@ approvers:
 reviewers:
   - joshbranham
   - robinpercy
+labels:
+- sig/cluster-lifecycle

--- a/config/jobs/kubernetes/node-problem-detector/OWNERS
+++ b/config/jobs/kubernetes/node-problem-detector/OWNERS
@@ -8,3 +8,5 @@ approvers:
   - Random-Liu
   - andyxning
   - dchen1107
+labels:
+- sig/node

--- a/config/jobs/kubernetes/org/OWNERS
+++ b/config/jobs/kubernetes/org/OWNERS
@@ -14,3 +14,5 @@ approvers:
 - grodrigues3
 - idvoretskyi
 - spiffxp
+labels:
+- sig/contributor-experience

--- a/config/jobs/kubernetes/publishing-bot/OWNERS
+++ b/config/jobs/kubernetes/publishing-bot/OWNERS
@@ -10,3 +10,6 @@ approvers:
 - mfojtik
 - nikhita
 - sttts
+labels:
+- sig/release
+- area/release-eng

--- a/config/jobs/kubernetes/repo-infra/OWNERS
+++ b/config/jobs/kubernetes/repo-infra/OWNERS
@@ -8,5 +8,5 @@ approvers:
 - clarketm
 - fejta
 - mikedanese
-
-
+labels:
+- sig/testing

--- a/config/jobs/kubernetes/sig-api-machinery/OWNERS
+++ b/config/jobs/kubernetes/sig-api-machinery/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 approvers:
 - lavalamp
 - deads2k
+labels:
+- sig/api-machinery

--- a/config/jobs/kubernetes/sig-apps/OWNERS
+++ b/config/jobs/kubernetes/sig-apps/OWNERS
@@ -8,3 +8,5 @@ approvers:
 - mattfarina
 - prydonius
 - kow3ns
+labels:
+- sig/apps

--- a/config/jobs/kubernetes/sig-cli/OWNERS
+++ b/config/jobs/kubernetes/sig-cli/OWNERS
@@ -8,3 +8,5 @@ approvers:
 - AdoHe
 - pwittrock
 - soltysh
+labels:
+- sig/cli

--- a/config/jobs/kubernetes/sig-instrumentation/OWNERS
+++ b/config/jobs/kubernetes/sig-instrumentation/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 approvers:
 - piosz
 - brancz
+labels:
+- sig/instrumentation

--- a/config/jobs/kubernetes/sig-network/OWNERS
+++ b/config/jobs/kubernetes/sig-network/OWNERS
@@ -14,3 +14,5 @@ approvers:
 - jingax10
 - mrhohn
 - rramkumar1
+labels:
+- sig/network

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -8,3 +8,5 @@ approvers:
 - yujuhong
 - Random-Liu
 - dchen1107
+labels:
+- sig/node

--- a/config/jobs/kubernetes/sig-scalability/OWNERS
+++ b/config/jobs/kubernetes/sig-scalability/OWNERS
@@ -11,3 +11,6 @@ approvers:
 - mm4tt
 - shyamjvs
 - wojtek-t
+
+labels:
+- sig/scalability

--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 approvers:
 - bsalamat
 - k82cn
+labels:
+- sig/scheduling

--- a/config/jobs/kubernetes/sig-storage/OWNERS
+++ b/config/jobs/kubernetes/sig-storage/OWNERS
@@ -6,3 +6,5 @@ reviewers:
 approvers:
 - saad-ali
 - msau42
+labels:
+- sig/storage


### PR DESCRIPTION
I pushed a change to a sig-node job and was surprised it didn't get auto-labeled as such