### PR TITLE
labels: Remove sig-pm label now that deleteAfter date has passed

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -99,7 +99,6 @@ larger set of contributors to apply/remove them.
 | <a id="sig/multicluster" href="#sig/multicluster">`sig/multicluster`</a> | Categorizes an issue or PR as relevant to sig-multicluster. <br><br> This was previously `sig/federation`, `sig/federation (deprecated - do not use)`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/network" href="#sig/network">`sig/network`</a> | Categorizes an issue or PR as relevant to sig-network.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/node" href="#sig/node">`sig/node`</a> | Categorizes an issue or PR as relevant to sig-node.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="sig/pm" href="#sig/pm">`sig/pm`</a> | REMOVING. This will be deleted after 2020-04-20 00:00:00 +0000 UTC <br><br> Categorizes an issue or PR as relevant to sig-pm.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/release" href="#sig/release">`sig/release`</a> | Categorizes an issue or PR as relevant to sig-release.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/scalability" href="#sig/scalability">`sig/scalability`</a> | Categorizes an issue or PR as relevant to sig-scalability.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="sig/scheduling" href="#sig/scheduling">`sig/scheduling`</a> | Categorizes an issue or PR as relevant to sig-scheduling.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -512,13 +512,6 @@ default:
       prowPlugin: label
       addedBy: anyone
     - color: d2b48c
-      description: Categorizes an issue or PR as relevant to sig-pm.
-      name: sig/pm
-      target: both
-      prowPlugin: label
-      addedBy: anyone
-      deleteAfter: 2020-04-20T00:00:00Z
-    - color: d2b48c
       description: Categorizes an issue or PR as relevant to sig-release.
       name: sig/release
       target: both


### PR DESCRIPTION
(Part of https://github.com/kubernetes/community/issues/4721 and follow-up to https://github.com/kubernetes/test-infra/pull/17221.)

/hold **until `deleteAfter` date (4/20) has passed**
/assign @spiffxp @cblecker

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

