### PR TITLE
Azure: delete msft.asc after installing azure-cli & add additional fields in API model

### DIFF
--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -141,6 +141,7 @@ type KubernetesConfig struct {
 	CloudProviderRateLimitQPS        float64           `json:"cloudProviderRateLimitQPS,omitempty"`
 	CloudProviderRateLimitBucket     int               `json:"cloudProviderRateLimitBucket,omitempty"`
 	APIServerConfig                  map[string]string `json:"apiServerConfig,omitempty"`
+	CloudControllerManagerConfig     map[string]string `json:"cloudControllerManagerConfig,omitempty"`
 	KubernetesImageBase              string            `json:"kubernetesImageBase,omitempty"`
 	ControllerManagerConfig          map[string]string `json:"controllerManagerConfig,omitempty"`
 	KubeletConfig                    map[string]string `json:"kubeletConfig,omitempty"`
@@ -194,6 +195,7 @@ type AgentPoolProfile struct {
 	Extensions             []map[string]string `json:"extensions,omitempty"`
 	OSDiskSizeGB           int                 `json:"osDiskSizeGB,omitempty" validate:"min=0,max=1023"`
 	EnableVMSSNodePublicIP bool                `json:"enableVMSSNodePublicIP,omitempty"`
+	StorageProfile         string              `json:"storageProfile,omitempty"`
 }
 
 type AzureClient struct {
@@ -486,6 +488,10 @@ func installAzureCLI() error {
 	}
 
 	if err := control.FinishRunning(exec.Command("apt-get", "install", "-y", "azure-cli")); err != nil {
+		return err
+	}
+
+	if err := os.Remove("msft.asc"); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- [Undirty](https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/91010/pull-kubernetes-e2e-aks-engine-azure/1260218606029901824/finished.json) the Kubernetes version by deleting msft.asc created during azure cli installation;
- Add additional fields in API model struct 

/assign @feiskyer 