### PR TITLE
move ibzib and rmmh to emeritus_approvers

### DIFF
--- a/gubernator/OWNERS
+++ b/gubernator/OWNERS
@@ -1,15 +1,14 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- ibzib
 - Katharine
-- rmmh
 - stevekuznetsov
 approvers:
-- ibzib
 - Katharine
-- rmmh
 - stevekuznetsov
+emeritus_approvers:
+- ibzib
+- rmmh
 
 labels:
 - area/gubernator


### PR DESCRIPTION
This appears to be the only relevant OWNERS file.

FYI @ibzib @rmmh 

cc @Katharine not sure if you want to move also.

xref: https://github.com/kubernetes/test-infra/issues/15799#issuecomment-576500280