### PR TITLE
bugzilla: copy all comments when cloning bug

### DIFF
--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -297,6 +297,7 @@ func TestCloneBugStruct(t *testing.T) {
 			Component:       []string{"TestComponent"},
 			Flags:           []Flag{{ID: 1, Name: "Test Flag"}},
 			Groups:          []string{"group1"},
+			ID:              123,
 			Keywords:        []string{"segfault"},
 			OperatingSystem: "Fedora",
 			Platform:        "x86_64",
@@ -311,10 +312,8 @@ func TestCloneBugStruct(t *testing.T) {
 			Version:         []string{"31"},
 		},
 		comments: []Comment{{
-			Text:       "There is a segfault that occurs when opening applications.",
-			IsPrivate:  true,
-			IsMarkdown: true,
-			Tags:       []string{"description"},
+			Text:      "There is a segfault that occurs when opening applications.",
+			IsPrivate: true,
 		}},
 		expected: BugCreate{
 			Alias:            []string{"this_is_an_alias"},
@@ -333,10 +332,56 @@ func TestCloneBugStruct(t *testing.T) {
 			Summary:          "Segfault when opening program",
 			TargetMilestone:  "milestone1",
 			Version:          []string{"31"},
-			Description:      "This is a clone of Bug #0. This is the description of that bug:\nThere is a segfault that occurs when opening applications.",
+			Description:      "+++ This bug was initially created as a clone of Bug #123 +++\n\nThere is a segfault that occurs when opening applications.",
 			CommentIsPrivate: true,
-			IsMarkdown:       true,
-			CommentTags:      []string{"description"},
+		},
+	}, {
+		name: "Clone bug with multiple comments",
+		bug: Bug{
+			ID: 123,
+		},
+		comments: []Comment{{
+			Text: "There is a segfault that occurs when opening applications.",
+		}, {
+			Text:         "This is another comment.",
+			Time:         time.Date(2020, time.May, 7, 2, 3, 4, 0, time.UTC),
+			CreationTime: time.Date(2020, time.May, 7, 2, 3, 4, 0, time.UTC),
+			Tags:         []string{"description"},
+			Creator:      "Test Commenter",
+		}},
+		expected: BugCreate{
+			Description: `+++ This bug was initially created as a clone of Bug #123 +++
+
+There is a segfault that occurs when opening applications.
+
+--- Additional comment from Test Commenter on 2020-05-07 02:03:04 UTC ---
+
+This is another comment.`,
+		},
+	}, {
+		name: "Clone bug with one private comments",
+		bug: Bug{
+			ID: 123,
+		},
+		comments: []Comment{{
+			Text: "There is a segfault that occurs when opening applications.",
+		}, {
+			Text:         "This is another comment.",
+			Time:         time.Date(2020, time.May, 7, 2, 3, 4, 0, time.UTC),
+			CreationTime: time.Date(2020, time.May, 7, 2, 3, 4, 0, time.UTC),
+			IsPrivate:    true,
+			Tags:         []string{"description"},
+			Creator:      "Test Commenter",
+		}},
+		expected: BugCreate{
+			Description: `+++ This bug was initially created as a clone of Bug #123 +++
+
+There is a segfault that occurs when opening applications.
+
+--- Additional comment from Test Commenter on 2020-05-07 02:03:04 UTC ---
+
+This is another comment.`,
+			CommentIsPrivate: true,
 		},
 	}}
 	for _, testCase := range testCases {

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1197,7 +1197,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			name:                "failure to clone bug for cherrypick results in error",
 			bugs:                []bugzilla.Bug{{Product: "Test", Component: []string{"TestComponent"}, TargetRelease: []string{"v2"}, ID: 123, Status: "CLOSED", Severity: "urgent"}},
 			bugComments:         map[int][]bugzilla.Comment{123: {{BugID: 123, Count: 0, Text: "This is a bug"}}},
-			bugCreateErrors:     []string{"This is a clone of Bug #123. This is the description of that bug:\nThis is a bug"},
+			bugCreateErrors:     []string{"+++ This bug was initially created as a clone of Bug #123 +++\n\nThis is a bug"},
 			prs:                 []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}, {Number: 2, Body: "This is an automated cherry-pick of #1.\n\n/assign user", Title: "[v1] " + base.body}},
 			body:                "[v1] " + base.body,
 			cherryPick:          true,


### PR DESCRIPTION
This changes the way that the description of the bugzilla clone is formatted to be more in line with what bugzilla's web UI clone does.

/cc @alvaroaleman 