### PR TITLE
Allow milestone-maintainers to restart jobs on Prow UI

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -67,6 +67,7 @@ deck:
     '*':
       github_team_ids:
       - 2009231 # test-infra-admins
+      - 2460384 # milestone-maintainers
 
 prowjob_namespace: default
 pod_namespace: test-pods


### PR DESCRIPTION
Let's please allow more folks to re-run jobs as needed. picked
milestone-maintainers as i am on it :)

Signed-off-by: Davanum Srinivas <davanum@gmail.com>