### PR TITLE
Remove kubemacs from apisnoop, move cloudbuild dir

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -21,29 +21,7 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/webapp/
-    - name: apisnoop-push-kubemacs-images
-      cluster: test-infra-trusted
-      annotations:
-        testgrid-dashboards: conformance-apisnoop
-        testgrid-tab-name: apisnoop-kubemacs-image
-        testgrid-alert-email: apisnoop@ii.coop
-        description: Builds the kubemacs image for APISnoop deployments
-      decorate: true
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200213-0032cdb
-            command:
-              - /run.sh
-            args:
-              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
-              - --project=k8s-staging-apisnoop
-              - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
-              - --env-passthrough=PULL_BASE_REF
-              - apps/kubemacs/
+              - apps/webapp/app
     - name: apisnoop-push-auditlogger-images
       cluster: test-infra-trusted
       annotations:
@@ -65,7 +43,7 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/auditlogger/
+              - apps/auditlogger/app
     - name: apisnoop-push-postgres-images
       cluster: test-infra-trusted
       annotations:
@@ -87,7 +65,7 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/postgres/
+              - apps/postgres/app
     - name: apisnoop-push-hasura-images
       cluster: test-infra-trusted
       annotations:
@@ -109,4 +87,4 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/hasura/
+              - apps/hasura/app


### PR DESCRIPTION
Each app now has it's Dockerfile and cloudbuild in /apps/APPNAME/app


Co-Authored-By: Caleb Woodbine <caleb@ii.coop>