### PR TITLE
jobs: rm ci-kubernetes-soak-gke-cos-containerd

### DIFF
--- a/config/jobs/gke/containerd/gke-test-containerd.yaml
+++ b/config/jobs/gke/containerd/gke-test-containerd.yaml
@@ -341,37 +341,3 @@ periodics:
   annotations:
     testgrid-dashboards: google-gke
     testgrid-tab-name: cos-gke-1.13-alpha-cluster-features
-- interval: 12h
-  name: ci-kubernetes-soak-gke-cos-containerd
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-    preset-cos-containerd-env: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=820
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --cluster=
-      - --deployment=gke
-      - --down=false
-      - --extract=ci/latest
-      - --gcp-cloud-sdk=gs://cloud-sdk-testing/ci/staging
-      - --gcp-node-image=cos_containerd
-      - --gcp-project=k8s-jkns-e2e-gci-gke-staging
-      - --gcp-zone=us-central1-f
-      - --ginkgo-parallel
-      - --gke-create-command=container clusters create --quiet
-      - --gke-environment=test
-      - --provider=gke
-      - --soak
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
-      - --timeout=800m
-      - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200413-9f25a5c-master
-  annotations:
-    testgrid-dashboards: google-soak
-    testgrid-tab-name: gke-cos-containerd


### PR DESCRIPTION
It's been failing for 615 days continuously and hasn't passed
since it was introduced on 2018-08-08