### PR TITLE
move post-kuberentes-push-images job back to test-infra-trusted

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -5,7 +5,7 @@ postsubmits:
     # The name should be changed to match the repo name above
     - name: post-kubernetes-push-images
       # TODO: move this to a more appropriate cluster.
-      cluster: k8s-infra-prow-build-trusted
+      cluster: test-infra-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one


### PR DESCRIPTION
it relies on secrets not yet available in k8s-infra-prow-build-trusted