### PR TITLE
Remove sig-instrumentation failing tests and empty dashboards

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -26,59 +26,6 @@ periodics:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-es-logging
 - interval: 30m
-  name: ci-kubernetes-e2e-gci-gce-sd-logging
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_LOGGING_DESTINATION=gcp
-      - --env=TEST_CLUSTER_LOG_LEVEL=--v=2
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gci-gce-sd-logging
-- interval: 30m
-  name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1400
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --deployment=gke
-      - --extract=ci/k8s-beta
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-sd-logging-gci-1.14
-- interval: 30m
   name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
   labels:
     preset-service-account: "true"
@@ -106,137 +53,28 @@ periodics:
     testgrid-dashboards: google-gke-stackdriver
     testgrid-tab-name: gke-sd-logging-gci-latest
 - interval: 30m
-  name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
+  name: ci-kubernetes-e2e-gci-gce-sd-logging
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
   spec:
     containers:
     - args:
-      - --timeout=1400
+      - --timeout=1340
       - --bare
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --deployment=gke
-      - --extract=ci/k8s-stable1
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-sd-logging-gci-1.13
-- interval: 30m
-  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1400
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --deployment=gke
-      - --extract=ci/k8s-beta
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-sd-logging-ubuntu-1.14
-- interval: 30m
-  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1400
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --deployment=gke
+      - --env=KUBE_LOGGING_DESTINATION=gcp
+      - --env=TEST_CLUSTER_LOG_LEVEL=--v=2
       - --extract=ci/latest
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-sd-logging-ubuntu-latest
-- interval: 30m
-  name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1400
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --deployment=gke
-      - --extract=ci/k8s-stable1
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=ubuntu
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-
-  annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-sd-logging-ubuntu-1.13
-- interval: 30m
-  name: ci-kubernetes-e2e-gke-stackdriver
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=70
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --deployment=gke
-      - --extract=ci/latest
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
       - --gcp-node-image=gci
-      - --gcp-project=k8s-jkns-e2e-gke-stackdriver
-      - --gcp-zone=us-west1-c
-      - --gke-environment=test
-      - --provider=gke
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
-      - --timeout=50m
+      - --gcp-zone=us-west1-b
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
+      - --timeout=1320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
+
   annotations:
-    testgrid-dashboards: google-gke-stackdriver
-    testgrid-tab-name: gke-stackdriver
+    testgrid-dashboards: google-gce
+    testgrid-tab-name: gci-gce-sd-logging

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -15,22 +15,6 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gke
       base_options: include-filter-by-regex=sig-instrumentation
       description: instrumentation gke e2e tests for master branch
-    - name: gce-cos-1.12-default
-      test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable2-default
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: instrumentation gce e2e tests for 1.12 branch
-    - name: gke-cos-1.12-default
-      test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable2-default
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: instrumentation gke e2e tests for 1.12 branch
-    - name: gce-cos-1.11-default
-      test_group_name: ci-kubernetes-e2e-gce-cos-k8sstable3-default
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: instrumentation gce e2e tests for 1.11 branch
-    - name: gke-cos-1.11-default
-      test_group_name: ci-kubernetes-e2e-gke-cos-k8sstable3-default
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: instrumentation gke e2e tests for 1.11 branch
     - name: gci-gce-serial
       test_group_name: ci-kubernetes-e2e-gci-gce-serial
       base_options: include-filter-by-regex=sig-instrumentation
@@ -47,28 +31,4 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-sd-logging
       base_options: include-filter-by-regex=sig-instrumentation
       description: sig-instrumentation gce stackdriver logging e2e tests for master branch
-    - name: gke-sd-logging-gci-latest
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-latest
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for master branch with COS
-    - name: gke-sd-logging-ubuntu-latest
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-latest
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for master branch with Ubuntu
-    - name: gke-sd-logging-gci-1.14
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-beta
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for 1.14 branch with COS
-    - name: gke-sd-logging-ubuntu-1.14
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-beta
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for 1.14 branch with Ubuntu
-    - name: gke-sd-logging-gci-1.13
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-gci-stable1
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for 1.13 branch with COS
-    - name: gke-sd-logging-ubuntu-1.13
-      test_group_name: ci-kubernetes-e2e-gke-sd-logging-ubuntu-stable1
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gke stackdriver logging e2e tests for 1.13 branch with Ubuntu
 - name: sig-instrumentation-image-pushes


### PR DESCRIPTION
Removing:
* Unsupported k8s versions (1.11, 1.12, 1.14)
* Stackdriver tests that fail to start

Leaving:
* Stackdriver tests as they have cases passing https://k8s-testgrid.appspot.com/sig-instrumentation-tests#gci-gce-sd-logging
* Elasticsearch tests to confirm with owner
* GKE dashboard as they require additional changes in parent directory

/cc @brancz