### PR TITLE
jobs: pin ci-kubernetes-node-e2e-kubelet to spare project

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -21,6 +21,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
+      - --gcp-project=k8s-jkns-gke-gci-soak
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"


### PR DESCRIPTION
so we know it can work with boskos managed projects, but until we get
a pool set aside for node jobs, I'd rather prevent them from using
the pool used by most e2e jobs, in case a network ban happens again

/cc @dims