### PR TITLE
Make pull-kubernetes-conformance-kind-ga-only-parallel required

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -254,7 +254,7 @@ presubmits:
       testgrid-dashboards: sig-testing-kind
 
   - name: pull-kubernetes-conformance-kind-ga-only-parallel
-    optional: true
+    optional: false
     always_run: true
     decorate: true
     skip_branches:


### PR DESCRIPTION
The ga-only conformance job has been release blocking and [very reliable](https://testgrid.k8s.io/conformance-all#conformance-ga-only&width=20)

The parallel presubmit has flagged accidental introduction of conformance tests depending on non-GA features, but only informationally. This makes it required.

/sig testing release
/cc @spiffxp @justaugustus 
fyi @BenTheElder 