### PR TITLE
Migrate k/perf-tests presubmites to Prow.

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -489,3 +489,17 @@ presubmits:
             requests:
               cpu: 1
               memory: "2Gi"
+
+  - name: pull-perf-tests-verify-all
+    decorate: true
+    always_run: true
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-perf-tests-verify-all
+    spec:
+      containers:
+      - image: golang:1:13
+        command:
+        - make
+        args:
+        - verify-all


### PR DESCRIPTION
We no longer use Travis, but I've found those presubmits very useful.

/hold
/ref https://github.com/kubernetes/perf-tests/issues/552