### PR TITLE
docs: change script of create Hmacs token  to new format

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -127,7 +127,7 @@ you give to GitHub for validating webhooks. Generate it using any reasonable
 randomness-generator, eg `openssl rand -hex 20`.
 
 ```sh
-# openssl rand -hex 20 > /path/to/hook/secret
+# echo -e "'*':\n  - value: `openssl rand -hex 20`\n    expiry: 9999-10-02T15:00:00Z" > /path/to/hook/secret
 kubectl create secret generic hmac-token --from-file=hmac=/path/to/hook/secret
 ```
 


### PR DESCRIPTION
docs: change script of create Hmacs token  to new format
Signed-off-by: Alan Zhu <zg.zhu@daocloud.io>

```
{"component":"hook","error":"error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]github.hmacsForRepo","file":"prow/github/hmac.go:97","func":"k8s.io/test-infra/prow/github.extractHmacs","level":"info","msg":"couldn't unmarshal the hmac secret as hierarchical file. Parsing as single token format","time":"2020-04-17T13:09:23Z"}
```