### PR TITLE
Create YYYYMMDD-deadbeef-test-infra tags for each variant

### DIFF
--- a/images/bazel/cloudbuild.yaml
+++ b/images/bazel/cloudbuild.yaml
@@ -1,18 +1,24 @@
 steps:
   - name: gcr.io/cloud-builders/docker
-    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION',
-            '--build-arg', 'NEW_VERSION=$_NEW_VERSION',
-            '--build-arg', 'OLD_VERSION=$_OLD_VERSION',
-            '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION',
-            '.' ]
+    args: 
+    - build
+    - --tag=gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION
+    - --build-arg=NEW_VERSION=$_NEW_VERSION
+    - --build-arg=OLD_VERSION=$_OLD_VERSION
+    - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION
+    - .
   - name: gcr.io/cloud-builders/docker
-    args: [ 'tag', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION', 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION']
+    args:
+    - tag
+    - gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION
+    - gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION
+    - gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_GIT_TAG-$_CONFIG
+    - gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_GIT_TAG-$_CONFIG
 substitutions:
   _GIT_TAG: '12345'
+  _CONFIG: foo
   _NEW_VERSION: something
   _OLD_VERSION: something
-options:
-  substitution_option: ALLOW_LOOSE
 images:
-  - 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION'
-  - 'gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION'
+- gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:$_NEW_VERSION-from-$_OLD_VERSION
+- gcr.io/$PROJECT_ID/launcher.gcr.io/google/bazel:latest-$_NEW_VERSION-from-$_OLD_VERSION

--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -1,10 +1,9 @@
 variants:
-  2.2.0-from-0.25.2:
+  kubernetes:
+    CONFIG: kubernetes-master # Used by the kubernetes repo master branch
     NEW_VERSION: 2.2.0
     OLD_VERSION: 0.25.2
-  2.2.0-from-0.23.2:
-    NEW_VERSION: 2.2.0
-    OLD_VERSION: 0.23.2
   test-infra:
-    NEW_VERSION: 2.2.0
-    OLD_VERSION: 2.0.0
+    CONFIG: test-infra # Used by test-infra repo
+    NEW_VERSION: 3.0.0
+    OLD_VERSION: 2.2.0


### PR DESCRIPTION
* Change the test-infra variant to go to 3.0.0 from 2.2.0
* Reduce to a single kubernetes variant for the master branch


This should reduce friction around these bumps:
* Changing the NEW_VERSION/OLD_VERSION should cause prow to create these new variants
* This should have a new `20200417-deadbeef-test-infra` tag
* The new tag for the test-infra variant should cause the image bumper to update it

This matches the pattern we use for kubekins:

https://github.com/kubernetes/test-infra/blob/90b062a8b4177eb36b09b5acfcf1b211df64b39f/images/kubekins-e2e/cloudbuild.yaml#L31-L32