### PR TITLE
Fixing service-apis make commands

### DIFF
--- a/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
+++ b/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
@@ -17,7 +17,8 @@ presubmits:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
         args:
-          - make controller
+          - make
+          - controller
         # docker-in-docker needs privileged mode.
         securityContext:
           privileged: true
@@ -38,7 +39,8 @@ presubmits:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
         args:
-          - make verify
+          - make
+          - verify
         # docker-in-docker needs privileged mode.
         securityContext:
           privileged: true


### PR DESCRIPTION
Well that wasn't going to work. Have verified that this pattern should actually work with other examples like this: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml#L15

/cc @danehans @bowei 