### PR TITLE
Force a sync to avoid log truncation

### DIFF
--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -153,6 +153,7 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 			return fmt.Errorf("couldn't create %s: %v", p, err)
 		}
 
+		defer f.Sync()
 		defer f.Close()
 
 		cmd.Stdout = f


### PR DESCRIPTION
Compare the following files:
- https://storage.googleapis.com/kubernetes-jenkins/logs/post-node-driver-registrar-push-images/1252806915545632768/artifacts/build.log
- https://console.cloud.google.com/cloud-build/builds/a547448a-39e3-4154-9618-5617f0b34319;step=0?project=k8s-staging-csi

You can see that the first url has some text cut off at the end. File
created by `os.Create` is unbuffered, so there is nothing to flush.
Let's try `Sync` to see if that helps

Signed-off-by: Davanum Srinivas <davanum@gmail.com>