### PR TITLE
Revert "Checkconfig: Add validation for tide context policy"

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -85,6 +85,5 @@ go_test(
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",
-        "@io_k8s_utils//pointer:go_default_library",
     ],
 )

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -89,7 +89,6 @@ const (
 	mismatchedTideWarning        = "mismatched-tide"
 	mismatchedTideLenientWarning = "mismatched-tide-lenient"
 	tideStrictBranchWarning      = "tide-strict-branch"
-	tideContextPolicy            = "tide-context-policy"
 	nonDecoratedJobsWarning      = "non-decorated-jobs"
 	jobNameLengthWarning         = "long-job-names"
 	jobRefsDuplicationWarning    = "duplicate-job-refs"
@@ -104,7 +103,6 @@ const (
 var defaultWarnings = []string{
 	mismatchedTideWarning,
 	tideStrictBranchWarning,
-	tideContextPolicy,
 	mismatchedTideLenientWarning,
 	nonDecoratedJobsWarning,
 	jobNameLengthWarning,
@@ -317,11 +315,6 @@ func main() {
 	}
 	if o.warningEnabled(tideStrictBranchWarning) {
 		if err := validateStrictBranches(cfg.ProwConfig); err != nil {
-			errs = append(errs, err)
-		}
-	}
-	if o.warningEnabled(tideContextPolicy) {
-		if err := validateTideContextPolicy(cfg); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -936,50 +929,4 @@ func validateInRepoConfig(cfg *config.Config, filePath, repoIdentifier string) e
 	}
 
 	return nil
-}
-
-func validateTideContextPolicy(cfg *config.Config) error {
-	// We can not know all possible branches without asking GitHub, so instead we verify
-	// all branches that are explicitly configured on any job. This will hopefully catch
-	// most cases.
-	allKnownOrgRepoBranches := map[string]sets.String{}
-	for orgRepo, jobs := range cfg.PresubmitsStatic {
-		if _, ok := allKnownOrgRepoBranches[orgRepo]; !ok {
-			allKnownOrgRepoBranches[orgRepo] = sets.String{}
-		}
-
-		for _, job := range jobs {
-			allKnownOrgRepoBranches[orgRepo].Insert(job.Branches...)
-		}
-	}
-
-	// We have to disableInRepoConfig for this check, else we will
-	// attempt to clone the repo if its enabled
-	originalInRepoConfig := cfg.InRepoConfig
-	cfg.InRepoConfig = config.InRepoConfig{}
-	defer func() { cfg.InRepoConfig = originalInRepoConfig }()
-
-	var errs []error
-	for orgRepo, branches := range allKnownOrgRepoBranches {
-		split := strings.Split(orgRepo, "/")
-		if n := len(split); n != 2 {
-			errs = append(errs, fmt.Errorf("expected to get two results when splitting string %s by '/', got %d", orgRepo, n))
-			continue
-		}
-		org, repo := split[0], split[1]
-
-		if branches.Len() == 0 {
-			// Make sure we always test at least one branch per repo
-			// to catch cases where ppl only have jobs with empty branch
-			// configs.
-			branches.Insert("master")
-		}
-		for _, branch := range branches.List() {
-			if _, err := cfg.GetTideContextPolicy(nil, org, repo, branch, nil, ""); err != nil {
-				errs = append(errs, fmt.Errorf("context policy for %s branch in %s/%s is invalid: %w", branch, org, repo, err))
-			}
-		}
-	}
-
-	return utilerrors.NewAggregate(errs)
 }

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -28,11 +28,10 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/diff"
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
-	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
@@ -1305,78 +1304,5 @@ func TestValidateInRepoConfig(t *testing.T) {
 		if errString != tc.expectedErr {
 			t.Errorf("expected error %q does not match actual error %q", tc.expectedErr, errString)
 		}
-	}
-}
-
-func TestValidateTideContextPolicy(t *testing.T) {
-	cfg := func(m ...func(*config.Config)) *config.Config {
-		cfg := &config.Config{}
-		cfg.PresubmitsStatic = map[string][]config.Presubmit{}
-		for _, mod := range m {
-			mod(cfg)
-		}
-		return cfg
-	}
-
-	testCases := []struct {
-		name          string
-		cfg           *config.Config
-		expectedError string
-	}{
-		{
-			name: "overlapping branch config, error",
-			cfg: cfg(func(c *config.Config) {
-				c.PresubmitsStatic["a/b"] = []config.Presubmit{
-					{Reporter: config.Reporter{Context: "a"}, Brancher: config.Brancher{Branches: []string{"a"}}},
-					{AlwaysRun: true, Reporter: config.Reporter{Context: "a"}},
-				}
-			}),
-			expectedError: "context policy for a branch in a/b is invalid: contexts a are defined as required and required if present",
-		},
-		{
-			name: "overlapping branch config with empty branch configs, error",
-			cfg: cfg(func(c *config.Config) {
-				c.PresubmitsStatic["a/b"] = []config.Presubmit{
-					{Reporter: config.Reporter{Context: "a"}},
-					{AlwaysRun: true, Reporter: config.Reporter{Context: "a"}},
-				}
-			}),
-			expectedError: "context policy for master branch in a/b is invalid: contexts a are defined as required and required if present",
-		},
-		{
-			name: "overlapping branch config, inrepoconfig enabled, error",
-			cfg: cfg(func(c *config.Config) {
-				c.InRepoConfig.Enabled = map[string]*bool{"*": utilpointer.BoolPtr(true)}
-				c.PresubmitsStatic["a/b"] = []config.Presubmit{
-					{Reporter: config.Reporter{Context: "a"}, Brancher: config.Brancher{Branches: []string{"a"}}},
-					{AlwaysRun: true, Reporter: config.Reporter{Context: "a"}},
-				}
-			}),
-			expectedError: "context policy for a branch in a/b is invalid: contexts a are defined as required and required if present",
-		},
-		{
-			name: "no overlapping branch config, no error",
-			cfg: cfg(func(c *config.Config) {
-				c.PresubmitsStatic["a/b"] = []config.Presubmit{
-					{Reporter: config.Reporter{Context: "a"}, Brancher: config.Brancher{Branches: []string{"a"}}},
-					{AlwaysRun: true, Reporter: config.Reporter{Context: "a"}, Brancher: config.Brancher{Branches: []string{"b"}}},
-				}
-			}),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// Needed so regexes get compiled
-			tc.cfg.SetPresubmits(tc.cfg.PresubmitsStatic)
-
-			errMsg := ""
-			if err := validateTideContextPolicy(tc.cfg); err != nil {
-				errMsg = err.Error()
-			}
-			if errMsg != tc.expectedError {
-				t.Errorf("expected error %q, got error %q", tc.expectedError, errMsg)
-			}
-		})
 	}
 }


### PR DESCRIPTION
This reverts commit e647ad266572e105d7e1ec78fa6d1374c49af50e.
Explanation here: https://github.com/kubernetes/test-infra/pull/17340#discussion_r418211086

/assign @BenTheElder @alvaroaleman @fejta 