### PR TITLE
prow/plugins/label: consider only comment creation actions

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -121,7 +121,7 @@ func getLabelsFromGenericMatches(matches [][]string, additionalLabels []string, 
 }
 
 func handle(gc githubClient, log *logrus.Entry, additionalLabels []string, e *github.GenericCommentEvent) error {
-	if github.GenericCommentActionDeleted == e.Action {
+	if e.Action != github.GenericCommentActionCreated {
 		return nil
 	}
 

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -575,6 +575,17 @@ func TestLabel(t *testing.T) {
 			expectedBotComment:    false,
 			action:                github.GenericCommentActionDeleted,
 		},
+		{
+			name:                  "Don't take action while editing body",
+			body:                  "/kind bug",
+			repoLabels:            []string{labels.Bug},
+			issueLabels:           []string{},
+			expectedNewLabels:     []string{},
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+			expectedBotComment:    false,
+			action:                github.GenericCommentActionEdited,
+		},
 	}
 
 	for _, tc := range testcases {


### PR DESCRIPTION
In the current case, the plugin also considers Edit actions. This means
that if a comment body contained a command like `/remove-sig foo`, the
plugin will try to remove the `sig/foo` label when the comment body is
edited.

Since the `sig/foo` label would have been removed during comment creation,
the second removal during comment edit would fail with a comment, causing
spam.

See examples of spam in:
  - https://github.com/kubernetes/community/issues/4736 (due to edit of https://github.com/kubernetes/community/issues/4736#issuecomment-617791760)
  - https://github.com/kubernetes/k8s.io/issues/782 (due to edit of top-level body)

/assign @cblecker 
cc @mrbobbytables @bartsmykla 