### PR TITLE
pr-creator: configurable "maintainer_can_modify" value for PR

### DIFF
--- a/experiment/autobumper/BUILD.bazel
+++ b/experiment/autobumper/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//experiment/autobumper/bumper:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/github:go_default_library",
+        "//robots/pr-creator/updater:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -68,19 +68,19 @@ func (w HideSecretsWriter) Write(content []byte) (int, error) {
 // with "matchTitle" from "source" to "branch"
 // "images" contains the tag replacements that have been made which is returned from "UpdateReferences([]string{"."}, extraFiles)"
 // "images" and "extraLineInPRBody" are used to generate commit summary and body of the PR
-func UpdatePR(gc github.Client, org, repo string, images map[string]string, extraLineInPRBody string, matchTitle, source, branch string) error {
-	return UpdatePullRequest(gc, org, repo, makeCommitSummary(images), generatePRBody(images, extraLineInPRBody), matchTitle, source, branch)
+func UpdatePR(gc github.Client, org, repo string, images map[string]string, extraLineInPRBody string, matchTitle, source, branch string, allowMods bool) error {
+	return UpdatePullRequest(gc, org, repo, makeCommitSummary(images), generatePRBody(images, extraLineInPRBody), matchTitle, source, branch, allowMods)
 }
 
 // UpdatePullRequest updates with github client "gc" the PR of github repo org/repo
 // with "title" and "body" of PR matching "matchTitle" from "source" to "branch"
-func UpdatePullRequest(gc github.Client, org, repo, title, body, matchTitle, source, branch string) error {
-	return UpdatePullRequestWithLabels(gc, org, repo, title, body, matchTitle, source, branch, nil)
+func UpdatePullRequest(gc github.Client, org, repo, title, body, matchTitle, source, branch string, allowMods bool) error {
+	return UpdatePullRequestWithLabels(gc, org, repo, title, body, matchTitle, source, branch, allowMods, nil)
 }
 
-func UpdatePullRequestWithLabels(gc github.Client, org, repo, title, body, matchTitle, source, branch string, labels []string) error {
+func UpdatePullRequestWithLabels(gc github.Client, org, repo, title, body, matchTitle, source, branch string, allowMods bool, labels []string) error {
 	logrus.Info("Creating or updating PR...")
-	n, err := updater.EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle, gc, labels)
+	n, err := updater.EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle, allowMods, gc, labels)
 	if err != nil {
 		return fmt.Errorf("failed to ensure PR exists: %v", err)
 	}

--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/test-infra/experiment/autobumper/bumper"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/robots/pr-creator/updater"
 )
 
 const (
@@ -174,7 +175,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to push changes.")
 	}
 
-	if err := bumper.UpdatePR(gc, githubOrg, githubRepo, images, getAssignment(), "Update prow to", o.githubLogin+":"+remoteBranch, "master", true); err != nil {
+	if err := bumper.UpdatePR(gc, githubOrg, githubRepo, images, getAssignment(), "Update prow to", o.githubLogin+":"+remoteBranch, "master", updater.PreventMods); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}
 }

--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -174,7 +174,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to push changes.")
 	}
 
-	if err := bumper.UpdatePR(gc, githubOrg, githubRepo, images, getAssignment(), "Update prow to", o.githubLogin+":"+remoteBranch, "master"); err != nil {
+	if err := bumper.UpdatePR(gc, githubOrg, githubRepo, images, getAssignment(), "Update prow to", o.githubLogin+":"+remoteBranch, "master", true); err != nil {
 		logrus.WithError(err).Fatal("PR creation failed.")
 	}
 }

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -74,7 +74,7 @@ func optionsFromFlags() options {
 	fs.StringVar(&o.branch, "branch", "", "Repo branch to merge into")
 	fs.StringVar(&o.source, "source", "", "The user:branch to merge from")
 
-	fs.BoolVar(&o.allowMods, "allow-mods", true, "Indicates whether maintainers can modify the pull request")
+	fs.BoolVar(&o.allowMods, "allow-mods", updater.PreventMods, "Indicates whether maintainers can modify the pull request")
 	fs.BoolVar(&o.confirm, "confirm", false, "Set to mutate github instead of a dry run")
 	fs.BoolVar(&o.local, "local", false, "Allow source to be local-branch instead of remote-user:branch")
 	fs.StringVar(&o.title, "title", "", "Title of PR")

--- a/robots/pr-creator/main.go
+++ b/robots/pr-creator/main.go
@@ -33,12 +33,13 @@ import (
 type options struct {
 	github flagutil.GitHubOptions
 
-	branch  string
-	confirm bool
-	local   bool
-	org     string
-	repo    string
-	source  string
+	branch    string
+	allowMods bool
+	confirm   bool
+	local     bool
+	org       string
+	repo      string
+	source    string
 
 	title      string
 	matchTitle string
@@ -73,6 +74,7 @@ func optionsFromFlags() options {
 	fs.StringVar(&o.branch, "branch", "", "Repo branch to merge into")
 	fs.StringVar(&o.source, "source", "", "The user:branch to merge from")
 
+	fs.BoolVar(&o.allowMods, "allow-mods", true, "Indicates whether maintainers can modify the pull request")
 	fs.BoolVar(&o.confirm, "confirm", false, "Set to mutate github instead of a dry run")
 	fs.BoolVar(&o.local, "local", false, "Allow source to be local-branch instead of remote-user:branch")
 	fs.StringVar(&o.title, "title", "", "Title of PR")
@@ -98,7 +100,7 @@ func main() {
 		logrus.WithError(err).Fatal("Failed to create github client")
 	}
 
-	n, err := updater.EnsurePR(o.org, o.repo, o.title, o.body, o.source, o.branch, o.matchTitle, gc)
+	n, err := updater.EnsurePR(o.org, o.repo, o.title, o.body, o.source, o.branch, o.matchTitle, o.allowMods, gc)
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to ensure PR exists.")
 	}

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -24,6 +24,12 @@ import (
 	"k8s.io/test-infra/prow/github"
 )
 
+// Indicates whether maintainers can modify a pull request in fork.
+const (
+	AllowMods   = true
+	PreventMods = false
+)
+
 type updateClient interface {
 	UpdatePullRequest(org, repo string, number int, title, body *string, open *bool, branch *string, canModify *bool) error
 	BotName() (string, error)

--- a/robots/pr-creator/updater/updater.go
+++ b/robots/pr-creator/updater/updater.go
@@ -67,17 +67,16 @@ func UpdatePR(org, repo, title, body, matchTitle string, gc updateClient) (*int,
 	return &n, nil
 }
 
-func EnsurePR(org, repo, title, body, source, branch, matchTitle string, gc ensureClient) (*int, error) {
-	return EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle, gc, nil)
+func EnsurePR(org, repo, title, body, source, branch, matchTitle string, allowMods bool, gc ensureClient) (*int, error) {
+	return EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle, allowMods, gc, nil)
 }
 
-func EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle string, gc ensureClient, labels []string) (*int, error) {
+func EnsurePRWithLabels(org, repo, title, body, source, branch, matchTitle string, allowMods bool, gc ensureClient, labels []string) (*int, error) {
 	n, err := UpdatePR(org, repo, title, body, matchTitle, gc)
 	if err != nil {
 		return nil, fmt.Errorf("update error: %v", err)
 	}
 	if n == nil {
-		allowMods := true
 		pr, err := gc.CreatePullRequest(org, repo, title, body, source, branch, allowMods)
 		if err != nil {
 			return nil, fmt.Errorf("create error: %v", err)

--- a/robots/pr-creator/updater/updater_test.go
+++ b/robots/pr-creator/updater/updater_test.go
@@ -66,7 +66,7 @@ func TestEnsurePRWithLabel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			prNumberPtr, err := EnsurePRWithLabels(org, repo, "title", "body", "source", "branch", "matchTitle", tc.client, labels)
+			prNumberPtr, err := EnsurePRWithLabels(org, repo, "title", "body", "source", "branch", "matchTitle", true, tc.client, labels)
 			if err != nil {
 				t.Fatalf("error: %v", err)
 			}

--- a/robots/pr-creator/updater/updater_test.go
+++ b/robots/pr-creator/updater/updater_test.go
@@ -66,7 +66,7 @@ func TestEnsurePRWithLabel(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			prNumberPtr, err := EnsurePRWithLabels(org, repo, "title", "body", "source", "branch", "matchTitle", true, tc.client, labels)
+			prNumberPtr, err := EnsurePRWithLabels(org, repo, "title", "body", "source", "branch", "matchTitle", PreventMods, tc.client, labels)
 			if err != nil {
 				t.Fatalf("error: %v", err)
 			}


### PR DESCRIPTION
Currently, all Istio developers have repo-level **write** permission. For security reasons, there are _specific_ PRs created via `pr-creator` that we want to be immutable (e.g. `auto-merge` PRs).

**GH API docs**: _Create a pull request_ -> [`maintainer_can_modify`](https://developer.github.com/v3/pulls/#input)

https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork

cc @howardjohn 