### PR TITLE
Explicitly set HOME for gcb-docker-gcloud

### DIFF
--- a/images/gcb-docker-gcloud/Dockerfile
+++ b/images/gcb-docker-gcloud/Dockerfile
@@ -40,8 +40,9 @@ RUN echo http://dl-cdn.alpinelinux.org/alpine/latest-stable/community >> /etc/ap
     gcloud info > /workspace/gcloud-info.txt
 
 # Install docker Buildx for fast docker builds
-RUN mkdir -p  ~/.docker/cli-plugins \
-    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64" --output ~/.docker/cli-plugins/docker-buildx \
-    && chmod a+x ~/.docker/cli-plugins/docker-buildx
+ENV HOME=/root
+RUN mkdir -p  $HOME/.docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64" --output $HOME/.docker/cli-plugins/docker-buildx \
+    && chmod a+x $HOME/.docker/cli-plugins/docker-buildx
 
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
- Do not rely on `.` fix the directory to `/root`
- use $HOME when we build the image
- `ENV` ensure the same env var is available at runtime as well (docker CLI needs this to look up the directory for the plugins)