### PR TITLE
Add an instance template to boskos-http dashboard

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos-http.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos-http.jsonnet
@@ -20,13 +20,13 @@ local histogramQuantileDuration(phi, selector='') = prometheus.target(
         legendFormat=std.format('phi=%s', phi),
     );
 
-local boskosTemplate(name, labelInQuery) = template.new(
+local boskosTemplate(name, labelInQuery, includeAll) = template.new(
         name,
         'prometheus',
         std.format('label_values(boskos_http_request_duration_seconds_bucket, %s)', labelInQuery),
         label=name,
         allValues='.*',
-        includeAll=true,
+        includeAll=includeAll,
         refresh='time',
     );
 
@@ -35,8 +35,9 @@ dashboard.new(
         time_from='now-1h',
         schemaVersion=18,
       )
-.addTemplate(boskosTemplate('path', 'path'))
-.addTemplate(boskosTemplate('status', 'status'))
+.addTemplate(boskosTemplate('instance', 'instance', false))
+.addTemplate(boskosTemplate('path', 'path', true))
+.addTemplate(boskosTemplate('status', 'status', true))
 .addPanel(
     (graphPanel.new(
         'Latency distribution for path ${path} and status ${status}',


### PR DESCRIPTION
It doesn't make much sense to aggregate http metrics across multiple
boskos instances, so don't allow "All" as a valid option