### PR TITLE
Job validation: Check for duplicate contexts

### DIFF
--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -4184,8 +4184,8 @@ func TestValidatePresubmits(t *testing.T) {
 		{
 			name: "Duplicate jobname causes error",
 			presubmits: []Presubmit{
-				{JobBase: JobBase{Name: "a"}},
-				{JobBase: JobBase{Name: "a"}},
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "foo"}},
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "bar"}},
 			},
 			expectedError: "duplicated presubmit job: a",
 		},
@@ -4198,13 +4198,18 @@ func TestValidatePresubmits(t *testing.T) {
 		},
 		{
 			name:          "Invalid JobBase causes error",
-			presubmits:    []Presubmit{{}},
+			presubmits:    []Presubmit{{Reporter: Reporter{Context: "foo"}}},
 			expectedError: `invalid presubmit job : name: must match regex "^[A-Za-z0-9-._]+$"`,
 		},
 		{
 			name:          "Invalid triggering config causes error",
-			presubmits:    []Presubmit{{Trigger: "some-trogger", JobBase: JobBase{Name: "my-job"}}},
+			presubmits:    []Presubmit{{Trigger: "some-trigger", JobBase: JobBase{Name: "my-job"}, Reporter: Reporter{Context: "foo"}}},
 			expectedError: `Either both of job.Trigger and job.RerunCommand must be set, wasnt the case for job "my-job"`,
+		},
+		{
+			name:          "Invalid reporting config causes error",
+			presubmits:    []Presubmit{{JobBase: JobBase{Name: "my-job"}}},
+			expectedError: "invalid presubmit job my-job: job is set to report but has no context configured",
 		},
 	}
 
@@ -4238,15 +4243,20 @@ func TestValidatePostsubmits(t *testing.T) {
 		{
 			name: "Duplicate jobname causes error",
 			postsubmits: []Postsubmit{
-				{JobBase: JobBase{Name: "a"}},
-				{JobBase: JobBase{Name: "a"}},
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "foo"}},
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "bar"}},
 			},
 			expectedError: "duplicated postsubmit job: a",
 		},
 		{
 			name:          "Invalid JobBase causes error",
-			postsubmits:   []Postsubmit{{}},
+			postsubmits:   []Postsubmit{{Reporter: Reporter{Context: "foo"}}},
 			expectedError: `invalid postsubmit job : name: must match regex "^[A-Za-z0-9-._]+$"`,
+		},
+		{
+			name:          "Invalid reporting config causes error",
+			postsubmits:   []Postsubmit{{JobBase: JobBase{Name: "my-job"}}},
+			expectedError: "invalid postsubmit job my-job: job is set to report but has no context configured",
 		},
 	}
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -4182,6 +4182,13 @@ func TestValidatePresubmits(t *testing.T) {
 			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
 		},
 		{
+			name: "Duplicate context on different branch doesn't cause error",
+			presubmits: []Presubmit{
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "repeated"}, Brancher: Brancher{Branches: []string{"master"}}},
+				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}, Brancher: Brancher{Branches: []string{"next"}}},
+			},
+		},
+		{
 			name: "Duplicate jobname causes error",
 			presubmits: []Presubmit{
 				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "foo"}},
@@ -4239,6 +4246,13 @@ func TestValidatePostsubmits(t *testing.T) {
 				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}},
 			},
 			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
+		},
+		{
+			name: "Duplicate context on different branch doesn't cause error",
+			postsubmits: []Postsubmit{
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "repeated"}, Brancher: Brancher{Branches: []string{"master"}}},
+				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}, Brancher: Brancher{Branches: []string{"next"}}},
+			},
 		},
 		{
 			name: "Duplicate jobname causes error",

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -4181,6 +4181,31 @@ func TestValidatePresubmits(t *testing.T) {
 			},
 			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
 		},
+		{
+			name: "Duplicate jobname causes error",
+			presubmits: []Presubmit{
+				{JobBase: JobBase{Name: "a"}},
+				{JobBase: JobBase{Name: "a"}},
+			},
+			expectedError: "duplicated presubmit job: a",
+		},
+		{
+			name: "Duplicate jobname on different branches doesn't cause error",
+			presubmits: []Presubmit{
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "foo"}, Brancher: Brancher{Branches: []string{"master"}}},
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "foo"}, Brancher: Brancher{Branches: []string{"next"}}},
+			},
+		},
+		{
+			name:          "Invalid JobBase causes error",
+			presubmits:    []Presubmit{{}},
+			expectedError: `invalid presubmit job : name: must match regex "^[A-Za-z0-9-._]+$"`,
+		},
+		{
+			name:          "Invalid triggering config causes error",
+			presubmits:    []Presubmit{{Trigger: "some-trogger", JobBase: JobBase{Name: "my-job"}}},
+			expectedError: `Either both of job.Trigger and job.RerunCommand must be set, wasnt the case for job "my-job"`,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -4209,6 +4234,19 @@ func TestValidatePostsubmits(t *testing.T) {
 				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}},
 			},
 			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
+		},
+		{
+			name: "Duplicate jobname causes error",
+			postsubmits: []Postsubmit{
+				{JobBase: JobBase{Name: "a"}},
+				{JobBase: JobBase{Name: "a"}},
+			},
+			expectedError: "duplicated postsubmit job: a",
+		},
+		{
+			name:          "Invalid JobBase causes error",
+			postsubmits:   []Postsubmit{{}},
+			expectedError: `invalid postsubmit job : name: must match regex "^[A-Za-z0-9-._]+$"`,
 		},
 	}
 

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -4165,3 +4165,61 @@ func TestDefaultAndValidateReportTemplate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidatePresubmits(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		presubmits    []Presubmit
+		expectedError string
+	}{
+		{
+			name: "Duplicate context causes error",
+			presubmits: []Presubmit{
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "repeated"}},
+				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}},
+			},
+			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		var errMsg string
+		err := validatePresubmits(tc.presubmits, "")
+		if err != nil {
+			errMsg = err.Error()
+		}
+		if errMsg != tc.expectedError {
+			t.Errorf("expected error '%s', got error '%s'", tc.expectedError, errMsg)
+		}
+	}
+}
+
+func TestValidatePostsubmits(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		postsubmits   []Postsubmit
+		expectedError string
+	}{
+		{
+			name: "Duplicate context causes error",
+			postsubmits: []Postsubmit{
+				{JobBase: JobBase{Name: "a"}, Reporter: Reporter{Context: "repeated"}},
+				{JobBase: JobBase{Name: "b"}, Reporter: Reporter{Context: "repeated"}},
+			},
+			expectedError: `[jobs b and a report to the same GitHub context "repeated", jobs a and b report to the same GitHub context "repeated"]`,
+		},
+	}
+
+	for _, tc := range testCases {
+		var errMsg string
+		err := validatePostsubmits(tc.postsubmits, "")
+		if err != nil {
+			errMsg = err.Error()
+		}
+		if errMsg != tc.expectedError {
+			t.Errorf("expected error '%s', got error '%s'", tc.expectedError, errMsg)
+		}
+	}
+}

--- a/prow/statusreconciler/status_test.go
+++ b/prow/statusreconciler/status_test.go
@@ -269,7 +269,7 @@ func getPresubmits(names []string) []config.Presubmit {
 				Spec: spec,
 			},
 			AlwaysRun: true,
-			Reporter:  config.Reporter{Context: "boo"},
+			Reporter:  config.Reporter{Context: name},
 		}
 		presubmits = append(presubmits, ps)
 	}


### PR DESCRIPTION
This PR extends the job validation to check for duplicate contexts. Also while I was it I:

* Added tests for `validatePresubmits` and `validatePostsubmits`
* Extended `validatePostsubmit` to check for invalid reporting config. We only validated that for presubmits, as we used to only report on presubmits

/assign @stevekuznetsov 