### PR TITLE
Update Kubespray CI image and add approver

### DIFF
--- a/config/jobs/kubernetes-sigs/kubespray/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubespray/OWNERS
@@ -8,6 +8,7 @@ reviewers:
 - mirwan
 - riverzhang
 - woopstar
+- miouge1
 approvers:
 - ant31
 - mattymo
@@ -16,3 +17,4 @@ approvers:
 - mirwan
 - riverzhang
 - woopstar
+- miouge1

--- a/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubespray/kubespray-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: quay.io/kubespray/kubespray:v2.12.5
+      - image: quay.io/kubespray/kubespray:v2.13.0
         args:
         - yamllint
         - "--strict"


### PR DESCRIPTION
[v2.13.0](https://github.com/kubernetes-sigs/kubespray/releases/tag/v2.13.0) was released over the weekend, so let's switch to that image for CI.

Also adding myself as approver since now I'm member of the kubernetes org (https://github.com/kubernetes/org/pull/1836)