### PR TITLE
crier: allow users to opt in to slack reporting per job

### DIFF
--- a/prow/config/secret/agent.go
+++ b/prow/config/secret/agent.go
@@ -57,6 +57,20 @@ func (a *Agent) Start(paths []string) error {
 	return nil
 }
 
+// Add registers a new path to the agent.
+func (a *Agent) Add(path string) error {
+	secret, err := LoadSingleSecret(path)
+	if err != nil {
+		return err
+	}
+
+	a.setSecret(path, secret)
+
+	// Start one goroutine for each file to monitor and update the secret's values.
+	go a.reloadSecret(path)
+	return nil
+}
+
 // reloadSecret will begin polling the secret file at the path. If the first load
 // fails, Start with return the error and abort. Future load failures will log
 // the failure message but continue attempting to load.

--- a/prow/crier/reporters/slack/BUILD.bazel
+++ b/prow/crier/reporters/slack/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/slack:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/prow/crier/reporters/slack/reporter.go
+++ b/prow/crier/reporters/slack/reporter.go
@@ -27,6 +27,7 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/pjutil"
 	slackclient "k8s.io/test-infra/prow/slack"
 )
 
@@ -39,9 +40,16 @@ type slackReporter struct {
 	dryRun bool
 }
 
-func channel(cfg config.SlackReporter, pj *v1.ProwJob) string {
+func jobChannel(pj *v1.ProwJob) (string, bool) {
 	if pj.Spec.ReporterConfig != nil && pj.Spec.ReporterConfig.Slack != nil && pj.Spec.ReporterConfig.Slack.Channel != "" {
-		return pj.Spec.ReporterConfig.Slack.Channel
+		return pj.Spec.ReporterConfig.Slack.Channel, true
+	}
+	return "", false
+}
+
+func channel(cfg config.SlackReporter, pj *v1.ProwJob) string {
+	if channel, set := jobChannel(pj); set {
+		return channel
 	}
 	return cfg.Channel
 }
@@ -78,6 +86,13 @@ func (sr *slackReporter) GetName() string {
 }
 
 func (sr *slackReporter) ShouldReport(pj *v1.ProwJob) bool {
+	logger := sr.logger.WithFields(pjutil.ProwJobFields(pj))
+	// if a user specifically put a channel on their job, they want
+	// it to be reported regardless of what other settings exist
+	if _, set := jobChannel(pj); set {
+		logger.Debugf("reporting as channel is explicitly set")
+		return true
+	}
 	config := sr.config(pj.Spec.Refs)
 
 	stateShouldReport := false
@@ -96,8 +111,7 @@ func (sr *slackReporter) ShouldReport(pj *v1.ProwJob) bool {
 		}
 	}
 
-	sr.logger.WithField("prowjob", pj.Name).
-		Debugf("reporting=%t", stateShouldReport && typeShouldReport)
+	logger.Debugf("reporting=%t", stateShouldReport && typeShouldReport)
 	return stateShouldReport && typeShouldReport
 }
 

--- a/prow/crier/reporters/slack/reporter.go
+++ b/prow/crier/reporters/slack/reporter.go
@@ -19,7 +19,6 @@ package slack
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -115,16 +114,11 @@ func (sr *slackReporter) ShouldReport(pj *v1.ProwJob) bool {
 	return stateShouldReport && typeShouldReport
 }
 
-func New(cfg func(refs *prowapi.Refs) config.SlackReporter, dryRun bool, tokenFile string) (*slackReporter, error) {
-	token, err := ioutil.ReadFile(tokenFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read -token-file: %v", err)
-	}
-
+func New(cfg func(refs *prowapi.Refs) config.SlackReporter, dryRun bool, token func() []byte) *slackReporter {
 	return &slackReporter{
-		client: slackclient.NewClient(func() []byte { return token }),
+		client: slackclient.NewClient(token),
 		config: cfg,
 		logger: logrus.WithField("component", reporterName),
 		dryRun: dryRun,
-	}, nil
+	}
 }


### PR DESCRIPTION
When a user explicitly adds a Slack channel to their job configuration,
we should treat that as an explicit opt into Slack reporting, even if
there's no global configuration to allow this. Today, it's not possible
to opt periodics without repositories into reporting, for instance.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @clarketm @cjwagner @alvaroaleman  