### PR TITLE
[capz] Add conformance test as optional presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -13,6 +13,10 @@ periodics:
       repo: cluster-api-provider-azure
       base_ref: master
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200414-0c2810c-master

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -170,3 +170,32 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: verify-boilerplate
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+  - name: pull-cluster-api-provider-azure-conformance-v1alpha3
+    always_run: false
+    optional: true
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    extra_refs:
+    - org: kubernetes
+      repo: kubernetes
+      base_ref: master
+      path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200414-0c2810c-master
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: pull-conformance-v1alpha3


### PR DESCRIPTION
Recently added a periodic capz conformance job in #17172. This PR adds a copy of that job as a presubmit that is optional and does not run by default to allow faster dev iteration as we evolve the new conformance job.