### PR TITLE
Add kops grid generator to autobumper

### DIFF
--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -39,8 +39,9 @@ const (
 )
 
 var extraFiles = map[string]bool{
-	"releng/generate_tests.py":       true,
-	"images/kubekins-e2e/Dockerfile": true,
+	"config/jobs/kubernetes/kops/build-grid.py": true,
+	"releng/generate_tests.py":                  true,
+	"images/kubekins-e2e/Dockerfile":            true,
 }
 
 func cdToRootDir() error {


### PR DESCRIPTION
This stops the generator getting out of sync with the generated
jobs (which are already updated).