### PR TITLE
Simplifying service-apis presubmits to build and verify

### DIFF
--- a/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
+++ b/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
@@ -1,78 +1,5 @@
 presubmits:
   kubernetes-sigs/service-apis:
-  - name: pull-service-apis-boilerplate
-    annotations:
-      testgrid-dashboards: sig-network-service-apis
-      testgrid-tab-name: boilerplate
-    decorate: true
-    path_alias: sigs.k8s.io/service-apis
-    always_run: true
-    skip_report: false
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
-        command:
-          # generic runner script, handles DIND, bazelrc for caching, etc.
-          - runner.sh
-        args:
-        - ./hack/verify-boilerplate.sh
-
-  - name: pull-service-apis-gofmt
-    annotations:
-      testgrid-dashboards: sig-network-service-apis
-      testgrid-tab-name: gofmt
-    decorate: true
-    path_alias: sigs.k8s.io/service-apis
-    always_run: true
-    skip_report: false
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
-        command:
-          # generic runner script, handles DIND, bazelrc for caching, etc.
-          - runner.sh
-        args:
-        - ./hack/verify-gofmt.sh
-
-  - name: pull-service-apis-golint
-    annotations:
-      testgrid-dashboards: sig-network-service-apis
-      testgrid-tab-name: golint
-    decorate: true
-    path_alias: sigs.k8s.io/service-apis
-    always_run: true
-    skip_report: false
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
-        command:
-          # generic runner script, handles DIND, bazelrc for caching, etc.
-          - runner.sh
-        args:
-          - ./hack/verify-golint.sh
-
-  - name: pull-service-apis-docs
-    annotations:
-      testgrid-dashboards: sig-network-service-apis
-      testgrid-tab-name: docs
-    decorate: true
-    path_alias: sigs.k8s.io/service-apis
-    always_run: true
-    skip_report: false
-    labels:
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
-        command:
-          # generic runner script, handles DIND, bazelrc for caching, etc.
-          - runner.sh
-        args:
-        - ./hack/verify-docs.sh
-        # docker-in-docker needs privileged mode.
-        securityContext:
-          privileged: true
-
   - name: pull-service-apis-build
     annotations:
       testgrid-dashboards: sig-network-service-apis
@@ -90,7 +17,28 @@ presubmits:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
         args:
-          - make
+          - make controller
+        # docker-in-docker needs privileged mode.
+        securityContext:
+          privileged: true
+  - name: pull-service-apis-verify
+    annotations:
+      testgrid-dashboards: sig-network-service-apis
+      testgrid-tab-name: verify
+    labels:
+      preset-dind-enabled: "true"
+    decorate: true
+    path_alias: sigs.k8s.io/service-apis
+    always_run: true
+    skip_report: false
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
+        command:
+          # generic runner script, handles DIND, bazelrc for caching, etc.
+          - runner.sh
+        args:
+          - make verify
         # docker-in-docker needs privileged mode.
         securityContext:
           privileged: true


### PR DESCRIPTION
It looks like we missed adding verify-proto here when we added the task in the service-apis repo. Although I liked having all the tasks separated out as individual jobs, this changes it to run all `hack/verify-*` scripts in one go so we don't end up missing any new verify scripts here in the future.

For context, this came up in this PR: https://github.com/kubernetes-sigs/service-apis/pull/146 

/cc @bowei @aojea @danehans 