### PR TITLE
Make individual Tide pool alert expose pool labels.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -33,7 +33,7 @@
           {
             alert: 'TidePool error rate: individual',
             expr: |||
-              (max(sum(increase(tidepoolerrors{org!="kubeflow"}[10m])) by (org, repo, branch)) or vector(0)) >= 3
+              ((sum(increase(tidepoolerrors{org!="kubeflow"}[10m])) by (org, repo, branch)) or vector(0)) >= 3
             |||,
             'for': '5m',
             labels: {


### PR DESCRIPTION
Instead of a single `{}` query result when the query is positive, we now get one or more results like `{branch="master",org="kubernetes-sigs",repo="multi-tenancy"}` for each problematic pool.
This will let us silence the alert for specific pools.
/assign @stevekuznetsov @hongkailiu 