### PR TITLE
prow: fixup nil pointer introduced by s3 refactoring of gcs-upload

### DIFF
--- a/pkg/io/BUILD.bazel
+++ b/pkg/io/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/io/providers:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/s3/s3manager:go_default_library",
         "@com_github_googlecloudplatform_testgrid//util/gcs:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",

--- a/pkg/io/option.go
+++ b/pkg/io/option.go
@@ -18,6 +18,7 @@ package io
 
 import (
 	"cloud.google.com/go/storage"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"gocloud.dev/blob"
 	"google.golang.org/api/googleapi"
 )
@@ -55,7 +56,13 @@ func (wo WriterOptions) Apply(writer *storage.Writer, o *blob.WriterOptions) {
 	}
 
 	if wo.BufferSize != nil {
-		o.BufferSize = int(*wo.BufferSize)
+		// aws sdk throws an error if the BufferSize is smaller
+		// than the MinUploadPartSize
+		if *wo.BufferSize < s3manager.MinUploadPartSize {
+			o.BufferSize = int(s3manager.MinUploadPartSize)
+		} else {
+			o.BufferSize = int(*wo.BufferSize)
+		}
 	}
 	if wo.ContentEncoding != nil {
 		o.ContentEncoding = *wo.ContentEncoding

--- a/prow/pod-utils/gcs/metadata.go
+++ b/prow/pod-utils/gcs/metadata.go
@@ -43,8 +43,8 @@ type Finished = metadata.Finished
 //
 // and the simplified filename would be build-log.txt (excluding the
 // content encoding extension).
-func WriterOptionsFromFileName(filename string) (string, *io.WriterOptions) {
-	attrs := &io.WriterOptions{}
+func WriterOptionsFromFileName(filename string) (string, io.WriterOptions) {
+	attrs := io.WriterOptions{}
 	segments := strings.Split(filename, ".")
 	index := len(segments) - 1
 	segment := segments[index]

--- a/prow/pod-utils/gcs/metadata_test.go
+++ b/prow/pod-utils/gcs/metadata_test.go
@@ -33,13 +33,13 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 		name             string
 		filename         string
 		expectedFileName string
-		expectedAttrs    *io.WriterOptions
+		expectedAttrs    io.WriterOptions
 	}{
 		{
 			name:             "txt",
 			filename:         "build-log.txt",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
@@ -47,7 +47,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "txt.gz",
 			filename:         "build-log.txt.gz",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentEncoding: utilpointer.StringPtr("gzip"),
 				ContentType:     utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
@@ -56,7 +56,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "txt.gzip",
 			filename:         "build-log.txt.gzip",
 			expectedFileName: "build-log.txt",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentEncoding: utilpointer.StringPtr("gzip"),
 				ContentType:     utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
@@ -65,7 +65,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "bare gz",
 			filename:         "gz",
 			expectedFileName: "gz",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
@@ -73,7 +73,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "gz",
 			filename:         "build-log.gz",
 			expectedFileName: "build-log",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
@@ -81,7 +81,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "gzip",
 			filename:         "build-log.gzip",
 			expectedFileName: "build-log",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("application/gzip"),
 			},
 		},
@@ -89,7 +89,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "json",
 			filename:         "events.json",
 			expectedFileName: "events.json",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("application/json"),
 			},
 		},
@@ -97,7 +97,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "json.gz",
 			filename:         "events.json.gz",
 			expectedFileName: "events.json",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentEncoding: utilpointer.StringPtr("gzip"),
 				ContentType:     utilpointer.StringPtr("application/json"),
 			},
@@ -106,7 +106,7 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "log",
 			filename:         "journal.log",
 			expectedFileName: "journal.log",
-			expectedAttrs: &io.WriterOptions{
+			expectedAttrs: io.WriterOptions{
 				ContentType: utilpointer.StringPtr("text/plain; charset=utf-8"),
 			},
 		},
@@ -114,13 +114,13 @@ func TestWriterOptionsFromFileName(t *testing.T) {
 			name:             "empty",
 			filename:         "",
 			expectedFileName: "",
-			expectedAttrs:    &io.WriterOptions{},
+			expectedAttrs:    io.WriterOptions{},
 		},
 		{
 			name:             "dot",
 			filename:         ".",
 			expectedFileName: ".",
-			expectedAttrs:    &io.WriterOptions{},
+			expectedAttrs:    io.WriterOptions{},
 		},
 	}
 


### PR DESCRIPTION
The refactoring of gcs-upload yesterday introduced a critical bug (and probably breaks a lot of builds, #16722). This PR fixes the nil pointer introduced #16722