### PR TITLE
still build in 1.17 presubmit (!)

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1253,6 +1253,7 @@ presubmits:
         - --deployment=kind
         - --kind-binary-version=stable
         - --kind-config-path=./../../k8s.io/kubeadm/tests/e2e/kind/ha-cp/ha-cp.yaml
+        - --build=quick
         - --up
         - --test
         - --check-version-skew=false


### PR DESCRIPTION
🤦‍♂ I haven't used `kubetest` in ages, the tooling in newer kubernetes branches is saner ... 

cc @amwat 
follow up to https://github.com/kubernetes/test-infra/pull/17154