### PR TITLE
Add non dry run flag to horologium

### DIFF
--- a/config/prow/cluster/starter.yaml
+++ b/config/prow/cluster/starter.yaml
@@ -383,6 +383,7 @@ spec:
       - name: horologium
         image: gcr.io/k8s-prow/horologium:v20200429-134f66873
         args:
+        - --dry-run=false
         - --config-path=/etc/config/config.yaml
         volumeMounts:
         - name: config


### PR DESCRIPTION
Otherwise it will complain that a dry run and no deck url is specified per default.