### PR TITLE
bootstrap: env substitution typo

### DIFF
--- a/images/bootstrap/runner.sh
+++ b/images/bootstrap/runner.sh
@@ -26,7 +26,7 @@ fi
 
 # runs custom docker data root cleanup binary and debugs remaining resources
 cleanup_dind() {
-    if [[ "{DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
+    if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
         echo "Cleaning up after docker"
         docker ps -aq | xargs -r docker rm -f || true
         service docker stop || true


### PR DESCRIPTION
`"{DOCKER_IN_DOCKER_ENABLED-false}"` is a pure bash string, this will
never equal to `"true"`. As a result, those containers may never be
cleaned up.