### PR TITLE
disable-disk-cache-partitions-by-auth-header is not yet legacy.

### DIFF
--- a/ghproxy/ghproxy.go
+++ b/ghproxy/ghproxy.go
@@ -114,7 +114,7 @@ func flagOptions() *options {
 	o := &options{}
 	flag.StringVar(&o.dir, "cache-dir", "", "Directory to cache to if using a disk cache.")
 	flag.IntVar(&o.sizeGB, "cache-sizeGB", 0, "Cache size in GB per unique token if using a disk cache.")
-	flag.BoolVar(&o.diskCacheDisableAuthHeaderPartitioning, "legacy-disable-disk-cache-partitions-by-auth-header", true, "Whether to disable partitioning a disk cache by auth header. Disabling this will start a new cache at $cache_dir/$sha256sum_of_authorization_header for each unique authorization header. Bigger setups are advise to manually warm this up from an existing cache. This option will be removed and set to `false` in the future")
+	flag.BoolVar(&o.diskCacheDisableAuthHeaderPartitioning, "disable-disk-cache-partitions-by-auth-header", true, "Whether to disable partitioning a disk cache by auth header. Disabling this will start a new cache at $cache_dir/$sha256sum_of_authorization_header for each unique authorization header. Bigger setups are advise to manually warm this up from an existing cache. This option will be removed and set to `false` in the future")
 	flag.StringVar(&o.redisAddress, "redis-address", "", "Redis address if using a redis cache e.g. localhost:6379.")
 	flag.IntVar(&o.port, "port", 8888, "Port to listen on.")
 	flag.StringVar(&o.upstream, "upstream", "https://api.github.com", "Scheme, host, and base path of reverse proxy upstream.")
@@ -133,10 +133,6 @@ func main() {
 	flag.Parse()
 	if err := o.validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid arguments.")
-	}
-
-	if o.diskCacheDisableAuthHeaderPartitioning {
-		logrus.Warningf("The deprecated `--legacy-disable-disk-cache-partitions-by-auth-header` flags value is `true`. If you are a bigger Prow setup, you should copy your existing cache directory to the directory mentioned in the `%s` messages to warm up the partitioned-by-auth-header cache, then set the flag to false. If you are a smaller Prow setup or just started using ghproxy you can just unconditionally set it to `false`.", ghcache.LogMessageWithDiskPartitionFields)
 	}
 
 	var cache http.RoundTripper


### PR DESCRIPTION
We have yet to come up with a reasonable migration story

/assign @alvaroaleman @stevekuznetsov @cjwagner 