### PR TITLE
releng: Build pause image in k8s-staging-kubernetes

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -52,32 +52,6 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    - name: post-kubernetes-push-image-pause
-      cluster: test-infra-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/pause\/'
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-build-image
-              - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --gcb-config=build/pause/cloudbuild.yaml
-              - .
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers
   kubernetes/release:
     - name: post-release-push-image-kube-cross
       cluster: test-infra-trusted

--- a/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
@@ -1,0 +1,28 @@
+postsubmits:
+  kubernetes/kubernetes:
+    - name: post-kubernetes-push-image-pause
+      cluster: test-infra-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^build\/pause\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: deployer # TODO(fejta): use pusher
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-kubernetes
+              - --scratch-bucket=gs://k8s-staging-kubernetes-gcb
+              - --gcb-config=build/pause/cloudbuild.yaml
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers


### PR DESCRIPTION
The pause image should be built in the `k8s-staging-kubernetes` GCP project instead of `k8s-staging-build-image`, since it's currently a top-level image and not a build image.

(Follow-up to https://github.com/kubernetes/test-infra/pull/17476 and needed for https://github.com/kubernetes/kubernetes/pull/90665.)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @dims 
cc: @kubernetes/release-engineering 
/sig release
/area release-eng