### PR TITLE
Checkconfig: Add validation for tide context policy

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -85,5 +85,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )


### PR DESCRIPTION
/assign @fejta @stevekuznetsov 

To avoid discovering this at runtime with errors like
```
{"branch":"release-4.3","component":"tide","controller":"status-update","error":"failed to set up context register: contexts ci/prow/shellcheck, ci/prow/tf-lint, ci/prow/yaml-lint are defined as required and required if present","file":"prow/tide/status.go:371","func":"k8s.io/test-infra/prow/tide.(*statusController).setStatuses.func1","level":"error","msg":"getting expected status","org":"openshift","pr":3460,"repo":"installer","sha":"e05a6363aa9e40cd3f341ada8ee3beb9dcabeda3","time":"2020-04-22T15:18:55Z"}
```