### PR TITLE
Fixes to HMAC management phase1

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -101,6 +101,7 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *May 18, 2020* `expiry` field has been replaced with `created_at` in the HMAC secret.
  - *April 24, 2020* Horologium now defaults to `--dry-run=true`
  - *April 23, 2020* Explicitly setting `--config-path` is now required.
  - *April 23, 2020* Update the `autobump` image to at least `v20200422-8c8546d74` before June 2020.

--- a/prow/github/hmac_test.go
+++ b/prow/github/hmac_test.go
@@ -23,9 +23,9 @@ import (
 var globalSecret = `
 '*':
   - value: abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2018-10-02T15:00:00Z
 `
 
 var defaultTokenGenerator = func() []byte {

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -43,56 +43,43 @@ var ice = github.IssueCommentEvent{
 var repoLevelSecret = `
 '*':
   - value: key1
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
-foo:
-  - value: key3
-    expiry: 9999-10-02T15:00:00Z
-  - value: key4
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 foo/bar:
   - value: 123abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key6
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 `
 
 var orgLevelSecret = `
 '*':
   - value: key1
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 foo:
   - value: 123abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key4
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 `
 
 var globalSecret = `
 '*':
   - value: 123abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
-`
-
-var expiredGlobalSecret = `
-'*':
-  - value: 123abc
-    expiry: 2019-10-02T15:00:00Z
-  - value: key2
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 `
 
 var missingMatchingSecret = `
 somerandom:
   - value: 123abc
-    expiry: 2019-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 `
 
 var secretInOldFormat = `123abc`
@@ -152,34 +139,10 @@ func TestHook(t *testing.T) {
 			shouldSucceed: true,
 		},
 		{
-			name:   "Token not matching at any level.",
-			secret: []byte("123abcd"),
-			tokenGenerator: func() []byte {
-				return []byte(repoLevelSecret)
-			},
-			shouldSucceed: false,
-		},
-		{
-			name:   "Token matching but expired.",
-			secret: []byte("123abc"),
-			tokenGenerator: func() []byte {
-				return []byte(expiredGlobalSecret)
-			},
-			shouldSucceed: false,
-		},
-		{
-			name:   "Token matching at organization level but repo level token mismatch.",
-			secret: []byte("key3"),
-			tokenGenerator: func() []byte {
-				return []byte(expiredGlobalSecret)
-			},
-			shouldSucceed: false,
-		},
-		{
 			name:   "Token not matching anywhere (wildcard token missing).",
 			secret: []byte("123abc"),
 			tokenGenerator: func() []byte {
-				return []byte(expiredGlobalSecret)
+				return []byte(missingMatchingSecret)
 			},
 			shouldSucceed: false,
 		},

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -35,19 +35,14 @@ func TestServeHTTPErrors(t *testing.T) {
 		var repoLevelSecret = `
 '*':
   - value: abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key2
-    expiry: 2018-10-02T15:00:00Z
-foo:
-  - value: key3
-    expiry: 9999-10-02T15:00:00Z
-  - value: key4
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 foo/bar:
   - value: 123abc
-    expiry: 9999-10-02T15:00:00Z
+    created_at: 2019-10-02T15:00:00Z
   - value: key6
-    expiry: 2018-10-02T15:00:00Z
+    created_at: 2020-10-02T15:00:00Z
 `
 		return []byte(repoLevelSecret)
 	}


### PR DESCRIPTION
Some fixes to the HMAC management tool phase1, as per the update in the [design doc](https://docs.google.com/document/d/1m3nFfPt95kbe6BQdWp5BrZMSPkBo5mFb2nuMq1OeE24/edit?ts=5e1f65f9#heading=h.1lxac62rvsv0)

1. Configuring repo-level and org-level webhooks at the same time for a repo is not a valid use case, as there will be duplicated webhook events. So remove the related unit tests.

2. `expiry` is not needed in the secret, as we won't want a token to be expired without being noticed. Instead, add a field called `created_at` as it's needed to determine if an existing token needs to be rotated based on the new configurations.

3. Add a new check in the `checkconfig` tool to disallow org-level and repo-level webhooks to be configured at the same time on a given repo.

After these changes, the new secret file will be like:
```
'*':
  - value: key1
    created_at: 2019-10-02T15:00:00Z
  - value: key2
    created_at: 2020-10-02T15:00:00Z
foo/bar:
  - value: 123abc
    created_at: 2019-10-02T15:00:00Z
  - value: key6
    created_at: 2020-10-02T15:00:00Z
```

or 

```
'*':
  - value: key1
    created_at: 2019-10-02T15:00:00Z
  - value: key2
    created_at: 2020-10-02T15:00:00Z
foo:
  - value: 123abc
    created_at: 2019-10-02T15:00:00Z
  - value: key4
    created_at: 2020-10-02T15:00:00Z
```

/cc @cjwagner @clarketm 