### PR TITLE
kops grid: don't run tests all at the same time

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -46,7 +46,7 @@ template = """
       - --provider=aws
       - --test_args={{test_args}}
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200417-6b47d16-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200420-e830a3a-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: {{tab}}

--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 import json
+import zlib
 
 template = """
-- interval: 8h
-  name: e2e-kops-grid{{suffix}}
+- name: e2e-kops-grid{{suffix}}
+  cron: '{{cron}}'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -52,6 +53,25 @@ template = """
     testgrid-tab-name: {{tab}}
 """
 
+# We support rapid focus on a few tests of high concern
+# This should be used for temporary tests we are evaluating,
+# and ideally linked to a bug, and removed once the bug is fixed
+hotlist = [
+]
+
+def simple_hash(s):
+    return zlib.crc32(s.encode())
+
+def build_cron(key, on_hotlist):
+    minute = simple_hash("minutes:" + key) % 60
+    hour = simple_hash("hours:" + key) % 24
+
+    # hotlist tests run hourly
+    if on_hotlist:
+        return "%d * * * *" % (minute)
+
+    # we normally run once per day
+    return "%d %d * * *" % (minute, hour)
 
 def build_test(cloud='aws', distro=None, networking=None):
     # pylint: disable=too-many-statements,too-many-branches
@@ -98,7 +118,7 @@ def build_test(cloud='aws', distro=None, networking=None):
 
     kops_args = kops_args.strip()
 
-    test_args = r"""--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort""" # pylint: disable=line-too-long
+    test_args = r'--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort' # pylint: disable=line-too-long
 
     suffix = ""
     if cloud:
@@ -110,6 +130,8 @@ def build_test(cloud='aws', distro=None, networking=None):
 
     tab = 'kops-grid' + suffix
 
+    cron = build_cron(tab, on_hotlist=(tab in hotlist))
+
     y = template
     y = y.replace('{{tab}}', tab)
     y = y.replace('{{suffix}}', suffix)
@@ -118,6 +140,7 @@ def build_test(cloud='aws', distro=None, networking=None):
     y = y.replace('{{kops_image}}', kops_image)
     y = y.replace('{{kops_args}}', kops_args)
     y = y.replace('{{test_args}}', test_args)
+    y = y.replace('{{cron}}', cron)
     out = y
 
     spec = {

--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -57,6 +57,10 @@ template = """
 # This should be used for temporary tests we are evaluating,
 # and ideally linked to a bug, and removed once the bug is fixed
 hotlist = [
+    # flannel networking issues: https://github.com/kubernetes/kops/pull/8381#issuecomment-616689498
+    'kops-grid-aws-flannel-centos7',
+    'kops-grid-aws-flannel-rhel7',
+    'kops-grid-aws-flannel-rhel8',
 ]
 
 def simple_hash(s):

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -40,7 +40,7 @@ periodics:
 
 # {"cloud": "aws", "networking": "flannel", "distro": "centos7"}
 - name: e2e-kops-grid-aws-flannel-centos7
-  cron: '14 2 * * *'
+  cron: '14 * * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -225,7 +225,7 @@ periodics:
 
 # {"cloud": "aws", "networking": "flannel", "distro": "rhel7"}
 - name: e2e-kops-grid-aws-flannel-rhel7
-  cron: '12 14 * * *'
+  cron: '12 * * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -262,7 +262,7 @@ periodics:
 
 # {"cloud": "aws", "networking": "flannel", "distro": "rhel8"}
 - name: e2e-kops-grid-aws-flannel-rhel8
-  cron: '1 23 * * *'
+  cron: '1 * * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -2,8 +2,8 @@
 periodics:
 
 # {"cloud": "aws", "networking": "flannel", "distro": "amazonlinux2"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-amazonlinux2
+- name: e2e-kops-grid-aws-flannel-amazonlinux2
+  cron: '52 19 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -39,8 +39,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-amazonlinux2
 
 # {"cloud": "aws", "networking": "flannel", "distro": "centos7"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-centos7
+- name: e2e-kops-grid-aws-flannel-centos7
+  cron: '14 2 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -76,8 +76,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-centos7
 
 # {"cloud": "aws", "networking": "flannel", "distro": "coreos"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-coreos
+- name: e2e-kops-grid-aws-flannel-coreos
+  cron: '35 5 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -113,8 +113,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-coreos
 
 # {"cloud": "aws", "networking": "flannel", "distro": "debian9"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-debian9
+- name: e2e-kops-grid-aws-flannel-debian9
+  cron: '42 22 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -150,8 +150,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-debian9
 
 # {"cloud": "aws", "networking": "flannel", "distro": "debian10"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-debian10
+- name: e2e-kops-grid-aws-flannel-debian10
+  cron: '19 14 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -187,8 +187,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-debian10
 
 # {"cloud": "aws", "networking": "flannel", "distro": "flatcar"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-flatcar
+- name: e2e-kops-grid-aws-flannel-flatcar
+  cron: '52 20 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -224,8 +224,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-flatcar
 
 # {"cloud": "aws", "networking": "flannel", "distro": "rhel7"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-rhel7
+- name: e2e-kops-grid-aws-flannel-rhel7
+  cron: '12 14 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -261,8 +261,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-rhel7
 
 # {"cloud": "aws", "networking": "flannel", "distro": "rhel8"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-rhel8
+- name: e2e-kops-grid-aws-flannel-rhel8
+  cron: '1 23 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -298,8 +298,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-rhel8
 
 # {"cloud": "aws", "networking": "flannel", "distro": "ubuntu1604"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-ubuntu1604
+- name: e2e-kops-grid-aws-flannel-ubuntu1604
+  cron: '21 14 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -335,8 +335,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-ubuntu1604
 
 # {"cloud": "aws", "networking": "flannel", "distro": "ubuntu1804"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-ubuntu1804
+- name: e2e-kops-grid-aws-flannel-ubuntu1804
+  cron: '47 20 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -372,8 +372,8 @@ periodics:
     testgrid-tab-name: kops-grid-aws-flannel-ubuntu1804
 
 # {"cloud": "aws", "networking": "flannel", "distro": "ubuntu2004"}
-- interval: 8h
-  name: e2e-kops-grid-aws-flannel-ubuntu2004
+- name: e2e-kops-grid-aws-flannel-ubuntu2004
+  cron: '21 2 * * *'
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"


### PR DESCRIPTION
Spread them randomly over a 24 hour window using the cron spec, and hash
values derived from their name.

Also boost some tests of interest to run hourly, currently the flannel
on rhel tests.