### PR TITLE
Deck runlocal supports listing jobs dynamically

### DIFF
--- a/prow/cmd/deck/localdata/.gitignore
+++ b/prow/cmd/deck/localdata/.gitignore
@@ -1,3 +1,4 @@
+prowjobs.json
 prowjobs.js
 plugin-help.js
 tide.js

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -334,11 +334,11 @@ func main() {
 		content, err := ioutil.ReadFile(staticPjsPath)
 		if err != nil {
 			logrus.WithError(err).Fatal("Failed to read jobs from prowjobs.json.")
-		} else if err = json.Unmarshal(content, &pjs); err == nil {
-			fjc.pjs = &pjs
-		} else {
+		}
+		if err = json.Unmarshal(content, &pjs); err != nil {
 			logrus.WithError(err).Fatal("Failed to unmarshal jobs from prowjobs.json.")
 		}
+		fjc.pjs = &pjs
 		pjListingClient = &fjc
 	} else {
 		fallbackHandler = http.NotFound

--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -21,7 +21,7 @@ if [[ "${1}" == "openshift" ]]; then
 	HOST="https://deck-ci.svc.ci.openshift.org"
 fi
 
-curl "${HOST}/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec" > prowjobs.js
+curl "${HOST}/prowjobs.js" > prowjobs.json
 curl "${HOST}/tide.js?var=tideData" > tide.js
 curl "${HOST}/tide-history.js?var=tideHistory" > tide-history.js
 curl "${HOST}/plugin-help.js?var=allHelp" > plugin-help.js

--- a/prow/cmd/deck/runlocal
+++ b/prow/cmd/deck/runlocal
@@ -20,6 +20,7 @@ HOST="https://prow.k8s.io"
 if [[ "${1}" == "openshift" ]]; then
 	HOST="https://deck-ci.svc.ci.openshift.org"
 fi
+
 curl "${HOST}/prowjobs.js?var=allBuilds&omit=annotations,labels,decoration_config,pod_spec" > prowjobs.js
 curl "${HOST}/tide.js?var=tideData" > tide.js
 curl "${HOST}/tide-history.js?var=tideHistory" > tide-history.js


### PR DESCRIPTION
Enhancement for running Deck locally, by listing Prow jobs dynamically.

Before this change, Deck runlocal lists jobs from a pregenerated data, so there is no way to debug any job listing functions with runlocal mode. This PR provides a way to use the same code path for listing Prow jobs as running Deck in prod. 

- Made it possible to debug hidden repo related code
- Also reduce the divergence of `localOnlyMain` and `prodOnlyMain`

Fixing: #17509 