### PR TITLE
ghproxy: add token hash label to cache response metric

### DIFF
--- a/ghproxy/ghcache/BUILD.bazel
+++ b/ghproxy/ghcache/BUILD.bazel
@@ -43,5 +43,8 @@ go_test(
         "partitioner_test.go",
     ],
     embed = [":go_default_library"],
-    deps = ["@io_k8s_apimachinery//pkg/util/diff:go_default_library"],
+    deps = [
+        "//ghproxy/ghmetrics:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+    ],
 )

--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -35,6 +35,8 @@ type requestCoalescer struct {
 	keys map[string]*responseWaiter
 
 	delegate http.RoundTripper
+
+	hasher ghmetrics.Hasher
 }
 
 type responseWaiter struct {
@@ -129,7 +131,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}()
 
-	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), authHeaderHash(req))
+	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), r.hasher.Hash(req))
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
 	}

--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -129,7 +129,7 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}()
 
-	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"))
+	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), authHeaderHash(req))
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
 	}

--- a/ghproxy/ghcache/coalesce_test.go
+++ b/ghproxy/ghcache/coalesce_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"k8s.io/test-infra/ghproxy/ghmetrics"
 	"net/http"
 	"net/url"
 	"reflect"
@@ -74,6 +75,7 @@ func TestRoundTrip(t *testing.T) {
 	coalesce := &requestCoalescer{
 		keys:     make(map[string]*responseWaiter),
 		delegate: delegate,
+		hasher:   ghmetrics.NewCachingHasher(),
 	}
 	wg := sync.WaitGroup{}
 	wg.Add(100)
@@ -119,6 +121,7 @@ func TestCacheModeHeader(t *testing.T) {
 	coalesce := &requestCoalescer{
 		keys:     make(map[string]*responseWaiter),
 		delegate: delegate,
+		hasher:   ghmetrics.NewCachingHasher(),
 	}
 
 	checkMode := func(resp *http.Response, expected CacheResponseMode) {

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -158,20 +158,7 @@ type upstreamTransport struct {
 
 func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	etag := req.Header.Get("if-none-match")
-
-	// get authorization header to convert to sha256
-	authHeader := req.Header.Get("Authorization")
-	if authHeader == "" {
-		logrus.Warn("Couldn't retrieve 'Authorization' header, adding to unknown bucket")
-		authHeader = "unknown"
-	}
-	logrus.WithFields(logrus.Fields{
-		"words":      len(strings.Split(authHeader, " ")),
-		"length":     len(authHeader),
-		"user-agent": req.Header.Get("User-Agent"),
-		"source-ip":  req.RemoteAddr,
-	}).Debug("Hashing auth header.")
-	authHeaderHash := fmt.Sprintf("%x", sha256.Sum256([]byte(authHeader))) // use %x to make this a utf-8 string for use as a label
+	authHeaderHash := authHeaderHash(req)
 
 	reqStartTime := time.Now()
 	// Don't modify request, just pass to delegate.
@@ -204,6 +191,16 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 	ghmetrics.CollectGitHubRequestMetrics(authHeaderHash, req.URL.Path, strconv.Itoa(resp.StatusCode), req.Header.Get("User-Agent"), roundTripTime.Seconds())
 
 	return resp, nil
+}
+
+func authHeaderHash(req *http.Request) string {
+	// get authorization header to convert to sha256
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" {
+		logrus.Warn("Couldn't retrieve 'Authorization' header, adding to unknown bucket")
+		authHeader = "unknown"
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(authHeader))) // use %x to make this a utf-8 string for use as a label
 }
 
 const LogMessageWithDiskPartitionFields = "Not using a partitioned cache because legacyDisablePartitioningByAuthHeader is true"

--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -154,11 +154,12 @@ func (c *throttlingTransport) RoundTrip(req *http.Request) (*http.Response, erro
 // This instructs the cache to store the response, but always consider it stale.
 type upstreamTransport struct {
 	delegate http.RoundTripper
+	hasher   ghmetrics.Hasher
 }
 
 func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	etag := req.Header.Get("if-none-match")
-	authHeaderHash := authHeaderHash(req)
+	authHeaderHash := u.hasher.Hash(req)
 
 	reqStartTime := time.Now()
 	// Don't modify request, just pass to delegate.
@@ -254,12 +255,14 @@ type CachePartitionCreator func(partitionKey string) httpcache.Cache
 // NewFromCache creates a GitHub cache RoundTripper that is backed by the
 // specified httpcache.Cache implementation.
 func NewFromCache(delegate http.RoundTripper, cache CachePartitionCreator, maxConcurrency int) http.RoundTripper {
+	hasher := ghmetrics.NewCachingHasher()
 	return newPartitioningRoundTripper(func(partitionKey string) http.RoundTripper {
 		cacheTransport := httpcache.NewTransport(cache(partitionKey))
-		cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{delegate: delegate})
+		cacheTransport.Transport = newThrottlingTransport(maxConcurrency, upstreamTransport{delegate: delegate, hasher: hasher})
 		return &requestCoalescer{
 			keys:     make(map[string]*responseWaiter),
 			delegate: cacheTransport,
+			hasher:   hasher,
 		}
 	})
 }

--- a/ghproxy/ghmetrics/BUILD.bazel
+++ b/ghproxy/ghmetrics/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "ghmetrics.go",
         "ghpath.go",
+        "hash.go",
     ],
     importpath = "k8s.io/test-infra/ghproxy/ghmetrics",
     visibility = ["//visibility:public"],

--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -65,7 +65,7 @@ var cacheCounter = prometheus.NewCounterVec(
 		Name: "ghcache_responses",
 		Help: "How many cache responses of each cache response mode there are.",
 	},
-	[]string{"mode", "path", "user_agent"},
+	[]string{"mode", "path", "user_agent", "token_hash"},
 )
 
 // timeoutDuration provides the 'github_request_timeouts' histogram that keeps
@@ -150,8 +150,8 @@ func userAgentWithoutVersion(userAgent string) string {
 }
 
 // CollectCacheRequestMetrics records a cache outcome for a specific path
-func CollectCacheRequestMetrics(mode, path, userAgent string) {
-	cacheCounter.With(prometheus.Labels{"mode": mode, "path": simplifier.Simplify(path), "user_agent": userAgentWithoutVersion(userAgent)}).Inc()
+func CollectCacheRequestMetrics(mode, path, userAgent, tokenHash string) {
+	cacheCounter.With(prometheus.Labels{"mode": mode, "path": simplifier.Simplify(path), "user_agent": userAgentWithoutVersion(userAgent), "token_hash": tokenHash}).Inc()
 }
 
 // CollectRequestTimeoutMetrics publishes the duration of timed-out requests by

--- a/ghproxy/ghmetrics/hash.go
+++ b/ghproxy/ghmetrics/hash.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ghmetrics
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+// Hasher knows how to hash an authorization header from a request
+type Hasher interface {
+	Hash(req *http.Request) string
+}
+
+func NewCachingHasher() Hasher {
+	return &cachingHasher{
+		lock:   sync.RWMutex{},
+		hashes: map[string]string{},
+	}
+}
+
+type cachingHasher struct {
+	lock   sync.RWMutex
+	hashes map[string]string
+}
+
+func (h *cachingHasher) Hash(req *http.Request) string {
+	// get authorization header to convert to sha256
+	authHeader := req.Header.Get("Authorization")
+	if authHeader == "" {
+		logrus.Warn("Couldn't retrieve 'Authorization' header, adding to unknown bucket")
+		authHeader = "unknown"
+	}
+	h.lock.RLock()
+	hash, cached := h.hashes[authHeader]
+	h.lock.RUnlock()
+	if cached {
+		return hash
+	}
+
+	h.lock.Lock()
+	hash = fmt.Sprintf("%x", sha256.Sum256([]byte(authHeader))) // use %x to make this a utf-8 string for use as a label
+	h.hashes[authHeader] = hash
+	h.lock.Unlock()
+	return hash
+}


### PR DESCRIPTION
Without this label on the metric it's not possible to filter cache
responses by the user making the requests.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman @cjwagner 