### PR TITLE
Remove ci-kubernetes-e2e-gce-min-node-permissions

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
@@ -24,30 +24,3 @@ periodics:
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gce-ha-master
-- interval: 24h
-  name: ci-kubernetes-e2e-gce-min-node-permissions
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=520
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      # TODO(@ihmccreery): is this right?
-      - --env=KUBE_GCE_NODE_SERVICE_ACCOUNT=min-node-permissions@k8s-min-node-permissions.iam.gserviceaccount.com
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-project=k8s-min-node-permissions
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --test_args=--ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
-      - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200404-7b4af8e-master
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gce-min-node-permissions


### PR DESCRIPTION
It has never passed in 923 days since it first ran on 2017-09-28