### PR TITLE
Use k8s-infra-prow-build-trusted for an image-pushing job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-infra-tools.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes/k8s.io:
     - name: post-k8sio-infra-tools-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: wg-k8s-infra-k8sio
       decorate: true
@@ -9,7 +9,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:


### PR DESCRIPTION
I picked an image that wg-k8s-infra owns to prove that
this works