### PR TITLE
Update enhancements approval config

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -45,7 +45,6 @@ approve:
   - kubernetes/contrib
   - kubernetes/dashboard
   - kubernetes/dns
-  - kubernetes/enhancements
   - kubernetes/examples
   - kubernetes/federation
   - kubernetes/gengo
@@ -69,6 +68,7 @@ approve:
   require_self_approval: false
   lgtm_acts_as_approve: true
 - repos:
+  - kubernetes/enhancements
   - kubernetes/kops
   - kubernetes/kubernetes
   - kubernetes-client


### PR DESCRIPTION
This PR updates the prow config for the k/enhancements repo, disabling the
lgtm_acts_as_approve feature.

References: https://github.com/kubernetes/enhancements/issues/1730

Signed-off-by: Jeremy Rickard <rickardj@vmware.com>