### PR TITLE
Boskos: Avoid error-level logs if possible

### DIFF
--- a/boskos/handlers/handlers_test.go
+++ b/boskos/handlers/handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -43,6 +44,8 @@ import (
 	"k8s.io/test-infra/boskos/crds"
 	"k8s.io/test-infra/boskos/ranch"
 )
+
+var update = flag.Bool("update", false, "If the fixtures should be updated")
 
 func init() {
 	// Don't actually sleep in tests
@@ -852,12 +855,15 @@ func TestDefault(t *testing.T) {
 
 func compareWithFixture(testName string, actualData []byte) error {
 	goldenFile := fmt.Sprintf("testdata/%s.golden", strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(testName, " ", "_"), "/", "-")))
+	if *update {
+		ioutil.WriteFile(goldenFile, actualData, 0644)
+	}
 	expected, err := ioutil.ReadFile(goldenFile)
 	if err != nil {
 		return fmt.Errorf("error reading fixture %q: %v", goldenFile, err)
 	}
 	if !bytes.Equal(expected, actualData) {
-		return fmt.Errorf("fixture %s\n%s\n does not match received data\n%s\n", goldenFile, string(expected), string(actualData))
+		return fmt.Errorf("fixture %s\n%s\n does not match received data\n%s\n. If this is expeted, please re-run the test with `-update` to update the fixture", goldenFile, string(expected), string(actualData))
 	}
 
 	return nil

--- a/boskos/handlers/testdata/testacquirebystate-alreadyowned-response.golden
+++ b/boskos/handlers/testdata/testacquirebystate-alreadyowned-response.golden
@@ -1,1 +1,1 @@
-no available resource state1, try again later.
+AcquireByState: no available resource state1, try again later.

--- a/boskos/handlers/testdata/testacquirebystate-nostate-response.golden
+++ b/boskos/handlers/testdata/testacquirebystate-nostate-response.golden
@@ -1,1 +1,1 @@
-no available resource state1, try again later.
+AcquireByState: no available resource state1, try again later.


### PR DESCRIPTION
We still log a lot of normal and expected conditions on error level, for instance
```
{ "msg": "No available resource", "level": "error", "component": "boskos", "file": "boskos/handlers/handlers.go:122", "error": "no available resource aws-quota-slice, try again later.", "func": "k8s.io/test-infra/boskos/handlers.handleAcquire.func1" }
```

This makes finding real errors hard. This PR downgrades the logs to debug where its not a 5xx.

/assign @stevekuznetsov @ixdy 