### PR TITLE
Add a Prow job for building Kubernetes using most recent Golang version

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -1,0 +1,25 @@
+periodics:
+- name: ci-build-and-push-k8s-at-golang-tip
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-golang
+    testgrid-tab-name: build-and-push-k8s-at-golang-tip
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/bootstrap:v20200302-ca9526d
+        args:
+        - --root=/go/src
+        - --repo=k8s.io/perf-tests=master
+        - --timeout=60
+        - --scenario=execute
+        - --
+        - make
+        - --
+        - --directory=/go/src/k8s.io/perf-tests/golang
+        - K8S_COMMIT=28ec82ddbdfc09619ce00a2aae498cb3c9d3ebc8 # head of release-1.18 branch as of 2020-04-28
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true

--- a/config/testgrids/kubernetes/sig-scalability/config.yaml
+++ b/config/testgrids/kubernetes/sig-scalability/config.yaml
@@ -7,6 +7,7 @@ dashboard_groups:
     - sig-scalability-perf-tests
     - sig-scalability-benchmarks
     - sig-scalability-experiments
+    - sig-scalability-golang
 
 dashboards:
 - name: sig-scalability-gce
@@ -15,3 +16,4 @@ dashboards:
 - name: sig-scalability-perf-tests
 - name: sig-scalability-benchmarks
 - name: sig-scalability-experiments
+- name: sig-scalability-golang


### PR DESCRIPTION
Prow job based on perf-tests script from PR [#1189](https://github.com/kubernetes/perf-tests/pull/1189). I tested it on our internal Prow and it works.

/sig scalability