### PR TITLE
move all kind CI binary downloads to use community infra

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -1,26 +1,6 @@
 # sigs.k8s.io/kind postsubmits
 postsubmits:
   kubernetes-sigs/kind:
-  - name: ci-kind-build
-    decorate: true
-    path_alias: sigs.k8s.io/kind
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-master
-        command:
-        - runner.sh
-        - ./hack/ci/push-latest-cli.sh
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-testing-kind
-      testgrid-tab-name: ci build
-      testgrid-alert-email: bentheelder@google.com
-      description: kind CI build
   - name: ci-kind-unit
     decorate: true
     path_alias: sigs.k8s.io/kind

--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -29,8 +29,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      # TODO(https://github.com/kubernetes-sigs/kind/issues/1392) use community-owned bucket instead
-      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: FOCUS
         value: "."
@@ -81,8 +80,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      # TODO(https://github.com/kubernetes-sigs/kind/issues/1392) use community-owned bucket instead
-      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       # enable IPV6 in bootstrap image
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -1,26 +1,4 @@
 periodics:
-# build a couple times a day so our status stays green :-)
-# this is extremely cheap to run currently
-- interval: 6h
-  name: ci-kind-build
-  decorate: true
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
-  labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-master
-      command:
-      - runner.sh
-      - ./hack/ci/push-latest-cli.sh
-      # we need privileged mode in order to do docker in docker
-      securityContext:
-        privileged: true
 - name: ci-kind-unit
   interval: 6h
   decorate: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -574,9 +574,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64
-        && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh
-        | sh
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: FOCUS
         value: .
@@ -621,9 +619,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64
-        && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh
-        | sh
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: DOCKER_IN_DOCKER_IPV6_ENABLED
         value: "true"
@@ -1331,9 +1327,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64
-          && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh
-          | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: FOCUS
           value: .

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -251,7 +251,7 @@ periodics:
       - wrapper.sh
       - bash
       - -c
-      - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+      - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       - name: BUILD_TYPE
         value: bazel

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: FOCUS
           value: "."
@@ -121,7 +121,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: FOCUS
           value: "."
@@ -176,7 +176,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: FOCUS
           value: "."
@@ -230,7 +230,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: BUILD_TYPE
           value: bazel
@@ -274,7 +274,7 @@ presubmits:
         - wrapper.sh
         - bash
         - -c
-        - curl -sSLo "${PATH%%:*}/kind" https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/kind-linux-amd64 && chmod +x "${PATH%%:*}/kind" && curl -sSL https://storage.googleapis.com/bentheelder-kind-ci-builds/latest/e2e-k8s.sh | sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
         env:
         - name: BUILD_TYPE
           value: bazel


### PR DESCRIPTION
no more `bentheelder-kind-ci-builds`

bonus magic `curl | tar $PATH` hijinks :sparkles: 

/cc @justaugustus @amwat @aojea @spiffxp 

fixes: https://github.com/kubernetes-sigs/kind/issues/1392