### PR TITLE
Deprecate plank reporting.

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -94,6 +94,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 14, 2020* GitHub reporting via plank is deprecated, set --github-workers=1 on crier before July 2020.
  - *March 27, 2020*  The deprecated `allow_cancellations` option has been removed from
    Plank and the Jenkins operator.
  - *March 19, 2020* The `rerun_auth_config` config field has been deprecated in

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -28,7 +28,6 @@ import (
 	"google.golang.org/api/option"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
-	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	prowjobinformer "k8s.io/test-infra/prow/client/informers/externalversions"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
@@ -256,7 +255,7 @@ func main() {
 			logrus.WithError(err).Fatal("Error getting GitHub client.")
 		}
 
-		githubReporter := githubreporter.NewReporter(githubClient, cfg, v1.ProwJobAgent(o.reportAgent))
+		githubReporter := githubreporter.NewReporter(githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))
 		controllers = append(
 			controllers,
 			crier.NewController(

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -20,14 +20,22 @@ go_binary(
 
 go_library(
     name = "go_default_library",
-    srcs = ["main.go"],
+    srcs = [
+        "main.go",
+        "reporter.go",
+    ],
     importpath = "k8s.io/test-infra/prow/cmd/plank",
     deps = [
         "//pkg/flagutil:go_default_library",
+        "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/client/informers/externalversions:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
+        "//prow/crier:go_default_library",
+        "//prow/crier/reporters/github:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -28,7 +29,6 @@ import (
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
-	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
@@ -48,7 +48,7 @@ type options struct {
 
 	dryRun     bool
 	kubernetes prowflagutil.KubernetesOptions
-	github     prowflagutil.GitHubOptions
+	github     prowflagutil.GitHubOptions // TODO(fejta): remove
 }
 
 func gatherOptions(fs *flag.FlagSet, args ...string) options {
@@ -58,7 +58,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.selector, "label-selector", labels.Everything().String(), "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
-	fs.BoolVar(&o.skipReport, "skip-report", false, "Whether or not to ignore report with githubClient")
+	fs.BoolVar(&o.skipReport, "skip-report", false, "Validate that crier is reporting to github, not plank")
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
@@ -96,22 +96,20 @@ func main() {
 
 	pjutil.ServePProf()
 
-	configAgent := &config.Agent{}
+	var configAgent config.Agent
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
 		logrus.WithError(err).Fatal("Error starting config agent.")
 	}
 	cfg := configAgent.Config
 
-	secretAgent := &secret.Agent{}
-	if o.github.TokenPath != "" {
-		if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
-			logrus.WithError(err).Fatal("Error starting secrets agent.")
+	var reporter func(context.Context)
+	if !o.skipReport {
+		logrus.Warn("Plank no longer supports github reporting, migrate to crier before June 2020")
+		var err error
+		reporter, err = deprecatedReporter(o.github, o.kubernetes, o.dryRun, cfg)
+		if err != nil {
+			logrus.WithError(err).Fatal("Error creating github reporter")
 		}
-	}
-
-	githubClient, err := o.github.GitHubClient(secretAgent, o.dryRun)
-	if err != nil {
-		logrus.WithError(err).Fatal("Error getting GitHub client.")
 	}
 
 	infrastructureClusterConfig, err := o.kubernetes.InfrastructureClusterConfig(o.dryRun)
@@ -132,7 +130,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating build cluster clients.")
 	}
 
-	c, err := plank.NewController(mgr.GetClient(), buildClusterClients, githubClient, nil, cfg, o.totURL, o.selector, o.skipReport)
+	c, err := plank.NewController(mgr.GetClient(), buildClusterClients, nil, cfg, o.totURL, o.selector)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating plank controller.")
 	}
@@ -140,6 +138,9 @@ func main() {
 	// Expose prometheus metrics
 	metrics.ExposeMetrics("plank", cfg().PushGateway)
 	// gather metrics for the jobs handled by plank.
+	if reporter != nil {
+		interrupts.Run(reporter)
+	}
 	interrupts.TickLiteral(func() {
 		start := time.Now()
 		c.SyncMetrics()

--- a/prow/cmd/plank/reporter.go
+++ b/prow/cmd/plank/reporter.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowjobinformer "k8s.io/test-infra/prow/client/informers/externalversions"
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/config/secret"
+	"k8s.io/test-infra/prow/crier"
+	githubreporter "k8s.io/test-infra/prow/crier/reporters/github"
+	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/kube"
+)
+
+func deprecatedReporter(github flagutil.GitHubOptions, kubernetes flagutil.KubernetesOptions, dryRun bool, cfg config.Getter) (func(context.Context), error) {
+	var secretAgent secret.Agent
+	if github.TokenPath != "" {
+		if err := secretAgent.Start([]string{github.TokenPath}); err != nil {
+			return nil, fmt.Errorf("start secret agent: %w", err)
+		}
+	}
+
+	githubClient, err := github.GitHubClient(&secretAgent, dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("github client: %w", err)
+	}
+
+	prowjobClientset, err := kubernetes.ProwJobClientset(cfg().ProwJobNamespace, dryRun)
+	if err != nil {
+		return nil, fmt.Errorf("prow client: %w", err)
+	}
+
+	const resync = 0
+	prowjobInformerFactory := prowjobinformer.NewSharedInformerFactoryWithOptions(prowjobClientset, resync, prowjobinformer.WithNamespace(cfg().ProwJobNamespace))
+	informer := prowjobInformerFactory.Prow().V1().ProwJobs()
+	githubReporter := githubreporter.NewReporter(githubClient, cfg, prowapi.ProwJobAgent(""))
+	controller := crier.NewController(
+		prowjobClientset,
+		kube.RateLimiter(githubReporter.GetName()),
+		informer,
+		githubReporter,
+		1)
+	return controller.Run, nil
+}

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -64,7 +64,7 @@ func (o *GitHubOptions) addFlags(wantDefaultGitHubTokenPath bool, fs *flag.FlagS
 	o.endpoint = NewStrings(github.DefaultAPIEndpoint)
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.graphqlEndpoint, "github-graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub GraphQL API endpoint (may differ for enterprise).")
-	defaultGitHubTokenPath := ""
+	var defaultGitHubTokenPath string
 	if wantDefaultGitHubTokenPath {
 		defaultGitHubTokenPath = "/etc/github/oauth"
 	}

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -13,8 +13,6 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/crier/reporters/github:go_default_library",
-        "//prow/github:go_default_library",
         "//prow/pjutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
@@ -37,9 +35,6 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/crier/reporters/github:go_default_library",
-        "//prow/github:go_default_library",
-        "//prow/github/report:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
@@ -47,7 +42,6 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],


### PR DESCRIPTION
Crier now owns this behavior.
* Delete plank's reporting logic
* Make plank spawn a crier github reporter (if necessary).
  - Warn if this is happening.
* DRY the logic for creating the github reporter controller
  - So plank and crier can both use it.
* Remove plank reporting unit tests.

ref https://github.com/GoogleCloudPlatform/oss-test-infra/issues/181