### PR TITLE
Azure: create a periodic job to run conformance against master with capz

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -269,3 +269,42 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests latest kubernetes master with aks-engine
     testgrid-num-columns-recent: '30'
+- interval: 24h
+  name: ci-kubernetes-e2e-capz-conformance-master
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200422-8c8546d-master
+      command:
+      - "runner.sh"
+      - "./scripts/ci-conformance.sh"
+      env:
+      - name: FOCUS
+        value: "\\[Conformance\\]|\\[NodeConformance\\]"
+      - name: SKIP
+        value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-conformance-master-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Runs conformance & node conformance tests latest kubernetes master with cluster-api-provider-azure
+    testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Creating a periodic job to run conformance tests against a capz cluster without out-of-tree components to compare test results with https://testgrid.k8s.io/provider-azure-periodic#k8s-e2e-conformance-master.

/assign @chewong @feiskyer 
/cc @ritazh 