### PR TITLE
plugins/approve: do not approve empty PRs

### DIFF
--- a/prow/plugins/approve/approvers/approvers_test.go
+++ b/prow/plugins/approve/approvers/approvers_test.go
@@ -404,7 +404,7 @@ func TestIsApproved(t *testing.T) {
 			filenames:         []string{},
 			currentlyApproved: sets.NewString(),
 			testSeed:          0,
-			isApproved:        true,
+			isApproved:        false,
 		},
 		{
 			testName:          "Single Root File PR Approved",

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -484,10 +484,11 @@ func (ap Approvers) GetCCs() []string {
 }
 
 // AreFilesApproved returns a bool indicating whether or not OWNERS files associated with
-// the PR are approved.  If this returns true, the PR may still not be fully approved depending
-// on the associated issue requirement
+// the PR are approved.  A PR with no OWNERS files is not considered approved. If this
+// returns true, the PR may still not be fully approved depending on the associated issue
+// requirement
 func (ap Approvers) AreFilesApproved() bool {
-	return ap.UnapprovedFiles().Len() == 0
+	return len(ap.owners.filenames) != 0 && ap.UnapprovedFiles().Len() == 0
 }
 
 // RequirementsMet returns a bool indicating whether the PR has met all approval requirements:


### PR DESCRIPTION
It can be confusing to humans when the bot auto-approves a PR that has no 
changes, this is usually a mistake by the PR author

ref: https://kubernetes.slack.com/archives/C1J0BPD2M/p1586389332162800?thread_ts=1586389250.162400&cid=C1J0BPD2M