### PR TITLE
Migrate some release-branch jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -5,6 +5,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: Conformance - GCE - 1.15
+  cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-k8s-ssh: "true"
@@ -18,6 +19,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -64,6 +66,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.15-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.15
+  cluster: k8s-infra-prow-build
   interval: 24h
   labels:
     preset-k8s-ssh: "true"
@@ -78,7 +81,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -95,6 +98,7 @@ periodics:
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.15-informing
     testgrid-tab-name: node-kubelet-features-1.15
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -109,7 +113,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project=k8s-jkns-ci-node-e2e
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -335,6 +339,7 @@ periodics:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: integration-1.15
+  cluster: k8s-infra-prow-build
   interval: 24h
   labels:
     preset-dind-enabled: "true"
@@ -364,6 +369,7 @@ periodics:
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.15-blocking, google-unit
     testgrid-tab-name: verify-1.15
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.15

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -5,6 +5,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: Conformance - GCE - 1.16
+  cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-k8s-ssh: "true"
@@ -18,6 +19,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -64,6 +66,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.16
+  cluster: k8s-infra-prow-build
   interval: 6h
   labels:
     preset-k8s-ssh: "true"
@@ -78,7 +81,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -95,6 +98,7 @@ periodics:
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.16-informing
     testgrid-tab-name: node-kubelet-features-1.16
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -109,7 +113,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project=k8s-jkns-ci-node-e2e
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -341,6 +345,7 @@ periodics:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: integration-1.16
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.16
@@ -372,6 +377,7 @@ periodics:
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: verify-1.16
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.16

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -7,6 +7,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: skew-cluster-latest-kubectl-k8s-stable1-gce
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -23,6 +24,7 @@ periodics:
       - --check-version-skew=false
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25
@@ -40,6 +42,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: Conformance - GCE - 1.17
+  cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-k8s-ssh: "true"
@@ -53,6 +56,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -99,6 +103,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.17
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-k8s-ssh: "true"
@@ -113,7 +118,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -130,6 +135,7 @@ periodics:
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.17-informing
     testgrid-tab-name: node-kubelet-features-1.17
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -144,7 +150,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project=k8s-jkns-ci-node-e2e
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -395,6 +401,7 @@ periodics:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: integration-1.17
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.17
@@ -426,6 +433,7 @@ periodics:
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: verify-1.17
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.17

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -7,6 +7,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: skew-cluster-latest-kubectl-beta-gce
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -23,6 +24,7 @@ periodics:
       - --check-version-skew=false
       - --extract=ci/k8s-stable1
       - --extract=ci/latest
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25
@@ -40,6 +42,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: Conformance - GCE - 1.18
+  cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-k8s-ssh: "true"
@@ -53,6 +56,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -99,6 +103,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.18-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.18
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -113,7 +118,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project-type=node-e2e-project
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -130,6 +135,7 @@ periodics:
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.18-informing
     testgrid-tab-name: node-kubelet-features-1-18
+  cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
@@ -144,7 +150,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --deployment=node
-      - --gcp-project=k8s-jkns-ci-node-e2e
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
@@ -398,6 +404,7 @@ periodics:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.18-blocking, google-unit
     testgrid-tab-name: integration-1.18
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.18
@@ -429,6 +436,7 @@ periodics:
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.18-blocking, google-unit
     testgrid-tab-name: verify-1.18
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.18


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/17488

For all release branches, this migrates the following periodics:
- conformance
- node-kubelet
- node-kubelet-features
- integration
- verify

See https://github.com/kubernetes/test-infra/pull/17488#issuecomment-623668396 for results of migrating some of the release-master-blocking jobs

I've since increased the pool of projects, and have it monitored: https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1&from=now-7d&to=now&fullscreen&panelId=7