### PR TITLE
don't use kind + bazel on 1.17

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1243,8 +1243,6 @@ presubmits:
       path_alias: sigs.k8s.io/kind
       repo: kind
     labels:
-      preset-bazel-remote-cache-enabled: "true"
-      preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
@@ -1255,7 +1253,6 @@ presubmits:
         - --deployment=kind
         - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
-        - --build=bazel
         - --up
         - --test
         - --check-version-skew=false


### PR DESCRIPTION
/cc @spiffxp @justaugustus 

FYI @neolit123, the "stable" version doesn't work now, and we don't want to upgrade a release branch to HEAD.

This is the only place I found us using kind + bazel in the kubernetes 1.17 branch, so we can just disable that for now until we upgrade or find the change.