### PR TITLE
bugzilla: Fix and re-enable bugzilla plugin cherrypick support

### DIFF
--- a/prow/bugzilla/BUILD.bazel
+++ b/prow/bugzilla/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
     deps = [
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -161,13 +161,15 @@ func (c *client) UpdateBug(id int, update BugUpdate) error {
 	return err
 }
 
+// CreateBug creates a new bug on the server.
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#create-bug
 func (c *client) CreateBug(bug *BugCreate) (int, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "CreateBug", "bug": bug})
 	body, err := json.Marshal(bug)
 	if err != nil {
 		return 0, fmt.Errorf("failed to marshal create payload: %v", err)
 	}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/rest/bug/", c.endpoint), bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/rest/bug", c.endpoint), bytes.NewBuffer(body))
 	if err != nil {
 		return 0, err
 	}
@@ -220,14 +222,33 @@ func cloneBugStruct(bug *Bug, comments []Comment) *BugCreate {
 	return newBug
 }
 
-func (c *client) CloneBug(bug *Bug) (int, error) {
+// clone handles the bz client calls for the bug cloning process and allows us to share the implementation
+// between the real and fake client to prevent bugs from accidental discrepencies between the two.
+func clone(c Client, bug *Bug) (int, error) {
 	comments, err := c.GetComments(bug.ID)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get parent bug's comments: %v", err)
 	}
-	return c.CreateBug(cloneBugStruct(bug, comments))
+	id, err := c.CreateBug(cloneBugStruct(bug, comments))
+	if err != nil {
+		return id, err
+	}
+	depends := BugUpdate{
+		DependsOn: &IDUpdate{
+			Add: []int{bug.ID},
+		},
+	}
+	err = c.UpdateBug(id, depends)
+	return id, err
 }
 
+// CloneBug clones a bug by creating a new bug with the same fields, copying the description, and updating the bug to depend on the original bug
+func (c *client) CloneBug(bug *Bug) (int, error) {
+	return clone(c, bug)
+}
+
+// GetComments gets a list of comments for a specific bug ID.
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/comment.html#get-comments
 func (c *client) GetComments(bugID int) ([]Comment, error) {
 	logger := c.logger.WithFields(logrus.Fields{methodField: "GetComments", "id": bugID})
 	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/rest/bug/%d/comment", c.endpoint, bugID), nil)

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -129,7 +129,7 @@ func TestCreateBug(t *testing.T) {
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
 		}
-		if !strings.HasPrefix(r.URL.Path, "/rest/bug/") {
+		if !strings.HasPrefix(r.URL.Path, "/rest/bug") {
 			t.Errorf("incorrect path to create a bug: %s", r.URL.Path)
 			http.Error(w, "400 Bad Request", http.StatusBadRequest)
 			return
@@ -384,8 +384,8 @@ func TestUpdateBug(t *testing.T) {
 				if err != nil {
 					t.Errorf("failed to read update body: %v", err)
 				}
-				if actual, expected := string(raw), `{"status":"UPDATED"}`; actual != expected {
-					t.Errorf("got incorrect udpate: expected %v, got %v", expected, actual)
+				if actual, expected := string(raw), `{"depends_on":{"add":[1705242]},"status":"UPDATED"}`; actual != expected {
+					t.Errorf("got incorrect update: expected %v, got %v", expected, actual)
 				}
 			} else if id == 2 {
 				w.Header().Set("Content-Type", "application/json")
@@ -399,13 +399,20 @@ func TestUpdateBug(t *testing.T) {
 	defer testServer.Close()
 	client := clientForUrl(testServer.URL)
 
+	update := BugUpdate{
+		DependsOn: &IDUpdate{
+			Add: []int{1705242},
+		},
+		Status: "UPDATED",
+	}
+
 	// this should run an update
-	if err := client.UpdateBug(1705243, BugUpdate{Status: "UPDATED"}); err != nil {
+	if err := client.UpdateBug(1705243, update); err != nil {
 		t.Errorf("expected no error, but got one: %v", err)
 	}
 
 	// this should 404
-	err := client.UpdateBug(1, BugUpdate{Status: "UPDATE"})
+	err := client.UpdateBug(1, update)
 	if err == nil {
 		t.Error("expected an error, but got none")
 	} else if !IsNotFound(err) {
@@ -413,7 +420,7 @@ func TestUpdateBug(t *testing.T) {
 	}
 
 	// this is a 200 with an error payload
-	if err := client.UpdateBug(2, BugUpdate{Status: "UPDATE"}); err == nil {
+	if err := client.UpdateBug(2, update); err == nil {
 		t.Error("expected an error, but got none")
 	}
 }

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -340,7 +340,7 @@ func TestCloneBugStruct(t *testing.T) {
 		},
 	}}
 	for _, testCase := range testCases {
-		newBug := cloneBugStruct(&testCase.bug, testCase.comments)
+		newBug := cloneBugStruct(&testCase.bug, nil, testCase.comments)
 		if !reflect.DeepEqual(*newBug, testCase.expected) {
 			t.Errorf("%s: Difference in expected BugCreate and actual: %s", testCase.name, cmp.Diff(testCase.expected, *newBug))
 		}

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -18,7 +18,6 @@ package bugzilla
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -73,6 +72,16 @@ func (c *Fake) UpdateBug(id int, update BugUpdate) error {
 	if bug, exists := c.Bugs[id]; exists {
 		bug.Status = update.Status
 		bug.Resolution = update.Resolution
+		if update.Version != "" {
+			bug.Version = []string{update.Version}
+		}
+		if update.DependsOn != nil {
+			if len(update.DependsOn.Set) > 0 {
+				bug.DependsOn = update.DependsOn.Set
+			} else {
+				bug.DependsOn = sets.NewInt(bug.DependsOn...).Insert(update.DependsOn.Add...).Delete(update.DependsOn.Remove...).List()
+			}
+		}
 		c.Bugs[id] = bug
 		return nil
 	}
@@ -122,6 +131,7 @@ func (c *Fake) CreateBug(bug *BugCreate) (int, error) {
 		Component:       bug.Component,
 		Flags:           bug.Flags,
 		Groups:          bug.Groups,
+		ID:              newID,
 		Keywords:        bug.Keywords,
 		OperatingSystem: bug.OperatingSystem,
 		Platform:        bug.Platform,
@@ -158,7 +168,7 @@ func (c *Fake) CreateBug(bug *BugCreate) (int, error) {
 	return newID, nil
 }
 
-// GetBug retrieves the bug comments, if registered, or an error, if set,
+// GetComments retrieves the bug comments, if registered, or an error, if set,
 // or responds with an error that matches IsNotFound
 func (c *Fake) GetComments(id int) ([]Comment, error) {
 	if c.BugErrors.Has(id) {
@@ -170,12 +180,9 @@ func (c *Fake) GetComments(id int) ([]Comment, error) {
 	return nil, &requestError{statusCode: http.StatusNotFound, message: "bug comments not registered in the fake"}
 }
 
+// CloneBug clones a bug by creating a new bug with the same fields, copying the description, and updating the bug to depend on the original bug
 func (c *Fake) CloneBug(bug *Bug) (int, error) {
-	comments, err := c.GetComments(bug.ID)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get parent bug's comments: %v", err)
-	}
-	return c.CreateBug(cloneBugStruct(bug, comments))
+	return clone(c, bug)
 }
 
 // the Fake is a Client

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -219,11 +219,23 @@ type Flag struct {
 // BugUpdate contains fields to update on a Bug. See API documentation at:
 // https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
 type BugUpdate struct {
+	// DependOn specifies the bugs that this bug depends on
+	DependsOn *IDUpdate `json:"depends_on,omitempty"`
 	// Status is the current status of the bug.
 	Status     string `json:"status,omitempty"`
 	Resolution string `json:"resolution,omitempty"`
-	// Version are the versions the bug was reported against.
-	Version []string `json:"version,omitempty"`
+	// Version is the version the bug was reported against.
+	Version string `json:"version,omitempty"`
+}
+
+// IDUpdate is the struct used in Update calls to update fields that are arrays of IDs (ex. DependsOn)
+type IDUpdate struct {
+	// Add contains Bug IDs to add to this field.
+	Add []int `json:"add,omitempty"`
+	// Remove specifies Bug IDs to remove from this field. If the bug IDs are not already in the field, they will be ignored.
+	Remove []int `json:"remove,omitempty"`
+	// Set is An exact set of bug IDs to set this field to, overriding the current value. If Set is specified, then Add and Remove will be ignored.
+	Set []int `json:"set,omitempty"`
 }
 
 // ExternalBug contains details about an external bug linked to a Bugzilla bug.

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -149,6 +149,9 @@ type BugCreate struct {
 	Severity string `json:"severity,omitempty"`
 	// Status is the current status of the bug.
 	Status string `json:"status,omitempty"`
+	// SubComponents are the subcomponents of the component for the bug. The key is the Component name, while the value is an array of length 1 containing the subcomponent name.
+	// This is a Red Hat bugzilla specific extra field.
+	SubComponents map[string][]string `json:"sub_components,omitempty"`
 	// Summary is the summary of this bug.
 	Summary string `json:"summary,omitempty"`
 	// TargetMilestone is the milestone that this bug is supposed to be fixed by, or for closed bugs, the milestone that it was fixed for.

--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/flagutil:go_default_library",
         "//prow/config:go_default_library",
         "//prow/config/secret:go_default_library",
+        "//prow/external-plugins/cherrypicker/lib:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
@@ -48,7 +49,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//prow/external-plugins/cherrypicker/lib:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/prow/external-plugins/cherrypicker/lib/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/lib/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["lib.go"],
+    importpath = "k8s.io/test-infra/prow/external-plugins/cherrypicker/lib",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/external-plugins/cherrypicker/lib/lib.go
+++ b/prow/external-plugins/cherrypicker/lib/lib.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cherrypicker
+
+import "fmt"
+
+// CreateCherrypickBody creates the body of a cherrypick PR
+func CreateCherrypickBody(num int, requestor, note string) string {
+	cherryPickBody := fmt.Sprintf("This is an automated cherry-pick of #%d", num)
+	if len(requestor) != 0 {
+		cherryPickBody = fmt.Sprintf("%s\n\n/assign %s", cherryPickBody, requestor)
+	}
+	if len(note) != 0 {
+		cherryPickBody = fmt.Sprintf("%s\n\n%s", cherryPickBody, note)
+	}
+	return cherryPickBody
+}

--- a/prow/plugins/bugzilla/BUILD.bazel
+++ b/prow/plugins/bugzilla/BUILD.bazel
@@ -25,10 +25,12 @@ go_test(
     deps = [
         "//prow/bugzilla:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/external-plugins/cherrypicker/lib:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -43,6 +43,7 @@ var (
 	refreshCommandMatch  = regexp.MustCompile(`(?mi)^/bugzilla refresh\s*$`)
 	qaAssignCommandMatch = regexp.MustCompile(`(?mi)^/bugzilla assign-qa\s*$`)
 	qaReviewCommandMatch = regexp.MustCompile(`(?mi)^/bugzilla cc-qa\s*$`)
+	cherrypickPRMatch    = regexp.MustCompile(`This is an automated cherry-pick of #([0-9]+)`)
 )
 
 const (
@@ -210,6 +211,19 @@ func handlePullRequest(pc plugins.Agent, pre github.PullRequestEvent) error {
 	return nil
 }
 
+func getCherryPickMatch(pre github.PullRequestEvent) (bool, int, string, error) {
+	cherrypickMatch := cherrypickPRMatch.FindStringSubmatch(pre.PullRequest.Body)
+	if cherrypickMatch != nil {
+		cherrypickOf, err := strconv.Atoi(cherrypickMatch[1])
+		if err != nil {
+			// should be impossible based on the regex
+			return false, 0, "", fmt.Errorf("Failed to parse cherrypick bugID as int - is the regex correct? Err: %v", err)
+		}
+		return true, cherrypickOf, pre.PullRequest.Base.Ref, nil
+	}
+	return false, 0, "", nil
+}
+
 // digestPR determines if any action is necessary and creates the objects for handle() if it is
 func digestPR(log *logrus.Entry, pre github.PullRequestEvent, validateByDefault *bool) (*event, error) {
 	// These are the only actions indicating the PR title may have changed or that the PR merged
@@ -228,21 +242,28 @@ func digestPR(log *logrus.Entry, pre github.PullRequestEvent, validateByDefault 
 		title   = pre.PullRequest.Title
 	)
 
-	// Make sure the PR title is referencing a bug
 	e := &event{org: org, repo: repo, baseRef: baseRef, number: number, merged: pre.PullRequest.Merged, state: pre.PullRequest.State, body: title, htmlUrl: pre.PullRequest.HTMLURL, login: pre.PullRequest.User.Login}
-	mat := titleMatch.FindStringSubmatch(title)
-	if mat == nil {
-		// in the case that the title used to reference a bug and no longer does we
-		// want to handle this to remove labels
-		e.missing = true
-	} else {
-		id, err := strconv.Atoi(mat[1])
-		if err != nil {
-			// should be impossible based on the regex
-			log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
-			return nil, err
+	// Check if PR is a cherrypick
+	cherrypick, cherrypickFromPRNum, cherrypickTo, err := getCherryPickMatch(pre)
+	if err != nil {
+		log.WithError(err).Debug("Failed to identify if PR is a cherrypick")
+		return nil, err
+	} else if cherrypick {
+		if pre.Action != github.PullRequestActionOpened {
+			return nil, nil
 		}
-		e.bugId = id
+		e.cherrypick = true
+		e.cherrypickFromPRNum = cherrypickFromPRNum
+		e.cherrypickTo = cherrypickTo
+		return e, nil
+	}
+	// Make sure the PR title is referencing a bug
+	e.bugId, e.missing, err = bugIDFromTitle(title)
+	// in the case that the title used to reference a bug and no longer does we
+	// want to handle this to remove labels
+	if err != nil {
+		log.WithError(err).Debug("Failed to get bug ID from title")
+		return nil, err
 	}
 
 	// when exiting early from errors trying to find out if the PR previously referenced a bug,
@@ -263,15 +284,13 @@ func digestPR(log *logrus.Entry, pre github.PullRequestEvent, validateByDefault 
 		// we're detecting this best-effort so we can handle it anyway
 		return intermediate, nil
 	}
-	prevMat := titleMatch.FindStringSubmatch(changes.Title.From)
-	if prevMat == nil {
+	prevId, missing, err := bugIDFromTitle(changes.Title.From)
+	if missing {
 		// title did not previously reference a bug
 		return intermediate, nil
-	}
-	prevId, err := strconv.Atoi(prevMat[1])
-	if err != nil {
+	} else if err != nil {
 		// should be impossible based on the regex, ignore err as this is best-effort
-		log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
+		log.WithError(err).Debug("Failed get previous bug ID")
 		return intermediate, nil
 	}
 
@@ -324,18 +343,12 @@ func digestComment(gc githubClient, log *logrus.Entry, gce github.GenericComment
 	}
 
 	e := &event{org: org, repo: repo, baseRef: pr.Base.Ref, number: number, merged: pr.Merged, state: pr.State, body: gce.Body, htmlUrl: gce.HTMLURL, login: gce.User.Login, assign: assign, cc: cc}
-	mat := titleMatch.FindStringSubmatch(pr.Title)
-	if mat == nil {
-		e.missing = true
-		return e, nil
-	}
-	id, err := strconv.Atoi(mat[1])
+	e.bugId, e.missing, err = bugIDFromTitle(pr.Title)
 	if err != nil {
 		// should be impossible based on the regex
-		log.WithError(err).Debug("Failed to parse bug ID as int - is the regex correct?")
+		log.WithError(err).Debug("Failed to get bug ID from PR title")
 		return nil, err
 	}
-	e.bugId = id
 
 	return e, nil
 }
@@ -347,6 +360,9 @@ type event struct {
 	state                string
 	body, htmlUrl, login string
 	assign, cc           bool
+	cherrypick           bool
+	cherrypickFromPRNum  int
+	cherrypickTo         string
 }
 
 func (e *event) comment(gc githubClient) func(body string) error {
@@ -409,6 +425,10 @@ func handle(e event, gc githubClient, bc bugzilla.Client, options plugins.Bugzil
 	// merges follow a different pattern from the normal validation
 	if e.merged {
 		return handleMerge(e, gc, bc, options, log)
+	}
+	// cherrypicks follow a different pattern than normal validation
+	if e.cherrypick {
+		return handleCherrypick(e, gc, bc, options, log)
 	}
 
 	var needsValidLabel, needsInvalidLabel bool
@@ -817,6 +837,68 @@ func handleMerge(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 		return comment(fmt.Sprintf("%s %s", mergedMessage("All"), outcomeMessage("")))
 	}
 	return comment(fmt.Sprintf("%s %s\n%s", mergedMessage("Some"), unmergedMessage, outcomeMessage("")))
+}
+
+func handleCherrypick(e event, gc githubClient, bc bugzilla.Client, options plugins.BugzillaBranchOptions, log *logrus.Entry) error {
+	comment := e.comment(gc)
+	// get the info for the PR being cherrypicked from
+	pr, err := gc.GetPullRequest(e.org, e.repo, e.cherrypickFromPRNum)
+	if err != nil {
+		log.WithError(err).Warn("Unexpected error getting title of pull request being cherrypicked from.")
+		return comment(formatError(fmt.Sprintf("creating a cherry-pick bug in Bugzilla: failed to check the state of cherrypicked pull request at https://github.com/%s/%s/pull/%d", e.org, e.repo, e.cherrypickFromPRNum), bc.Endpoint(), e.bugId, err))
+	}
+	// Attempt to identify bug from PR title
+	bugID, bugMissing, err := bugIDFromTitle(pr.Title)
+	if bugMissing {
+		log.Debugf("Parent PR %d doesn't have associated bug; not creating cherrypicked bug", pr.Number)
+		// if there is no bugzilla bug, we should simply ignore this PR
+		return nil
+	} else if err != nil {
+		// should be impossible based on the regex
+		log.WithError(err).Debugf("Failed to get bug ID from PR title \"%s\"", pr.Title)
+		return comment(formatError(fmt.Sprintf("creating a cherry-pick bug in Bugzilla: could not get bug ID from PR title \"%s\"", pr.Title), bc.Endpoint(), 0, err))
+	}
+	oldLink := fmt.Sprintf(bugLink, bugID, bc.Endpoint(), bugID)
+	// Since getBug generates a comment itself, we have to add a prefix explaining that this was a cherrypick attempt to the comment
+	commentWithPrefix := func(body string) error {
+		return comment(fmt.Sprintf("Failed to create a cherry-pick bug in Bugzilla: %s", body))
+	}
+	bug, err := getBug(bc, bugID, log, commentWithPrefix)
+	if err != nil || bug == nil {
+		return err
+	}
+	cloneID, err := bc.CloneBug(bug)
+	if err != nil {
+		log.WithError(err).Debugf("Failed to clone bug %d", bugID)
+		return comment(formatError(fmt.Sprintf("creating a cherry-pick bug in Bugzilla: encountered error cloning %s for cherrypick", oldLink), bc.Endpoint(), e.bugId, err))
+	}
+	cloneLink := fmt.Sprintf(bugLink, cloneID, bc.Endpoint(), cloneID)
+	// Update the version of the bug to the target release
+	update := bugzilla.BugUpdate{
+		Version: *options.TargetRelease,
+	}
+	err = bc.UpdateBug(cloneID, update)
+	if err != nil {
+		log.WithError(err).Debugf("Unable to update version and dependencies for bug %d", cloneID)
+		return comment(formatError(fmt.Sprintf("updating cherry-pick bug in Bugzilla: Created cherrypick %s, but encountered error updating version for bugzilla %s", cloneLink, cloneLink), bc.Endpoint(), e.bugId, err))
+	}
+	// Replace old bugID in title with new cloneID
+	newTitle := strings.Replace(e.body, fmt.Sprintf("Bug %d", bugID), fmt.Sprintf("Bug %d", cloneID), 1)
+	response := fmt.Sprintf("%s has been cloned as %s. Retitling PR to link against new bug.\n/retitle %s", oldLink, cloneLink, newTitle)
+	return comment(response)
+}
+
+func bugIDFromTitle(title string) (int, bool, error) {
+	mat := titleMatch.FindStringSubmatch(title)
+	if mat == nil {
+		return 0, true, nil
+	}
+	bugID, err := strconv.Atoi(mat[1])
+	if err != nil {
+		// should be impossible based on the regex
+		return 0, false, fmt.Errorf("Failed to parse bug ID (%s) as int", mat[1])
+	}
+	return bugID, false, nil
 }
 
 func getBug(bc bugzilla.Client, bugId int, log *logrus.Entry, comment func(string) error) (*bugzilla.Bug, error) {

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -29,11 +30,14 @@ import (
 
 	"k8s.io/test-infra/prow/bugzilla"
 	prowconfig "k8s.io/test-infra/prow/config"
+	cherrypicker "k8s.io/test-infra/prow/external-plugins/cherrypicker/lib"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 )
+
+var allowEvent = cmp.AllowUnexported(event{})
 
 func TestHelpProvider(t *testing.T) {
 	rawConfig := `default:
@@ -143,7 +147,7 @@ orgs:
 	}
 
 	if actual := help; !reflect.DeepEqual(actual, expected) {
-		t.Errorf("resolved incorrect plugin help: %v", diff.ObjectReflectDiff(actual, expected))
+		t.Errorf("resolved incorrect plugin help: %v", cmp.Diff(actual, expected, allowEvent))
 	}
 }
 
@@ -279,6 +283,61 @@ func TestDigestPR(t *testing.T) {
 			},
 		},
 		{
+			name: "cherrypicked PR gets cherrypick event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionOpened,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "release-4.4",
+					},
+					Number:  3,
+					Title:   "[release-4.4] Bug 123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+					Body: `This is an automated cherry-pick of #2
+
+/assign user`,
+				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "release-4.4", number: 3, body: "[release-4.4] Bug 123: fixed it!", htmlUrl: "http.com", login: "user", cherrypick: true, cherrypickFromPRNum: 2, cherrypickTo: "release-4.4",
+			},
+		},
+		{
+			name: "edited cherrypicked PR gets no cherrypick event",
+			pre: github.PullRequestEvent{
+				Action: github.PullRequestActionEdited,
+				PullRequest: github.PullRequest{
+					Base: github.PullRequestBranch{
+						Repo: github.Repo{
+							Owner: github.User{
+								Login: "org",
+							},
+							Name: "repo",
+						},
+						Ref: "release-4.4",
+					},
+					Number:  3,
+					Title:   "[release-4.4] Bug 123: fixed it!",
+					HTMLURL: "http.com",
+					User: github.User{
+						Login: "user",
+					},
+					Body: `This is an automated cherry-pick of #2
+
+/assign user`,
+				},
+			},
+		},
+		{
 			name: "title change referencing same bug gets no event",
 			pre: github.PullRequestEvent{
 				Action: github.PullRequestActionOpened,
@@ -393,7 +452,7 @@ func TestDigestPR(t *testing.T) {
 			}
 
 			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get correct event: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+				t.Errorf("%s: did not get correct event: %v", testCase.name, cmp.Diff(actual, expected, allowEvent))
 			}
 		})
 	}
@@ -587,7 +646,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			}
 
 			if actual, expected := event, testCase.expected; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: did not get correct event: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+				t.Errorf("%s: did not get correct event: %v", testCase.name, cmp.Diff(actual, expected, allowEvent))
 			}
 
 			checkComments(client, testCase.name, testCase.expectedComment, t)
@@ -607,14 +666,21 @@ func TestHandle(t *testing.T) {
 		org: "org", repo: "repo", baseRef: "branch", number: 1, bugId: 123, body: "Bug 123: fixed it!", htmlUrl: "http.com", login: "user",
 	}
 	var testCases = []struct {
-		name                 string
-		labels               []string
-		missing              bool
-		merged               bool
+		name                string
+		labels              []string
+		missing             bool
+		merged              bool
+		cherryPick          bool
+		cherryPickFromPRNum int
+		cherryPickTo        string
+		// the "e.body" for PRs is the PR title; this field can be used to replace the "body" for PR handles for cases where the body != description
+		body                 string
 		externalBugs         []bugzilla.ExternalBug
 		prs                  []github.PullRequest
 		bugs                 []bugzilla.Bug
+		bugComments          map[int][]bugzilla.Comment
 		bugErrors            []int
+		bugCreateErrors      []string
 		options              plugins.BugzillaBranchOptions
 		expectedLabels       []string
 		expectedComment      string
@@ -1051,6 +1117,129 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 			expectedBug: &bugzilla.Bug{ID: 123, Status: "CLOSED", Severity: "urgent"},
 		},
+		{
+			name:                "Cherrypick PR results in cloned bug creation",
+			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
+			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
+			body:                "[v1] " + base.body,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			expectedComment: `org/repo#1:@user: [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) has been cloned as [Bugzilla bug 124](www.bugzilla/show_bug.cgi?id=124). Retitling PR to link against new bug.
+/retitle [v1] Bug 124: fixed it!
+
+<details>
+
+In response to [this](http.com):
+
+>[v1] Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+			expectedBug: &bugzilla.Bug{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v1"}, ID: 124, DependsOn: []int{123}, Severity: "urgent"},
+		},
+		{
+			name:                "parent PR of cherrypick not existing results in error",
+			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
+			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
+			prs:                 []github.PullRequest{{Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
+			body:                "[v1] " + base.body,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			expectedComment: `org/repo#1:@user: An error was encountered creating a cherry-pick bug in Bugzilla: failed to check the state of cherrypicked pull request at https://github.com/org/repo/pull/1 for bug 123 on the Bugzilla server at www.bugzilla:
+> pull request number 1 does not exist
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>[v1] Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:                "failure to obtain parent bug for cherrypick results in error",
+			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
+			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
+			bugErrors:           []int{123},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
+			body:                "[v1] " + base.body,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			expectedComment: `org/repo#1:@user: Failed to create a cherry-pick bug in Bugzilla: An error was encountered searching for bug 123 on the Bugzilla server at www.bugzilla:
+> injected error getting bug
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>[v1] Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:                "failure to clone bug for cherrypick results in error",
+			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
+			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
+			bugCreateErrors:     []string{"This is a clone of Bug #123. This is the description of that bug:\nThis is a bug"},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
+			body:                "[v1] " + base.body,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			expectedComment: `org/repo#1:@user: An error was encountered creating a cherry-pick bug in Bugzilla: encountered error cloning [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) for cherrypick for bug 123 on the Bugzilla server at www.bugzilla:
+> injected error creating new bug
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>[v1] Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			// Since the clone does an update operation as part of the clone, this error still occurs in the call to `CloneBug`.
+			// We cannot easily test the error handling of the version update call, as that happens after the DependsOn update done during cloning
+			name:                "failure to update bug for results in error",
+			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, Version: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
+			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
+			bugErrors:           []int{124},
+			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
+			body:                "[v1] " + base.body,
+			cherryPick:          true,
+			cherryPickFromPRNum: 1,
+			cherryPickTo:        "v1",
+			options:             plugins.BugzillaBranchOptions{TargetRelease: &v1},
+			expectedComment: `org/repo#1:@user: An error was encountered creating a cherry-pick bug in Bugzilla: encountered error cloning [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) for cherrypick for bug 123 on the Bugzilla server at www.bugzilla:
+> injected error updating bug
+Please contact an administrator to resolve this issue, then request a bug refresh with <code>/bugzilla refresh</code>.
+
+<details>
+
+In response to [this](http.com):
+
+>[v1] Bug 123: fixed it!
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1068,20 +1257,29 @@ Instructions for interacting with me using PR comments are available [here](http
 				gc.PullRequests[pr.Number] = &pr
 			}
 			bc := bugzilla.Fake{
-				EndpointString: "www.bugzilla",
-				Bugs:           map[int]bugzilla.Bug{},
-				BugErrors:      sets.NewInt(),
-				ExternalBugs:   map[int][]bugzilla.ExternalBug{},
+				EndpointString:  "www.bugzilla",
+				Bugs:            map[int]bugzilla.Bug{},
+				BugComments:     testCase.bugComments,
+				BugErrors:       sets.NewInt(),
+				BugCreateErrors: sets.NewString(),
+				ExternalBugs:    map[int][]bugzilla.ExternalBug{},
 			}
 			for _, bug := range testCase.bugs {
 				bc.Bugs[bug.ID] = bug
 			}
 			bc.BugErrors.Insert(testCase.bugErrors...)
+			bc.BugCreateErrors.Insert(testCase.bugCreateErrors...)
 			for _, externalBug := range testCase.externalBugs {
 				bc.ExternalBugs[externalBug.BugzillaBugID] = append(bc.ExternalBugs[externalBug.BugzillaBugID], externalBug)
 			}
 			e.missing = testCase.missing
 			e.merged = testCase.merged
+			e.cherrypick = testCase.cherryPick
+			e.cherrypickFromPRNum = testCase.cherryPickFromPRNum
+			e.cherrypickTo = testCase.cherryPickTo
+			if testCase.body != "" {
+				e.body = testCase.body
+			}
 			err := handle(e, &gc, &bc, testCase.options, logrus.WithField("testCase", testCase.name))
 			if err != nil {
 				t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
@@ -1107,12 +1305,12 @@ Instructions for interacting with me using PR comments are available [here](http
 
 			if testCase.expectedBug != nil {
 				if actual, expected := bc.Bugs[testCase.expectedBug.ID], *testCase.expectedBug; !reflect.DeepEqual(actual, expected) {
-					t.Errorf("%s: got incorrect bug after update: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
+					t.Errorf("%s: got incorrect bug after update: %s", testCase.name, cmp.Diff(actual, expected, allowEvent))
 				}
 			}
 			if len(testCase.expectedExternalBugs) > 0 {
 				if actual, expected := bc.ExternalBugs[testCase.expectedBug.ID], testCase.expectedExternalBugs; !reflect.DeepEqual(actual, expected) {
-					t.Errorf("%s: got incorrect external bugs after update: %s", testCase.name, diff.ObjectReflectDiff(actual, expected))
+					t.Errorf("%s: got incorrect external bugs after update: %s", testCase.name, cmp.Diff(actual, expected, allowEvent))
 				}
 			}
 		})
@@ -1416,10 +1614,10 @@ func TestValidateBug(t *testing.T) {
 				t.Errorf("%s: didn't validate bug correctly, expected %t got %t", testCase.name, testCase.valid, valid)
 			}
 			if !reflect.DeepEqual(validations, testCase.validations) {
-				t.Errorf("%s: didn't get correct validations: %v", testCase.name, diff.ObjectReflectDiff(testCase.validations, validations))
+				t.Errorf("%s: didn't get correct validations: %v", testCase.name, cmp.Diff(testCase.validations, validations, allowEvent))
 			}
 			if !reflect.DeepEqual(why, testCase.why) {
-				t.Errorf("%s: didn't get correct reasons why: %v", testCase.name, diff.ObjectReflectDiff(testCase.why, why))
+				t.Errorf("%s: didn't get correct reasons why: %v", testCase.name, cmp.Diff(testCase.why, why, allowEvent))
 			}
 		})
 	}
@@ -1486,5 +1684,51 @@ func TestProcessQuery(t *testing.T) {
 				t.Errorf("%s: Expected \"%s\", got \"%s\"", testCase.name, testCase.expected, response)
 			}
 		})
+	}
+}
+
+func TestGetCherrypickPRMatch(t *testing.T) {
+	var prNum = 123
+	var branch = "v2"
+	var testCases = []struct {
+		name      string
+		requestor string
+		note      string
+	}{{
+		name: "No requestor or string",
+	}, {
+		name:      "Include requestor",
+		requestor: "user",
+	}, {
+		name: "Include note",
+		note: "this is a test",
+	}, {
+		name:      "Include requestor and note",
+		requestor: "user",
+		note:      "this is a test",
+	}}
+	var pr = &github.PullRequestEvent{
+		PullRequest: github.PullRequest{
+			Base: github.PullRequestBranch{
+				Ref: branch,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		testPR := *pr
+		testPR.PullRequest.Body = cherrypicker.CreateCherrypickBody(prNum, testCase.requestor, testCase.note)
+		cherrypick, cherrypickOfPRNum, cherrypickTo, err := getCherryPickMatch(testPR)
+		if err != nil {
+			t.Fatalf("%s: Got error but did not expect one: %v", testCase.name, err)
+		}
+		if !cherrypick {
+			t.Errorf("%s: Expected cherrypick to be true, but got false", testCase.name)
+		}
+		if cherrypickOfPRNum != prNum {
+			t.Errorf("%s: Got incorrect PR num: Expected %d, got %d", testCase.name, prNum, cherrypickOfPRNum)
+		}
+		if cherrypickTo != "v2" {
+			t.Errorf("%s: Got incorrect cherrypick to branch: Expected %s, got %s", testCase.name, branch, cherrypickTo)
+		}
 	}
 }


### PR DESCRIPTION
This reverts the revert of bugzilla plugin cherrypick support and fixes the problems that caused the changes to be reverted.

/cc @stevekuznetsov 