### PR TITLE
Make needs-rebase respect GitHub's mergestatestatus field

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3215,9 +3215,9 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			switch pr.MergeableState {
 			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
 				c.logger.WithFields(logrus.Fields{
-					"repo":				fmt.Sprintf("%v/%v", org, repo),
-					"pr":      			number,
-					"mergeablestate": 	pr.MergeableState,
+					"repo":           fmt.Sprintf("%v/%v", org, repo),
+					"pr":             number,
+					"mergeablestate": pr.MergeableState,
 				}).Infof("PR is in unmergeable state.")
 				return false, nil
 			default:

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3210,7 +3210,19 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			return false, errors.New("pull request was merged while checking mergeability")
 		}
 		if pr.Mergable != nil {
-			return *pr.Mergable, nil
+			// In certain cases, the mergeable field is lying.
+			switch pr.MergeableState {
+			case MergeableStateBehind:
+				fallthrough
+			case MergeableStateBlocked:
+				fallthrough
+			case MergeableStateDraft:
+				fallthrough
+			case MergeableStateUnknown:
+				return false, fmt.Errorf("pull request is in unmergeable state %v", pr.MergeableState)
+			default:
+				return *pr.Mergable, nil
+			}
 		}
 		if try+1 < maxTries {
 			c.time.Sleep(backoff)

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3213,7 +3213,7 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 		if pr.Mergable != nil {
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
-			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
+			case MergeableStateBehind:
 				c.logger.WithFields(logrus.Fields{
 					"repo":           fmt.Sprintf("%v/%v", org, repo),
 					"pr":             number,

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3196,6 +3196,7 @@ func (c *client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent,
 // Mergeability is calculated by a background job on GitHub and is not immediately available when
 // new commits are added so the PR must be polled until the background job completes.
 func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, error) {
+	c.log("IsMergeable", org, repo, number)
 	backoff := time.Second * 3
 	maxTries := 3
 	for try := 0; try < maxTries; try++ {
@@ -3213,7 +3214,11 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
 			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
-				c.log("IsMergeable: %v/%v:%v is in unmergeable state %q", org, repo, number, pr.MergeableState)
+				c.logger.WithFields(logrus.Fields{
+					"repo":				fmt.Sprintf("%v/%v", org, repo),
+					"pr":      			number,
+					"mergeablestate": 	pr.MergeableState,
+				}).Infof("PR is in unmergeable state.")
 				return false, nil
 			default:
 				return *pr.Mergable, nil

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3213,7 +3213,8 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
 			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
-				return false, fmt.Errorf("pull request is in unmergeable state %v", pr.MergeableState)
+				c.log("IsMergeable: %v/%v:%v is in unmergeable state %q", org, repo, number, pr.MergeableState)
+				return false, nil
 			default:
 				return *pr.Mergable, nil
 			}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -3212,13 +3212,7 @@ func (c *client) IsMergeable(org, repo string, number int, SHA string) (bool, er
 		if pr.Mergable != nil {
 			// In certain cases, the mergeable field is lying.
 			switch pr.MergeableState {
-			case MergeableStateBehind:
-				fallthrough
-			case MergeableStateBlocked:
-				fallthrough
-			case MergeableStateDraft:
-				fallthrough
-			case MergeableStateUnknown:
+			case MergeableStateBehind, MergeableStateBlocked, MergeableStateDraft, MergeableStateUnknown:
 				return false, fmt.Errorf("pull request is in unmergeable state %v", pr.MergeableState)
 			default:
 				return *pr.Mergable, nil

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -218,52 +218,48 @@ func TestIsMember(t *testing.T) {
 }
 
 func TestIsMergeable(t *testing.T) {
-	testCases := []struct {
-		name           string
+	type testCase struct {
 		mergeableState MergeableState
 		expectedResult bool
 		isErrExpected  bool
-	}{
-		{
-			name:           "should be true when MergeableState is clean",
-			mergeableState: MergeableStateClean,
-			expectedResult: true,
-			isErrExpected:  false,
-		},
-		{
-			name:           "should be true when MergeableState is unstable",
-			mergeableState: MergeableStateUnstable,
-			expectedResult: true,
-			isErrExpected:  false,
-		},
-		{
-			name:           "should be false when MergeableState is behind",
-			mergeableState: MergeableStateBehind,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is blocked",
-			mergeableState: MergeableStateBlocked,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is draft",
-			mergeableState: MergeableStateDraft,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
-		{
-			name:           "should be false when MergeableState is unknown",
-			mergeableState: MergeableStateUnknown,
-			expectedResult: false,
-			isErrExpected:  true,
-		},
 	}
+
+	testCases := make(map[string]testCase)
+	testCases["should be true when MergeableState is clean"] = testCase{
+		mergeableState: MergeableStateClean,
+		expectedResult: true,
+		isErrExpected:  false,
+	}
+	testCases["should be true when MergeableState is unstable"] = testCase{
+		mergeableState: MergeableStateUnstable,
+		expectedResult: true,
+		isErrExpected:  false,
+	}
+	testCases["should be false when MergeableState is behind"] = testCase{
+		mergeableState: MergeableStateBehind,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is blocked"] = testCase{
+		mergeableState: MergeableStateBlocked,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is draft"] = testCase{
+		mergeableState: MergeableStateDraft,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+	testCases["should be false when MergeableState is unknown"] = testCase{
+		mergeableState: MergeableStateUnknown,
+		expectedResult: false,
+		isErrExpected:  true,
+	}
+
 	mergable := true
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
+	for name := range testCases {
+		tc := testCases[name]
+		t.Run(name, func(t *testing.T) {
 			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.Method != http.MethodGet {
 					t.Errorf("Bad method: %s", r.Method)

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -238,22 +238,22 @@ func TestIsMergeable(t *testing.T) {
 	testCases["should be false when MergeableState is behind"] = testCase{
 		mergeableState: MergeableStateBehind,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is blocked"] = testCase{
 		mergeableState: MergeableStateBlocked,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is draft"] = testCase{
 		mergeableState: MergeableStateDraft,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 	testCases["should be false when MergeableState is unknown"] = testCase{
 		mergeableState: MergeableStateUnknown,
 		expectedResult: false,
-		isErrExpected:  true,
+		isErrExpected:  false,
 	}
 
 	mergable := true

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -240,19 +240,19 @@ func TestIsMergeable(t *testing.T) {
 		expectedResult: false,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is blocked"] = testCase{
+	testCases["should be true when MergeableState is blocked"] = testCase{
 		mergeableState: MergeableStateBlocked,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is draft"] = testCase{
+	testCases["should be true when MergeableState is draft"] = testCase{
 		mergeableState: MergeableStateDraft,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
-	testCases["should be false when MergeableState is unknown"] = testCase{
+	testCases["should be true when MergeableState is unknown"] = testCase{
 		mergeableState: MergeableStateUnknown,
-		expectedResult: false,
+		expectedResult: true,
 		isErrExpected:  false,
 	}
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -233,6 +233,28 @@ type PullRequestEvent struct {
 	GUID string
 }
 
+type MergeableState string
+
+const (
+	// MergeableStateBehind means the head ref is out of date.
+	// Only possible when a repo has "require branches to be up to date before merging" enabled.
+	MergeableStateBehind MergeableState = "behind"
+	// MergeableStateBlocked means the PR is not mergeable.
+	MergeableStateBlocked = "blocked"
+	// MergeableStateClean means the PR is mergeable, and all statuses are passing.
+	MergeableStateClean = "clean"
+	// MergeableStateDirty means the merge commit cannot be cleanly created.
+	MergeableStateDirty = "dirty"
+	// MergeableStateDraft means the PR is in Draft mode, and cannot be merged.
+	MergeableStateDraft = "draft"
+	// MergeableStateHasHooks means the PR is mergeable, but subject to pre-receive hooks (GitHub Enterprise only)
+	MergeableStateHasHooks = "has_hooks"
+	// MergeableStateUnknown means the state cannot currently be determined.
+	MergeableStateUnknown = "unknown"
+	// MergeableStateUnstable means the PR is mergeable, but has non-passing statuses.
+	MergeableStateUnstable = "unstable"
+)
+
 // PullRequest contains information about a PullRequest.
 type PullRequest struct {
 	ID                 int               `json:"id"`
@@ -262,6 +284,10 @@ type PullRequest struct {
 	// background job was started to compute it. When the job is complete, the response
 	// will include a non-null value for the mergeable attribute.
 	Mergable *bool `json:"mergeable,omitempty"`
+	// ref https://developer.github.com/v4/enum/mergestatestatus/
+	// This is present, but not documented for REST API responses.
+	// It is documented in the equivalent GraphQL API.
+	MergeableState MergeableState `json:"mergeable_state,omitempty"`
 	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
 	Milestone *Milestone `json:"milestone,omitempty"`
 }


### PR DESCRIPTION
It turns out that, based on some GitHub repo settings, the `needs-rebase` service can't always tell if a PR is actually mergeable, because GitHub's API tells lies in some cases.

The response from `GetPullRequest()` has a field literally called `mergeable` that is _sometimes_ wrong - it only considers git merge-ability, not GitHub merge-ability. This means that if GitHub repo has the "Require branches to be up-to-date before merging" setting enabled, and a PR is mergeable by git, but not up-to-date with `master`, then:

- `needs-rebase` will not mark it as requiring a rebase.
- `tide` will see that the PR meets mergeability criteria, add it to a subpool, and attempt to merge it.

Unfortunately, `tide` will get back an error from GitHub when it tries to merge the PR, resulting in all PRs behind this one in the subpool being blocked from merging as well.

This PR changes the behavior of `needs-rebase` so that it will now look at the value of the `mergeable_state` field in the `GetPullRequest()` response, which contains a much more granular mergeability status, including the state `behind` to describe the scenario I outlined above.

It also turns out that there are other states in that field that equate to "Not Mergeable" as well.

The upshot of this PR is that when `needs-rebase` asks the Prow GitHub client if a PR is mergeable, the client will say "No" in the cases where git might let it merge, but GitHub won't.

I added tests around this functionality (there were no existing tests covering `IsMergeable()` at all), and we are using this functionality in `improbable`'s internal Prow deployment already.