### PR TITLE
Add GCS_ARTIFACTS_DIR env var handling in pod-utils

### DIFF
--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -665,6 +665,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
@@ -702,6 +703,247 @@ func TestProwJobToPod(t *testing.T) {
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
 								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+					},
+					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(10),
+					Volumes: []coreapi.Volume{
+						{
+							Name: "logs",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "tools",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "gcs-credentials",
+							VolumeSource: coreapi.VolumeSource{
+								Secret: &coreapi.SecretVolumeSource{
+									SecretName: "secret-name",
+								},
+							},
+						},
+						{
+							Name: "clonerefs-tmp",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						cookieVolumeOnly("yummy/.gitcookies"),
+						{
+							Name: "code",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			podName: "pod",
+			buildID: "blabla",
+			labels:  map[string]string{"needstobe": "inherited"},
+			pjSpec: prowapi.ProwJobSpec{
+				Type: prowapi.PresubmitJob,
+				Job:  "job-name",
+				DecorationConfig: &prowapi.DecorationConfig{
+					Timeout:     &prowapi.Duration{Duration: 120 * time.Minute},
+					GracePeriod: &prowapi.Duration{Duration: 10 * time.Second},
+					UtilityImages: &prowapi.UtilityImages{
+						CloneRefs:  "clonerefs:tag",
+						InitUpload: "initupload:tag",
+						Entrypoint: "entrypoint:tag",
+						Sidecar:    "sidecar:tag",
+					},
+					GCSConfiguration: &prowapi.GCSConfiguration{
+						Bucket:       "gs://my-bucket",
+						PathStrategy: "legacy",
+						DefaultOrg:   "kubernetes",
+						DefaultRepo:  "kubernetes",
+						MediaTypes:   map[string]string{"log": "text/plain"},
+					},
+					GCSCredentialsSecret: "secret-name",
+					CookiefileSecret:     "yummy/.gitcookies",
+				},
+				Agent: prowapi.KubernetesAgent,
+				Refs: &prowapi.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []prowapi.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}},
+					PathAlias: "somewhere/else",
+				},
+				ExtraRefs: []prowapi.Refs{},
+				PodSpec: &coreapi.PodSpec{
+					Containers: []coreapi.Container{
+						{
+							Image:   "tester",
+							Command: []string{"/bin/thing"},
+							Args:    []string{"some", "args"},
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+							},
+						},
+					},
+				},
+			},
+			expected: &coreapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+					Labels: map[string]string{
+						kube.CreatedByProw:     "true",
+						kube.ProwJobTypeLabel:  "presubmit",
+						kube.ProwJobIDLabel:    "pod",
+						"needstobe":            "inherited",
+						kube.OrgLabel:          "org-name",
+						kube.RepoLabel:         "repo-name",
+						kube.PullLabel:         "1",
+						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
+					},
+					Annotations: map[string]string{
+						kube.ProwJobAnnotation: "job-name",
+					},
+				},
+				Spec: coreapi.PodSpec{
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
+					InitContainers: []coreapi.Container{
+						{
+							Name:    "clonerefs",
+							Image:   "clonerefs:tag",
+							Command: []string{"/clonerefs"},
+							Args:    []string{"--cookiefile=" + cookiePathOnly("yummy/.gitcookies")},
+							Env: []coreapi.EnvVar{
+								{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"` + cookiePathOnly("yummy/.gitcookies") + `"}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+								{
+									Name:      "clonerefs-tmp",
+									MountPath: "/tmp",
+								},
+								cookieMountOnly("yummy/.gitcookies"),
+							},
+						},
+						{
+							Name:    "initupload",
+							Image:   "initupload:tag",
+							Command: []string{"/initupload"},
+							Env: []coreapi.EnvVar{
+								{Name: "INITUPLOAD_OPTIONS", Value: `{"bucket":"gs://my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}`},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+						{
+							Name:    "place-entrypoint",
+							Image:   "entrypoint:tag",
+							Command: []string{"/bin/cp"},
+							Args: []string{
+								"/entrypoint",
+								"/tools/entrypoint",
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+							},
+						},
+					},
+					Containers: []coreapi.Container{
+						{
+							Name:       "test",
+							Image:      "tester",
+							Command:    []string{"/tools/entrypoint"},
+							Args:       []string{},
+							WorkingDir: "/home/prow/go/src/somewhere/else",
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+								{Name: "ARTIFACTS", Value: "/logs/artifacts"},
+								{Name: "BUILD_ID", Value: "blabla"},
+								{Name: "BUILD_NUMBER", Value: "blabla"},
+								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
+								{Name: "GOPATH", Value: "/home/prow/go"},
+								{Name: "JOB_NAME", Value: "job-name"},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+								{Name: "JOB_TYPE", Value: "presubmit"},
+								{Name: "PROW_JOB_ID", Value: "pod"},
+								{Name: "PULL_BASE_REF", Value: "base-ref"},
+								{Name: "PULL_BASE_SHA", Value: "base-sha"},
+								{Name: "PULL_NUMBER", Value: "1"},
+								{Name: "PULL_PULL_SHA", Value: "pull-sha"},
+								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
+								{Name: "REPO_NAME", Value: "repo-name"},
+								{Name: "REPO_OWNER", Value: "org-name"},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+							},
+						},
+						{
+							Name:    "sidecar",
+							Image:   "sidecar:tag",
+							Command: []string{"/sidecar"},
+							Env: []coreapi.EnvVar{
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"gs://my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -904,6 +1146,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
@@ -1153,6 +1396,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
@@ -1417,6 +1661,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
@@ -1628,6 +1873,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/logs/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"periodic","job":"job-name","buildid":"blabla","prowjobid":"pod"}`},
@@ -1820,6 +2066,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "BUILD_ID", Value: "blabla"},
 								{Name: "BUILD_NUMBER", Value: "blabla"},
 								{Name: "CI", Value: "true"},
+								{Name: "GCS_ARTIFACTS_DIR", Value: "gs://my-bucket/pr-logs/pull/org-name_repo-name/1/job-name/blabla/artifacts"},
 								{Name: "GOPATH", Value: "/home/prow/go"},
 								{Name: "JOB_NAME", Value: "job-name"},
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},

--- a/prow/pod-utils/downwardapi/jobspec.go
+++ b/prow/pod-utils/downwardapi/jobspec.go
@@ -86,7 +86,7 @@ const (
 	jobTypeEnv   = "JOB_TYPE"
 	prowJobIDEnv = "PROW_JOB_ID"
 
-	buildIDEnv     = "BUILD_ID"
+	BuildIDEnv     = "BUILD_ID"
 	prowBuildIDEnv = "BUILD_NUMBER" // Deprecated, will be removed in the future.
 
 	repoOwnerEnv   = "REPO_OWNER"
@@ -104,7 +104,7 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 	env := map[string]string{
 		ci:           "true",
 		jobNameEnv:   spec.Job,
-		buildIDEnv:   spec.BuildID,
+		BuildIDEnv:   spec.BuildID,
 		prowJobIDEnv: spec.ProwJobID,
 		jobTypeEnv:   string(spec.Type),
 	}
@@ -143,7 +143,7 @@ func EnvForSpec(spec JobSpec) (map[string]string, error) {
 
 // EnvForType returns the slice of environment variables to export for jobType
 func EnvForType(jobType prowapi.ProwJobType) []string {
-	baseEnv := []string{ci, jobNameEnv, JobSpecEnv, jobTypeEnv, prowJobIDEnv, buildIDEnv, prowBuildIDEnv}
+	baseEnv := []string{ci, jobNameEnv, JobSpecEnv, jobTypeEnv, prowJobIDEnv, BuildIDEnv, prowBuildIDEnv}
 	refsEnv := []string{repoOwnerEnv, repoNameEnv, pullBaseRefEnv, pullBaseShaEnv, pullRefsEnv}
 	pullEnv := []string{pullNumberEnv, pullPullShaEnv}
 


### PR DESCRIPTION
Handling of `GCS_ARTIFACTS_DIR` environment variable is required prior porting SIG Scalability tests to pod-utils. It was previously handled by _test-infra/jenkins/bootstrap.py_ and it's required to properly export logs using logexporter from cluster nodes after tests execution.

This issue explains the reason behind using logexporter for SIG Scalability tests: [kubernetes/issues/48513](https://github.com/kubernetes/kubernetes/issues/48513) and #3401 was the way it was solved.

/sig scalability