### PR TITLE
Kops - Skip "session affinity for service with type clusterIP" tests for Cilium

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -133,7 +133,7 @@ periodics:
       - --kops-ssh-user=ubuntu
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|affinity.*clusterIP
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200415-b949900-master
   annotations:


### PR DESCRIPTION
Let's make Cilium periodic e2e green for now.
/cc @rifelpet @olemarkus 