### PR TITLE
Scrape metrics from greenhouse

### DIFF
--- a/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
+++ b/config/prow/cluster/monitoring/additional-scrape-configs_secret.yaml
@@ -11,6 +11,11 @@ stringData:
         - targets:
             - "104.197.27.114:9090"  # external ip boskos-metrics in k8s-prow-builds cluster
             - "35.225.208.117:9090"  # external ip boskos-metrics in k8s-infra-prow-build cluster
+    - job_name: greenhouse-metrics
+      metrics_path: /prometheus
+      static_configs:
+        - targets:
+            - "35.225.115.154" # external ip greenhouse-metrics for k8s-prow-builds
     - job_name: blackbox
       metrics_path: /probe
       params:


### PR DESCRIPTION
the old dashboard in velodrome assumed an influxdb datasource so I'd like to play with prometheus queries before trying to port over