### PR TITLE
Support for S3 default credential provider chain

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -465,9 +465,7 @@ func (d *DecorationConfig) Validate() error {
 	if d.GCSConfiguration == nil {
 		return errors.New("GCS upload configuration is not specified")
 	}
-	if d.GCSCredentialsSecret == "" && d.S3CredentialsSecret == "" {
-		return errors.New("neither GCS nor S3 credential secret are specified")
-	}
+
 	if err := d.GCSConfiguration.Validate(); err != nil {
 		return fmt.Errorf("GCS configuration is invalid: %v", err)
 	}

--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -87,10 +87,6 @@ func (o *Options) Validate() error {
 		if o.Bucket == "" {
 			return errors.New("GCS upload was requested no GCS bucket was provided")
 		}
-
-		if o.GcsCredentialsFile == "" && o.S3CredentialsFile == "" {
-			return errors.New("blob storage upload was requested but neither GCS nor S3 credentials file was provided")
-		}
 	}
 
 	return o.GCSConfiguration.Validate()

--- a/prow/io/providers/providers.go
+++ b/prow/io/providers/providers.go
@@ -67,8 +67,12 @@ func GetBucket(ctx context.Context, s3Credentials []byte, path string) (*blob.Bu
 	if storageProvider == providerS3 && len(s3Credentials) > 0 {
 		return getS3Bucket(ctx, s3Credentials, bucket)
 	}
-
-	bkt, err := blob.OpenBucket(ctx, fmt.Sprintf("%s://%s", storageProvider, bucket))
+	urlstr := fmt.Sprintf("%s://%s", storageProvider, bucket)
+	qmarkIdx := strings.Index(path, "?")
+	if qmarkIdx >= 0 {
+		urlstr += path[qmarkIdx:]
+	}
+	bkt, err := blob.OpenBucket(ctx, urlstr)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file bucket: %v", err)
 	}


### PR DESCRIPTION
This PR enables default credential provider chain using the fallback gocloud default discovery. Thanks to @sbueringer for the direction.

This has been tested with AWS S3 and the changes done are:
- Removed checking of GCS or S3 credentials in DecorationConfig validation 
- Fixes wrong bucket path passed to [opener.Writer](https://github.com/kubernetes/test-infra/blob/master/prow/pod-utils/gcs/upload.go#L182) when `gcs_configuration.bucket` contains query parameter
- Fixes query parameter not passed in provider [blob.OpenBucket](https://github.com/kubernetes/test-infra/blob/master/prow/io/providers/providers.go#L71)

/cc @sbueringer 