### PR TITLE
jobs: remove velodrome creds from metrics-kettle

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -112,22 +112,25 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      - name: VELODROME_INFLUXDB_CONFIG
-        value: /etc/velodrome-influxdb/config.json
+      # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
+      # - name: VELODROME_INFLUXDB_CONFIG
+      #   value: /etc/velodrome-influxdb/config.json
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
         readOnly: true
-      - name: influxdb
-        mountPath: /etc/velodrome-influxdb
-        readOnly: true
+      # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
+      # - name: influxdb
+      #   mountPath: /etc/velodrome-influxdb
+      #   readOnly: true
     volumes:
     - name: service
       secret:
         secretName: triage-service-account
-    - name: influxdb
-      secret:
-        secretName: velodrome-influxdb
+    # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
+    # - name: influxdb
+    #   secret:
+    #     secretName: velodrome-influxdb
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '12'


### PR DESCRIPTION
missed this when doing the same for metrics-bigquery (ref: https://github.com/kubernetes/test-infra/pull/16837)