### PR TITLE
Mark pull-kubernetes-conformance-kind-ga-only-parallel required

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -254,7 +254,6 @@ presubmits:
       testgrid-dashboards: sig-testing-kind
 
   - name: pull-kubernetes-conformance-kind-ga-only-parallel
-    optional: true
     always_run: true
     decorate: true
     skip_branches:


### PR DESCRIPTION
aka make the job merge-blocking

This job caught conformance tests exercising something that wasn't marked as GA yet (ref: https://github.com/kubernetes/kubernetes/pull/90367#issuecomment-624283211)

A postsubmit would have caught this eventually, but this seems like it's been flake free enough to consider making it merge-blocking.

WDYT?

/cc @BenTheElder