### PR TITLE
Fix k/release repo version in ci-build-and-push-k8s-at-golang-tip

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -20,6 +20,7 @@ periodics:
         - --
         - --directory=/go/src/k8s.io/perf-tests/golang
         - K8S_COMMIT=e97c570a4ba5ba1e2285d3278396937feaa15385 # head of release-1.18 branch as of 2020-04-28
+        - K8S_RELEASE_COMMIT=5ad08a0987f35d7b7280e847078987f58c6f8e1f # head of master branch as of 2020-05-04
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
More details: [link](https://github.com/kubernetes/perf-tests/pull/1226).

[That](https://github.com/kubernetes/perf-tests/pull/1226) perf-tests PR needs to be merged first. Only then we can proceed with merging this PR.

/sig scalability
/assign mm4tt