### PR TITLE
Kops - Use kubekins-e2e:latest-1.14 for k8s 1.14

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -189,7 +189,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200218-a445c54-1.14
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-1.14
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops


### PR DESCRIPTION
Test is failing with strange error, maybe this will fix it.
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-1-14/1255570960824668160