### PR TITLE
bugzilla: handle non-creation events on cherry-picks as normal

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -249,13 +249,12 @@ func digestPR(log *logrus.Entry, pre github.PullRequestEvent, validateByDefault 
 		log.WithError(err).Debug("Failed to identify if PR is a cherrypick")
 		return nil, err
 	} else if cherrypick {
-		if pre.Action != github.PullRequestActionOpened {
-			return nil, nil
+		if pre.Action == github.PullRequestActionOpened {
+			e.cherrypick = true
+			e.cherrypickFromPRNum = cherrypickFromPRNum
+			e.cherrypickTo = cherrypickTo
+			return e, nil
 		}
-		e.cherrypick = true
-		e.cherrypickFromPRNum = cherrypickFromPRNum
-		e.cherrypickTo = cherrypickTo
-		return e, nil
 	}
 	// Make sure the PR title is referencing a bug
 	e.bugId, e.missing, err = bugIDFromTitle(title)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -312,7 +312,7 @@ func TestDigestPR(t *testing.T) {
 			},
 		},
 		{
-			name: "edited cherrypicked PR gets no cherrypick event",
+			name: "edited cherrypicked PR gets normal event",
 			pre: github.PullRequestEvent{
 				Action: github.PullRequestActionEdited,
 				PullRequest: github.PullRequest{
@@ -335,6 +335,9 @@ func TestDigestPR(t *testing.T) {
 
 /assign user`,
 				},
+			},
+			expected: &event{
+				org: "org", repo: "repo", baseRef: "release-4.4", number: 3, bugId: 123, body: "[release-4.4] Bug 123: fixed it!", htmlUrl: "http.com", login: "user",
 			},
 		},
 		{


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @AlexNPavel 