### PR TITLE
jobs: move pull-kubernetes-integration release-branch jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -981,6 +981,32 @@ presubmits:
           privileged: true
   - always_run: true
     branches:
+    # we migrated to podutils for v1.16+
+    - release-1.15
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    name: pull-kubernetes-integration
+    spec:
+      containers:
+      - args:
+        - "--job=$(JOB_NAME)"
+        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
+        - "--service-account=/etc/service-account/service-account.json"
+        - "--upload=gs://kubernetes-jenkins/pr-logs"
+        - "--timeout=60"
+        - --scenario=kubernetes_verify
+        - --
+        - "--branch=${PULL_BASE_REF}"
+        - --prow
+        image: gcr.io/k8s-testimages/bootstrap:v20200403-ebc6206
+        resources:
+          requests:
+            cpu: 4
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
     - release-1.15
     decorate: true
     name: pull-kubernetes-typecheck

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1048,6 +1048,28 @@ presubmits:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-1.16
         name: main
         resources: {}
+  - always_run: true
+    branches:
+    - release-1.16
+    decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-1.16
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
   - always_run: false
     branches:
     - release-1.16

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1098,6 +1098,28 @@ presubmits:
     branches:
     - release-1.17
     decorate: true
+    labels:
+      preset-dind-enabled: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-integration
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - ./hack/jenkins/test-dockerized.sh
+        command:
+        - runner.sh
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-1.17
+        name: ""
+        resources:
+          requests:
+            cpu: "4"
+        securityContext:
+          privileged: true
+  - always_run: true
+    branches:
+    - release-1.17
+    decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -1,33 +1,5 @@
 presubmits:
   kubernetes/kubernetes:
-  - name: pull-kubernetes-integration
-    always_run: true
-    branches:
-    # we migrated to podutils for v1.16+
-    - release-1.15
-    - release-1.14
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/bootstrap:v20200403-ebc6206
-        args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=60"
-        - --scenario=kubernetes_verify
-        - --
-        - "--branch=${PULL_BASE_REF}"
-        - --prow
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 4
   # this replaces the bootstrap / scenario based job going forward
   - name: pull-kubernetes-integration
     always_run: true
@@ -46,50 +18,6 @@ presubmits:
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-master
-        command:
-        - runner.sh
-        args:
-        - ./hack/jenkins/test-dockerized.sh
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 4
-  - name: pull-kubernetes-integration
-    always_run: true
-    decorate: true
-    branches:
-    - release-1.17 # per-release job
-    path_alias: k8s.io/kubernetes
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-1.17
-        command:
-        - runner.sh
-        args:
-        - ./hack/jenkins/test-dockerized.sh
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 4
-  - name: pull-kubernetes-integration
-    always_run: true
-    decorate: true
-    branches:
-    - release-1.16 # per-release job
-    path_alias: k8s.io/kubernetes
-    labels:
-      preset-service-account: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-1.16
         command:
         - runner.sh
         args:


### PR DESCRIPTION
pretend as if config-forker had been run so that these jobs are
properly removed with other release-branch jobs when it comes
time to drop support for a version of kubernetes

manually moved over the v1.15 variant which is bootstrap-based

dropped support for v1.14

fixes: #15638