### PR TITLE
labels: Set deletion for 'sig/pm' and add 'area/enhancements'

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -99,7 +99,7 @@ larger set of contributors to apply/remove them.
 | <a id="sig/multicluster" href="#sig/multicluster">`sig/multicluster`</a> | Categorizes an issue or PR as relevant to sig-multicluster. <br><br> This was previously `sig/federation`, `sig/federation (deprecated - do not use)`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/network" href="#sig/network">`sig/network`</a> | Categorizes an issue or PR as relevant to sig-network.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/node" href="#sig/node">`sig/node`</a> | Categorizes an issue or PR as relevant to sig-node.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="sig/pm" href="#sig/pm">`sig/pm`</a> | Categorizes an issue or PR as relevant to sig-pm.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="sig/pm" href="#sig/pm">`sig/pm`</a> | REMOVING. This will be deleted after 2020-04-20 00:00:00 +0000 UTC <br><br> Categorizes an issue or PR as relevant to sig-pm.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/release" href="#sig/release">`sig/release`</a> | Categorizes an issue or PR as relevant to sig-release.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/scalability" href="#sig/scalability">`sig/scalability`</a> | Categorizes an issue or PR as relevant to sig-scalability.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/scheduling" href="#sig/scheduling">`sig/scheduling`</a> | Categorizes an issue or PR as relevant to sig-scheduling.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
@@ -221,6 +221,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/developer-guide" href="#area/developer-guide">`area/developer-guide`</a> | Issues or PRs related to the developer guide| label | |
 | <a id="area/devstats" href="#area/devstats">`area/devstats`</a> | Issues or PRs related to the devstats subproject| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
+| <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/eu-summit" href="#area/eu-summit">`area/eu-summit`</a> | Issues or PRs related to the Contributor Summit in Europe| label | |
 | <a id="area/github-management" href="#area/github-management">`area/github-management`</a> | Issues or PRs related to GitHub Management subproject| label | |
 | <a id="area/na-summit" href="#area/na-summit">`area/na-summit`</a> | Issues or PRs related to the Contributor Summit in North America| label | |
@@ -232,6 +233,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="area/code-organization" href="#area/code-organization">`area/code-organization`</a> | Issues or PRs related to kubernetes code organization| label | |
+| <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="kind/kep" href="#kind/kep">`kind/kep`</a> | Categorizes KEP tracking issues and PRs modifying the KEP directory| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
@@ -294,6 +296,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
 | <a id="area/release-team" href="#area/release-team">`area/release-team`</a> | Issues or PRs related to the release-team subproject| label | |
 
@@ -307,6 +310,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/conformance" href="#area/conformance">`area/conformance`</a> | Issues or PRs related to kubernetes conformance tests| label | |
 | <a id="area/deflake" href="#area/deflake">`area/deflake`</a> | Issues or PRs related to deflaking kubernetes tests| label | |
 | <a id="area/e2e-test-framework" href="#area/e2e-test-framework">`area/e2e-test-framework`</a> | Issues or PRs related to refactoring the kubernetes e2e test framework| label | |
+| <a id="area/enhancements" href="#area/enhancements">`area/enhancements`</a> | Issues or PRs related to the Enhancements subproject| label | |
 | <a id="area/ghproxy" href="#area/ghproxy">`area/ghproxy`</a> | Issues or PRs related to code in /ghproxy| label | |
 | <a id="area/github-management" href="#area/github-management">`area/github-management`</a> | Issues or PRs related to GitHub Management subproject| label | |
 | <a id="area/gopherage" href="#area/gopherage">`area/gopherage`</a> | Issues or PRs related to code in /gopherage| humans | |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -517,6 +517,7 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
+      deleteAfter: 2020-04-20T00:00:00Z
     - color: d2b48c
       description: Categorizes an issue or PR as relevant to sig-release.
       name: sig/release
@@ -761,6 +762,11 @@ repos:
         target: both
         addedBy: label
       - color: 0052cc
+        description: Issues or PRs related to the Enhancements subproject
+        name: area/enhancements
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to GitHub Management subproject
         name: area/github-management
         target: both
@@ -795,6 +801,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to kubernetes code organization
         name: area/code-organization
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the Enhancements subproject
+        name: area/enhancements
         target: both
         addedBy: label
       - color: 0052cc
@@ -963,6 +974,11 @@ repos:
   kubernetes/sig-release:
     labels:
       - color: 0052cc
+        description: Issues or PRs related to the Enhancements subproject
+        name: area/enhancements
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to the Release Engineering subproject
         name: area/release-eng
         previously:
@@ -1004,6 +1020,11 @@ repos:
       - color: 0052cc
         description: Issues or PRs related to refactoring the kubernetes e2e test framework
         name: area/e2e-test-framework
+        target: both
+        addedBy: label
+      - color: 0052cc
+        description: Issues or PRs related to the Enhancements subproject
+        name: area/enhancements
         target: both
         addedBy: label
       - color: 0052cc

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -619,7 +619,7 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-      deleteAfter: 2020-04-08T00:00:00+00:00
+      deleteAfter: 2020-04-08T00:00:00Z
     - color: d2b48c
       description: Categorizes an issue or PR as relevant to wg-security-audit.
       name: wg/security-audit


### PR DESCRIPTION
Several of the [issues that are labeled with `sig/pm`](https://github.com/search?q=is%3Aopen+is%3Aissue+label%3Asig%2Fpm+archived%3Afalse) pertain to the Enhancements subproject.

With the [retirement of SIG PM](https://groups.google.com/d/topic/kubernetes-dev/RU8iINF758Y/discussion), let's: ~rename this label to represent the Enhancements subproject instead.~
- this PR, which will delete `sig/pm` after 2020-04-20, and adds `area/enhancements`
- a followup PR which removes the `sig/pm` label spec
- @justaugustus will manually add `area/enhancements` to the relevant issues/PRs

(_Part of the [umbrella for SIG PM retirement](https://github.com/kubernetes/community/issues/4721)._)

cc: @johnbelamaric @mrbobbytables @jeremyrickard 