### PR TITLE
deck: fix github links to use option value

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -227,6 +227,7 @@ var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the
 	l("favicon.ico"),
 	l("github-login",
 		l("redirect")),
+	l("github-link"),
 	l("job-history",
 		v("job")),
 	l("log"),
@@ -599,6 +600,18 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGe
 		mux.Handle("/tide-history.js", gziphandler.GzipHandler(handleTideHistory(ta, logrus.WithField("handler", "/tide-history.js"))))
 	}
 
+	secure := !o.allowInsecure
+
+	// Handles link to github
+	mux.HandleFunc("/github-link", func(w http.ResponseWriter, r *http.Request) {
+		scheme := "http"
+		if secure {
+			scheme = "https"
+		}
+		redirectURL := scheme + "://" + o.github.Host + "/" + r.URL.Query().Get("dest")
+		http.Redirect(w, r, redirectURL, http.StatusFound)
+	})
+
 	// Enable Git OAuth feature if oauthURL is provided.
 	var goa *githuboauth.Agent
 	if o.oauthURL != "" {
@@ -649,8 +662,6 @@ func prodOnlyMain(cfg config.Getter, pluginAgent *plugins.ConfigAgent, authCfgGe
 			&githubOAuthConfig,
 			&o.github,
 			logrus.WithField("client", "pr-status"))
-
-		secure := !o.allowInsecure
 
 		clientCreator := func(accessToken string) prstatus.GitHubClient {
 			return o.github.GitHubClientWithAccessToken(accessToken)

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -274,6 +274,7 @@ func main() {
 	if err := o.Validate(); err != nil {
 		logrus.WithError(err).Fatal("Invalid options")
 	}
+
 	defer interrupts.WaitForGracefulShutdown()
 	pjutil.ServePProf()
 

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1250,3 +1250,25 @@ func TestSpyglassConfigDefaulting(t *testing.T) {
 		})
 	}
 }
+
+func TestHandleGitHubLink(t *testing.T) {
+	ghoptions := flagutil.GitHubOptions{Host: "github.mycompany.com"}
+	org, repo := "org", "repo"
+	handler := HandleGitHubLink(ghoptions.Host, true)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/github-login?dest=%s/%s", org, repo), nil)
+	if err != nil {
+		t.Fatalf("Error making request: %v", err)
+	}
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("Bad error code: %d", rr.Code)
+	}
+	resp := rr.Result()
+	defer resp.Body.Close()
+	actual := resp.Header.Get("Location")
+	expected := fmt.Sprintf("https://%s/%s/%s", ghoptions.Host, org, repo)
+	if expected != actual {
+		t.Fatalf("%v", actual)
+	}
+}

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1255,7 +1255,7 @@ func TestHandleGitHubLink(t *testing.T) {
 	ghoptions := flagutil.GitHubOptions{Host: "github.mycompany.com"}
 	org, repo := "org", "repo"
 	handler := HandleGitHubLink(ghoptions.Host, true)
-	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/github-login?dest=%s/%s", org, repo), nil)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("/github-link?dest=%s/%s", org, repo), nil)
 	if err != nil {
 		t.Fatalf("Error making request: %v", err)
 	}

--- a/prow/cmd/deck/static/common/common.ts
+++ b/prow/cmd/deck/static/common/common.ts
@@ -97,7 +97,7 @@ export namespace cell {
     const bl = document.createElement("a");
     bl.href = pushCommitLink;
     if (!bl.href) {
-      bl.href = `https://github.com/${repo}/commit/${SHA}`;
+      bl.href = `/github-link?dest=${repo}/commit/${SHA}`;
     }
     bl.text = `${ref} (${SHA.slice(0, 7)})`;
     c.appendChild(bl);
@@ -122,7 +122,7 @@ export namespace cell {
     if (pull.link) {
       pl.href = pull.link;
     } else {
-      pl.href = `https://github.com/${repo}/pull/${pull.number}`;
+      pl.href = `/github-link?dest=${repo}/pull/${pull.number}`;
     }
     pl.text = pull.number.toString();
     if (pull.title) {
@@ -137,7 +137,7 @@ export namespace cell {
       if (pull.commit_link) {
         cl.href = pull.commit_link;
       } else {
-        cl.href = `https://github.com/${repo}/pull/${pull.number}/commits/${pull.sha}`;
+        cl.href = `/github-link?dest=${repo}/pull/${pull.number}/commits/${pull.sha}`;
       }
       cl.text = pull.sha.slice(0, 7);
       elem.appendChild(cl);
@@ -149,7 +149,7 @@ export namespace cell {
       if (pull.author_link) {
         al.href = pull.author_link;
       } else {
-        al.href = "https://github.com/" + pull.author;
+        al.href = "/github-link?dest=" + pull.author;
       }
       al.text = pull.author;
       elem.appendChild(al);

--- a/prow/cmd/deck/static/pr/pr.ts
+++ b/prow/cmd/deck/static/pr/pr.ts
@@ -536,7 +536,7 @@ function createPRCardTitle(pr: PullRequest, tidePools: TidePool[], jobStatus: Va
     subtitle.classList.add("mdl-card__subtitle-text");
 
     const link = document.createElement("a");
-    link.href = `https://github.com/${pr.Repository.NameWithOwner}/pull/${pr.Number}`;
+    link.href = `/github-link?dest=${pr.Repository.NameWithOwner}/pull/${pr.Number}`;
     link.appendChild(title);
 
     const prTitleText = document.createElement("div");

--- a/prow/cmd/deck/static/prow/prow.ts
+++ b/prow/cmd/deck/static/prow/prow.ts
@@ -592,7 +592,7 @@ function redraw(fz: FuzzySearch): void {
             } else {
                 let repoLink = repo_link;
                 if (!repoLink) {
-                    repoLink = `https://github.com/${org}/${repo}`;
+                    repoLink = `/github-link?dest=${org}/${repo}`;
                 }
                 r.appendChild(cell.link(`${org}/${repo}`, repoLink));
             }
@@ -789,7 +789,7 @@ function batchRevisionCell(build: ProwJob): HTMLTableDataCellElement {
         if (link) {
             l.href = link;
         } else {
-            l.href = `https://github.com/${org}/${repo}/pull/${prNumber}`;
+            l.href = `/github-link?dest=${org}/${repo}/pull/${prNumber}`;
         }
         l.text = prNumber.toString();
         c.appendChild(document.createTextNode("#"));

--- a/prow/cmd/deck/static/tide-history/tide-history.ts
+++ b/prow/cmd/deck/static/tide-history/tide-history.ts
@@ -250,12 +250,12 @@ function redrawRecords(recs: FilteredRecord[]): void {
 
       r.appendChild(cell.link(
         `${rec.repo} ${rec.branch}`,
-        `https://github.com/${rec.repo}/tree/${rec.branch}`,
+        `/github-link?dest=${rec.repo}/tree/${rec.branch}`,
       ));
       if (rec.baseSHA) {
           r.appendChild(cell.link(
             rec.baseSHA.slice(0, 7),
-            `https://github.com/${rec.repo}/commit/${rec.baseSHA}`,
+            `/github-link?dest=${rec.repo}/commit/${rec.baseSHA}`,
           ));
       } else {
           r.appendChild(cell.text(""));

--- a/prow/cmd/deck/static/tide/tide.ts
+++ b/prow/cmd/deck/static/tide/tide.ts
@@ -124,7 +124,7 @@ function redrawQueries(): void {
 
         // GitHub query search link
         const a = createLink(
-            `https://github.com/search?utf8=${encodeURIComponent("\u2713")}&q=${encodeURIComponent(query)}`,
+            `/github-link?dest=search?utf8=${encodeURIComponent("\u2713")}&q=${encodeURIComponent(query)}`,
             "GitHub Search Link",
         );
         li.appendChild(a);
@@ -141,7 +141,7 @@ function redrawQueries(): void {
             const ul = document.createElement("ul");
             const innerLi = document.createElement("li");
             for (let j = 0; j < orgs.length; j++) {
-                innerLi.appendChild(createLink("https://github.com/" + orgs[j], orgs[j]));
+                innerLi.appendChild(createLink("/github-link?dest=" + orgs[j], orgs[j]));
                 if (j + 1 < repos.length) {
                     innerLi.appendChild(document.createTextNode(", "));
                 }
@@ -158,7 +158,7 @@ function redrawQueries(): void {
             const ul = document.createElement("ul");
             const innerLi = document.createElement("li");
             for (let j = 0; j < repos.length; j++) {
-                innerLi.appendChild(createLink("https://github.com/" + repos[j], repos[j]));
+                innerLi.appendChild(createLink("/github-link?dest=" + repos[j], repos[j]));
                 if (j + 1 < repos.length) {
                     innerLi.appendChild(document.createTextNode(", "));
                 }
@@ -171,7 +171,7 @@ function redrawQueries(): void {
             const ul = document.createElement("ul");
             const innerLi = document.createElement("li");
             for (let j = 0; j < excludedRepos.length; j++) {
-                innerLi.appendChild(createLink("https://github.com/" + excludedRepos[j], excludedRepos[j]));
+                innerLi.appendChild(createLink("/github-link?dest=" + excludedRepos[j], excludedRepos[j]));
                 if (j + 1 < excludedRepos.length) {
                     innerLi.appendChild(document.createTextNode(", "));
                 }
@@ -237,7 +237,7 @@ function createHistoryCell(pool: TidePool): HTMLTableDataCellElement {
 
 function createRepoCell(pool: TidePool): HTMLTableDataCellElement {
     const deckLink = `/?repo=` + encodeURIComponent(`${pool.Org}/${pool.Repo}`);
-    const branchLink = `https://github.com/${pool.Org}/${pool.Repo}/tree/${pool.Branch}`;
+    const branchLink = `/github-link?dest=${pool.Org}/${pool.Repo}/tree/${pool.Branch}`;
     const linksTD = document.createElement("td");
     linksTD.appendChild(createLink(deckLink, `${pool.Org}/${pool.Repo}`));
     linksTD.appendChild(document.createTextNode(" "));
@@ -304,7 +304,7 @@ function addPRsToElem(elem: HTMLElement, pool: TidePool, prs?: PullRequest[]): v
     if (prs) {
         for (let i = 0; i < prs.length; i++) {
             const a = document.createElement("a");
-            a.href = `https://github.com/${pool.Org}/${pool.Repo}/pull/${prs[i].Number}`;
+            a.href = `/github-link?dest=${pool.Org}/${pool.Repo}/pull/${prs[i].Number}`;
             a.appendChild(document.createTextNode("#" + prs[i].Number));
             a.id = `pr-${pool.Org}-${pool.Repo}-${prs[i].Number}-${nextID()}`;
             if (prs[i].Title) {


### PR DESCRIPTION
For people using GitHub Enterprise, they see the PR link broken because it links to "github.com."