### PR TITLE
customize bootstrap upload path via env var

### DIFF
--- a/images/bootstrap/entrypoint.sh
+++ b/images/bootstrap/entrypoint.sh
@@ -20,10 +20,12 @@ set -o pipefail
 # get test-infra for latest bootstrap etc
 git clone https://github.com/kubernetes/test-infra
 
+BOOTSTRAP_UPLOAD_BUCKET_PATH=${BOOTSTRAP_UPLOAD_BUCKET_PATH:-"gs://kubernetes-jenkins/logs"}
+
 # actually start bootstrap and the job, under the runner (which handles dind etc.)
 /usr/local/bin/runner.sh \
     ./test-infra/jenkins/bootstrap.py \
         --job="${JOB_NAME}" \
         --service-account="${GOOGLE_APPLICATION_CREDENTIALS}" \
-        --upload='gs://kubernetes-jenkins/logs' \
+        --upload="${BOOTSTRAP_UPLOAD_BUCKET_PATH}" \
         "$@"


### PR DESCRIPTION
this can also be achieved by each job appending their own flag
--upload="gs://other-bucket/other-path", but env vars are something
we could inject in via a prow preset if we wanted to change all jobs
to upload someplace new en-masse without necessarily touching all jobs