### PR TITLE
kops: capture sysctl settings

### DIFF
--- a/kubetest/dump_test.go
+++ b/kubetest/dump_test.go
@@ -219,6 +219,9 @@ func Test_logDumperNode_dump(t *testing.T) {
 			command: "sudo journalctl --output=short-precise",
 		},
 		&mockCommand{
+			command: "sudo sysctl --all",
+		},
+		&mockCommand{
 			command: "sudo systemctl list-units -t service --no-pager --no-legend --all",
 			stdout: []byte(
 				"kubelet.service                      loaded active running kubelet daemon\n" +
@@ -262,6 +265,7 @@ func Test_logDumperNode_dump(t *testing.T) {
 	if err != nil {
 		t.Errorf("error building logDumper: %v", err)
 	}
+	dumper.DumpSysctls = true
 
 	n, err := dumper.connectToNode(context.Background(), "nodename1", "host1")
 	if err != nil {
@@ -299,6 +303,7 @@ func Test_logDumperNode_dump(t *testing.T) {
 		"nodename1/kern.log",
 		"nodename1/journal.log",
 		"nodename1/kubelet.log",
+		"nodename1/sysctl.conf",
 		"nodename1/kube-controller-manager.log",
 		"nodename1/kube-controller-manager.log.1",
 		"nodename1/kube-controller-manager.log.2.gz",

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -529,6 +529,9 @@ func (k kops) DumpClusterLogs(localPath, gcsPath string) error {
 		return err
 	}
 
+	// Capture sysctl settings
+	logDumper.DumpSysctls = true
+
 	ctx, cancel := context.WithCancel(context.TODO())
 	defer cancel()
 


### PR DESCRIPTION
We're seeing some differences across OSes, particularly around flannel
networking.  One workaround is to change some sysctls, so let's
capture those sysctl values.