### PR TITLE
update controller-runtime and kubebuilder OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -240,3 +240,37 @@ aliases:
     - frapposelli
     - yastij
     - randomvariable
+  # end sigs.k8s.io/cluster-api-provider-vsphere/OWNERS_ALIASES
+
+  # mostly copied from sigs.k8s.io/controller-runtime/OWNERS_ALIASES
+  controller-runtime-admins:
+  - directxman12
+  - mengqiy
+
+  controller-runtime-maintainers:
+  - vincepri
+
+  controller-runtime-approvers:
+  - gerred
+
+  controller-runtime-reviewers:
+  - alvaroaleman
+  - alenkacz
+  - vincepri
+  - alexeldeib
+
+  controller-runtime-emeritus-maintainers:
+  - pwittrock
+
+  # mostly copied from sigs.k8s.io/kubebuilder/OWNERS_ALIASES
+  kubebuilder-admins:
+  - mengqiy
+  - directxman12
+
+  kubebuilder-reviewers:
+  - alexeldeib
+
+  kubebuilder-emeritus-approvers: 
+  - pwittrock
+
+  # end sigs.k8s.io/kubebuilder/OWNERS_ALIASES

--- a/config/jobs/kubernetes-sigs/controller-runtime/OWNERS
+++ b/config/jobs/kubernetes-sigs/controller-runtime/OWNERS
@@ -1,7 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-reviewers:
-  - directxman12
-  - pwittrock
 approvers:
-  - directxman12
-  - pwittrock
+  - controller-runtime-admins
+  - controller-runtime-maintainers
+  - controller-runtime-approvers
+  - controller-runtime-emeritus-maintainers
+reviewers:
+  - controller-runtime-admins
+  - controller-runtime-reviewers
+  - controller-runtime-approvers

--- a/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubebuilder/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/devel/owners.md
-reviwers:
-  - directxman12
-  - mengqiy
-  - pwittrock
+
 approvers:
-  - directxman12
-  - mengqiy
-  - pwittrock
+  - kubebuilder-admins
+  - kubebuilder-emeritus-approvers
+reviewers:
+  - kubebuilder-admins
+  - kubebuilder-reviewers


### PR DESCRIPTION
Both projects now have proper aliases with uses assigned to roles, we should use those. We have a very small list of people in these OWNERS files currently.

The effect of this change is purely additive -- no one is losing any permissions.