### PR TITLE
bump kubekins-e2e to v20200428-06f6e3b

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -43,7 +43,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
@@ -69,7 +69,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src

--- a/config/jobs/README.md
+++ b/config/jobs/README.md
@@ -130,7 +130,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190618-b782256-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - "./scripts/ci-aws-cred-test.sh"
 ```

--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
@@ -46,7 +46,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes"
@@ -81,7 +81,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --job=$(JOB_NAME)
       - --root=/go/src

--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -41,7 +41,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - sh
         - -c
@@ -85,7 +85,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - sh
         - -c
@@ -129,7 +129,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
         command:
         - sh
         - -c
@@ -173,7 +173,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
         command:
         - sh
         - -c
@@ -204,7 +204,7 @@ presubmits:
     spec:
       containers:
       # Use go 1.10 for old branches, because gofmt result changed in go 1.11.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.12
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -222,7 +222,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -249,7 +249,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-windows-cri
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=github.com/helm/charts=$(PULL_REFS)"
         - "--root=/go/src/"
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test=false
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-apps
     testgrid-tab-name: charts-gce

--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -131,7 +131,7 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         imagePullPolicy: Always
         command:
         - "./test/tools/project-cleaner/project_cleaner.sh"

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -261,7 +261,7 @@ postsubmits:
       mountPath: /var/lib/docker
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:
@@ -283,7 +283,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -307,7 +307,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -335,7 +335,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -351,7 +351,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -369,7 +369,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -389,7 +389,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/presubmit-tests-mkp.sh
   - name: kubeflow-pipeline-upgrade-test
@@ -400,7 +400,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ./test/upgrade-tests.sh
         args:
@@ -429,7 +429,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -395,7 +395,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -435,7 +435,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -475,7 +475,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -515,7 +515,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -555,7 +555,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -595,7 +595,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -635,7 +635,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -675,7 +675,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -715,7 +715,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -755,7 +755,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -795,7 +795,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -841,7 +841,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -887,7 +887,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -933,7 +933,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -979,7 +979,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/gen-jobs.sh
+++ b/config/jobs/kubernetes-csi/gen-jobs.sh
@@ -28,7 +28,7 @@ latest_stable_k8s_minor_version="1.18"
 hostpath_driver_version="v1.4.0-rc4"
 
 # We need this image because it has Docker in Docker and go.
-dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20200421-ebf44f0-master"
+dind_image="gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master"
 
 # All kubernetes-csi repos which are part of the hostpath driver example.
 # For these repos we generate the full test matrix. For each entry here

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -36,7 +36,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -51,7 +51,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -43,7 +43,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -63,7 +63,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -85,7 +85,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -107,7 +107,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -79,7 +79,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -110,7 +110,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -160,7 +160,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -210,7 +210,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -264,7 +264,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -317,7 +317,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -370,7 +370,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -414,7 +414,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -444,7 +444,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -53,7 +53,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -77,7 +77,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -108,7 +108,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -155,7 +155,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -204,7 +204,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -248,7 +248,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -31,7 +31,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -53,7 +53,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -77,7 +77,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -108,7 +108,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -157,7 +157,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -100,7 +100,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -147,7 +147,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -180,7 +180,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -238,7 +238,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -299,7 +299,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -357,7 +357,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -416,7 +416,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -482,7 +482,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -540,7 +540,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -598,7 +598,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -656,7 +656,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -712,7 +712,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -775,7 +775,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -55,7 +55,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -93,7 +93,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-conformance.sh"
@@ -131,7 +131,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-conformance.sh"
@@ -180,7 +180,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -236,7 +236,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -48,7 +48,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
             command:
               - "runner.sh"
               - "./scripts/ci-e2e-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -53,7 +53,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         - "verify"
@@ -88,7 +88,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -128,7 +128,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -163,7 +163,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -37,7 +37,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -75,7 +75,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -93,7 +93,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - "runner.sh"
         - "make"
@@ -111,7 +111,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         imagePullPolicy: Always
         command:
         - "./hack/verify-bazel.sh"
@@ -128,7 +128,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-test.sh"
@@ -145,7 +145,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-build.sh"
@@ -162,7 +162,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         imagePullPolicy: Always
         command:
         - "./hack/verify_boilerplate.py"
@@ -188,7 +188,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -33,7 +33,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
@@ -34,7 +34,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "runner.sh"
       - "./scripts/ci-test.sh"
@@ -67,7 +67,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -115,7 +115,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -163,7 +163,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -212,7 +212,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -74,7 +74,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./scripts/ci-test.sh"
     annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -51,7 +51,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             cpu: "1000m"
@@ -82,7 +82,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - hack/check-format.sh
     annotations:
@@ -113,7 +113,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - hack/check-lint.sh
     annotations:
@@ -129,7 +129,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - hack/check-vet.sh
     annotations:
@@ -184,7 +184,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - hack/verify-crds.sh
     annotations:
@@ -200,7 +200,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             cpu: "500m"
@@ -228,7 +228,7 @@ presubmits:
     max_concurrency: 3
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -31,7 +31,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -56,7 +56,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - runner.sh
           - "./scripts/ci-capd-e2e.sh"
@@ -84,7 +84,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "./scripts/ci-build.sh"
   annotations:
@@ -104,7 +104,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -129,7 +129,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           args:
             - runner.sh
             - "./scripts/ci-capd-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -34,7 +34,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -56,7 +56,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-apidiff
@@ -70,7 +70,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "runner.sh"
         - "make"
@@ -92,7 +92,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -113,7 +113,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - ./scripts/ci-integration.sh
@@ -140,7 +140,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - runner.sh
           - "./scripts/ci-capd-e2e.sh"
@@ -167,7 +167,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./hack/verify-all.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -75,7 +75,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.5.0"
       - "--root=/go/src"
@@ -41,7 +41,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.4.0"
       - "--root=/go/src"
@@ -78,7 +78,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -113,7 +113,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -149,7 +149,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - ./hack/ci/build-all.sh
@@ -24,7 +24,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make
@@ -40,7 +40,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         - ./hack/verify/all.sh
@@ -108,7 +108,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -206,7 +206,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -247,7 +247,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -288,7 +288,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -329,7 +329,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -370,7 +370,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.13
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -411,7 +411,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.12
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -12,7 +12,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - make
@@ -36,7 +36,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -78,7 +78,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -127,7 +127,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       # skip serial tests and run with --ginkgo-parallel
       - name: "PARALLEL"
@@ -172,7 +172,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -223,7 +223,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.12
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -265,7 +265,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.13
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -307,7 +307,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -349,7 +349,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         - test
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -52,7 +52,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -6,6 +6,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./hack/ci/test.sh"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -59,7 +59,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -89,7 +89,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -119,7 +119,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - make
@@ -74,7 +74,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           - runner.sh
           - make

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -60,7 +60,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -89,7 +89,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -125,7 +125,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -167,7 +167,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -213,7 +213,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -245,7 +245,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -281,7 +281,7 @@ postsubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
+++ b/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
@@ -12,7 +12,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
@@ -34,7 +34,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -46,7 +46,7 @@ presubmits:
     optional: true
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -72,7 +72,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -87,7 +87,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -103,7 +103,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -119,7 +119,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -135,7 +135,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -151,7 +151,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -167,7 +167,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -56,7 +56,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -74,7 +74,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -136,7 +136,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.15-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.15-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - kubetest
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest
@@ -186,7 +186,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -79,7 +79,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -135,7 +135,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -30,7 +30,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -89,7 +89,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -151,7 +151,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -209,7 +209,7 @@ periodics:
 #     path_alias: k8s.io/kubernetes
 #   spec:
 #     containers:
-#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 #       command:
 #       - runner.sh
 #       - kubetest
@@ -263,7 +263,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -316,7 +316,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -369,7 +369,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -426,7 +426,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -488,7 +488,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -546,7 +546,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -600,7 +600,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -21,7 +21,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "runner.sh"
       - "./kubeadm/hack/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - go
       args:
@@ -33,7 +33,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - bash
       - -c

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - go
         args:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - bash
         - -c

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -44,7 +44,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -100,7 +100,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -121,7 +121,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -140,7 +140,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -166,7 +166,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -191,7 +191,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -27,7 +27,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
       testgrid-num-columns-recent: '30'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -34,7 +34,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - make
         args:
@@ -150,7 +150,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -171,7 +171,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -195,7 +195,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:
@@ -226,7 +226,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             cpu: "1000m"
@@ -257,7 +257,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
+++ b/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -29,7 +29,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -27,7 +27,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-gkespec
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-serial
@@ -91,7 +91,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-gkespec
@@ -123,7 +123,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-serial
@@ -155,7 +155,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-gkespec
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-serial
@@ -219,7 +219,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-gkespec
@@ -251,7 +251,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-serial
@@ -283,7 +283,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-gkespec
@@ -315,7 +315,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-serial
@@ -347,7 +347,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-gkespec
@@ -379,7 +379,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-serial
@@ -411,7 +411,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-gkespec
@@ -443,7 +443,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-serial
@@ -475,7 +475,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-gkespec
@@ -507,7 +507,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-serial
@@ -538,7 +538,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -569,7 +569,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -600,7 +600,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -631,7 +631,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -662,7 +662,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -693,7 +693,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -724,7 +724,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -755,7 +755,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -786,7 +786,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -817,7 +817,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -848,7 +848,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -879,7 +879,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -910,7 +910,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -941,7 +941,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -972,7 +972,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -1003,7 +1003,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1034,7 +1034,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1065,7 +1065,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1096,7 +1096,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1127,7 +1127,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1158,7 +1158,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1189,7 +1189,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1220,7 +1220,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1251,7 +1251,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1278,7 +1278,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1306,7 +1306,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1336,7 +1336,7 @@ periodics:
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1364,7 +1364,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-1.18-informing
@@ -1393,7 +1393,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.18-informing
@@ -1426,7 +1426,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1453,7 +1453,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1481,7 +1481,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1510,7 +1510,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.17-informing
@@ -1539,7 +1539,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-1.17-informing
@@ -1568,7 +1568,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.17-informing
@@ -1601,7 +1601,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1628,7 +1628,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1656,7 +1656,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1684,7 +1684,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.16-informing
@@ -1713,7 +1713,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-1.16-informing
@@ -1742,7 +1742,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.16-informing
@@ -1775,7 +1775,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1803,7 +1803,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.15-blocking
@@ -1830,7 +1830,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.15-blocking
@@ -1858,7 +1858,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.15-informing
@@ -1887,7 +1887,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-1.15-informing
@@ -1916,7 +1916,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.15-informing
@@ -1949,7 +1949,7 @@ periodics:
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.15-blocking

--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -47,7 +47,7 @@ template = """
       - --provider=aws
       - --test_args={{test_args}}
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: {{tab}}

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -66,7 +66,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -102,7 +102,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -138,7 +138,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -174,7 +174,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -211,7 +211,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -247,7 +247,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -283,7 +283,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -319,7 +319,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -355,7 +355,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -29,7 +29,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-stable
@@ -64,7 +64,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-gce-latest
@@ -98,7 +98,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-canary-gce-stable
@@ -128,7 +128,7 @@ periodics:
 #       - --provider=gce
 #       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
 #       - --timeout=120m
-#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 #   annotations:
 #     testgrid-dashboards: google-kops-gce, sig-cluster-lifecycle-kops
 #     testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -32,7 +32,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws
@@ -69,7 +69,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-amazonlinux2
@@ -106,7 +106,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-centos7
@@ -143,7 +143,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-debian9
@@ -180,7 +180,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-debian10
@@ -217,7 +217,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flatcar
@@ -254,7 +254,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-rhel7
@@ -291,7 +291,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-rhel8
@@ -328,7 +328,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-ubuntu1604
@@ -365,7 +365,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-ubuntu1804
@@ -402,7 +402,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-ubuntu2004
@@ -438,7 +438,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico
@@ -475,7 +475,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-amazonlinux2
@@ -512,7 +512,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-centos7
@@ -549,7 +549,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-debian9
@@ -586,7 +586,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-debian10
@@ -623,7 +623,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-flatcar
@@ -660,7 +660,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-rhel7
@@ -697,7 +697,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-rhel8
@@ -734,7 +734,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-ubuntu1604
@@ -771,7 +771,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-ubuntu1804
@@ -808,7 +808,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-calico-ubuntu2004
@@ -844,7 +844,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium
@@ -881,7 +881,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-amazonlinux2
@@ -918,7 +918,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-centos7
@@ -955,7 +955,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-debian9
@@ -992,7 +992,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-debian10
@@ -1029,7 +1029,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-flatcar
@@ -1066,7 +1066,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-rhel7
@@ -1103,7 +1103,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-rhel8
@@ -1140,7 +1140,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-ubuntu1604
@@ -1177,7 +1177,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-ubuntu1804
@@ -1214,7 +1214,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-cilium-ubuntu2004
@@ -1250,7 +1250,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel
@@ -1287,7 +1287,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-amazonlinux2
@@ -1324,7 +1324,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-centos7
@@ -1361,7 +1361,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-debian9
@@ -1398,7 +1398,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-debian10
@@ -1435,7 +1435,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-flatcar
@@ -1472,7 +1472,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-rhel7
@@ -1509,7 +1509,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-rhel8
@@ -1546,7 +1546,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-ubuntu1604
@@ -1583,7 +1583,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-ubuntu1804
@@ -1620,7 +1620,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-flannel-ubuntu2004
@@ -1656,7 +1656,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan
@@ -1693,7 +1693,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-amazonlinux2
@@ -1730,7 +1730,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-centos7
@@ -1767,7 +1767,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-debian9
@@ -1804,7 +1804,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-debian10
@@ -1841,7 +1841,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-flatcar
@@ -1878,7 +1878,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-rhel7
@@ -1915,7 +1915,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-rhel8
@@ -1952,7 +1952,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-ubuntu1604
@@ -1989,7 +1989,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-ubuntu1804
@@ -2026,7 +2026,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-grid-aws-kopeio-vxlan-ubuntu2004

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -100,7 +100,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-containerd
@@ -235,7 +235,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
       - --timeout=45m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-updown

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-amazon-vpc
@@ -65,7 +65,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-calico
@@ -100,7 +100,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-canal
@@ -135,7 +135,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|affinity.*clusterIP
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-cilium
@@ -170,7 +170,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-flannel
@@ -205,7 +205,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-kopeio
@@ -239,7 +239,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-kuberouter
@@ -274,7 +274,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-weave
@@ -309,7 +309,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-cni-lyft

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -28,7 +28,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-latest
@@ -60,7 +60,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.18
@@ -92,7 +92,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.17
@@ -124,7 +124,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
     testgrid-tab-name: kops-aws-k8s-1.16
@@ -156,7 +156,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
@@ -189,7 +189,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -15,7 +15,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -251,7 +251,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -272,7 +272,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -293,7 +293,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -314,7 +314,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -337,7 +337,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -361,7 +361,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -382,7 +382,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -403,7 +403,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -427,7 +427,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:
@@ -449,7 +449,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
       args:
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
@@ -482,7 +482,7 @@ postsubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -20,7 +20,7 @@ presubmits:
       preset-e2e-platform-aws: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./kinder/hack/verify-all.sh"
 
@@ -31,7 +31,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -53,7 +53,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - "./operator/hack/verify-all.sh"

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -150,7 +150,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: ZONE
         value: us-central1-a

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -72,7 +72,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -109,7 +109,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -181,7 +181,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -217,7 +217,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -252,7 +252,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
         - name: ZONE
           value: us-central1-a

--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - go
         args:

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -29,7 +29,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-proto
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 - interval: 2h
@@ -72,7 +72,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 
@@ -110,7 +110,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -148,7 +148,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/kubernetes-sigs/application=master
       - --upload=gs://kubernetes-jenkins/logs/
@@ -57,7 +57,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 
   annotations:
@@ -81,7 +81,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -38,7 +38,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -69,7 +69,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -100,7 +100,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -131,7 +131,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -184,7 +184,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -209,7 +209,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -244,7 +244,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -269,7 +269,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -295,7 +295,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     # TODO: add to release blocking dashboards once run is successful

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -44,4 +44,4 @@ presubmits:
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=400m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -75,7 +75,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   # kubectl skew tests
   annotations:
@@ -105,7 +105,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -132,7 +132,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -160,7 +160,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-cli-master
@@ -194,7 +194,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -222,7 +222,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -249,7 +249,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\]  --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -277,7 +277,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -303,7 +303,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -331,7 +331,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -358,7 +358,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -385,7 +385,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -411,7 +411,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -36,7 +36,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
       args:
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-kubernetes-e2e-aws-eks-1-13: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
       args:
       - --timeout=320

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kubernetes-e2e-aws-eks-1-13: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         imagePullPolicy: Always
         args:
         - --root=/go/src

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.15.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -164,7 +164,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         command:
         - runner.sh
         - kubetest
@@ -217,7 +217,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - kubetest
@@ -272,7 +272,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - kubetest
@@ -327,7 +327,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -164,7 +164,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         command:
         - runner.sh
         - kubetest
@@ -217,7 +217,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest
@@ -272,7 +272,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest
@@ -327,7 +327,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -164,7 +164,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - runner.sh
         - kubetest
@@ -217,7 +217,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest
@@ -272,7 +272,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest
@@ -327,7 +327,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -164,7 +164,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         command:
         - runner.sh
         - kubetest
@@ -217,7 +217,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -272,7 +272,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -327,7 +327,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -69,7 +69,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -124,7 +124,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -179,7 +179,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         - kubetest
@@ -232,7 +232,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest
@@ -289,7 +289,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - "runner.sh"
       - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -28,4 +28,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
@@ -19,7 +19,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:HAMaster\] --minStartupPods=8
       - --timeout=220m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -55,7 +55,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -99,7 +99,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -152,7 +152,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -209,7 +209,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           resources:
             requests:
               memory: "6Gi"
@@ -240,7 +240,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -291,7 +291,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionHash|Audit|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource|CSIInlineVolume)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -323,7 +323,7 @@ periodics:
       - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-default
@@ -360,7 +360,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-ubuntu-master-default
@@ -402,7 +402,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-ubuntu-master-containerd
@@ -434,7 +434,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=70m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-alpha-enabled-default
@@ -462,7 +462,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionHash|Audit|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes|RunAsGroup|TTLAfterFinished|NodeLease|VolumeSnapshotDataSource|CSIInlineVolume)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-alpha-features
@@ -493,7 +493,7 @@ periodics:
       - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: gce-cos-master-flaky-repro
@@ -518,7 +518,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-flaky
@@ -544,7 +544,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-single-flake-attempt
@@ -569,7 +569,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-reboot
@@ -598,7 +598,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-serial
@@ -627,7 +627,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-slow
@@ -660,7 +660,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gce-multizone
@@ -690,7 +690,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gce-gci
@@ -720,7 +720,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.15
@@ -750,7 +750,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.14
@@ -779,7 +779,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.13
@@ -808,7 +808,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.12

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-pull-gce-device-plugin-gpu: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -54,7 +54,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -84,7 +84,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -114,7 +114,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -144,7 +144,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -174,7 +174,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -205,7 +205,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -236,7 +236,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-master-1.13-cluster-downgrade

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -41,4 +41,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster
@@ -52,7 +52,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-parallel
@@ -81,7 +81,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new
@@ -111,7 +111,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new-parallel
@@ -139,7 +139,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master
@@ -168,7 +168,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master-parallel
@@ -197,7 +197,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster
@@ -227,7 +227,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster-parallel
@@ -255,7 +255,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster
@@ -283,7 +283,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster-new
@@ -311,7 +311,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-master
@@ -341,7 +341,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster
@@ -372,7 +372,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster-parallel

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200424-a0ea3b9-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -46,7 +46,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
   annotations:
     testgrid-dashboards: google-gce

--- a/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
+++ b/config/jobs/kubernetes/sig-network/ci-e2e-gce-netd.yaml
@@ -938,7 +938,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-gci-gce-netd
@@ -965,7 +965,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -997,7 +997,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-ubuntu-gce-netd
@@ -1025,7 +1025,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1061,7 +1061,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:NetworkPolicy\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-containerd-gce-netd
@@ -1094,7 +1094,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: calico
@@ -1130,7 +1130,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-network\] --ginkgo.skip=\[Slow\]|\[Flaky\]|\[Feature:Networking-IPv6\]|\[Disruptive\]|\[Feature:ServiceLoadBalancer\]|\[Feature:PerformanceDNS\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-netd
     testgrid-tab-name: e2e-containerd-gce-calico

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -15,7 +15,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       command:
       - runner.sh
       - kubetest
@@ -66,7 +66,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - runner.sh
       - kubetest
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       command:
       - runner.sh
       - kubetest
@@ -168,7 +168,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -92,7 +92,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -114,7 +114,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -142,7 +142,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --timeout=340
       - --bare
@@ -173,7 +173,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --timeout=340
       - --bare
@@ -205,7 +205,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --timeout=340
       - --bare
@@ -233,7 +233,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --timeout=340
       - --bare

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -37,7 +37,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ipvs
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -86,7 +86,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gce-alpha-api
@@ -114,7 +114,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance
@@ -141,7 +141,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance
@@ -166,7 +166,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -192,7 +192,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance-nodecache
@@ -220,7 +220,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance-nodecache
@@ -246,7 +246,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -270,7 +270,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress
@@ -298,7 +298,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gci-gce-ingress-manual-network
@@ -328,7 +328,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: ip-alias
@@ -354,7 +354,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
@@ -379,7 +379,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -403,7 +403,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -427,7 +427,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
@@ -452,7 +452,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gci-gce-basic-sctp
@@ -477,4 +477,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:SCTP\]
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -45,7 +45,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -63,7 +63,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/containerd/containerd=release/1.2
       - --repo=github.com/containerd/cri=release/1.2
@@ -82,7 +82,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/containerd/containerd=release/1.3
       - --repo=github.com/containerd/cri=release/1.3
@@ -121,7 +121,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci
@@ -151,7 +151,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.13
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.2
@@ -181,7 +181,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.3
@@ -212,7 +212,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
@@ -223,7 +223,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -253,7 +253,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.13
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.13
@@ -283,7 +283,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -313,7 +313,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -343,7 +343,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.13
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.13
@@ -373,7 +373,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -424,7 +424,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: soak-gci-gce
@@ -434,7 +434,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -451,7 +451,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -485,7 +485,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-device-plugin-gpu
@@ -517,7 +517,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-multizone
@@ -545,7 +545,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-stackdriver
@@ -573,7 +573,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci
@@ -602,7 +602,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-alpha-features
@@ -629,7 +629,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-es-logging
@@ -654,7 +654,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-flaky
@@ -682,7 +682,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-containerd
     testgrid-tab-name: e2e-gci-ingress
@@ -712,7 +712,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-ip-alias
@@ -739,7 +739,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-proto
@@ -764,7 +764,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-reboot
@@ -791,7 +791,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging
@@ -822,7 +822,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging-k8s-resources
@@ -847,7 +847,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-serial
@@ -873,7 +873,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-slow
@@ -897,7 +897,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-statefulset
@@ -925,7 +925,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
@@ -936,7 +936,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -966,7 +966,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -996,7 +996,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1026,7 +1026,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1056,7 +1056,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1104,7 +1104,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
@@ -1131,7 +1131,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
@@ -1142,7 +1142,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1171,7 +1171,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1208,7 +1208,7 @@ periodics:
   spec:
     containers:
     - name: ci-cri-containerd-cri-validation-windows
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -35,7 +35,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -40,7 +40,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -70,7 +70,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -101,7 +101,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -138,7 +138,7 @@ periodics:
     testgrid-tab-name: node-kubelet-features
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -165,7 +165,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -195,7 +195,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -225,7 +225,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=320
@@ -255,7 +255,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -285,7 +285,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -316,7 +316,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -74,7 +74,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m     # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -90,7 +90,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -124,7 +124,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -162,7 +162,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -196,7 +196,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -34,7 +34,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         command:
         - infra/gcp/backup_tools/backup_test.sh
         env:
@@ -57,7 +57,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./test-e2e/cip/e2e-entrypoint-from-container.sh"
         env:
@@ -85,7 +85,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./test-e2e/cip-auditor/entrypoint-from-container.sh"
         env:
@@ -111,7 +111,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -89,7 +89,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -120,7 +120,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -195,7 +195,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
   tags:
@@ -249,7 +249,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
       securityContext:
@@ -292,7 +292,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -388,7 +388,7 @@ periodics:
         value: release-1.15
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       imagePullPolicy: Always
       name: ""
       resources:
@@ -438,7 +438,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.15.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources: {}
 - annotations:
@@ -472,7 +472,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       name: ""
       resources:
         requests:
@@ -508,7 +508,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -584,7 +584,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -626,7 +626,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -667,7 +667,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -716,7 +716,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources: {}
   - always_run: true
@@ -747,7 +747,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -791,7 +791,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -841,7 +841,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         name: ""
         resources:
           requests:
@@ -897,7 +897,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -974,7 +974,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: main
         resources: {}
         securityContext:
@@ -1020,7 +1020,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: main
         resources: {}
   - always_run: false
@@ -1063,7 +1063,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         name: ""
         resources:
           requests:
@@ -1110,7 +1110,7 @@ presubmits:
           value: release-1.15
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -56,7 +56,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -89,7 +89,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -120,7 +120,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -201,7 +201,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
   tags:
@@ -255,7 +255,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
       securityContext:
@@ -298,7 +298,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -358,7 +358,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources:
         requests:
@@ -396,7 +396,7 @@ periodics:
         value: release-1.16
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -446,7 +446,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.16.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources: {}
 - annotations:
@@ -480,7 +480,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources:
         requests:
@@ -523,7 +523,7 @@ periodics:
         value: ipv6
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
       name: ""
       resources:
         requests:
@@ -559,7 +559,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -635,7 +635,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -677,7 +677,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -718,7 +718,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -763,7 +763,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources: {}
   - always_run: true
@@ -794,7 +794,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -835,7 +835,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -892,7 +892,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         name: ""
         resources:
           requests:
@@ -948,7 +948,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -1025,7 +1025,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: main
         resources: {}
         securityContext:
@@ -1045,7 +1045,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: main
         resources: {}
   - always_run: true
@@ -1063,7 +1063,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -1110,7 +1110,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         name: ""
         resources:
           requests:
@@ -1157,7 +1157,7 @@ presubmits:
           value: release-1.16
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -30,7 +30,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -59,7 +59,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -91,7 +91,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -124,7 +124,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -155,7 +155,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -248,7 +248,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
   tags:
@@ -309,7 +309,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
       securityContext:
@@ -352,7 +352,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -412,7 +412,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources:
         requests:
@@ -450,7 +450,7 @@ periodics:
         value: release-1.17
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       imagePullPolicy: Always
       name: ""
       resources:
@@ -498,7 +498,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.17.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources: {}
 - annotations:
@@ -532,7 +532,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources:
         requests:
@@ -575,7 +575,7 @@ periodics:
         value: ipv6
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       name: ""
       resources:
         requests:
@@ -611,7 +611,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -688,7 +688,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -730,7 +730,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -775,7 +775,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources: {}
   - always_run: true
@@ -815,7 +815,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -848,7 +848,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -889,7 +889,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -947,7 +947,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         name: ""
         resources:
           requests:
@@ -1012,7 +1012,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -1089,7 +1089,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: main
         resources: {}
         securityContext:
@@ -1109,7 +1109,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:
@@ -1131,7 +1131,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: main
         resources: {}
   - always_run: true
@@ -1158,7 +1158,7 @@ presubmits:
           value: release-1.17
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         imagePullPolicy: Always
         name: ""
         resources:
@@ -1201,7 +1201,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -30,7 +30,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -59,7 +59,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -91,7 +91,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -124,7 +124,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -155,7 +155,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -245,7 +245,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
       securityContext:
@@ -313,7 +313,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
   tags:
@@ -355,7 +355,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -415,7 +415,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources:
         requests:
@@ -453,7 +453,7 @@ periodics:
         value: release-1.18
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       imagePullPolicy: Always
       name: ""
       resources:
@@ -501,7 +501,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -544,7 +544,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
 - annotations:
@@ -669,7 +669,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -746,7 +746,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -785,7 +785,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -824,7 +824,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -871,7 +871,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -922,7 +922,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -967,7 +967,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources: {}
   - always_run: true
@@ -1007,7 +1007,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1040,7 +1040,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1081,7 +1081,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1139,7 +1139,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1204,7 +1204,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1281,7 +1281,7 @@ presubmits:
         env:
         - name: WHAT
           value: vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: main
         resources: {}
         securityContext:
@@ -1301,7 +1301,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: ""
         resources:
           requests:
@@ -1360,7 +1360,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         name: main
         resources: {}
   - always_run: true
@@ -1387,7 +1387,7 @@ presubmits:
           value: release-1.18
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -8,7 +8,7 @@ periodics:
     testgrid-tab-name: snapshots-cleanup
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -13,7 +13,7 @@ periodics:
 #    testgrid-tab-name: max-persistent-vol-per-pod
 #  spec:
 #    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 #        args:
 #          - --repo=k8s.io/kubernetes=master
 #          - --repo=k8s.io/perf-tests=master
@@ -55,7 +55,7 @@ periodics:
 #    testgrid-tab-name: max-persistent-vol-per-node
 #  spec:
 #    containers:
-#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+#      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 #        args:
 #          - --repo=k8s.io/kubernetes=master
 #          - --repo=k8s.io/perf-tests=master
@@ -96,7 +96,7 @@ periodics:
     testgrid-tab-name: storage
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -135,7 +135,7 @@ periodics:
     testgrid-tab-name: calico
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: "calico"
@@ -190,7 +190,7 @@ periodics:
     testgrid-tab-name: experimental-load
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master
@@ -242,7 +242,7 @@ periodics:
     testgrid-tab-name: experimental-load-containerd
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master
@@ -295,7 +295,7 @@ periodics:
     testgrid-tab-name: gce-cos-master-scalability-100-containerd
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master
@@ -346,7 +346,7 @@ periodics:
     testgrid-tab-name: gce-cos-master-scalability-100-nodekiller
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -13,7 +13,7 @@ periodics:
     testgrid-tab-name: node-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -53,7 +53,7 @@ periodics:
     testgrid-tab-name: node-containerd-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -98,7 +98,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -160,7 +160,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -218,7 +218,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -279,7 +279,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -327,7 +327,7 @@ periodics:
     testgrid-tab-name: kubemark-100-benchmark
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -354,7 +354,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -383,7 +383,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -420,7 +420,7 @@ periodics:
     testgrid-tab-name: kube-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -455,7 +455,7 @@ periodics:
     testgrid-tab-name: node-local-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -50,7 +50,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -100,7 +100,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -151,7 +151,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -174,7 +174,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -242,7 +242,7 @@ presubmits:
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -338,7 +338,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -391,7 +391,7 @@ presubmits:
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
             - --use-logexporter
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           resources:
             requests:
               memory: "6Gi"
@@ -451,7 +451,7 @@ presubmits:
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
             - --use-logexporter
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           resources:
             requests:
               memory: "6Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -35,7 +35,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=240m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       resources:
         requests:
           cpu: 6
@@ -94,7 +94,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       resources:
         requests:
           cpu: 6
@@ -123,7 +123,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -45,7 +45,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -95,7 +95,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -136,7 +136,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -195,7 +195,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -236,7 +236,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -276,7 +276,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -313,7 +313,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-disruptive
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Disruptive\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=240m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         resources:
           requests:
             memory: "6Gi"
@@ -342,7 +342,7 @@ periodics:
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -366,7 +366,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -388,7 +388,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-num-columns-recent: '20'
     testgrid-num-failures-to-alert: '6'

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -63,7 +63,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         env:
         # enable IPV6 in bootstrap image
         - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -112,7 +112,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -154,7 +154,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"
@@ -195,7 +195,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.14
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -23,7 +23,7 @@ periodics:
     timeout: 6h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - bash
@@ -84,7 +84,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - bash
@@ -137,7 +137,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       - bash

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -20,7 +20,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - make
         - verify
@@ -46,7 +46,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - make
         - verify
@@ -78,7 +78,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - runner.sh
         args:
@@ -50,7 +50,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -54,7 +54,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       args:
       - "--timeout=140"
       - "--bare"

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -13,7 +13,7 @@ periodics:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - runner.sh
             - bash
@@ -40,7 +40,7 @@ periodics:
         path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
           command:
             - runner.sh
             - bash

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -18,7 +18,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -59,7 +59,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -87,7 +87,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
@@ -131,7 +131,7 @@ periodics:
         value: "win1909"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
@@ -177,7 +177,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows
     testgrid-tab-name: gce-windows-2019-master-alpha-features
@@ -221,7 +221,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-windows
     testgrid-tab-name: gce-windows-2019-serial
@@ -265,7 +265,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-master
@@ -311,7 +311,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
       name: ""
       resources: {}
   annotations:
@@ -345,7 +345,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "gcr.io/gke-release/pause-win:1.2.1"
@@ -399,7 +399,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "mcr.microsoft.com/windows/servercore/iis"
@@ -481,7 +481,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
+++ b/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
         command:
         - "./hack/verify-all.sh"
     annotations:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -40,7 +40,7 @@ periodics:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
       - --janitor-path=boskos/cmd/janitor/gcp_janitor.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
       resources:
         requests:
           cpu: 5
@@ -65,7 +65,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
       resources:
         requests:
           cpu: 5
@@ -91,7 +91,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
       resources:
         requests:
           cpu: 5

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-experimental
         command:
         - ./hack/verify-file-perms.sh
     annotations:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1127,7 +1127,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
       command:
       - infra/gcp/backup_tools/backup.sh
       env:

--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -120,7 +120,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 							},
 						},
 					},
@@ -129,7 +129,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Terminated: &v1.ContainerStateTerminated{
@@ -145,7 +145,7 @@ func TestHintFromPodInfo(t *testing.T) {
 		},
 		{
 			name:     "stuck images are reported by name",
-			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master". Check your images.`,
+			expected: `The test container could not start because it could not pull "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master". Check your images.`,
 			info: k8sreporter.PodReport{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -155,7 +155,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 							},
 						},
 					},
@@ -164,7 +164,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -189,7 +189,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 								VolumeMounts: []v1.VolumeMount{
 									{
 										Name:      "some-volume",
@@ -214,7 +214,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{
@@ -246,7 +246,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 							},
 						},
 					},
@@ -269,7 +269,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 							},
 						},
 					},
@@ -298,7 +298,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						Containers: []v1.Container{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 							},
 						},
 					},
@@ -307,7 +307,7 @@ func TestHintFromPodInfo(t *testing.T) {
 						ContainerStatuses: []v1.ContainerStatus{
 							{
 								Name:  "test",
-								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200131-0997840-master",
+								Image: "gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master",
 								Ready: false,
 								State: v1.ContainerState{
 									Waiting: &v1.ContainerStateWaiting{

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -45,7 +45,7 @@ PROW_CONFIG_TEMPLATE = """
       containers:
       - args:
         env:
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
 """
 
 

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -645,23 +645,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.18
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.18
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.18
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.17
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.17
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.17
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.16
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.16
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.16
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.15
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200427-84e5e2b-1.15
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200428-cdaab98-1.15
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
brought to you by:
```
find: kubekins-e2e:v\d+-.+-(.+)
replace: kubekins-e2e:v20200428-cdaab98-$1
```
/cc @amwat @dims @spiffxp 