### PR TITLE
cluster-api-provider-do: enable prow plugins and milestone applier

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -324,6 +324,10 @@ milestone_applier:
     master: v0.5
     release-0.4: v0.4
     release-0.3: v0.3
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+    master: v0.3
+    release-0.4: v0.4
+    release-0.3: v0.3
 
 repo_milestone:
   # Default maintainer
@@ -349,6 +353,10 @@ repo_milestone:
     maintainers_id: 3063852
     maintainers_team: cluster-api-provider-azure-maintainers
     maintainers_friendly_name: Cluster API Provider Azure Maintainers
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+    maintainers_id: 2978501
+    maintainers_team: cluster-api-provider-digitalocean-maintainers
+    maintainers_friendly_name: Cluster API Provider DigitalOcean Maintainers
   kubernetes-sigs/cluster-api-provider-docker:
     maintainers_id: 3297612
     maintainers_team: cluster-api-provider-docker-maintainers
@@ -822,6 +830,13 @@ plugins:
   - milestone
 
   kubernetes-sigs/cluster-api-provider-azure:
+  - milestone
+  - milestoneapplier
+  - milestonestatus
+  - release-note
+  - require-matching-label
+
+  kubernetes-sigs/cluster-api-provider-digitalocean:
   - milestone
   - milestoneapplier
   - milestonestatus


### PR DESCRIPTION
Enable prow plugins and milestone for `kubernetes-sigs/cluster-api-provider-digitalocean`

Dont know if do other things, please let me know if something is missing


/assign @dims @cblecker 

/cc @xmudrii @MorrisLaw @prksu 