### PR TITLE
Switch to the test-infra bazelbuild variant.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -108,7 +108,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - experiment/resultstore/push.sh
         env:
@@ -128,7 +128,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - prow/push.sh
         env:
@@ -181,7 +181,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0 # whatever image you use here must have bash 4.4+
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - boskos/push.sh
         env:
@@ -639,7 +639,7 @@ postsubmits:
     spec:
       serviceAccountName: testgrid-config-updater
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         env:
         - name: USE_BAZEL_VERSION
           value: real  # Ignore .bazelversion
@@ -663,7 +663,7 @@ postsubmits:
     spec:
       serviceAccountName: deployer # TODO(fejta): should be pusher
       containers:
-      - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+      - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - ./boskos/update_prow_config.sh
         env:
@@ -827,7 +827,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion
@@ -867,7 +867,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion
@@ -907,7 +907,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200420-42ca103-2.2.0
+    - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
       env:
       - name: USE_BAZEL_VERSION
         value: real  # Ignore .bazelversion


### PR DESCRIPTION
This has both 2.2.0 (current) and 3.0.0 (potentially next) installed.

Tag from https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-bazelbuild/1252675046963417088

/assign @chases2 @clarketm @cjwagner 
