### PR TITLE
Enable blockade for design-proposals

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -151,6 +151,11 @@ blockades:
   - ^keps/
   explanation: "KEPs have been relocated to [kubernetes/enhancements](https://git.k8s.io/enhancements/)! Please submit any updates there."
 - repos:
+  - kubernetes/community
+  blockregexps:
+  - ^contributors/design-proposals/
+  explanation: "The Design Proposal process has been deprecated in favor of [Kubernetes Enhancement Proposals (KEP)](https://git.k8s.io/enhancements/). These documents are here for historical purposes only."
+- repos:
   - kubernetes/enhancements
   blockregexps:
   - ^keps/NEXT_KEP_NUMBER$


### PR DESCRIPTION
Design proposals have been deprecated for some time now -- However this hasn't stopped folks from opening PRs to update them that often flounder (ref: https://github.com/kubernetes/community/pull/4627, ref: https://github.com/kubernetes/community/pull/4317), or open a PR to add features (ref: https://github.com/kubernetes/community/pull/3890).

With that I think it'd be a good idea to just nip it in the bud for now till their eventual [migration to the k/enhancements repo for archival](https://github.com/kubernetes/community/issues/2565#issuecomment-596857139).

/cc @justaugustus @cblecker @nikhita 