### PR TITLE
ListTeamRepos ignore repos with invalid permission

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2879,7 +2879,15 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 			return &[]Repo{}
 		},
 		func(obj interface{}) {
-			repos = append(repos, *(obj.(*[]Repo))...)
+			for _, repo := range *obj.(*[]Repo) {
+				// Currently, GitHub API returns false for all permission levels
+				// for a repo on which the team has 'Maintain' or 'Triage' role.
+				// This check is to avoid listing a repo under the team but
+				// showing the permission level as none.
+				if LevelFromPermissions(repo.Permissions) != None {
+					repos = append(repos, repo)
+				}
+			}
 		},
 	)
 	if err != nil {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -2268,3 +2268,26 @@ func TestAuthHeaderGetsSet(t *testing.T) {
 		})
 	}
 }
+func TestListTeamRepos(t *testing.T) {
+	ts := simpleTestServer(t, "/teams/1/repos",
+		[]Repo{
+			{
+				Name:        "repo-bar",
+				Permissions: RepoPermissions{Pull: true},
+			},
+			{
+				Name: "repo-invalid-permission-level",
+			},
+		},
+	)
+	defer ts.Close()
+	c := getClient(ts.URL)
+	repos, err := c.ListTeamRepos(1)
+	if err != nil {
+		t.Errorf("Didn't expect error: %v", err)
+	} else if len(repos) != 1 {
+		t.Errorf("Expected one repo, found %d: %v", len(repos), repos)
+	} else if repos[0].Name != "repo-bar" {
+		t.Errorf("Wrong repos: %v", repos)
+	}
+}


### PR DESCRIPTION
GitHub client's ListTeamRepos now ignores any repos with an invalid
permission level, i.e. 'none', for the team.
This allows Peribolos to avoid listing repos with permissions it cannot
parse, e.g. 'Maintain' and 'Triage' that are not currently exposed by
the GitHub API V3. Fixes #14325 

