### PR TITLE
Revert "Migrate k/perf-tests presubmites to Prow."

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -489,17 +489,3 @@ presubmits:
             requests:
               cpu: 1
               memory: "2Gi"
-
-  - name: pull-perf-tests-verify-all
-    decorate: true
-    always_run: true
-    annotations:
-      testgrid-dashboards: presubmits-kubernetes-scalability
-      testgrid-tab-name: pull-perf-tests-verify-all
-    spec:
-      containers:
-      - image: golang:1.13
-        command:
-        - make
-        args:
-        - verify-all


### PR DESCRIPTION
This reverts commit 5dc026bf24d406dedbaa283efbf91683e6eb29a9.

It seems to be an issue, which I can't reproduce locally, with go version and testing. I'll have a look tomorrow morning. But let's not block other PRs in the meantime. 

/assign @wojtek-t 