### PR TITLE
github: use 'Bearer' authentication type

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -798,7 +798,7 @@ func (c *client) doRequest(method, path, accept string, body interface{}) (*http
 }
 
 func (c *client) authHeader() string {
-	return fmt.Sprintf("Token %s", c.getToken())
+	return fmt.Sprintf("Bearer %s", c.getToken())
 }
 
 // userInfo provides the 'github_user_info' vector that is indexed


### PR DESCRIPTION
The GitHub V3 REST documentation instructs users to use 'token' as the
authorization header type, but this is not a valid type as per the
IANA/RFC. The 'bearer' type is correct, works with GitHub V3 and matches
what we send for V4. As a side-effect, using this will allow for the
hashes used to identify requests to uniquely identify users whether they
are sending v3 or v4 requests through ghproxy.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

```
$ curl -s -H "Authorization: Bearer $( kubectl get secret github-credentials-openshift-merge-robot -o jsonpath={.data.oauth} | base64 --decode )" https://api.github.com/user | jq .login
"openshift-merge-robot"
$ curl -s -H "Authorization: Bearer $( kubectl get secret github-credentials-openshift-ci-robot -o jsonpath={.data.oauth} | base64 --decode )" https://api.github.com/user | jq .login
"openshift-ci-robot"
```

/assign @alvaroaleman @cjwagner 