### PR TITLE
Checkconfig: Prevent validateUnknownFields from manipulating config

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -73,6 +73,7 @@ go_binary(
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -195,6 +195,21 @@ func main() {
 		logrus.Fatalf("Error parsing options - %v", err)
 	}
 
+	if err := validate(o); err != nil {
+		switch e := err.(type) {
+		case utilerrors.Aggregate:
+			reportWarning(o.strict, e)
+		default:
+			logrus.WithError(err).Fatal("Validation failed")
+		}
+
+	} else {
+		logrus.Info("checkconfig passes without any error!")
+	}
+
+}
+
+func validate(o options) error {
 	// use all warnings by default
 	if len(o.warnings.Strings()) == 0 {
 		if o.expensive {
@@ -206,13 +221,13 @@ func main() {
 
 	configAgent := config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {
-		logrus.WithError(err).Fatal("Error loading Prow config.")
+		return fmt.Errorf("error loading prow config: %w", err)
 	}
 	cfg := configAgent.Config()
 
 	if o.prowYAMLRepoName != "" {
 		if err := validateInRepoConfig(cfg, o.prowYAMLPath, o.prowYAMLRepoName); err != nil {
-			logrus.WithError(err).Fatal("Error validating .prow.yaml")
+			return fmt.Errorf("error validating .prow.yaml: %w", err)
 		}
 	}
 
@@ -220,7 +235,7 @@ func main() {
 	var pcfg *plugins.Configuration
 	if o.pluginConfig != "" {
 		if err := pluginAgent.Load(o.pluginConfig, true); err != nil {
-			logrus.WithError(err).Fatal("Error loading Prow plugin config.")
+			return fmt.Errorf("error loading Prow plugin config: %w", err)
 		}
 		pcfg = pluginAgent.Config()
 	}
@@ -232,18 +247,18 @@ func main() {
 	var errs []error
 	if pcfg != nil && o.warningEnabled(verifyOwnersFilePresence) {
 		if o.github.TokenPath == "" {
-			logrus.Fatal("Cannot verify OWNERS file presence without a GitHub token")
+			return errors.New("cannot verify OWNERS file presence without a GitHub token")
 		}
 		secretAgent := &secret.Agent{}
 		if o.github.TokenPath != "" {
 			if err := secretAgent.Start([]string{o.github.TokenPath}); err != nil {
-				logrus.WithError(err).Fatal("Error starting secrets agent.")
+				return fmt.Errorf("error starting secrets agent: %w", err)
 			}
 		}
 
 		githubClient, err := o.github.GitHubClient(secretAgent, false)
 		if err != nil {
-			logrus.WithError(err).Fatal("Error getting GitHub client.")
+			return fmt.Errorf("error loading GitHub client: %w", err)
 		}
 		githubClient.Throttle(3000, 100) // 300 hourly tokens, bursts of 100
 		// 404s are expected to happen, no point in retrying
@@ -300,18 +315,18 @@ func main() {
 	if o.warningEnabled(unknownFieldsWarning) {
 		cfgBytes, err := ioutil.ReadFile(o.configPath)
 		if err != nil {
-			logrus.WithError(err).Fatal("Error loading Prow config for validation.")
+			return fmt.Errorf("error reading Prow config for validation: %w", err)
 		}
-		if err := validateUnknownFields(cfg, cfgBytes, o.configPath); err != nil {
+		if err := validateUnknownFields(&config.Config{}, cfgBytes, o.configPath); err != nil {
 			errs = append(errs, err)
 		}
 	}
 	if pcfg != nil && o.warningEnabled(unknownFieldsWarning) {
 		pcfgBytes, err := ioutil.ReadFile(o.pluginConfig)
 		if err != nil {
-			logrus.WithError(err).Fatal("Error loading Prow plugin config for validation.")
+			return fmt.Errorf("error reading Prow plugin config for validation: %w", err)
 		}
-		if err := validateUnknownFields(pcfg, pcfgBytes, o.pluginConfig); err != nil {
+		if err := validateUnknownFields(&plugins.Configuration{}, pcfgBytes, o.pluginConfig); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -325,12 +340,8 @@ func main() {
 			errs = append(errs, err)
 		}
 	}
-	if len(errs) > 0 {
-		reportWarning(o.strict, utilerrors.NewAggregate(errs))
-		return
-	}
 
-	logrus.Info("checkconfig passes without any error!")
+	return utilerrors.NewAggregate(errs)
 }
 func policyIsStrict(p config.Policy) bool {
 	if p.Protect == nil || !*p.Protect {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1389,3 +1389,25 @@ func TestValidateTideContextPolicy(t *testing.T) {
 		})
 	}
 }
+
+func TestValidate(t *testing.T) {
+	testCases := []struct {
+		name string
+		opts options
+	}{
+		{
+			name: "combined config",
+			opts: options{
+				configPath: "testdata/combined.yaml",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := validate(tc.opts); err != nil {
+				t.Fatalf("validation failed: %v", err)
+			}
+		})
+	}
+}

--- a/prow/cmd/checkconfig/testdata/combined.yaml
+++ b/prow/cmd/checkconfig/testdata/combined.yaml
@@ -1,0 +1,361 @@
+branch-protection:
+  allow_disabled_policies: true
+  protect: false
+  orgs:
+    maistra-prow-testing:
+      required_pull_request_reviews:
+        required_approving_review_count: 1
+        require_code_owner_reviews: false
+    Maistra:
+      required_pull_request_reviews:
+        required_approving_review_count: 2
+        require_code_owner_reviews: false
+deck:
+  spyglass:
+    size_limit: 500000000  # 500 MB
+    lenses:
+    - lens:
+        name: buildlog
+        config:
+          highlight_regexes:
+          - timed out
+          - 'ERROR:'
+          - (FAIL|Failure \[)\b
+          - panic\b
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+      required_files:
+      - build-log.txt
+    - lens:
+        name: junit
+      required_files:
+      - artifacts/junit.*\.xml
+plank:
+  job_url_prefix_config:
+    '*': "https://prow.maistra.io/view/gcs/"
+  default_decoration_configs:
+    '*':
+      timeout: 2h
+      grace_period: 15s
+      utility_images:
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200117-c08038c1c"
+        initupload: "gcr.io/k8s-prow/initupload:v20200117-c08038c1c"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200117-c08038c1c"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200117-c08038c1c"
+      gcs_configuration:
+        path_strategy: explicit
+        bucket: "maistra-prow-testing"
+      gcs_credentials_secret: "gcs-credentials"
+postsubmits:
+  Maistra/test-infra:
+  - name: deploy-prow
+    decorate: true
+    skip_report: false
+    run_if_changed: '^prow/'
+    labels:
+      preset-prow-deployer: "true"
+    max_concurrency: 1
+    branches:
+    - master
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        imagePullPolicy: Always
+        command:
+        - make
+        - gen-check
+        - update-prow
+  - name: push-containers
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/'
+    branches:
+      - master
+    labels:
+      preset-quay-pusher: "true"
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder.push
+        securityContext:
+          privileged: true
+presets:
+- labels:
+    preset-prow-deployer: "true"
+  env:
+  - name: KUBECONFIG
+    value: /creds/kubeconfig.yaml
+  volumeMounts:
+  - name: creds
+    mountPath: /creds
+    readOnly: true
+  volumes:
+  - name: creds
+    secret:
+      secretName: prow-deployer-kubeconfig
+- labels:
+    preset-quay-pusher: "true"
+  env:
+  - name: DOCKER_CONFIG
+    value: /creds/
+  volumeMounts:
+  - name: creds
+    mountPath: /creds
+    readOnly: true
+  volumes:
+  - name: creds
+    secret:
+      secretName: quay-pusher-dockercfg
+presubmits:
+  Maistra/maistra.github.io:
+  - name: lint
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-1.2
+      - maistra-1.1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - lint
+    trigger: "(?m)^/test lint"
+    rerun_command: "/test lint"
+  - name: check-links
+    decorate: true
+    always_run: true
+    skip_report: false
+    branches:
+      - maistra-1.2
+      - maistra-1.1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - check-links
+    trigger: "(?m)^/test check-links"
+    rerun_command: "/test check-links"
+  Maistra/istio-operator:
+  - name: unittests
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - maistra-1.1
+      - maistra-1.2
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - compile
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+  - name: gen-check
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - maistra-1.1
+      - maistra-1.2
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+  Maistra/test-infra:
+  - name: lint
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    branches:
+      - master
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - lint
+  - name: gen-check
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    branches:
+      - master
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - gen-check
+  - name: build-containers
+    decorate: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    run_if_changed: '^docker/'
+    branches:
+      - master
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - build-containers
+        securityContext:
+          privileged: true
+  Maistra/istio:
+  - name: unittests
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    branches:
+      - maistra-1.1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - init
+        - test
+        env:
+        - name: GOFLAGS
+          value: -mod=vendor
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+
+## The presubmits below are for the maistra-prow-testing org, which is our test bed
+  maistra-prow-testing/test-infra:
+  - name: build-containers
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/test-infra
+    skip_report: false
+    branches:
+      - master
+    max_concurrency: 1
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        imagePullPolicy: Always
+        command:
+        - entrypoint
+        - make
+        - maistra-builder
+        securityContext:
+          privileged: true
+  maistra-prow-testing/istio-operator:
+  - name: unittests
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - maistra-1.1
+      - maistra-1.2
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - test
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+  - name: gen-check
+    decorate: true
+    always_run: true
+    path_alias: github.com/maistra/istio-operator
+    skip_report: false
+    branches:
+      - maistra-1.1
+      - maistra-1.2
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.1"
+        command:
+        - make
+        - gen-check
+        env:
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+  maistra-prow-testing/istio:
+  - name: unittests
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    branches:
+      - maistra-1.0
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.0"
+        command:
+        - make
+        - init
+        - test
+        env:
+        - name: ISTIO_BUILD_BUCKET
+          value: "maistra-prow-testing"
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+  - name: integrationtests
+    decorate: true
+    always_run: true
+    path_alias: istio.io/istio
+    skip_report: false
+    branches:
+      - maistra-1.0
+    spec:
+      containers:
+      - image: "quay.io/maistra/maistra-builder:1.0"
+        command:
+        - make
+        - init
+        - test.integration.local
+        env:
+        - name: ISTIO_BUILD_BUCKET
+          value: "maistra-prow-testing"
+        - name: XDG_CACHE_HOME
+          value: /tmp/cache
+        - name: GOCACHE
+          value: /tmp/cache
+prowjob_namespace: default
+pod_namespace: test-pods
+sinker:
+  resync_period: 1h
+  max_prowjob_age: 168h
+  max_pod_age: 6h


### PR DESCRIPTION
    We re-used the existing config variables in validateUnknownFields as
    target for a yaml.Unmarshal, resulting in unrelated checks failing
    because fields we normally default get overwritten.

Fixes https://github.com/kubernetes/test-infra/issues/17474
/assign @stevekuznetsov 
/cc @jwendell 