### PR TITLE
Use 2.2.0 variant of bazelbuild.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -108,7 +108,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.1.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
         command:
         - experiment/resultstore/push.sh
         env:
@@ -128,7 +128,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0 # whatever image you use here must have bash 4.4+
         command:
         - prow/push.sh
         env:
@@ -181,7 +181,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0 # whatever image you use here must have bash 4.4+
         command:
         - boskos/push.sh
         env:
@@ -639,7 +639,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion
@@ -663,7 +663,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
         command:
         - ./boskos/update_prow_config.sh
         env:
@@ -827,7 +827,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion
@@ -867,7 +867,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion
@@ -907,7 +907,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.0.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200405-02a6dff-2.2.0
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion

--- a/images/bazelbuild/variants.yaml
+++ b/images/bazelbuild/variants.yaml
@@ -1,4 +1,6 @@
 variants:
+  3.0.0:
+    BAZEL_VERSION: 3.0.0
   2.2.0:
     BAZEL_VERSION: 2.2.0
   2.1.0:


### PR DESCRIPTION
This uses a different means of installing bazel (than the other images we use), so need to figure out how to put multiple bazel versions into this image.

/assign @spiffxp @alvaroaleman @chases2 

fixes https://github.com/kubernetes/test-infra/issues/17298