### PR TITLE
Add k8s-infra-prow-build's boskos to monitoring

### DIFF
--- a/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -10,6 +10,7 @@ stringData:
       static_configs:
         - targets:
             - "104.197.27.114:9090"  # external ip boskos-metrics in k8s-prow-builds cluster
+            - "35.225.208.117:9090"  # external ip boskos-metrics in k8s-infra-prow-build cluster
     - job_name: blackbox
       metrics_path: /probe
       params:

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -39,7 +39,7 @@ dashboard.new(
         {type: "gke-project", friendly: "GKE project"},
         {type: "gpu-project", friendly: "GPU project"},
         {type: "ingress-project", friendly: "Ingress project"},
-        {type: "istio-project", friendly: "Istio project"},
+        {type: "k8s-infra-gce-project", friendly: "K8s Infra GCE project"},
         {type: "node-e2e-project", friendly: "Node e2e project"},
         {type: "scalability-project", friendly: "Scalability project"},
         {type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}


### PR DESCRIPTION
I don't have access to the prometheus instance for
monitoring.prow.k8s.io so I'm not sure what the existing metrics look
like. This should work well with the existing boskos resources
dashboard.

I'm not sure how well this will work with the boskos server
dashboard. Do the scraped metrics automatically have a `host` or `target`
tag included in them that could be added as a parameter?

/cc @cjwagner @stevekuznetsov