### PR TITLE
add presubmit for Cluster API e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -154,3 +154,30 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-e2e
+  - name: pull-cluster-api-e2e
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    skip_branches:
+      - gh-pages
+      - release-0.2
+    path_alias: sigs.k8s.io/cluster-api
+    optional: true
+    always_run: false
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-master
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: "9000m"
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: pr-e2e-new


### PR DESCRIPTION
The new job for now is optional and runs only on demand.

Long term (when the new job is stable) this is going to replace pull-cluster-api-capd-e2e

/assign @vincepri 