### PR TITLE
Add label for Ukrainian language

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -367,6 +367,7 @@ larger set of contributors to apply/remove them.
 | <a id="language/pl" href="#language/pl">`language/pl`</a> | Issues or PRs related to Polish language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/pt" href="#language/pt">`language/pt`</a> | Issues or PRs related to Portuguese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/ru" href="#language/ru">`language/ru`</a> | Issues or PRs related to Russian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="language/uk" href="#language/uk">`language/uk`</a> | Issues or PRs related to Ukrainian language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/vi" href="#language/vi">`language/vi`</a> | Issues or PRs related to Vietnamese language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/zh" href="#language/zh">`language/zh`</a> | Issues or PRs related to Chinese language <br><br> This was previously `language/cn`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1289,6 +1289,12 @@ repos:
         prowPlugin: label
         addedBy: anyone
       - color: e9b3f9
+        description: Issues or PRs related to Ukrainian language
+        name: language/uk
+        target: both
+        prowPlugin: label
+        addedBy: anyone
+      - color: e9b3f9
         description: Issues or PRs related to Chinese language
         name: language/zh
         previously:


### PR DESCRIPTION
The website gained a Ukrainian localization in PR [#20020](https://github.com/kubernetes/website/pull/20020). Add a matching label, _language/uk_.