### PR TITLE
fix kind presubmits for old k/k versions

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -329,7 +329,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-1.14
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -370,7 +370,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-1.13
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"
@@ -411,7 +411,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-1.12
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20190812-5a136da-1.12
         env:
         # skip serial tests and run with --ginkgo-parallel
         - name: "PARALLEL"


### PR DESCRIPTION
With the last bump of the kubekins image , kind jobs prior 1.15 k/k version stopped to work.

Restore previous kubekins images for those jobs.
