### PR TITLE
label_sync: migrate wg/apply to wg/api-expression

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -116,8 +116,7 @@ larger set of contributors to apply/remove them.
 | <a id="triage/unresolved" href="#triage/unresolved">`triage/unresolved`</a> | Indicates an issue that can not or will not be resolved. <br><br> This was previously `close/unresolved`, `invalid`, `wontfix`, | humans | |
 | <a id="ug/big-data" href="#ug/big-data">`ug/big-data`</a> | Categorizes an issue or PR as relevant to ug-big-data. <br><br> This was previously `sig/big-data`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="ug/vmware" href="#ug/vmware">`ug/vmware`</a> | Categorizes an issue or PR as relevant to ug-vmware.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="wg/api-expression" href="#wg/api-expression">`wg/api-expression`</a> | Categorizes an issue or PR as relevant to wg-api-expression.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
-| <a id="wg/apply" href="#wg/apply">`wg/apply`</a> | Categorizes an issue or PR as relevant to wg-apply.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+| <a id="wg/api-expression" href="#wg/api-expression">`wg/api-expression`</a> | Categorizes an issue or PR as relevant to wg-api-expression. <br><br> This was previously `wg/apply`, | anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="wg/component-standard" href="#wg/component-standard">`wg/component-standard`</a> | Categorizes an issue or PR as relevant to wg-component-standard.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="wg/iot-edge" href="#wg/iot-edge">`wg/iot-edge`</a> | Categorizes an issue or PR as relevant to wg-iot-edge.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="wg/k8s-infra" href="#wg/k8s-infra">`wg/k8s-infra`</a> | Categorizes an issue or PR as relevant to wg-k8s-infra.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -578,12 +578,8 @@ default:
       target: both
       prowPlugin: label
       addedBy: anyone
-    - color: d2b48c
-      description: Categorizes an issue or PR as relevant to wg-apply.
-      name: wg/apply
-      target: both
-      prowPlugin: label
-      addedBy: anyone
+      previously:
+        - name: wg/apply
     - color: d2b48c
       description: Categorizes an issue or PR as relevant to wg-iot-edge.
       name: wg/iot-edge


### PR DESCRIPTION
WG Apply has been retired and WG API Expression is the successor. Ref: https://github.com/kubernetes/community/pull/4655

There are 39 issues/PRs open with `wg/apply` label currently - https://github.com/search?q=org%3Akubernetes+label%3Awg%2Fapply+is%3Aopen&type=Issues

/assign @kwiesmueller 
/hold
for confirmation from @kwiesmueller (WG API Expression lead)