### PR TITLE
releng: Update OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -203,6 +203,21 @@ aliases:
     - frapposelli
 ## END CUSTOM CONTENT
 
+  # copied from git.k8s.io/kubernetes/OWNERS_ALIASES
+  release-engineering-approvers:
+    - calebamiles # subproject owner
+    - justaugustus # subproject owner / Patch Release Team
+    - tpepper # subproject owner / Patch Release Team
+  release-engineering-reviewers:
+    - calebamiles # subproject owner
+    - cpanato # Branch Manager
+    - feiskyer # Patch Release Team
+    - hasheddan # Branch Manager
+    - hoegaarden # Patch Release Team
+    - justaugustus # subproject owner / Patch Release Team
+    - saschagrunert # Branch Manager
+    - tpepper # subproject owner / Patch Release Team
+
   # copied from sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
   cluster-api-admins:
     - detiber

--- a/config/jobs/kubernetes/release/OWNERS
+++ b/config/jobs/kubernetes/release/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - tpepper
 
 reviewers:
-- aleksandra-malinowska # Patch Release Team
 - cpanato # Branch Manager
 - dougm # Patch Release Team
 - feiskyer # Patch Release Team

--- a/config/jobs/kubernetes/release/OWNERS
+++ b/config/jobs/kubernetes/release/OWNERS
@@ -1,17 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- calebamiles
-- justaugustus
-- tpepper
+- release-engineering-approvers
 
 reviewers:
-- cpanato # Branch Manager
-- dougm # Patch Release Team
-- feiskyer # Patch Release Team
-- hoegaarden # Patch Release Team
-- idealhack # Patch Release Team
-- saschagrunert # Branch Manager
+- release-engineering-reviewers
 
 labels:
 - sig/release

--- a/config/jobs/kubernetes/sig-release/OWNERS
+++ b/config/jobs/kubernetes/sig-release/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - tpepper
 
 reviewers:
-- aleksandra-malinowska # Patch Release Team
 - cpanato # Branch Manager
 - dougm # Patch Release Team
 - feiskyer # Patch Release Team

--- a/config/jobs/kubernetes/sig-release/OWNERS
+++ b/config/jobs/kubernetes/sig-release/OWNERS
@@ -1,17 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- calebamiles
-- justaugustus
-- tpepper
+- release-engineering-approvers
 
 reviewers:
-- cpanato # Branch Manager
-- dougm # Patch Release Team
-- feiskyer # Patch Release Team
-- hoegaarden # Patch Release Team
-- idealhack # Patch Release Team
-- saschagrunert # Branch Manager
+- release-engineering-reviewers
 
 labels:
 - sig/release

--- a/config/testgrids/kubernetes/sig-release/OWNERS
+++ b/config/testgrids/kubernetes/sig-release/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - tpepper
 
 reviewers:
-- aleksandra-malinowska # Patch Release Team
 - cpanato # Branch Manager
 - dougm # Patch Release Team
 - feiskyer # Patch Release Team

--- a/config/testgrids/kubernetes/sig-release/OWNERS
+++ b/config/testgrids/kubernetes/sig-release/OWNERS
@@ -1,17 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- calebamiles
-- justaugustus
-- tpepper
+- release-engineering-approvers
 
 reviewers:
-- cpanato # Branch Manager
-- dougm # Patch Release Team
-- feiskyer # Patch Release Team
-- hoegaarden # Patch Release Team
-- idealhack # Patch Release Team
-- saschagrunert # Branch Manager
+- release-engineering-reviewers
 
 labels:
 - sig/release

--- a/releng/OWNERS
+++ b/releng/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - tpepper
 
 reviewers:
-- aleksandra-malinowska # Patch Release Team
 - cpanato # Branch Manager
 - dougm # Patch Release Team
 - feiskyer # Patch Release Team

--- a/releng/OWNERS
+++ b/releng/OWNERS
@@ -1,18 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- calebamiles
-- justaugustus
+- release-engineering-approvers
 - Katharine
-- tpepper
 
 reviewers:
-- cpanato # Branch Manager
-- dougm # Patch Release Team
-- feiskyer # Patch Release Team
-- hoegaarden # Patch Release Team
-- idealhack # Patch Release Team
-- saschagrunert # Branch Manager
+- release-engineering-reviewers
 
 labels:
 - sig/release


### PR DESCRIPTION
- Remove @aleksandra-malinowska from Patch Release Team (ref: https://github.com/kubernetes/sig-release/issues/987)
- Promote @hasheddan to Branch Manager (ref: https://github.com/kubernetes/sig-release/issues/1041)
- Use `OWNER_ALIASES` for Release Engineering reviewers/approvers

/assign @spiffxp @Katharine @fejta 
cc: @kubernetes/release-engineering 

