### PR TITLE
apply decoration config defaults in validation

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1137,12 +1137,13 @@ func defaultPeriodics(periodics []Periodic, c *Config) error {
 func (c *Config) finalizeJobConfig() error {
 	if c.decorationRequested() {
 
-		if _, ok := c.Plank.DefaultDecorationConfigs["*"]; !ok {
+		def, ok := c.Plank.DefaultDecorationConfigs["*"]
+		if !ok {
 			return errors.New("default_decoration_configs['*'] is missing")
 		}
 
 		for key, valCfg := range c.Plank.DefaultDecorationConfigs {
-			if err := valCfg.Validate(); err != nil {
+			if err := valCfg.ApplyDefault(def).Validate(); err != nil {
 				return fmt.Errorf("default_decoration_configs[%q]: validation error: %v", key, err)
 			}
 		}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -333,11 +333,11 @@ periodics:
 			expectError: true,
 		},
 		{
-			name: "with bad repo config",
+			name: "repo should inherit from default config",
 			rawConfig: `
 plank:
   default_decoration_configs:
-    '*': # good
+    '*':
       timeout: 2h
       grace_period: 15s
       utility_images:
@@ -351,14 +351,10 @@ plank:
         default_org: "kubernetes"
         default_repo: "kubernetes"
       gcs_credentials_secret: "default-service-account"
-    'org/bad': # bad
+    'org/inherit':
       timeout: 2h
       grace_period: 15s
-      utility_images:
-      # clonerefs: "clonerefs:default"
-        initupload: "initupload:default"
-        entrypoint: "entrypoint:default"
-        sidecar: "sidecar:default"
+      utility_images: {}
       gcs_configuration:
         bucket: "default-bucket"
         path_strategy: "legacy"
@@ -375,7 +371,6 @@ periodics:
       args:
       - "test"
       - "./..."`,
-			expectError: true,
 		},
 		{
 			name: "with default and repo, use default",


### PR DESCRIPTION
follow-up of https://github.com/kubernetes/test-infra/pull/17346

The decoration configs were validating without inheriting the default values. That cause the `checkconfig` to exit with failure.

/cc @fejta @stevekuznetsov @alvaroaleman 