### PR TITLE
Replace the removed plugin log label.

### DIFF
--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -165,6 +165,7 @@ type Agent struct {
 
 // NewAgent bootstraps a new config.Agent struct from the passed dependencies.
 func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientAgent *ClientAgent, metrics *Metrics, logger *logrus.Entry, plugin string) Agent {
+	logger = logger.WithField("plugin", plugin)
 	prowConfig := configAgent.Config()
 	pluginConfig := pluginConfigAgent.Config()
 	gitHubClient := clientAgent.GitHubClient.WithFields(logger.Data).ForPlugin(plugin)


### PR DESCRIPTION
This was accidentally removed in https://github.com/kubernetes/test-infra/pull/16782

/assign @stevekuznetsov 