### PR TITLE
adds k8s-staging-csi-secrets-store image pushing prow config

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
+++ b/config/jobs/image-pushing/k8s-staging-csi-secrets-store.yaml
@@ -1,0 +1,34 @@
+postsubmits:
+  # This is the github repo we'll build from. This block needs to be repeated
+  # for each repo.
+  kubernetes-sigs/secrets-store-csi-driver:
+    # The name should be changed to match the repo name above
+    - name: secrets-store-csi-driver-push-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # This is the name of some testgrid dashboard to report to.
+        # If this is the first one for your sig, you may need to create one
+        testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      decorate: true
+      # we only need to run if necessary (e.g.: the version was bumped)
+      run_if_changed: '^docker\/'
+      # this causes the job to only run on the master branch. Remove it if your
+      # job makes sense on every branch (unless it's setting a `latest` tag it
+      # probably does).
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-csi-secrets-store
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-csi-secrets-store-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --build-dir=.
+              - docker


### PR DESCRIPTION
Adds the prow config needed for pushing the CSI secrets store driver to a staging registry, from where the images will be pushed.

The secrets-store-csi-driver project group has already been created: https://github.com/kubernetes/k8s.io/pull/658