### PR TITLE
Migrate an e2e job to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -471,6 +471,7 @@ periodics:
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-flaky-repro
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -484,13 +485,13 @@ periodics:
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce
-      - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200430-cb59ea5-master


### PR DESCRIPTION
I chose an e2e job that is relatively close to the default e2e job
but is not release-blocking

Also this job should _not_ have ever been setting latest-green.txt,
that was probably copy-pasta leftover from when I originally created
this job