### PR TITLE
Setting kops-admin-access flag on GCE job 

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -249,6 +249,9 @@ periodics:
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-central1-c
       - --provider=gce
+      # Note: temporarily opening up traffic to k8s-apiserver during these tests (cloud firewall level).
+      # This should allow these tests to start running again (haven't even tried to run since early April).
+      - --kops-admin-access=0.0.0.0/0
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:latest-master


### PR DESCRIPTION
I think these jobs fail while trying to figure out the CLI args to configure the firewall for api access. I think the logic in `kubetest/kops.go` needs to be adjusted for GCP, but we should be able to get past this specific error by providing the `kops-admin-access` flag in our job. We can follow up to help sort out reasonable default test args. 
(recent, broken job)
 https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-canary/1254253129281572870

(older, broken job, that got much further than above)
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-kops-gce-canary/1246827288348069889

The more recent jobs never seem to run `kops create cluster...` they fail with an error like: 
`2020/04/26 03:37:59 main.go:312: Something went wrong: starting e2e cluster: external IP cannot be retrieved: https://v4.ifconfig.co returned 503 - ...`
