### PR TITLE
jobs: migrate some generated release-branch jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -532,6 +532,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -539,6 +540,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -563,6 +565,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -570,6 +573,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -594,6 +598,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -601,6 +606,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -625,6 +631,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -632,6 +639,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -656,6 +664,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -663,6 +672,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -687,6 +697,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -694,6 +705,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -718,6 +730,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -725,6 +738,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -749,6 +763,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -756,6 +771,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -780,6 +796,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -787,6 +804,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -811,6 +829,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -818,6 +837,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -842,6 +862,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -849,6 +870,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -873,6 +895,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -880,6 +903,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -904,6 +928,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -911,6 +936,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -935,6 +961,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -942,6 +969,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -966,6 +994,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -973,6 +1002,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -997,6 +1027,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1004,6 +1035,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1028,6 +1060,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1035,6 +1068,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1059,6 +1093,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1066,6 +1101,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1090,6 +1126,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1097,6 +1134,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1121,6 +1159,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1128,6 +1167,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1152,6 +1192,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1159,6 +1200,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1183,6 +1225,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1190,6 +1233,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1214,6 +1258,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1221,6 +1266,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1245,6 +1291,7 @@ periodics:
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
@@ -1252,6 +1299,7 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-serial
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1275,10 +1323,12 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1330,6 +1380,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
@@ -1337,6 +1388,7 @@ periodics:
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1360,11 +1412,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
     testgrid-dashboards: sig-release-1.18-informing
@@ -1389,11 +1443,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.18-informing
@@ -1418,6 +1474,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -1427,6 +1484,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1450,10 +1508,12 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1505,12 +1565,14 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.17-informing
@@ -1535,11 +1597,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
     testgrid-dashboards: sig-release-1.17-informing
@@ -1564,11 +1628,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.17-informing
@@ -1593,6 +1659,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -1602,6 +1669,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1625,10 +1693,12 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1680,11 +1750,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.16-informing
@@ -1709,11 +1781,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
     testgrid-dashboards: sig-release-1.16-informing
@@ -1738,11 +1812,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.16-informing
@@ -1767,6 +1843,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
@@ -1776,6 +1853,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1827,10 +1905,12 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
     testgrid-dashboards: sig-release-1.15-blocking
@@ -1854,11 +1934,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.15-informing
@@ -1883,11 +1965,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
     testgrid-dashboards: sig-release-1.15-informing
@@ -1912,11 +1996,13 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.15-informing
@@ -1941,6 +2027,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.15
+      - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
       - --env=KUBE_PROXY_DAEMONSET=true
@@ -1950,6 +2037,7 @@ periodics:
       - --runtime-config=api/all=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200507-36c6a27-master
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures
     testgrid-dashboards: sig-release-1.15-blocking

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -133,6 +133,12 @@ class E2ENodeTest:
         """Returns the Prow config for the job from the given fields."""
         prow_config = yaml.round_trip_load(PROW_CONFIG_TEMPLATE)
         prow_config['name'] = self.job_name
+        # use cluster from test_suite, or job, or not at all
+        if 'cluster' in test_suite:
+            prow_config['cluster'] = test_suite['cluster']
+        elif 'cluster' in self.job:
+            prow_config['cluster'] = self.job['cluster']
+        # pull interval or cron from job
         if 'interval' in self.job:
             del prow_config['cron']
             prow_config['interval'] = self.job['interval']
@@ -242,6 +248,11 @@ class E2ETest:
         """Returns the Prow config for the e2e job from the given fields."""
         prow_config = yaml.round_trip_load(PROW_CONFIG_TEMPLATE)
         prow_config['name'] = self.job_name
+        # use cluster from test_suite, or job, or not at all
+        if 'cluster' in test_suite:
+            prow_config['cluster'] = test_suite['cluster']
+        elif 'cluster' in self.job:
+            prow_config['cluster'] = self.job['cluster']
         if 'interval' in self.job:
             del prow_config['cron']
             prow_config['interval'] = self.job['interval']

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -541,19 +541,25 @@ k8sVersions:
 testSuites:
   alphafeatures:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=180m
     - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\]
       --minStartupPods=8
+    cluster: k8s-infra-prow-build
   default:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=120m
     - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       --minStartupPods=8
     - --ginkgo-parallel=30
+    cluster: k8s-infra-prow-build
   flaky:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=300m
     - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
+    cluster: k8s-infra-prow-build
   ingress:
     args:
     - --gcp-project-type=ingress-project
@@ -562,20 +568,26 @@ testSuites:
       --minStartupPods=8
   reboot:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=180m
     - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
+    cluster: k8s-infra-prow-build
   serial:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=660m
     - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\]
       --minStartupPods=8
     - --ginkgo-parallel=1
+    cluster: k8s-infra-prow-build
   slow:
     args:
+    - --gcp-project-type=k8s-infra-gce-project
     - --timeout=150m
     - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
       --minStartupPods=8
     - --ginkgo-parallel=30
+    cluster: k8s-infra-prow-build
   soak:
     args:
     - --check-version-skew=false


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/17488 and https://github.com/kubernetes/test-infra/pull/17560

For all release branches, this migrates the follow generated jobs
- alpha
- default
- reboot
- serial
- slow

avoiding ingress because that needs a project pool we haven't allocated in k8s-infra yet (not sure specifically what quota it needs bumped)

FYI @kubernetes/ci-signal @kubernetes/release-engineering

/hold
I'd like to wait a bit to see some job runs from https://github.com/kubernetes/test-infra/pull/17560 before pulling the trigger on this