### PR TITLE
Add the preset-do-credential preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presets.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presets.yaml
@@ -1,0 +1,10 @@
+presets:
+# Credentials for using DigitalOcean test account. Used for cluster-api-provider-digitalocean tests.
+- labels:
+    preset-do-credential: "true"
+  env:
+  - name: DIGITALOCEAN_ACCESS_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: cluster-api-provider-digitalocean-token
+        key: DIGITALOCEAN_ACCESS_TOKEN


### PR DESCRIPTION
This PR adds the `preset-do-credential` preset to be used by the cluster-api-provider-digitalocean project. The secret is already created in the cluster.