### PR TITLE
Bump Go version to 1.13 for svcat unit-tests

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: golang:1.12
+      - image: golang:1.13
         command:
         - make
         args:


### PR DESCRIPTION
**Description**

- Bump Go version to 1.13 for svcat unit-tests

/cc @jberkhahn 