### PR TITLE
Azure: create a periodic job to run conformance tests against a cluster w/o out-of-tree components

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -217,3 +217,55 @@ presubmits:
       testgrid-dashboards: provider-azure-upstream, provider-azure-presubmit
       testgrid-tab-name: pr-k8s-azure-file-e2e-master
       description: Run Azure File e2e test with Azure File in-tree volume plugin.
+periodics:
+- interval: 24h
+  name: ci-kubernetes-e2e-aks-engine-conformance-master
+  decorate: true
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200420-e830a3a-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --provider=skeleton
+      - --deployment=aksengine
+      - --aksengine-agentpoolcount=2
+      - --aksengine-admin-username=azureuser
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-orchestratorRelease=1.18
+      - --aksengine-mastervmsize=Standard_DS2_v2
+      - --aksengine-agentvmsize=Standard_DS2_v2
+      - --aksengine-deploy-custom-k8s
+      - --aksengine-location=westus2
+      - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+      - --aksengine-template-url=https://raw.githubusercontent.com/Azure/aks-engine/master/examples/kubernetes.json
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      # Specific test args
+      - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Flaky\]
+      - --ginkgo-parallel=30
+      - --timeout=420m
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-conformance-master
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs conformance & node conformance tests latest kubernetes master with aks-engine
+    testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Creating a periodic job to run conformance tests against an aks-engine cluster without out-of-tree components to compare test results with https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-conformance-v1alpha3.

/assign @feiskyer 
/cc @ritazh @CecileRobertMichon 