### PR TITLE
Ghcache: partition by Authorization header

### DIFF
--- a/ghproxy/README.md
+++ b/ghproxy/README.md
@@ -4,9 +4,7 @@ ghProxy is a reverse proxy HTTP cache optimized for use with the GitHub API (htt
 It is essentially just a reverse proxy wrapper around [ghCache](/ghproxy/ghcache) with Prometheus instrumentation to monitor disk usage.
 
 ghProxy is designed to reduce API token usage by allowing many components to
-share a single ghCache. Note that components must use the same API token to
-benefit from the cache and avoid clobbering existing cache entries for other
-tokens.
+share a single ghCache.
 
 ## with Prow
 

--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "coalesce.go",
         "ghcache.go",
+        "partitioner.go",
     ],
     importpath = "k8s.io/test-infra/ghproxy/ghcache",
     visibility = ["//visibility:public"],
@@ -37,7 +38,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["coalesce_test.go"],
+    srcs = [
+        "coalesce_test.go",
+        "partitioner_test.go",
+    ],
     embed = [":go_default_library"],
     deps = ["@io_k8s_apimachinery//pkg/util/diff:go_default_library"],
 )

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -91,10 +91,19 @@ var pendingOutboundConnectionsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
 	Help: "How many pending requests are waiting to be sent to GitHub servers.",
 })
 
+var cachePartitionsCounter = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "ghcache_cache_parititions",
+		Help: "Which cache partitions exist",
+	},
+	[]string{"token_hash"},
+)
+
 func init() {
 
 	prometheus.MustRegister(outboundConcurrencyGauge)
 	prometheus.MustRegister(pendingOutboundConnectionsGauge)
+	prometheus.MustRegister(cachePartitionsCounter)
 }
 
 func cacheResponseMode(headers http.Header) CacheResponseMode {
@@ -199,40 +208,58 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 // NewDiskCache creates a GitHub cache RoundTripper that is backed by a disk
 // cache.
+// It supports a partitioned cache.
 func NewDiskCache(delegate http.RoundTripper, cacheDir string, cacheSizeGB, maxConcurrency int) http.RoundTripper {
-	return NewFromCache(delegate, diskcache.NewWithDiskv(
-		diskv.New(diskv.Options{
-			BasePath:     path.Join(cacheDir, "data"),
-			TempDir:      path.Join(cacheDir, "temp"),
-			CacheSizeMax: uint64(cacheSizeGB) * uint64(1000000000), // convert G to B
-		})),
+	return NewFromCache(delegate,
+		func(partitionKey string) httpcache.Cache {
+			return diskcache.NewWithDiskv(
+				diskv.New(diskv.Options{
+					BasePath:     path.Join(cacheDir, "data", partitionKey),
+					TempDir:      path.Join(cacheDir, "temp", partitionKey),
+					CacheSizeMax: uint64(cacheSizeGB) * uint64(1000000000), // convert G to B
+				}))
+		},
 		maxConcurrency,
 	)
 }
 
 // NewMemCache creates a GitHub cache RoundTripper that is backed by a memory
 // cache.
+// It supports a partitioned cache.
 func NewMemCache(delegate http.RoundTripper, maxConcurrency int) http.RoundTripper {
-	return NewFromCache(delegate, httpcache.NewMemoryCache(), maxConcurrency)
+	return NewFromCache(delegate,
+		func(_ string) httpcache.Cache { return httpcache.NewMemoryCache() },
+		maxConcurrency)
 }
+
+// CachePartitionCreator creates a new cache partition using the given key
+type CachePartitionCreator func(partitionKey string) httpcache.Cache
 
 // NewFromCache creates a GitHub cache RoundTripper that is backed by the
 // specified httpcache.Cache implementation.
-func NewFromCache(delegate http.RoundTripper, cache httpcache.Cache, maxConcurrency int) http.RoundTripper {
-	cacheTransport := httpcache.NewTransport(cache)
-	cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{delegate: delegate})
-	return &requestCoalescer{
-		keys:     make(map[string]*responseWaiter),
-		delegate: cacheTransport,
-	}
+func NewFromCache(delegate http.RoundTripper, cache CachePartitionCreator, maxConcurrency int) http.RoundTripper {
+	return newPartitioningRoundTripper(func(partitionKey string) http.RoundTripper {
+		cacheTransport := httpcache.NewTransport(cache(partitionKey))
+		cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{delegate: delegate})
+		return &requestCoalescer{
+			keys:     make(map[string]*responseWaiter),
+			delegate: cacheTransport,
+		}
+	})
 }
 
 // NewRedisCache creates a GitHub cache RoundTripper that is backed by a Redis
 // cache.
+// Important note: The redis implementation does not support partitioning the cache
+// which means that requests to the same path from different tokens will invalidate
+// each other.
 func NewRedisCache(delegate http.RoundTripper, redisAddress string, maxConcurrency int) http.RoundTripper {
 	conn, err := redis.Dial("tcp", redisAddress)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error connecting to Redis")
 	}
-	return NewFromCache(delegate, rediscache.NewWithClient(conn), maxConcurrency)
+	redisCache := rediscache.NewWithClient(conn)
+	return NewFromCache(delegate,
+		func(_ string) httpcache.Cache { return redisCache },
+		maxConcurrency)
 }

--- a/ghproxy/ghcache/partitioner.go
+++ b/ghproxy/ghcache/partitioner.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"net/http"
 	"sync"
+
+	"github.com/sirupsen/logrus"
 )
 
 type roundTripperCreator func(partitionKey string) http.RoundTripper
@@ -53,6 +55,7 @@ func (prt *partitioningRoundTripper) RoundTrip(r *http.Request) (*http.Response,
 	prt.lock.Lock()
 	roundTripper, found := prt.roundTrippers[cachePartition]
 	if !found {
+		logrus.WithField("cache-parition-key", cachePartition).Info("Creating a new cache for partition")
 		cachePartitionsCounter.WithLabelValues(cachePartition).Add(1)
 		prt.roundTrippers[cachePartition] = prt.roundTripperCreator(cachePartition)
 		roundTripper = prt.roundTrippers[cachePartition]

--- a/ghproxy/ghcache/partitioner.go
+++ b/ghproxy/ghcache/partitioner.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghcache
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"sync"
+)
+
+type roundTripperCreator func(partitionKey string) http.RoundTripper
+
+// partitioningRoundTripper is a http.RoundTripper
+var _ http.RoundTripper = &partitioningRoundTripper{}
+
+func newPartitioningRoundTripper(rtc roundTripperCreator) *partitioningRoundTripper {
+	return &partitioningRoundTripper{
+		roundTripperCreator: rtc,
+		lock:                &sync.Mutex{},
+		roundTrippers:       map[string]http.RoundTripper{},
+	}
+}
+
+type partitioningRoundTripper struct {
+	roundTripperCreator roundTripperCreator
+	lock                *sync.Mutex
+	roundTrippers       map[string]http.RoundTripper
+}
+
+func getCachePartition(r *http.Request) string {
+	// Hash the key to make sure we dont leak it into the directory layout
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(r.Header.Get("Authorization"))))
+}
+
+func (prt *partitioningRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	cachePartition := getCachePartition(r)
+
+	prt.lock.Lock()
+	roundTripper, found := prt.roundTrippers[cachePartition]
+	if !found {
+		cachePartitionsCounter.WithLabelValues(cachePartition).Add(1)
+		prt.roundTrippers[cachePartition] = prt.roundTripperCreator(cachePartition)
+		roundTripper = prt.roundTrippers[cachePartition]
+	}
+	prt.lock.Unlock()
+
+	return roundTripper.RoundTrip(r)
+}

--- a/ghproxy/ghcache/partitioner_test.go
+++ b/ghproxy/ghcache/partitioner_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghcache
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+)
+
+type fakeRoundTripperCreator struct {
+	t             *testing.T
+	lock          *sync.Mutex
+	roundTrippers map[string]*fakeRoundTripper
+}
+
+func (frtc *fakeRoundTripperCreator) createRoundTripper(partitionKey string) http.RoundTripper {
+	frtc.lock.Lock()
+	defer frtc.lock.Unlock()
+	_, alreadyExists := frtc.roundTrippers[partitionKey]
+	if alreadyExists {
+		frtc.t.Fatalf("creation of already existing partition %q was requested", partitionKey)
+	}
+	frtc.roundTrippers[partitionKey] = &fakeRoundTripper{lock: &sync.Mutex{}}
+	return frtc.roundTrippers[partitionKey]
+}
+
+type fakeRoundTripper struct {
+	lock *sync.Mutex
+	used bool
+}
+
+func (frt *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	frt.lock.Lock()
+	frt.used = true
+	frt.lock.Unlock()
+	return &http.Response{}, nil
+}
+
+func TestPartitioningRoundTripper(t *testing.T) {
+	creator := &fakeRoundTripperCreator{
+		t:             t,
+		lock:          &sync.Mutex{},
+		roundTrippers: map[string]*fakeRoundTripper{},
+	}
+	partitioningRoundTripper := newPartitioningRoundTripper(creator.createRoundTripper)
+
+	requests := []*http.Request{
+		{Header: http.Header(map[string][]string{"Authorization": {"a"}})},
+		{Header: http.Header(map[string][]string{"Authorization": {"a"}})},
+		{Header: http.Header(map[string][]string{"Authorization": {"b"}})},
+		{Header: http.Header(map[string][]string{"Authorization": {"b"}})},
+		{Header: http.Header(map[string][]string{"Authorization": {"c"}})},
+		{Header: http.Header(map[string][]string{"Authorization": {"c"}})},
+	}
+
+	// Do these in parallel to verify thread safety
+	wg := &sync.WaitGroup{}
+	for _, request := range requests {
+		wg.Add(1)
+		request := request
+		go func() {
+			defer wg.Done()
+			_, err := partitioningRoundTripper.RoundTrip(request)
+			if err != nil {
+				t.Fatalf("RoundTrip: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if n := len(creator.roundTrippers); n != 3 {
+		t.Errorf("expected three roundtrippers, got %d (%v)", n, creator.roundTrippers)
+	}
+	for name, roundTripper := range creator.roundTrippers {
+		if !roundTripper.used {
+			t.Errorf("roundtripper %q wasnt used", name)
+		}
+	}
+}

--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -112,7 +112,7 @@ func (o *options) validate() error {
 func flagOptions() *options {
 	o := &options{}
 	flag.StringVar(&o.dir, "cache-dir", "", "Directory to cache to if using a disk cache.")
-	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB if using a disk cache.")
+	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB per unique token if using a disk cache.")
 	flag.StringVar(&o.redisAddress, "redis-address", "", "Redis address if using a redis cache e.g. localhost:6379.")
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")


### PR DESCRIPTION
Currently, ghcache uses the request url as cache key which means that if one instance is used with multiple tokens, requests to the same path will invalidate each other because they return different etags:

```
$ curl -Ss -i -H "Authorization: Bearer << some-token>>" https://api.github.com/users/alvaroaleman|grep -i etag:
ETag: "a14c08e67675f0ed57c680ea06a8ca1f"
```
vs
```
$ curl -Ss -i https://api.github.com/users/alvaroaleman|grep -i etag:
ETag: W/"0b9ccb547400349ca1f622f2cb02601a"
```

This PR fixes that by adding wrapper that creates a cache per unique `Authorization` header. 

/assign @stevekuznetsov @cjwagner 