### PR TITLE
releng: Fix args for debian-{base,iptables} and pause image builds

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -18,8 +18,8 @@ postsubmits:
             args:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --gcb-config=build/debian-base/cloudbuild.yaml
-              - .
+              - --build-dir=.
+              - build/debian-base
             env:
               - name: LOG_TO_STDOUT
                 value: "y"
@@ -44,8 +44,8 @@ postsubmits:
             args:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --gcb-config=build/debian-iptables/cloudbuild.yaml
-              - .
+              - --build-dir=.
+              - build/debian-iptables
             env:
               - name: LOG_TO_STDOUT
                 value: "y"

--- a/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
@@ -10,7 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
-        serviceAccountName: deployer # TODO(fejta): use pusher
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -18,8 +18,8 @@ postsubmits:
             args:
               - --project=k8s-staging-kubernetes
               - --scratch-bucket=gs://k8s-staging-kubernetes-gcb
-              - --gcb-config=build/pause/cloudbuild.yaml
-              - .
+              - --build-dir=.
+              - build/pause
             env:
               - name: LOG_TO_STDOUT
                 value: "y"


### PR DESCRIPTION
**Needed for the `debian-iptables` build in https://github.com/kubernetes/kubernetes/pull/90697.**

There were some image build failures after we merged https://github.com/kubernetes/test-infra/pull/17476, https://github.com/kubernetes/test-infra/pull/17485, and https://github.com/kubernetes/kubernetes/pull/90665:

- https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-kubernetes-push-image-debian-base/1256507463046270979
- https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-kubernetes-push-image-debian-iptables/1256507463046270981

These jobs need to use the root of kubernetes/kubernetes as the build directory (instead of `build/<image-name>`) because they're dependent on https://github.com/kubernetes/kubernetes/tree/master/third_party/multiarch/qemu-user-static.

So, we end up with a config similar to the e2e-test-image jobs:
https://github.com/kubernetes/test-infra/blob/8fe3dec9cbf7851b8b2facf6b9569498522c2eac/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml#L27-L35

The `pause` image build job didn't run because we moved trusted clusters in https://github.com/kubernetes/test-infra/pull/17489 and there was a service account mismatch, which is fixed here.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @dims 
cc: @kubernetes/release-engineering 
/sig release
/area release-eng