### PR TITLE
Add a node-e2e-project pool to boskos

### DIFF
--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 16  # 16 distributed janitor instances for gke
+  replicas: 4  # 4 distributed janitor instances for gke
   selector:
     matchLabels:
       app: boskos-janitor

--- a/prow/cluster/boskos-janitor.yaml
+++ b/prow/cluster/boskos-janitor.yaml
@@ -51,7 +51,7 @@ spec:
         image: gcr.io/k8s-prow/boskos/janitor:v20200416-c78ffe8ea
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project
+        - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,node-e2e-project
         - --pool-size=20
         - --
         - --hours=0

--- a/prow/cluster/boskos-reaper_deployment.yaml
+++ b/prow/cluster/boskos-reaper_deployment.yaml
@@ -21,4 +21,4 @@ spec:
         image: gcr.io/k8s-prow/boskos/reaper:v20200416-c78ffe8ea
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
-        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account
+        - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account,node-e2e-project

--- a/prow/cluster/boskos-resources.yaml
+++ b/prow/cluster/boskos-resources.yaml
@@ -554,3 +554,15 @@ resources:
     - k8s-presubmit-scale-45
   state: dirty
   type: scalability-presubmit-project
+- names:
+  - k8s-jkns-gke-ubuntu-1-6
+  - k8s-jkns-gke-ubuntu-1-6-alpha
+  - k8s-jkns-gke-ubuntu-1-6-as
+  - k8s-jkns-gke-ubuntu-1-6-flaky
+  - k8s-jkns-gke-ubuntu-1-6-ingres
+  - k8s-jkns-gke-ubuntu-1-6-reboot
+  - k8s-jkns-gke-ubuntu-1-6-serial
+  - k8s-jkns-gke-ubuntu-1-6-slow
+  - k8s-jkns-gke-ubuntu-1-6-updown
+  state: dirty
+  type: node-e2e-project

--- a/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -40,6 +40,7 @@ dashboard.new(
         {type: "gpu-project", friendly: "GPU project"},
         {type: "ingress-project", friendly: "Ingress project"},
         {type: "istio-project", friendly: "Istio project"},
+        {type: "node-e2e-project", friendly: "Node e2e project"},
         {type: "scalability-project", friendly: "Scalability project"},
         {type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
       ]


### PR DESCRIPTION
Take some of the gke projects that were removed in #17279 and turn them into a pool for node-e2e jobs, which currently pin to a single project

While I was here I tuned down gke-project janitors since there's not much for them to do

/cc @krzyzacy @ixdy 