### PR TITLE
CAPDO: Add image-pushing postsubmit

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -71,6 +71,31 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-cluster-api-azure-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/cluster-api-provider-digitalocean:
+    - name: post-cluster-api-provider-digitalocean-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-image-pushes
+        testgrid-alert-email: k8s-infra-staging-cluster-api-do@kubernetes.io
+      decorate: true
+      branches:
+        - ^master$
+        - ^release-0.3$
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-cluster-api-do
+              - --scratch-bucket=gs://k8s-staging-cluster-api-do-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
   kubernetes-sigs/cluster-api-provider-gcp:
     - name: post-cluster-api-provider-gcp-push-images
       cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
This PR adds the `post-cluster-api-provider-digitalocean-push-images` postsubmit to push images for [cluster-api-provider-digitalocean](https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean) project.

/hold
depends on https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/154

/cc @cpanato @prksu 