### PR TITLE
censor oauth token from the git commands

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -60,7 +60,7 @@ func Run(refs prowapi.Refs, dir, gitUserName, gitUserEmail, cookiePath string, e
 				message = err.Error()
 				record.Failed = true
 			}
-			record.Commands = append(record.Commands, Command{Command: formattedCommand, Output: output, Error: message})
+			record.Commands = append(record.Commands, Command{Command: censorGitCommand(formattedCommand, oauthToken), Output: output, Error: message})
 			if err != nil {
 				return err
 			}
@@ -89,6 +89,14 @@ func Run(refs prowapi.Refs, dir, gitUserName, gitUserEmail, cookiePath string, e
 	}
 
 	return record
+}
+
+func censorGitCommand(command, token string) string {
+	if token == "" {
+		return command
+	}
+	censored := bytes.ReplaceAll([]byte(command), []byte(token), []byte("CENSORED"))
+	return string(censored)
 }
 
 // PathForRefs determines the full path to where

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -535,3 +535,33 @@ func makeFakeGitRepo(fakeTimestamp int) (string, error) {
 	}
 	return fakeGitDir, nil
 }
+
+func TestCensorGitCommand(t *testing.T) {
+	testCases := []struct {
+		id       string
+		token    string
+		command  string
+		expected string
+	}{
+		{
+			id:       "no token",
+			command:  "git fetch https://github.com/kubernetes/test-infra.git",
+			expected: "git fetch https://github.com/kubernetes/test-infra.git",
+		},
+		{
+			id:       "with token",
+			token:    "123456789",
+			command:  "git fetch 123456789:x-oauth-basic@https://github.com/kubernetes/test-infra.git",
+			expected: "git fetch CENSORED:x-oauth-basic@https://github.com/kubernetes/test-infra.git",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.id, func(t *testing.T) {
+			censoredCommand := censorGitCommand(tc.command, tc.token)
+			if !reflect.DeepEqual(censoredCommand, tc.expected) {
+				t.Fatalf("expected: %s got %s", tc.expected, censoredCommand)
+			}
+		})
+	}
+}


### PR DESCRIPTION
closes #17386 

Even though we were censoring the OAuth token in the `clonerefs` output logs, the `Run` function was returning a `Record` that it's being used from the `clonerefs` binary to marshal the struct to a file that was being uploaded in GCS (see https://github.com/kubernetes/test-infra/blob/master/prow/clonerefs/run.go#L107-L114). That logic caused the OAuth token to leak in the artifacts.

/cc @stevekuznetsov @alvaroaleman @petr-muller 