### PR TITLE
prow: use private opener interface in tide, statusreconciler and gerrit

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -96,11 +96,17 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	return o
 }
 
+// opener has methods to read and write paths
+type opener interface {
+	Reader(ctx context.Context, path string) (io.ReadCloser, error)
+	Writer(ctx context.Context, path string, opts ...io.WriterOptions) (io.WriteCloser, error)
+}
+
 type syncTime struct {
 	val    client.LastSyncState
 	lock   sync.RWMutex
 	path   string
-	opener io.Opener
+	opener opener
 	ctx    context.Context
 }
 

--- a/prow/statusreconciler/status.go
+++ b/prow/statusreconciler/status.go
@@ -37,9 +37,15 @@ type statusClient interface {
 	Save() error
 }
 
+// opener has methods to read and write paths
+type opener interface {
+	Reader(ctx context.Context, path string) (io.ReadCloser, error)
+	Writer(ctx context.Context, path string, opts ...io.WriterOptions) (io.WriteCloser, error)
+}
+
 type statusController struct {
 	logger        *logrus.Entry
-	opener        io.Opener
+	opener        opener
 	statusURI     string
 	configPath    string
 	jobConfigPath string

--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -45,11 +45,17 @@ type History struct {
 	sync.Mutex
 	logSizeLimit int
 
-	opener io.Opener
+	opener opener
 	path   string
 }
 
-func readHistory(maxRecordsPerKey int, opener io.Opener, path string) (map[string]*recordLog, error) {
+// opener has methods to read and write paths
+type opener interface {
+	Reader(ctx context.Context, path string) (io.ReadCloser, error)
+	Writer(ctx context.Context, path string, opts ...io.WriterOptions) (io.WriteCloser, error)
+}
+
+func readHistory(maxRecordsPerKey int, opener opener, path string) (map[string]*recordLog, error) {
 	reader, err := opener.Reader(context.Background(), path)
 	if io.IsNotExist(err) { // No history exists yet. This is not an error.
 		return map[string]*recordLog{}, nil
@@ -82,7 +88,7 @@ func readHistory(maxRecordsPerKey int, opener io.Opener, path string) (map[strin
 	return logsByPool, nil
 }
 
-func writeHistory(opener io.Opener, path string, hist map[string][]*Record) error {
+func writeHistory(opener opener, path string, hist map[string][]*Record) error {
 	// a write's duration will scale with the volume of data to write but large
 	// data sets can finish in about 500ms; a timeout of 30s should not evict
 	// well-behaved writes


### PR DESCRIPTION
We should use private interfaces instead of the the one from `prow/io` so we don't have to implement all methods of the interface in the fakeOpeners. Also we now precisely know which methods are required in these cases and don't require other methods which won't be used here.

See also: https://github.com/kubernetes/test-infra/pull/17183#discussion_r409740786