### PR TITLE
Azure: don't use pip to install azure-cli

### DIFF
--- a/kubetest/aks.go
+++ b/kubetest/aks.go
@@ -345,30 +345,6 @@ func newSSHKeypair(bits int) (private, public []byte, err error) {
 	return privBytes, pubBytes, nil
 }
 
-func installAzureCLI() error {
-	if err := control.FinishRunning(exec.Command("curl", "-sL", "https://packages.microsoft.com/keys/microsoft.asc", "-o", "msft.asc")); err != nil {
-		return err
-	}
-
-	if err := control.FinishRunning(exec.Command("gpg", "--batch", "--yes", "-o", "/etc/apt/trusted.gpg.d/microsoft.asc.gpg", "--dearmor", "msft.asc")); err != nil {
-		return err
-	}
-
-	if err := control.FinishRunning(exec.Command("bash", "-c", "echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli $(lsb_release -cs) main\" | tee /etc/apt/sources.list.d/azure-cli.list")); err != nil {
-		return err
-	}
-
-	if err := control.FinishRunning(exec.Command("apt-get", "update")); err != nil {
-		return err
-	}
-
-	if err := control.FinishRunning(exec.Command("apt-get", "install", "-y", "azure-cli")); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 func (a *aksDeployer) dockerLogin() error {
 	cmd := &exec.Cmd{}
 	username := ""

--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -428,7 +428,7 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 func (c *aksEngineDeployer) azLogin() error {
 	// Check if azure-cli has been installed
 	if err := control.FinishRunning(exec.Command("az")); err != nil {
-		if err := control.FinishRunning(exec.Command("pip", "install", "azure-cli==2.2")); err != nil {
+		if err := installAzureCLI(); err != nil {
 			return err
 		}
 	}

--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"os/exec"
 	"path"
 	"time"
 
@@ -465,4 +466,28 @@ func toBool(b *bool) bool {
 		return false
 	}
 	return *b
+}
+
+func installAzureCLI() error {
+	if err := control.FinishRunning(exec.Command("curl", "-sL", "https://packages.microsoft.com/keys/microsoft.asc", "-o", "msft.asc")); err != nil {
+		return err
+	}
+
+	if err := control.FinishRunning(exec.Command("gpg", "--batch", "--yes", "-o", "/etc/apt/trusted.gpg.d/microsoft.asc.gpg", "--dearmor", "msft.asc")); err != nil {
+		return err
+	}
+
+	if err := control.FinishRunning(exec.Command("bash", "-c", "echo \"deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli $(lsb_release -cs) main\" | tee /etc/apt/sources.list.d/azure-cli.list")); err != nil {
+		return err
+	}
+
+	if err := control.FinishRunning(exec.Command("apt-get", "update")); err != nil {
+		return err
+	}
+
+	if err := control.FinishRunning(exec.Command("apt-get", "install", "-y", "azure-cli")); err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
Addressing an issue when installing azure-cli - https://github.com/kubernetes-sigs/azuredisk-csi-driver/pull/394#issuecomment-625826420

Using the steps described in https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-apt?view=azure-cli-latest#manual-install-instructions to install azure-cli instead of pip.

/assign @feiskyer 

