### PR TITLE
Migrate image-pushing jobs to k8s-infra-prow-build-trusted

### DIFF
--- a/config/jobs/image-pushing/README.md
+++ b/config/jobs/image-pushing/README.md
@@ -125,7 +125,7 @@ postsubmits:
   kubernetes-sigs/some-repo-name:
     # The name should be changed to match the repo name above
     - name: post-some-repo-name-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
@@ -137,7 +137,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
             command:

--- a/config/jobs/image-pushing/k8s-staging-apiserver-network-proxy.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apiserver-network-proxy.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/apiserver-network-proxy:
     - name: apiserver-network-proxy-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cloud-provider-apiserver-network-proxy
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   cncf/apisnoop:
     - name: apisnoop-push-webapp-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: conformance-apisnoop
         testgrid-tab-name: apisnoop-webapp-image
@@ -11,7 +11,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -23,7 +23,7 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - apps/webapp/app
     - name: apisnoop-push-auditlogger-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: conformance-apisnoop
         testgrid-tab-name: apisnoop-auditlogger-image
@@ -33,7 +33,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -45,7 +45,7 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - apps/auditlogger/app
     - name: apisnoop-push-postgres-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: conformance-apisnoop
         testgrid-tab-name: apisnoop-postgres-image
@@ -55,7 +55,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -67,7 +67,7 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - apps/postgres/app
     - name: apisnoop-push-hasura-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: conformance-apisnoop
         testgrid-tab-name: apisnoop-hasura-image
@@ -77,7 +77,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes-sigs/k8s-container-image-promoter:
     - name: cip-postsubmit-push-to-staging
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-blocking
         testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes/kubernetes:
     - name: post-kubernetes-push-image-debian-base
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -27,7 +27,7 @@ postsubmits:
         github_team_ids:
           - 2241179 # release-managers
     - name: post-kubernetes-push-image-debian-iptables
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -36,7 +36,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -54,7 +54,7 @@ postsubmits:
           - 2241179 # release-managers
   kubernetes/release:
     - name: post-release-push-image-kube-cross
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -63,7 +63,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/cluster-api:
     - name: post-cluster-api-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes
@@ -13,7 +13,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -26,7 +26,7 @@ postsubmits:
               - .
   kubernetes-sigs/cluster-api-provider-aws:
     - name: post-cluster-api-provider-aws-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes
@@ -37,7 +37,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -50,7 +50,7 @@ postsubmits:
               - .
   kubernetes-sigs/cluster-api-provider-azure:
     - name: post-cluster-api-provider-azure-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes, sig-cluster-lifecycle-cluster-api-provider-azure
         testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
@@ -61,7 +61,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -73,7 +73,7 @@ postsubmits:
               - .
   kubernetes-sigs/cluster-api-provider-gcp:
     - name: post-cluster-api-provider-gcp-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes
@@ -84,7 +84,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -97,7 +97,7 @@ postsubmits:
               - .
   kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm:
     - name: post-cluster-api-bootstrap-provider-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes
@@ -107,7 +107,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -120,7 +120,7 @@ postsubmits:
               - .
   kubernetes-sigs/cluster-api-provider-openstack:
     - name: post-cluster-api-provider-openstack-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-image-pushes
@@ -131,7 +131,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-csi.yaml
+++ b/config/jobs/image-pushing/k8s-staging-csi.yaml
@@ -4,7 +4,7 @@ postsubmits:
   kubernetes-csi/node-driver-registrar:
     # The name should be changed to match the repo name above
     - name: post-node-driver-registrar-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-storage-csi-node-driver-registrar
@@ -15,7 +15,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -4,7 +4,7 @@ postsubmits:
   kubernetes-sigs/descheduler:
     # The name should be changed to match the repo name above
     - name: post-descheduler-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-scheduling
@@ -14,7 +14,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dns.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes/dns:
     - name: dns-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-network-dns
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -5,7 +5,7 @@ postsubmits:
     # The name should be changed to match the repo name above
     - name: post-kubernetes-push-images
       # TODO: move this to a more appropriate cluster.
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
@@ -19,7 +19,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta)- use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-external-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-external-dns.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/external-dns:
     - name: post-external-dns-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-network-external-dns
@@ -11,7 +11,7 @@ postsubmits:
         - ^master$
         - ^v[0-9].*
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-kind.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kind.yaml
@@ -1,14 +1,14 @@
 postsubmits:
   kubernetes-sigs/kind:
     - name: post-kind-push-binaries
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-testing-kind
         testgrid-alert-email: kubernetes-engprod+alerts@google.com,antonio.ojea.garcia@gmail.com
         testgrid-num-columns-recent: '3'
       decorate: true
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes/kops:
     - name: kops-postsubmit-push-to-staging
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-cluster-lifecycle-kops
@@ -11,7 +11,7 @@ postsubmits:
         - ^master$
         - ^release-.*
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
@@ -1,7 +1,7 @@
 postsubmits:
   kubernetes/kubernetes:
     - name: post-kubernetes-push-image-pause
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io

--- a/config/jobs/image-pushing/k8s-staging-metrics-server.yaml
+++ b/config/jobs/image-pushing/k8s-staging-metrics-server.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/metrics-server:
     - name: post-metrics-server-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-instrumentation-image-pushes
@@ -12,7 +12,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
+++ b/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes/node-problem-detector:
     - name: node-problem-detector-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-node-node-problem-detector
@@ -29,4 +29,4 @@ postsubmits:
         volumes:
           - name: creds
             secret:
-              secretName: deployer-service-account
+              secretName: gcb-builder

--- a/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
+++ b/config/jobs/image-pushing/k8s-staging-provider-azure.yaml
@@ -4,7 +4,7 @@ postsubmits:
   kubernetes-sigs/cloud-provider-azure:
     # The name should be changed to match the repo name above
     - name: post-provider-azure-push-images
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one
@@ -19,7 +19,7 @@ postsubmits:
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/k8s-staging-releng.yaml
@@ -3,7 +3,7 @@ periodics:
 #                     ref: https://github.com/kubernetes/release/issues/911
 - interval: 10000h
   name: ci-kubernetes-prototype-build
-  cluster: test-infra-trusted
+  cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -11,7 +11,7 @@ periodics:
     base_ref: master
     path_alias: "k8s.io/release"
   spec:
-    serviceAccountName: deployer # TODO(fejta): use pusher
+    serviceAccountName: gcb-builder
     containers:
     - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
       command:
@@ -38,7 +38,7 @@ periodics:
 #                     ref: https://github.com/kubernetes/release/issues/911
 - interval: 10000h
   name: ci-kubernetes-prototype-build-fast
-  cluster: test-infra-trusted
+  cluster: k8s-infra-prow-build-trusted
   decorate: true
   extra_refs:
   - org: kubernetes
@@ -46,7 +46,7 @@ periodics:
     base_ref: master
     path_alias: "k8s.io/release"
   spec:
-    serviceAccountName: deployer # TODO(fejta): use pusher
+    serviceAccountName: gcb-builder
     containers:
     - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
       command:
@@ -72,7 +72,7 @@ periodics:
 postsubmits:
   kubernetes/release:
     - name: post-release-push-image-k8s-cloud-builder
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -81,7 +81,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -98,7 +98,7 @@ postsubmits:
         github_team_ids:
           - 2241179 # release-managers
     - name: post-release-push-image-releng-ci-bazel
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -107,7 +107,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -124,7 +124,7 @@ postsubmits:
         github_team_ids:
           - 2241179 # release-managers
     - name: post-release-push-image-kubepkg
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
@@ -132,7 +132,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:

--- a/config/jobs/image-pushing/k8s-staging-service-apis.yaml
+++ b/config/jobs/image-pushing/k8s-staging-service-apis.yaml
@@ -2,7 +2,7 @@ postsubmits:
   # this is the github repo we'll build from; this block needs to be repeated for each repo.
   kubernetes-sigs/k8s-container-image-promoter:
     - name: service-apis-postsubmit-push-to-staging
-      cluster: test-infra-trusted
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-network-service-apis
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:


### PR DESCRIPTION
k8s-infra-prow-build-trusted has a gcb-builder serviceaccount that is
capable of building/pushing artifacts to staging and releng projects