### PR TITLE
Explicitly setting --config-path is now required

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -94,6 +94,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *April 23, 2020* Explicitly setting `--config-path` is now required.
  - *April 23, 2020* Update the `autobump` image to at least `v20200422-8c8546d74` before June 2020.
  - *April 23, 2020* Deleted deprecated `default_decoration_config`.
  - *April 22, 2020* Deleted the `file_weight_count` blunderbuss option.

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -198,7 +198,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	o.kubernetes.AddFlags(fs)
 	o.github.AddFlagsWithoutDefaultGitHubTokenPath(fs)
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -926,15 +926,6 @@ func Test_gatherOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "empty config-path defaults to old value",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
-			},
-		},
-		{
 			name: "explicitly set both --hidden-only and --show-hidden to true",
 			args: map[string]string{
 				"--hidden-only": "true",

--- a/prow/cmd/exporter/main.go
+++ b/prow/cmd/exporter/main.go
@@ -47,7 +47,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		logrus.WithError(err).Fatalf("cannot parse args: '%s'", os.Args[1:])
 	}
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -29,7 +29,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/plugins:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -87,7 +87,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.webhookSecretFile, "hmac-secret-file", "/etc/webhook/hmac", "Path to the file containing the GitHub HMAC secret.")
 	fs.StringVar(&o.slackTokenFile, "slack-token-file", "", "Path to the file containing the Slack token to use.")
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -54,15 +53,6 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.configPath = "/random/value"
-			},
-		},
-		{
-			name: "empty config-path defaults to old value",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
 			},
 		},
 		{

--- a/prow/cmd/horologium/main.go
+++ b/prow/cmd/horologium/main.go
@@ -55,7 +55,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	o.kubernetes.AddFlags(fs)
 
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -262,15 +262,6 @@ func TestFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "empty config-path defaults to old value",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
-			},
-		},
-		{
 			name: "expicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",

--- a/prow/cmd/plank/BUILD.bazel
+++ b/prow/cmd/plank/BUILD.bazel
@@ -64,7 +64,6 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -66,7 +66,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	}
 
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/plank/main_test.go
+++ b/prow/cmd/plank/main_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 )
 
@@ -44,15 +43,6 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.configPath = "/random/value"
-			},
-		},
-		{
-			name: "empty config-path defaults to old value",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
 			},
 		},
 		{

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -72,7 +72,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 
 	o.kubernetes.AddFlags(fs)
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -715,15 +715,6 @@ func TestFlags(t *testing.T) {
 			},
 		},
 		{
-			name: "default config-path when empty",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
-			},
-		},
-		{
 			name: "expicitly set --dry-run=false",
 			args: map[string]string{
 				"--dry-run": "false",

--- a/prow/cmd/tide/BUILD.bazel
+++ b/prow/cmd/tide/BUILD.bazel
@@ -57,7 +57,6 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//prow/config:go_default_library",
         "//prow/flagutil:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -97,7 +97,6 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.statusURI, "status-path", "", "The /local/path, gs://path/to/object or s3://path/to/object to store status controller state. GCS writes will use the default object ACL for the bucket.")
 
 	fs.Parse(args)
-	o.configPath = config.ConfigPath(o.configPath)
 	return o
 }
 

--- a/prow/cmd/tide/main_test.go
+++ b/prow/cmd/tide/main_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 )
 
@@ -44,15 +43,6 @@ func Test_gatherOptions(t *testing.T) {
 			},
 			expected: func(o *options) {
 				o.configPath = "/random/value"
-			},
-		},
-		{
-			name: "empty config-path defaults to old value",
-			args: map[string]string{
-				"--config-path": "",
-			},
-			expected: func(o *options) {
-				o.configPath = config.DefaultConfigPath
 			},
 		},
 		{

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1403,20 +1403,6 @@ func (c *Config) ValidateJobConfig() error {
 	return utilerrors.NewAggregate(errs)
 }
 
-// DefaultConfigPath will be used if a --config-path is unset
-const DefaultConfigPath = "/etc/config/config.yaml"
-
-// ConfigPath returns the value for the component's configPath if provided
-// explicitly or default otherwise.
-func ConfigPath(value string) string {
-
-	if value != "" {
-		return value
-	}
-	logrus.Warningf("defaulting to %s until 15 July 2019, please migrate", DefaultConfigPath)
-	return DefaultConfigPath
-}
-
 func parseProwConfig(c *Config) error {
 	if err := ValidateController(&c.Plank.Controller); err != nil {
 		return fmt.Errorf("validating plank config: %v", err)


### PR DESCRIPTION
Follow-up to `April 2, 2019` announcement