### PR TITLE
Azure: add missing presets and resource requests to capz conformance e2e job

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -269,15 +269,15 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests latest kubernetes master with aks-engine
     testgrid-num-columns-recent: '30'
-- interval: 24h
+- interval: 3h
   name: ci-kubernetes-e2e-capz-conformance-master
   decorate: true
   decoration_config:
     timeout: 3h
   labels:
-    preset-service-account: "true"
-    preset-azure-cred: "true"
     preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-azure
@@ -302,6 +302,10 @@ periodics:
         value: "true"
       securityContext:
         privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
   annotations:
     testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
     testgrid-tab-name: k8s-e2e-conformance-master-capz


### PR DESCRIPTION
Follow up from #17375, fix for https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-capz-conformance-master/1253750569152024576/build-log.txt

Also increases the interval to 3h until the job is stable for faster iteration loops.

/assign @chewong 