### PR TITLE
Make status-reconciler use ghproxy.

### DIFF
--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -41,6 +41,8 @@ spec:
         - --plugin-config=/etc/plugins/plugins.yaml
         - --config-path=/etc/config/config.yaml
         - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy
+        - --github-endpoint=https://api.github.com
         - --job-config-path=/etc/job-config
         - --blacklist=kubernetes/kubernetes
         volumeMounts:


### PR DESCRIPTION
Resolves this warning:
```yaml
jsonPayload: {
  component: "status-reconciler"   
  file: "prow/flagutil/github.go:90"   
  func: "k8s.io/test-infra/prow/flagutil.(*GitHubOptions).Validate"   
  level: "error"   
  msg: "It doesn't look like you are using ghproxy to cache API calls to GitHub! This has become a required component of Prow and other components will soon be allowed to add features that may rapidly consume API ratelimit without caching. Starting May 1, 2020 use Prow components without ghproxy at your own risk! https://github.com/kubernetes/test-infra/tree/master/ghproxy#ghproxy"   
}
```
/assign @BenTheElder 