### PR TITLE
Update Ubuntu images used by node_e2e jobs

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -169,19 +169,19 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable1-resource2:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable1-resource3:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:

--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -150,19 +150,19 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable2-resource2:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable2-resource3:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:

--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -160,21 +160,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable2-resource2:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable2-resource3:
-    image: ubuntu-gke-1804-d1703-0-v20181113
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -182,21 +182,21 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   ubuntustable1-resource2:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable1-resource3:
-    image: ubuntu-gke-1804-bionic-20180921
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"

--- a/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:

--- a/jobs/e2e_node/containerd/cri-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config.yaml
@@ -1,6 +1,6 @@
 images:
   ubuntu:
-    image: ubuntu-gke-1604-xenial-v20180317-1
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable2:
     image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -3,7 +3,7 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1804-d1703-0-v20181113 # docker 17.03
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable1:
     image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17


### PR DESCRIPTION
These images also appear wildly out of date. None of the underlying OS's are out of LTS support, but I'm having trouble finding images that are more recent and likely to have potential CVE's addressed.

So I took a total guess and bumped everything up to latest
```
# ??? 
migrate ubuntu-gke-1604-xenial-v20180317-1  ubuntu-gke-1804-1-16-v20200330
# ???
migrate ubuntu-gke-1804-bionic-20180921     ubuntu-gke-1804-1-16-v20200330
# ???
migrate ubuntu-gke-1804-d1703-0-v20181113   ubuntu-gke-1804-1-16-v20200330
```

Some other options include:
- ubuntu-gke-1604-d1703-0-v20190212
- ubuntu-gke-1804-d1703-0-v20200206
- ubuntu-gke-1804-d1809-0-v20200207
- ubuntu-gke-1804-d1903-0-v20200207
- ubuntu-gke-1804-1-15-v20200330
(etc.)

I also am unclear whether it is necessary that these tests be run in OSS vs. internally at Google. I'm guessing it's to give signal to Canonical?

/cc @karan @derekwaynecarr