### PR TITLE
Allow k8s-infra approval of image-pushing jobs

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,6 +9,13 @@ aliases:
   - Katharine
   - michelle192837
 
+  # kubernetes.io org admins
+  wg-k8s-infra-oncall:
+  - cblecker
+  - dims
+  - spiffxp
+  - thockin
+
   # copied from git.k8s.io/community/OWNERS_ALIASES
   sig-api-machinery-leads:
     - deads2k

--- a/config/jobs/image-pushing/OWNERS
+++ b/config/jobs/image-pushing/OWNERS
@@ -4,8 +4,9 @@ options:
 
 # Oncallers with context on this
 reviewers:
-- Katharine
+- spiffxp
 
 # All oncallers
 approvers:
-- test-infra-oncall # oncall
+- test-infra-oncall
+- wg-k8s-infra-oncall

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -3,9 +3,8 @@ postsubmits:
   # for each repo.
   kubernetes/kubernetes:
     # The name should be changed to match the repo name above
-    - name: post-kubernetes-push-images
-      # TODO: move this to a more appropriate cluster.
-      cluster: test-infra-trusted
+    - name: post-kubernetes-push-e2e-test-images
+      cluster: k8s-infra-prow-build-trusted
       annotations:
         # This is the name of some testgrid dashboard to report to.
         # If this is the first one for your sig, you may need to create one

--- a/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
+++ b/config/jobs/image-pushing/k8s-staging-node-problem-detector.yaml
@@ -10,6 +10,7 @@ postsubmits:
       branches:
         - ^master$
       spec:
+        serviceAccountName: gcb-builder
         containers:
           - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
             command:
@@ -20,13 +21,3 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-npd-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /creds/service-account.json
-            volumeMounts:
-              - name: creds
-                mountPath: /creds
-        volumes:
-          - name: creds
-            secret:
-              secretName: gcb-builder


### PR DESCRIPTION
- Fixup two jobs that couldn't previously run on k8s-infra-prow-build-trusted
- Allow people who have kubernetes.io org admin privileges to act as k8s-infra-oncall until we have a better group for it
- Allow k8s-infra-oncall to approve image-pushing jobs
- Prevent image-pushing jobs from running on test-infra-cluster (so that k8s-infra people aren't approving jobs that have access to more secrets than they know about)

/cc @fejta @cjwagner
for the test-infra side of things

/wg k8s-infra
/cc @cblecker @dims @thockin
heads up

/hold
for comment