### PR TITLE
Bump timeout for pull-kubernetes-cross

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -13,7 +13,6 @@ presubmits:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=90"
         - --scenario=execute
         - --
         - --env=KUBE_RELEASE_RUN_TESTS=n


### PR DESCRIPTION
Drop the extra timeout so we use the default of 2 hours

Signed-off-by: Davanum Srinivas <davanum@gmail.com>