### PR TITLE
github: publish user info for token hashes

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -162,9 +162,7 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		"user-agent": req.Header.Get("User-Agent"),
 		"source-ip":  req.RemoteAddr,
 	}).Debug("Hashing auth header.")
-	hasher := sha256.New()
-	hasher.Write([]byte(authHeader))
-	authHeaderHash := fmt.Sprintf("%x", hasher.Sum(nil)) // use %x to make this a utf-8 string for use as a label
+	authHeaderHash := fmt.Sprintf("%x", sha256.Sum256([]byte(authHeader))) // use %x to make this a utf-8 string for use as a label
 
 	reqStartTime := time.Now()
 	// Don't modify request, just pass to delegate.

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
     deps = [
         "//ghproxy/ghcache:go_default_library",
         "//prow/version:go_default_library",
+        "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",


### PR DESCRIPTION
Currently, GitHub API interactions are sharded by the hash of the
authorization token used to make them, in order to track between
accounts that may be using ghproxy concurrently. This new metric allows
for a join on labels to identify those users by name.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @cjw