### PR TITLE
Bump up timeout value for ci-build-and-push-k8s-at-golang-tip

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -13,7 +13,7 @@ periodics:
         args:
         - --root=/go/src
         - --repo=k8s.io/perf-tests=master
-        - --timeout=60
+        - --timeout=75
         - --scenario=execute
         - --
         - make


### PR DESCRIPTION
There were occasional `ci-build-and-push-k8s-at-golang-tip` job failures due to prolonged Kubernetes building phase, e.g. [here](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-build-and-push-k8s-at-golang-tip/1257556466517151745) the build was long but successful, yet the task barely timed out before we were able to complete the pushing to GCS phase.

/sig scalability