### PR TITLE
Add two more scalability presubmits (verify-lint and verify-dashboard)

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -506,3 +506,37 @@ presubmits:
         - make
         args:
         - verify-all
+
+  - name: pull-perf-tests-verify-dashboard
+    # TODO(oxddr): make it non-optional once we are confident in the presubmit
+    optional: true
+    decorate: true
+    run_if_changed: ^clusterloader2/pkg/prometheus/manifests/dashboards/.*\.json$
+    path_alias: "k8s.io/perf-tests"
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-perf-tests-verify-dashboard
+    spec:
+      containers:
+      - image: python:3.7
+        command:
+        - make
+        args:
+        - verify-dashboard
+
+  - name: pull-perf-tests-verify-lint
+    # TODO(oxddr): make it non-optional once we are confident in the presubmit
+    optional: true
+    decorate: true
+    always_run: true
+    path_alias: "k8s.io/perf-tests"
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-scalability
+      testgrid-tab-name: pull-perf-tests-verify-lint
+    spec:
+      containers:
+      - image: golangci/golangci-lint:v1.26
+        command:
+        - make
+        args:
+        - verify-lint


### PR DESCRIPTION
1. `verify-lint` is being added via https://github.com/kubernetes/perf-tests/pull/1232
2. `verify-dashboard` is being moved to `python3` in https://github.com/kubernetes/perf-tests/pull/1236

ref https://github.com/kubernetes/perf-tests/issues/573 https://github.com/kubernetes/perf-tests/issues/552