### PR TITLE
Kops - Move HA test to EU

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -35,7 +35,7 @@ periodics:
     testgrid-tab-name: kops-aws-channelalpha
 
 - interval: 1h
-  name: e2e-kops-aws-misc-ha-uswest2
+  name: e2e-kops-aws-misc-ha-euwest1
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -49,7 +49,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-ha-uswest2.k8s.local
+      - --cluster=e2e-kops-aws-ha-euwest1.k8s.local
       - --deployment=kops
       - --env=KUBE_SSH_USER=admin
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable.txt
@@ -60,7 +60,7 @@ periodics:
       - --kops-nodes=6
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --kops-zones=us-west-2a,us-west-2b,us-west-2c
+      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
@@ -68,7 +68,7 @@ periodics:
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: google-aws, sig-cluster-lifecycle-kops
-    testgrid-tab-name: kops-aws-ha-uswest2
+    testgrid-tab-name: kops-aws-ha-euwest1
 
 - interval: 4h
   name: e2e-kops-aws-misc-containerd


### PR DESCRIPTION
This is pretty useful when etcd-manager tests are involved.
At the moment is failing because resources cannot be cleaned.
https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-misc-ha-uswest2/1255676585005027328
/cc @rifelpet 