### PR TITLE
go-runner should be in k8s-staging-build-image GCR bucket

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -52,6 +52,32 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
+    - name: post-kubernetes-push-image-go-runner
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^build\/go-runner\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --build-dir=.
+              - build/go-runner
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
   kubernetes/release:
     - name: post-release-push-image-kube-cross
       cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kubernetes.yaml
@@ -26,29 +26,3 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    - name: post-kubernetes-push-image-go-runner
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/go-runner\/'
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-kubernetes
-              - --scratch-bucket=gs://k8s-staging-kubernetes-gcb
-              - --build-dir=.
-              - build/go-runner
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers


### PR DESCRIPTION
Whoops. go-runner should be with debian-base/debian-iptables

Signed-off-by: Davanum Srinivas <davanum@gmail.com>