### PR TITLE
GCSUpload: Remove special case for GCP

### DIFF
--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -16,10 +16,8 @@ go_library(
         "//prow/pod-utils/downwardapi:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@com_google_cloud_go//storage:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_utils//pointer:go_default_library",
-        "@org_golang_google_api//option:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This PR removes the special case for GCS in the podutils/gcs package. We already have a special case for it within pkg/io.

Doing this in a dedicated PR so its trivial to revert if need be.

/assign @fejta @sbueringer 