### PR TITLE
GitV2: make usage nice

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/prow/flagutil/git.go
+++ b/prow/flagutil/git.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // GitOptions holds options for interacting with git.
@@ -86,5 +87,13 @@ func (o *GitOptions) GitClient(userClient github.UserClient, token func() []byte
 		}
 		return user.Login, nil
 	}
-	return git.NewClientFactory(o.host, o.useSSH, username, token, gitUser, censor)
+	opts := git.ClientFactoryOpts{
+		Host:     o.host,
+		UseSSH:   utilpointer.BoolPtr(o.useSSH),
+		Username: username,
+		Token:    token,
+		GitUser:  gitUser,
+		Censor:   censor,
+	}
+	return git.NewClientFactory(opts.Apply)
 }

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -475,3 +475,13 @@ func (r *Repo) MergeCommitsExistBetween(target, head string) (bool, error) {
 	}
 	return len(b) != 0, nil
 }
+
+// ShowRef returns the commit for a commitlike. Unlike rev-parse it does not require a checkout.
+func (i *Repo) ShowRef(commitlike string) (string, error) {
+	i.logger.Infof("Getting the commit sha for commitlike %s", commitlike)
+	out, err := i.gitCommand("show-ref", "-s", commitlike).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %v", commitlike, err)
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -516,3 +516,46 @@ func testMerging(clients localgit.Clients, t *testing.T) {
 		})
 	}
 }
+
+func TestShowRef(t *testing.T) {
+	testShowRef(localgit.New, t)
+}
+
+func TestShowRefV2(t *testing.T) {
+	testShowRef(localgit.NewV2, t)
+}
+
+func testShowRef(clients localgit.Clients, t *testing.T) {
+	const org, repo = "org", "repo"
+	lg, c, err := clients()
+	if err != nil {
+		t.Fatalf("failed to get clients: %v", err)
+	}
+	defer func() {
+		if err := lg.Clean(); err != nil {
+			t.Errorf("Error cleaning LocalGit: %v", err)
+		}
+		if err := c.Clean(); err != nil {
+			t.Errorf("Error cleaning Client: %v", err)
+		}
+	}()
+	if err := lg.MakeFakeRepo(org, repo); err != nil {
+		t.Fatalf("Making fake repo: %v", err)
+	}
+	reference, err := lg.RevParse(org, repo, "HEAD")
+	if err != nil {
+		t.Fatalf("lg.RevParse: %v", err)
+	}
+
+	client, err := c.ClientFor(org, repo)
+	if err != nil {
+		t.Fatalf("clientFor: %v", err)
+	}
+	res, err := client.ShowRef("HEAD")
+	if err != nil {
+		t.Fatalf("ShowRef: %v", err)
+	}
+	if res != reference {
+		t.Errorf("expeted result to be %s, was %s", reference, res)
+	}
+}

--- a/prow/git/v2/BUILD.bazel
+++ b/prow/git/v2/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//prow/git:go_default_library",
         "//prow/github:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -20,9 +20,11 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	utilpointer "k8s.io/utils/pointer"
 )
 
 // ClientFactory knows how to create clientFactory for repos
@@ -48,33 +50,103 @@ type repoClient struct {
 	interactor
 }
 
-// NewClientFactory allows for the creation of repository clients
-func NewClientFactory(host string, useSSH bool, username LoginGetter, token TokenGetter, gitUser GitUserGetter, censor Censor) (ClientFactory, error) {
-	cacheDir, err := ioutil.TempDir("", "gitcache")
+type ClientFactoryOpts struct {
+	// Host, defaults to "github.com" if unset
+	Host string
+	// UseSSH, defaults to false
+	UseSSH *bool
+	// The directory in which the cache should be
+	// created. Defaults to the "/var/tmp" on
+	// Linux and os.TempDir otherwise
+	CacheDirBase *string
+	// If unset, publishing action will error
+	Username LoginGetter
+	// If unset, publishing action will error
+	Token TokenGetter
+	// The git user to use.
+	GitUser GitUserGetter
+	// The censor to use. Not needed for anonymous
+	// actions.
+	Censor Censor
+}
+
+// Apply allows to use a ClientFactoryOpts as Opt
+func (cfo *ClientFactoryOpts) Apply(target *ClientFactoryOpts) {
+	if cfo.Host != "" {
+		target.Host = cfo.Host
+	}
+	if cfo.UseSSH != nil {
+		target.UseSSH = cfo.UseSSH
+	}
+	if cfo.CacheDirBase != nil {
+		target.CacheDirBase = cfo.CacheDirBase
+	}
+	if cfo.Token != nil {
+		target.Token = cfo.Token
+	}
+	if cfo.GitUser != nil {
+		target.Token = cfo.Token
+	}
+	if cfo.Censor != nil {
+		target.Censor = cfo.Censor
+	}
+}
+
+// ClientFactoryOpts allows to manipulate the options for a ClientFactory
+type ClientFactoryOpt func(*ClientFactoryOpts)
+
+func defaultClientFactoryOpts(cfo *ClientFactoryOpts) {
+	if cfo.Host == "" {
+		cfo.Host = "github.com"
+	}
+	if cfo.CacheDirBase == nil {
+		switch runtime.GOOS {
+		case "linux":
+			cfo.CacheDirBase = utilpointer.StringPtr("/var/tmp")
+		default:
+			cfo.CacheDirBase = utilpointer.StringPtr("")
+		}
+	}
+	if cfo.Censor == nil {
+		cfo.Censor = func(in []byte) []byte { return in }
+	}
+}
+
+// NewClientFactory allows for the creation of repository clients. It uses github.com
+// without authentication by default.
+func NewClientFactory(opts ...ClientFactoryOpt) (ClientFactory, error) {
+	o := ClientFactoryOpts{}
+	defaultClientFactoryOpts(&o)
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	cacheDir, err := ioutil.TempDir(*o.CacheDirBase, "gitcache")
 	if err != nil {
 		return nil, err
 	}
 	var remotes RemoteResolverFactory
-	if useSSH {
+	if o.UseSSH != nil && *o.UseSSH {
 		remotes = &sshRemoteResolverFactory{
-			host:     host,
-			username: username,
+			host:     o.Host,
+			username: o.Username,
 		}
 	} else {
 		remotes = &httpResolverFactory{
-			host:     host,
-			username: username,
-			token:    token,
+			host:     o.Host,
+			username: o.Username,
+			token:    o.Token,
 		}
 	}
 	return &clientFactory{
-		cacheDir:   cacheDir,
-		remotes:    remotes,
-		gitUser:    gitUser,
-		censor:     censor,
-		masterLock: &sync.Mutex{},
-		repoLocks:  map[string]*sync.Mutex{},
-		logger:     logrus.WithField("client", "git"),
+		cacheDir:     cacheDir,
+		cacheDirBase: *o.CacheDirBase,
+		remotes:      remotes,
+		gitUser:      o.GitUser,
+		censor:       o.Censor,
+		masterLock:   &sync.Mutex{},
+		repoLocks:    map[string]*sync.Mutex{},
+		logger:       logrus.WithField("client", "git"),
 	}, nil
 }
 
@@ -104,6 +176,8 @@ type clientFactory struct {
 
 	// cacheDir is the root under which cached clones of repos are created
 	cacheDir string
+	// cacheDirBase is the basedir under which create tempdirs
+	cacheDirBase string
 	// masterLock guards mutations to the repoLocks records
 	masterLock *sync.Mutex
 	// repoLocks guard mutating access to subdirectories under the cacheDir
@@ -161,7 +235,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 		return nil, err
 	}
 
-	repoDir, err := ioutil.TempDir("", "gitrepo")
+	repoDir, err := ioutil.TempDir(c.cacheDirBase, "gitrepo")
 	if err != nil {
 		return nil, err
 	}

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -61,7 +61,7 @@ func NewClientFactory(host string, useSSH bool, username LoginGetter, token Toke
 			username: username,
 		}
 	} else {
-		remotes = &simpleAuthResolverFactory{
+		remotes = &httpResolverFactory{
 			host:     host,
 			username: username,
 			token:    token,

--- a/prow/git/v2/executor.go
+++ b/prow/git/v2/executor.go
@@ -23,15 +23,15 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// Executor knows how to execute Git commands
-type Executor interface {
+// executor knows how to execute Git commands
+type executor interface {
 	Run(args ...string) ([]byte, error)
 }
 
 // Censor censors content to remove secrets
 type Censor func(content []byte) []byte
 
-func NewCensoringExecutor(dir string, censor Censor, logger *logrus.Entry) (Executor, error) {
+func NewCensoringExecutor(dir string, censor Censor, logger *logrus.Entry) (executor, error) {
 	g, err := exec.LookPath("git")
 	if err != nil {
 		return nil, err

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 )
@@ -61,6 +62,8 @@ type Interactor interface {
 	Diff(head, sha string) (changes []string, err error)
 	// MergeCommitsExistBetween determines if merge commits exist between target and HEAD
 	MergeCommitsExistBetween(target, head string) (bool, error)
+	// ShowRef returns the commit for a commitlike. Unlike rev-parse it does not require a checkout.
+	ShowRef(commitlike string) (string, error)
 }
 
 // cacher knows how to cache and update repositories in a central cache
@@ -326,4 +329,13 @@ func (i *interactor) MergeCommitsExistBetween(target, head string) (bool, error)
 		return false, fmt.Errorf("error verifying if merge commits exist between %q and %q: %v %s", target, head, err, string(out))
 	}
 	return len(out) != 0, nil
+}
+
+func (i *interactor) ShowRef(commitlike string) (string, error) {
+	i.logger.Infof("Getting the commit sha for commitlike %s", commitlike)
+	out, err := i.executor.Run("show-ref", "-s", commitlike)
+	if err != nil {
+		return "", fmt.Errorf("failed to get commit sha for commitlike %s: %v", commitlike, err)
+	}
+	return strings.TrimSpace(string(out)), nil
 }

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -81,7 +81,7 @@ type cloner interface {
 }
 
 type interactor struct {
-	executor Executor
+	executor executor
 	remote   RemoteResolver
 	dir      string
 	logger   *logrus.Entry

--- a/prow/git/v2/publisher.go
+++ b/prow/git/v2/publisher.go
@@ -34,7 +34,7 @@ type Publisher interface {
 type GitUserGetter func() (name, email string, err error)
 
 type publisher struct {
-	executor Executor
+	executor executor
 	remote   RemoteResolver
 	info     GitUserGetter
 	logger   *logrus.Entry

--- a/prow/git/v2/remote_test.go
+++ b/prow/git/v2/remote_test.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
-func TestSimpleAuthResolver(t *testing.T) {
+func TestHTTPResolver(t *testing.T) {
 	var testCases = []struct {
 		name        string
 		remote      func() (*url.URL, error)
@@ -73,7 +73,7 @@ func TestSimpleAuthResolver(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			actual, actualErr := simpleAuthResolver(testCase.remote, testCase.username, testCase.token)()
+			actual, actualErr := httpResolver(testCase.remote, testCase.username, testCase.token)()
 			if testCase.expectedErr && actualErr == nil {
 				t.Errorf("%s: expected an error but got none", testCase.name)
 			}
@@ -153,8 +153,29 @@ func TestSSHRemoteResolverFactory(t *testing.T) {
 	}
 }
 
-func TestSimpleAuthRemoteResolverFactory(t *testing.T) {
-	factory := simpleAuthResolverFactory{
+func TestHTTPResolverFactory_NoAuth(t *testing.T) {
+	t.Run("CentralRemote", func(t *testing.T) {
+		expected := "https://some-host.com/org/repo"
+		res, err := (&httpResolverFactory{host: "some-host.com"}).CentralRemote("org", "repo")()
+		if err != nil {
+			t.Fatalf("CentralRemote: %v", err)
+		}
+		if res != expected {
+			t.Errorf("Expected result to be %s, was %s", expected, res)
+		}
+	})
+
+	t.Run("PublishRemote", func(t *testing.T) {
+		expectedErr := "could not resolve remote: username not configured, no publish repo available"
+		_, err := (&httpResolverFactory{host: "some-host.com"}).PublishRemote("org", "repo")()
+		if err == nil || err.Error() != expectedErr {
+			t.Errorf("expectedErr to be %s, was %v", expectedErr, err)
+		}
+	})
+}
+
+func TestHTTPResolverFactory(t *testing.T) {
+	factory := httpResolverFactory{
 		host: "host.com",
 		username: usernameVendor([]stringWithError{
 			{str: "first", err: nil},


### PR DESCRIPTION
This PR does  a couple of things:

* Allow the gitv2 client to be used anonymously
* Make the gitv2 constructor functional opts based and default it to use github.com anonymously
* Expose a `Run` function on both the old and the new client to allow running arbitrary commands

/assign @stevekuznetsov @fejta 