### PR TITLE
Bump golang version used in gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG GO_VERSION
+
 # Includes bash, docker, and gcloud
-FROM golang:1.12.12-alpine
+FROM golang:${GO_VERSION}-alpine
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG

--- a/images/gcb-docker-gcloud/cloudbuild.yaml
+++ b/images/gcb-docker-gcloud/cloudbuild.yaml
@@ -1,10 +1,14 @@
 steps:
   - name: gcr.io/cloud-builders/docker
-    args: ['build', '-t', 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG',
-           '--build-arg', 'IMAGE_ARG=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG',
-           '.']
+    args:
+      - build
+      - --tag=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+      - --build-arg=IMAGE_ARG=gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG
+      - --build-arg=GO_VERSION=$_GO_VERSION
+      - .
     dir: images/gcb-docker-gcloud/
 substitutions:
   _GIT_TAG: '12345'
+  _GO_VERSION: 1.13.5
 images:
   - 'gcr.io/$PROJECT_ID/gcb-docker-gcloud:$_GIT_TAG'


### PR DESCRIPTION
- Bump golang version to 1.13.5 (1.12.x is old!)
- parameterize GO_VERSION in cloudbuild to help with bulk updates when
other images are being updated
- pass the GO_VERSION to the Dockerfile and use the specific verion of
golang alpine image.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>