### PR TITLE
Bump up limits for verify and cross presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -5,6 +5,8 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 2h
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20200428-cdaab98
@@ -13,7 +15,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=90"
         - --scenario=execute
         - --
         - --env=KUBE_RELEASE_RUN_TESTS=n

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -14,6 +14,8 @@ presubmits:
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
+    decoration_config:
+      timeout: 3h
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200428-06f6e3b-master
@@ -36,7 +38,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: 4
+            cpu: 6
 periodics:
 - interval: 1h
   name: ci-kubernetes-verify-master


### PR DESCRIPTION
Lots of failures for the last day or so and we haven't merged much as
well. Looking at:
https://prow.k8s.io/?repo=kubernetes%2Fkubernetes&type=batch&state=failure

pull-kubernetes-e2e-kind and pull-kubernetes-e2e-gce are hit by flakes
but pull-kubernetes-cross and pull-kubernetes-verify seem to be be
running slower and hitting timeouts.

for verify job:
- timeout up to 3 hours (override default)
- bump cpu to 6 (just like ci-kubernetes-verify-master)

for cross job:
- explicitly set 2 hours and drop the command line timeout of 90 minutes

Signed-off-by: Davanum Srinivas <davanum@gmail.com>