### PR TITLE
WIP: Set up service account for kops GCE instances

### DIFF
--- a/config/prow/cluster/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build_serviceaccounts.yaml
@@ -27,4 +27,13 @@ metadata:
   name: k8s-kops-test
   namespace: test-pods
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    # Kops GCE compute instance service account (nodes and masters)
+    iam.gke.io/gcp-service-account: kops-instance@kubernetes-jenkins-pull.iam.gserviceaccount.com
+  name: k8s-kops-instance
+  namespace: test-pods
+---
 # TODO(fejta): any other service accounts


### PR DESCRIPTION
**Problem:** 
All kops GCE jobs have been broken since we switched to Workload identity on prow a couple months ago. Kops expects certain things to be able to successfully execute a test run- one is a service account that the nodes will be launched as that has RW on gs://k8s-kops-gce/. 

The current implementation in prow allows us to assume the GSA `pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com` to _execute_ our job as `k8s-kops-test` KSA. Without specifying an instance service account, kops tries to use the default GSA which doesn't have the correct permissions on that bucket. 

kops has a `--gce-service-account` flag where we can provide the name of a service account for the instances to use, but this requires Service Account User or `iam.serviceAccounts.actAs` on the service account itself. So we get errors like: 
```
E0430 18:05:42.577918     242 op.go:136] GCE operation failed: googleapi: Error 400: The user does not have access to service account 'pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com'.  User: 'pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com'.  Ask a project owner to grant you the iam.serviceAccountUser role on the service account
```

**Proposal(s):**
We need help with the next step. I see how I can set up the relationship between a KSA and a GSA in prow, but I don't know how to set up permissions on that GSA. This PR is to help facilitate the discussion and implementation of next steps. 
~~I don't think we actually need this secondary service account `kops-instance`... it may be easier to just set up `iam.serviceAccounts.actAs` on `pr-kubekins`.~~
@fejta recommended a new service account for the instance SA and suggest to follow up with wg-k8s-infra.