### PR TITLE
Install latest docker-buildx explicitly for gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -39,4 +39,9 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/ap
         --usage-reporting=false && \
     gcloud info > /workspace/gcloud-info.txt
 
+# Install docker Buildx for fast docker builds
+RUN mkdir -p  ~/.docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64" --output ~/.docker/cli-plugins/docker-buildx \
+    && chmod a+x ~/.docker/cli-plugins/docker-buildx
+
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
In the latest image, we do have 19.03.5 of docker, but buildx plugin is
missing. So we need to install it explicitly.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>