### PR TITLE
kops/gce: renames tests and expands coverage

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -1,5 +1,40 @@
 periodics:
-- interval: 30m
+# Runs e2e on the cluster built with latest released kops and latest released k/k
+- interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+  name: e2e-kops-gce-stable
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    serviceAccountName: k8s-kops-test
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-gce-stable.k8s.local
+      - --deployment=kops
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --timeout=140m
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200424-a0ea3b9-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-gce-stable
+
+# Runs e2e on the cluster built with latest released kops and k/k master branch
+- interval: 1h
   labels:
     preset-k8s-ssh: "true"
   name: e2e-kops-gce-latest
@@ -18,8 +53,8 @@ periodics:
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/latest
-      - --ginkgo-parallel=30
+      - --extract=ci/latest
+      - --ginkgo-parallel
       - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -30,41 +65,40 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200424-a0ea3b9-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-gce-ha
+    testgrid-tab-name: kops-gce-latest
 
-
-# TODO(geojaz): These tests haven't worked for like months,
-# taking it one at a time till we get back online.
-
-# - interval: 1h
-#   name: e2e-kops-gce-channelalpha
-#   labels:
-#     preset-service-account: "true"
-#     preset-k8s-ssh: "true"
-#   decorate: true
-#   decoration_config:
-#     timeout: 140m
-#   spec:
-#     containers:
-#     - command:
-#       - runner.sh
-#       - /workspace/scenarios/kubernetes_e2e.py
-#       args:
-#       - --cluster=e2e-kops-gce-channelalpha.k8s.local
-#       - --deployment=kops
-#       - --extract=ci/latest
-#       - --ginkgo-parallel=30
-#       - --kops-args=--channel=alpha
-#       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-#       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-gce-green.txt
-#       - --kops-zones=us-central1-c
-#       - --provider=gce
-#       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-#       - --timeout=120m
-#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200424-a0ea3b9-master
-#   annotations:
-#     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
-#     testgrid-tab-name: kops-gce-channelalpha
+# Runs e2e on cluster built with kops master branch and latest released k/k
+- interval: 1h
+  labels:
+    preset-k8s-ssh: "true"
+  name: e2e-kops-canary-gce-stable
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    serviceAccountName: k8s-kops-test
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-canary-gce-stable.k8s.local
+      - --deployment=kops
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-build
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-zones=us-central1-c
+      - --provider=gce
+      - --timeout=140m
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200424-a0ea3b9-master
+  annotations:
+    testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
+    testgrid-tab-name: kops-canary-gce-stable
 
 # - interval: 30m
 #   name: e2e-kops-gce-ha


### PR DESCRIPTION
I'm working to get these kops gce tests to be more useful for us. 

This lays out three example scenarios for today:
```
# Runs e2e on the cluster built with latest released kops and latest released k8s
# Runs e2e on the cluster built with latest released kops and k/k master branch
# Runs e2e on cluster built with kops master branch and latest released kubernetes
```
I renamed the tests to try to capture as obviously as possible, what were trying to test in each of these cases and intend to maintain a similar naming scheme as more tests are included. 
