### PR TITLE
jobs: use bazel 2.2.0 for test-infra bazel test jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -11,7 +11,7 @@ periodics:
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - image: launcher.gcr.io/google/bazel:2.0.0
+    - image: launcher.gcr.io/google/bazel:2.2.0
       command:
       - hack/bazel.sh
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:2.0.0
+      - image: launcher.gcr.io/google/bazel:2.2.0
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:2.0.0
+      - image: launcher.gcr.io/google/bazel:2.2.0
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion


### PR DESCRIPTION
It's not clear to me whether these should be ignoring .bazelversion or not.

Right now the periodic is, so it's failing: https://k8s-testgrid.appspot.com/sig-testing-misc#ci-bazel is failing