### PR TITLE
testgrids: update OpenShift configuration

### DIFF
--- a/config/testgrids/openshift/groups.yaml
+++ b/config/testgrids/openshift/groups.yaml
@@ -15,6 +15,7 @@ dashboard_groups:
   - redhat-openshift-ocp-release-4.5-broken
   - redhat-openshift-ocp-release-4.5-informing
   - redhat-openshift-ocp-release-4.6-blocking
+  - redhat-openshift-ocp-release-4.6-broken
   - redhat-openshift-ocp-release-4.6-informing
   - redhat-openshift-okd-release-4.3-informing
   - redhat-openshift-okd-release-4.4-informing

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.3-informing.yaml
@@ -1207,6 +1207,60 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.3
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.3
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.3
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.3
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1343,6 +1397,12 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-gcp-upgrade-4.3
   name: release-openshift-origin-installer-e2e-gcp-upgrade-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.3
+  name: release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.3
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.3
+  name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.3
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.3
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.3

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
@@ -1346,7 +1346,7 @@ test_groups:
   name: release-openshift-ocp-installer-e2e-gcp-fips-4.4
 - gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-fips-serial-4.4
   name: release-openshift-ocp-installer-e2e-gcp-fips-serial-4.4
-- days_of_results: 60
+- days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-rt-4.4
   name: release-openshift-ocp-installer-e2e-gcp-rt-4.4
 - days_of_results: 60
@@ -1364,7 +1364,7 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.4
-- days_of_results: 60
+- days_of_results: 25
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-ovirt-4.4
   name: release-openshift-ocp-installer-e2e-ovirt-4.4
 - days_of_results: 60

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-broken.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-broken.yaml
@@ -19,6 +19,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.5
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.5
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-ocp-installer-e2e-azure-ovn-4.5
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -54,11 +81,44 @@ dashboards:
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
     test_group_name: release-openshift-ocp-installer-e2e-gcp-ovn-4.5
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.5
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.5
   name: redhat-openshift-ocp-release-4.5-broken
 test_groups:
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-cluster-logging-operator-e2e-4.5
+  name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.5
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.5
   name: release-openshift-ocp-installer-e2e-azure-ovn-4.5
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.5
   name: release-openshift-ocp-installer-e2e-gcp-ovn-4.5
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-elasticsearch-operator-e2e-4.5
+  name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.5

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-broken.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-broken.yaml
@@ -19,14 +19,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: release-openshift-ocp-installer-e2e-azure-ovn-4.4
+    name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-azure-ovn-4.4
+    test_group_name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.6
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -46,19 +46,19 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: release-openshift-ocp-installer-e2e-gcp-ovn-4.4
+    name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-installer-e2e-gcp-ovn-4.4
-  name: redhat-openshift-ocp-release-4.4-broken
+    test_group_name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.6
+  name: redhat-openshift-ocp-release-4.6-broken
 test_groups:
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-azure-ovn-4.4
-  name: release-openshift-ocp-installer-e2e-azure-ovn-4.4
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-cluster-logging-operator-e2e-4.6
+  name: release-openshift-ocp-installer-cluster-logging-operator-e2e-4.6
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-gcp-ovn-4.4
-  name: release-openshift-ocp-installer-e2e-gcp-ovn-4.4
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-elasticsearch-operator-e2e-4.6
+  name: release-openshift-ocp-installer-elasticsearch-operator-e2e-4.6


### PR DESCRIPTION
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>

Hold for https://github.com/openshift/release/pull/8503
/hold

generated with latest testgrid-config-generator
```sh
testgrid-config-generator \
           --prow-jobs-dir=${RELEASE}/ci-operator/jobs \
           --release-config=${RELEASE}/core-services/release-controller/_releases/ \
           --testgrid-config=${TEST_INFRA}/config/testgrids/openshift
```

/cc @stevekuznetsov @smarterclayton 