### PR TITLE
GitV2: Be able to recover from a failled mirror clone

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -250,7 +250,7 @@ func (c *clientFactory) ClientFor(org, repo string) (RepoClient, error) {
 	c.masterLock.Unlock()
 	c.repoLocks[cacheDir].Lock()
 	defer c.repoLocks[cacheDir].Unlock()
-	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+	if _, err := os.Stat(path.Join(cacheDir, "HEAD")); os.IsNotExist(err) {
 		// we have not yet cloned this repo, we need to do a full clone
 		if err := os.MkdirAll(cacheDir, os.ModePerm); err != nil && !os.IsExist(err) {
 			return nil, err


### PR DESCRIPTION
Currently, the gitv2 client can not recover from a failed mirror clone because it only does it if the target dir does not exist. However, the target dir is created before the actual clone is done, so if the clone fails, we are stuck and can never recover.

/assign @stevekuznetsov 