### PR TITLE
Azure: reduce capz conformance job frequency to 24h

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -271,7 +271,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs conformance & node conformance tests latest kubernetes master with aks-engine
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: ci-kubernetes-e2e-capz-conformance-master
   decorate: true
   decoration_config:


### PR DESCRIPTION
Reduce job interval to every 24 hours now that the job is stable.

/assign @chewong 