### PR TITLE
[capz] increase conformance job timeout

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -2,7 +2,7 @@ periodics:
 - name: periodic-cluster-api-provider-azure-conformance-v1alpha3
   decorate: true
   decoration_config:
-    timeout: 3h
+    timeout: 4h
   interval: 12h
   labels:
     preset-dind-enabled: "true"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -174,6 +174,8 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
+    decoration_config:
+      timeout: 4h
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_cluster-api-provider-azure/537/pull-cluster-api-provider-azure-conformance-v1alpha3/1250896562414948354

In the above run from today, the test suite passed but the job timed out at 2 hours before cleanup. Increasing the timeout to 4 hours in both the periodic and the presubmit job to allow for potentially slower test run and cleanup latency.

/assign @justaugustus @detiber @vincepri 