### PR TITLE
Update sig-scheduling owners

### DIFF
--- a/config/jobs/kubernetes/sig-scheduling/OWNERS
+++ b/config/jobs/kubernetes/sig-scheduling/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- bsalamat
-- k82cn
+- ahg-g
+- Huang-Wei
 approvers:
-- bsalamat
-- k82cn
+- ahg-g
+- Huang-Wei
 labels:
 - sig/scheduling

--- a/config/testgrids/kubernetes/sig-scheduling/OWNERS
+++ b/config/testgrids/kubernetes/sig-scheduling/OWNERS
@@ -1,8 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- bsalamat
-- k82cn
+- ahg-g
+- Huang-Wei
 approvers:
-- bsalamat
-- k82cn
+- ahg-g
+- Huang-Wei


### PR DESCRIPTION
Bobby and Klause are no longer taking the lead role. Update the OWNERS file to reflect its latest state.

/sig scheduling