### PR TITLE
Add 'Configurator' to Prow Images

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -123,7 +123,7 @@ postsubmits:
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|prow|ghproxy|label_sync|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd/transfigure)/'
+    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|prow|ghproxy|label_sync|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd)/'
     decorate: true
     spec:
       serviceAccountName: pusher

--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -47,6 +47,7 @@ prow_push(
             "commenter": "//robots/commenter:image",
             "pr-creator": "//robots/pr-creator:image",
             "issue-creator": "//robots/issue-creator:image",
+            "configurator": "//testgrid/cmd/configurator:image",
             "transfigure": "//testgrid/cmd/transfigure:image",
             "gcsweb": "//gcsweb/cmd/gcsweb:image",
         },


### PR DESCRIPTION
Prow Push should now create and maintain an image of Configurator at `gcr.io/k8s-prow/configurator`

Fixes #17400