### PR TITLE
Require --github-token-path to be set.

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -176,7 +176,8 @@ func (o *options) gatherOptions(flag *flag.FlagSet, args []string) error {
 	flag.Var(&o.excludeWarnings, "exclude-warning", "Warnings to exclude. Use repeatedly to provide a list of warnings to exclude")
 	flag.BoolVar(&o.expensive, "expensive-checks", false, "If set, additional expensive warnings will be enabled")
 	flag.BoolVar(&o.strict, "strict", false, "If set, consider all warnings as errors.")
-	o.github.AddFlagsWithoutDefaultGitHubTokenPath(flag)
+	o.github.AddFlags(flag)
+	o.github.AllowAnonymous = true
 	if err := flag.Parse(args); err != nil {
 		return fmt.Errorf("parse flags: %v", err)
 	}

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1064,7 +1064,8 @@ func TestVerifyOwnersPresence(t *testing.T) {
 func TestOptions(t *testing.T) {
 
 	var defaultGitHubOptions flagutil.GitHubOptions
-	defaultGitHubOptions.AddFlagsWithoutDefaultGitHubTokenPath(flag.NewFlagSet("", flag.ContinueOnError))
+	defaultGitHubOptions.AddFlags(flag.NewFlagSet("", flag.ContinueOnError))
+	defaultGitHubOptions.AllowAnonymous = true
 
 	StringsFlag := func(vals []string) flagutil.Strings {
 		var flag flagutil.Strings

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -954,7 +954,8 @@ func Test_gatherOptions(t *testing.T) {
 	for _, tc := range cases {
 		fs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 		ghoptions := flagutil.GitHubOptions{}
-		ghoptions.AddFlagsWithoutDefaultGitHubTokenPath(fs)
+		ghoptions.AddFlags(fs)
+		ghoptions.AllowAnonymous = true
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
 				configPath:            "yo",

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -105,6 +105,7 @@ func Test_gatherOptions(t *testing.T) {
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)
+			expected.github.TokenPath = flagutil.DefaultGitHubTokenPath
 			if tc.expected != nil {
 				tc.expected(expected)
 			}

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -204,7 +204,8 @@ func gatherOptions() options {
 	fs.IntVar(&o.pullNumber, "pull-number", 0, "Git pull number under test")
 	fs.StringVar(&o.pullSha, "pull-sha", "", "Git pull SHA under test")
 	fs.StringVar(&o.pullAuthor, "pull-author", "", "Git pull author under test")
-	o.github.AddFlagsWithoutDefaultGitHubTokenPath(fs)
+	o.github.AddFlags(fs)
+	o.github.AllowAnonymous = true
 	fs.Parse(os.Args[1:])
 	return o
 }

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -71,6 +71,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 }
 
 func (o *options) Validate() error {
+	o.github.AllowAnonymous = true
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {
 		if err := group.Validate(o.dryRun); err != nil {
 			return err

--- a/prow/cmd/plank/main_test.go
+++ b/prow/cmd/plank/main_test.go
@@ -99,6 +99,7 @@ func Test_gatherOptions(t *testing.T) {
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)
+			expected.github.AllowAnonymous = true
 			if tc.expected != nil {
 				tc.expected(expected)
 			}

--- a/prow/cmd/status-reconciler/main_test.go
+++ b/prow/cmd/status-reconciler/main_test.go
@@ -69,6 +69,7 @@ func TestGatherOptions(t *testing.T) {
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)
+			expected.github.TokenPath = flagutil.DefaultGitHubTokenPath
 			if tc.expected != nil {
 				tc.expected(expected)
 			}

--- a/prow/cmd/tide/main.go
+++ b/prow/cmd/tide/main.go
@@ -19,6 +19,7 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -71,12 +72,11 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage} {
+	for idx, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage} {
 		if err := group.Validate(o.dryRun); err != nil {
-			return err
+			return fmt.Errorf("%d: %w", idx, err)
 		}
 	}
-
 	return nil
 }
 

--- a/prow/cmd/tide/main_test.go
+++ b/prow/cmd/tide/main_test.go
@@ -106,11 +106,11 @@ func Test_gatherOptions(t *testing.T) {
 				syncThrottle:      800,
 				statusThrottle:    400,
 				maxRecordsPerPool: 1000,
-				github:            flagutil.GitHubOptions{},
 				kubernetes:        flagutil.KubernetesOptions{DeckURI: "http://whatever"},
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)
+			expected.github.TokenPath = flagutil.DefaultGitHubTokenPath
 			if tc.expected != nil {
 				tc.expected(expected)
 			}

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"net/http"
 	"os"
 	"strconv"
@@ -46,9 +47,9 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	for _, group := range []flagutil.OptionGroup{&o.github} {
+	for idx, group := range []flagutil.OptionGroup{&o.github} {
 		if err := group.Validate(o.dryRun); err != nil {
-			return err
+			return fmt.Errorf("%d: %w", idx, err)
 		}
 	}
 

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -52,9 +52,9 @@ type options struct {
 }
 
 func (o *options) Validate() error {
-	for _, group := range []flagutil.OptionGroup{&o.github} {
+	for idx, group := range []flagutil.OptionGroup{&o.github} {
 		if err := group.Validate(o.dryRun); err != nil {
-			return err
+			return fmt.Errorf("%d: %w", idx, err)
 		}
 	}
 

--- a/prow/prstatus/BUILD.bazel
+++ b/prow/prstatus/BUILD.bazel
@@ -35,7 +35,6 @@ go_test(
     srcs = ["prstatus_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/githuboauth:go_default_library",
         "@com_github_gorilla_sessions//:go_default_library",

--- a/prow/prstatus/prstatus.go
+++ b/prow/prstatus/prstatus.go
@@ -42,15 +42,10 @@ const (
 	loginKey     = "login"
 )
 
-type githubClient interface {
-	Query(context.Context, interface{}, map[string]interface{}) error
-	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
-}
-
-// PullRequestQueryHandler defines an interface that query handlers should implement.
-type PullRequestQueryHandler interface {
-	QueryPullRequests(context.Context, githubClient, string) ([]PullRequest, error)
-	GetHeadContexts(ghc githubClient, pr PullRequest) ([]Context, error)
+// pullRequestQueryHandler defines an interface that query handlers should implement.
+type pullRequestQueryHandler interface {
+	queryPullRequests(context.Context, githubQuerier, string) ([]PullRequest, error)
+	getHeadContexts(ghc githubStatusFetcher, pr PullRequest) ([]Context, error)
 }
 
 // UserData represents data returned to client request to the endpoint. It has a flag that indicates
@@ -72,7 +67,7 @@ type PullRequestWithContexts struct {
 type DashboardAgent struct {
 	repos  []string
 	goac   *githuboauth.Config
-	github *flagutil.GitHubOptions
+	github flagutil.GitHubOptions
 
 	log *logrus.Entry
 }
@@ -149,7 +144,7 @@ func NewDashboardAgent(repos []string, config *githuboauth.Config, github *flagu
 	return &DashboardAgent{
 		repos:  repos,
 		goac:   config,
-		github: github,
+		github: *github,
 		log:    log,
 	}
 }
@@ -169,11 +164,19 @@ func invalidateGitHubSession(w http.ResponseWriter, r *http.Request, session *se
 	return session.Save(r, w)
 }
 
+type GitHubClient interface {
+	githubQuerier
+	githubStatusFetcher
+	BotName() (string, error)
+}
+
+type githubClientCreator func(accessToken string) GitHubClient
+
 // HandlePrStatus returns a http handler function that handles request to /pr-status
 // endpoint. The handler takes user access token stored in the cookie to query to GitHub on behalf
 // of the user and serve the data in return. The Query handler is passed to the method so as it
 // can be mocked in the unit test..
-func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) http.HandlerFunc {
+func (da *DashboardAgent) HandlePrStatus(queryHandler pullRequestQueryHandler, createClient githubClientCreator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		serverError := func(action string, err error) {
 			da.log.WithError(err).Errorf("Error %s.", action)
@@ -199,11 +202,11 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 		// If access token exists, get user login using the access token. This is a
 		// chance to validate whether the access token is consumable or not. If
 		// not, we invalidate the sessions and continue as if not logged in.
-		token, ok := session.Values[tokenKey].(*oauth2.Token)
+		token, ok := session.Values[tokenKey].(*oauth2.Token) // TODO(fejta): client cache
 		var user *github.User
 		var botName string
 		if ok && token.Valid() {
-			githubClient := da.github.GitHubClientWithAccessToken(token.AccessToken)
+			githubClient := createClient(token.AccessToken)
 			var err error
 			botName, err = githubClient.BotName()
 			user = &github.User{Login: botName}
@@ -240,7 +243,7 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 			}
 
 			// Construct query
-			ghc := da.github.GitHubClientWithAccessToken(token.AccessToken)
+			ghc := da.github.GitHubClientWithAccessToken(token.AccessToken) // TODO(fejta): we should not recreate the client
 			query := da.ConstructSearchQuery(login)
 			if err := r.ParseForm(); err == nil {
 				if q := r.Form.Get("query"); q != "" {
@@ -254,14 +257,14 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 					query += fmt.Sprintf(" repo:\"%s\"", v)
 				}
 			}
-			pullRequests, err := queryHandler.QueryPullRequests(context.Background(), ghc, query)
+			pullRequests, err := queryHandler.queryPullRequests(context.Background(), ghc, query)
 			if err != nil {
 				serverError("Error with querying user data.", err)
 				return
 			}
 			var pullRequestWithContexts []PullRequestWithContexts
 			for _, pr := range pullRequests {
-				prcontexts, err := queryHandler.GetHeadContexts(ghc, pr)
+				prcontexts, err := queryHandler.getHeadContexts(ghc, pr)
 				if err != nil {
 					serverError("Error with getting head context of pr", err)
 					continue
@@ -290,9 +293,13 @@ func (da *DashboardAgent) HandlePrStatus(queryHandler PullRequestQueryHandler) h
 	}
 }
 
-// QueryPullRequests is a query function that returns a list of open pull requests owned by the user whose access token
+type githubQuerier interface {
+	Query(context.Context, interface{}, map[string]interface{}) error
+}
+
+// queryPullRequests is a query function that returns a list of open pull requests owned by the user whose access token
 // is consumed by the github client.
-func (da *DashboardAgent) QueryPullRequests(ctx context.Context, ghc githubClient, query string) ([]PullRequest, error) {
+func (da *DashboardAgent) queryPullRequests(ctx context.Context, ghc githubQuerier, query string) ([]PullRequest, error) {
 	var prs []PullRequest
 	vars := map[string]interface{}{
 		"query":        (githubql.String)(query),
@@ -326,8 +333,12 @@ func (da *DashboardAgent) QueryPullRequests(ctx context.Context, ghc githubClien
 	return prs, nil
 }
 
-// GetHeadContexts returns the status checks' contexts of the head commit of the PR.
-func (da *DashboardAgent) GetHeadContexts(ghc githubClient, pr PullRequest) ([]Context, error) {
+type githubStatusFetcher interface {
+	GetCombinedStatus(org, repo, ref string) (*github.CombinedStatus, error)
+}
+
+// getHeadContexts returns the status checks' contexts of the head commit of the PR.
+func (da *DashboardAgent) getHeadContexts(ghc githubStatusFetcher, pr PullRequest) ([]Context, error) {
 	org := string(pr.Repository.Owner.Login)
 	repo := string(pr.Repository.Name)
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))


### PR DESCRIPTION
Will continue defaulting for another month, now with a warning.
Also refactor prstatus unit test to be hermetic and not make github calls.