### PR TITLE
Create a test-infra variant of bazel.

### DIFF
--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -5,3 +5,6 @@ variants:
   2.2.0-from-0.23.2:
     NEW_VERSION: 2.2.0
     OLD_VERSION: 0.23.2
+  test-infra:
+    NEW_VERSION: 2.2.0
+    OLD_VERSION: 2.0.0


### PR DESCRIPTION
This image will install the current and next version of bazel we plan to use in test-infra.
By putting both these versions in the same image, we can configure jobs to use .bazelversion
and safely upgrade from one version to the next via a PR.

/assign @spiffxp @BenTheElder 

ref https://github.com/kubernetes/test-infra/pull/17276