### PR TITLE
[jobs] use node-e2e-project boskos pool for ci-containerd-node-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -233,7 +233,7 @@ periodics:
       - --
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/containerd-master/image-config.yaml
       - --deployment=node
-      - --gcp-project=cri-containerd-node-e2e
+      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/home/containerd/usr/local/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
       - --node-tests=true


### PR DESCRIPTION
Trying same change made in https://github.com/kubernetes/test-infra/pull/17349

Ref: https://github.com/kubernetes/kubernetes/issues/89847

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>