### PR TITLE
Modify gci option in --extract flag

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -75,8 +75,8 @@ func (l *extractStrategies) Set(value string) error {
 		`^(bazel)$`: localBazel,
 		`^(local)`:  local,
 		`^gke-?(default|channel-(rapid|regular|stable)|latest(-\d+.\d+(.\d+(-gke)?)?)?)?$`: gke,
-		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)$`: gci,
-		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)/(.+)$`: gciCi,
+		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)$`:                                     gci,
+		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)/(.+)$`:                                gciCi,
 		`^ci/(.+)$`:                   ci,
 		`^release/(latest.*)$`:        rc,
 		`^release/(stable.*)$`:        stable,
@@ -351,7 +351,7 @@ var parseGciExtractOption = func(option string) (string, map[string]string) {
 	family := arr[0]
 	paramsMap := map[string]string{
 		// default values
-		"project": "container-vm-image-staging",
+		"project":            "container-vm-image-staging",
 		"version-map-bucket": "container-vm-image-staging",
 	}
 	if len(arr) == 2 {

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -40,7 +40,7 @@ const (
 	none       extractMode = iota
 	localBazel             // local bazel
 	local                  // local
-	gci                    // gci/FAMILY, gci/FAMILY?project=IMAGE_PROJECT:version-map-bucket=BUCKET_NAME
+	gci                    // gci/FAMILY, gci/FAMILY?project=IMAGE_PROJECT:k8s-map-bucket=BUCKET_NAME
 	gciCi                  // gci/FAMILY/CI_VERSION
 	gke                    // gke(deprecated), gke-default, gke-latest, gke-channel-CHANNEL_NAME
 	ci                     // ci/latest, ci/latest-1.5
@@ -347,15 +347,15 @@ func setReleaseFromHTTP(prefix, suffix string, getSrc bool) error {
 }
 
 var parseGciExtractOption = func(option string) (string, map[string]string) {
-	arr := strings.Split(option, "?")
-	family := arr[0]
+	tokens := strings.Split(option, "?")
+	family := tokens[0]
 	paramsMap := map[string]string{
 		// default values
-		"project":            "container-vm-image-staging",
-		"version-map-bucket": "container-vm-image-staging",
+		"project":        "container-vm-image-staging",
+		"k8s-map-bucket": "container-vm-image-staging",
 	}
-	if len(arr) == 2 {
-		params := strings.Split(arr[1], ":")
+	if len(tokens) == 2 {
+		params := strings.Split(tokens[1], ":")
 		for _, param := range params {
 			kv := strings.Split(param, "=")
 			paramsMap[kv[0]] = kv[1]
@@ -368,8 +368,8 @@ var gcloudGetImageName = func(family string, project string) ([]byte, error) {
 	return control.Output(exec.Command("gcloud", "compute", "images", "describe-from-family", family, fmt.Sprintf("--project=%v", project), "--format=value(name)"))
 }
 
-func setupGciVars(family string, p string) (string, error) {
-	b, err := gcloudGetImageName(family, p)
+func setupGciVars(f string, p string) (string, error) {
+	b, err := gcloudGetImageName(f, p)
 	if err != nil {
 		return "", err
 	}
@@ -389,7 +389,7 @@ func setupGciVars(family string, p string) (string, error) {
 
 		"KUBE_OS_DISTRIBUTION": g,
 	}
-	if family == "gci-canary-test" {
+	if f == "gci-canary-test" {
 		var b bytes.Buffer
 		if err := httpRead("https://api.github.com/repos/docker/docker/releases", &b); err != nil {
 			return "", err
@@ -410,8 +410,8 @@ func setupGciVars(family string, p string) (string, error) {
 	return i, nil
 }
 
-func setReleaseFromGci(image string, versionMapBucket string, getSrc bool) error {
-	b, err := gsutilCat(fmt.Sprintf("gs://%s/k8s-version-map/%s", versionMapBucket, image))
+func setReleaseFromGci(image string, k8sMapBucket string, getSrc bool) error {
+	b, err := gsutilCat(fmt.Sprintf("gs://%s/k8s-version-map/%s", k8sMapBucket, image))
 	if err != nil {
 		return err
 	}
@@ -458,13 +458,13 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 	case gci, gciCi:
 		family, gciExtractParams := parseGciExtractOption(e.option)
 		project := gciExtractParams["project"]
-		versionMapBucket := gciExtractParams["version-map-bucket"]
+		k8sMapBucket := gciExtractParams["k8s-map-bucket"]
 		if i, err := setupGciVars(family, project); err != nil {
 			return err
 		} else if e.ciVersion != "" {
 			return setReleaseFromGcs("kubernetes-release-dev/ci", e.ciVersion, extractSrc)
 		} else {
-			return setReleaseFromGci(i, versionMapBucket, extractSrc)
+			return setReleaseFromGci(i, k8sMapBucket, extractSrc)
 		}
 	case gke:
 		// TODO(fejta): prod v staging v test

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -40,7 +40,7 @@ const (
 	none       extractMode = iota
 	localBazel             // local bazel
 	local                  // local
-	gci                    // gci/FAMILY
+	gci                    // gci/FAMILY, gci/FAMILY?project=IMAGE_PROJECT:version-map-bucket=BUCKET_NAME
 	gciCi                  // gci/FAMILY/CI_VERSION
 	gke                    // gke(deprecated), gke-default, gke-latest, gke-channel-CHANNEL_NAME
 	ci                     // ci/latest, ci/latest-1.5
@@ -75,8 +75,8 @@ func (l *extractStrategies) Set(value string) error {
 		`^(bazel)$`: localBazel,
 		`^(local)`:  local,
 		`^gke-?(default|channel-(rapid|regular|stable)|latest(-\d+.\d+(.\d+(-gke)?)?)?)?$`: gke,
-		`^gci/([\w-]+)$`:              gci,
-		`^gci/([\w-]+)/(.+)$`:         gciCi,
+		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)$`: gci,
+		`^gci/([\w-]+(?:\?{1}(?::?[\w-]+=[\w-]+)+)?)/(.+)$`: gciCi,
 		`^ci/(.+)$`:                   ci,
 		`^release/(latest.*)$`:        rc,
 		`^release/(stable.*)$`:        stable,
@@ -346,8 +346,25 @@ func setReleaseFromHTTP(prefix, suffix string, getSrc bool) error {
 	return getKube(url, strings.TrimSpace(string(release)), getSrc)
 }
 
-func setupGciVars(family string) (string, error) {
-	p := "container-vm-image-staging"
+var parseGciExtractOption = func(option string) (string, map[string]string) {
+	arr := strings.Split(option, "?")
+	family := arr[0]
+	paramsMap := map[string]string{
+		// default values
+		"project": "container-vm-image-staging",
+		"version-map-bucket": "container-vm-image-staging",
+	}
+	if len(arr) == 2 {
+		params := strings.Split(arr[1], ":")
+		for _, param := range params {
+			kv := strings.Split(param, "=")
+			paramsMap[kv[0]] = kv[1]
+		}
+	}
+	return family, paramsMap
+}
+
+func setupGciVars(family string, p string) (string, error) {
 	b, err := control.Output(exec.Command("gcloud", "compute", "images", "describe-from-family", family, fmt.Sprintf("--project=%v", p), "--format=value(name)"))
 	if err != nil {
 		return "", err
@@ -389,8 +406,8 @@ func setupGciVars(family string) (string, error) {
 	return i, nil
 }
 
-func setReleaseFromGci(image string, getSrc bool) error {
-	b, err := gsutilCat(fmt.Sprintf("gs://container-vm-image-staging/k8s-version-map/%s", image))
+func setReleaseFromGci(image string, versionMapBucket string, getSrc bool) error {
+	b, err := gsutilCat(fmt.Sprintf("gs://%s/k8s-version-map/%s", versionMapBucket, image))
 	if err != nil {
 		return err
 	}
@@ -435,12 +452,15 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		}
 		return getKube(fmt.Sprintf("file://%s", url), release, extractSrc)
 	case gci, gciCi:
-		if i, err := setupGciVars(e.option); err != nil {
+		family, gciExtractParams := parseGciExtractOption(e.option)
+		project := gciExtractParams["project"]
+		versionMapBucket := gciExtractParams["version-map-bucket"]
+		if i, err := setupGciVars(family, project); err != nil {
 			return err
 		} else if e.ciVersion != "" {
 			return setReleaseFromGcs("kubernetes-release-dev/ci", e.ciVersion, extractSrc)
 		} else {
-			return setReleaseFromGci(i, extractSrc)
+			return setReleaseFromGci(i, versionMapBucket, extractSrc)
 		}
 	case gke:
 		// TODO(fejta): prod v staging v test

--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -364,8 +364,12 @@ var parseGciExtractOption = func(option string) (string, map[string]string) {
 	return family, paramsMap
 }
 
+var gcloudGetImageName = func(family string, project string) ([]byte, error) {
+	return control.Output(exec.Command("gcloud", "compute", "images", "describe-from-family", family, fmt.Sprintf("--project=%v", project), "--format=value(name)"))
+}
+
 func setupGciVars(family string, p string) (string, error) {
-	b, err := control.Output(exec.Command("gcloud", "compute", "images", "describe-from-family", family, fmt.Sprintf("--project=%v", p), "--format=value(name)"))
+	b, err := gcloudGetImageName(family, p)
 	if err != nil {
 		return "", err
 	}

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -21,10 +21,62 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestParseGciExtractOption(t *testing.T) {
+	cases := []struct {
+		option          string
+		expectFamily    string
+		expectParamsMap map[string]string
+	}{
+		{
+			option:       "gci-canary",
+			expectFamily: "gci-canary",
+			expectParamsMap: map[string]string{
+				"project":            "container-vm-image-staging",
+				"version-map-bucket": "container-vm-image-staging",
+			},
+		},
+		{
+			option:       "gci-canary?project=test-project",
+			expectFamily: "gci-canary",
+			expectParamsMap: map[string]string{
+				"project":            "test-project",
+				"version-map-bucket": "container-vm-image-staging",
+			},
+		},
+		{
+			option:       "gci-canary?version-map-bucket=test-bucket",
+			expectFamily: "gci-canary",
+			expectParamsMap: map[string]string{
+				"project":            "container-vm-image-staging",
+				"version-map-bucket": "test-bucket",
+			},
+		},
+		{
+			option:       "gci-canary?project=test-project:version-map-bucket=test-bucket",
+			expectFamily: "gci-canary",
+			expectParamsMap: map[string]string{
+				"project":            "test-project",
+				"version-map-bucket": "test-bucket",
+			},
+		},
+	}
+
+	var gotFamily string
+	var gotParamsMap map[string]string
+
+	for _, tc := range cases {
+		gotFamily, gotParamsMap = parseGciExtractOption(tc.option)
+		if gotFamily != tc.expectFamily || !reflect.DeepEqual(gotParamsMap, tc.expectParamsMap) {
+			t.Errorf("got parseGciExtractOption(%q) = %q, %q; want %q, %q", tc.option, gotFamily, gotParamsMap, tc.expectFamily, tc.expectParamsMap)
+		}
+	}
+}
 
 func TestGetKube(t *testing.T) {
 	cases := []struct {
@@ -221,6 +273,105 @@ func TestExtractStrategies(t *testing.T) {
 			t.Errorf("extractStrategy(%q).Extract() returned err: %q", tc.option, err)
 		}
 
+		if gotURL != tc.expectURL || gotVersion != tc.expectVersion {
+			t.Errorf("extractStrategy(%q).Extract() wanted getKube(%q, %q), got getKube(%q, %q)", tc.option, tc.expectURL, tc.expectVersion, gotURL, gotVersion)
+		}
+	}
+}
+
+func TestGciExtractStrategy(t *testing.T) {
+	cases := []struct {
+		option                 string
+		expectURL              string
+		expectVersion          string
+		expectFamily           string
+		expectProject          string
+		expectVersionMapBucket string
+	}{
+		{
+			"gci/gci-canary",
+			"https://storage.googleapis.com/kubernetes-release/release",
+			"v1.2.3+abcde",
+			"gci-canary",
+			"container-vm-image-staging",
+			"gs://container-vm-image-staging/k8s-version-map/test-image",
+		},
+		{
+			"gci/gci-canary?project=test-project:version-map-bucket=test-bucket",
+			"https://storage.googleapis.com/kubernetes-release/release",
+			"v1.2.3+abcde",
+			"gci-canary",
+			"test-project",
+			"gs://test-bucket/k8s-version-map/test-image",
+		},
+		{
+			"gci/gci-canary?project=test-project/latest",
+			"https://storage.googleapis.com/kubernetes-release-dev/ci",
+			"1.2.3+abcde",
+			"gci-canary",
+			"test-project",
+			"gs://kubernetes-release-dev/ci/latest.txt",
+		},
+	}
+
+	var gotURL string
+	var gotVersion string
+	var gotFamily string
+	var gotProject string
+	var gotVersionMapBucket string
+
+	// getKube is tested independently, so mock it out here so we can test
+	// that different extraction strategies call getKube with the correct
+	// arguments.
+	oldGetKube := getKube
+	defer func() { getKube = oldGetKube }()
+	getKube = func(url, version string, _ bool) error {
+		gotURL = url
+		gotVersion = version
+		// This is needed or else Extract() will think that getKube failed.
+		os.Mkdir("kubernetes", 0775)
+		return nil
+	}
+
+	oldCat := gsutilCat
+	defer func() { gsutilCat = oldCat }()
+	gsutilCat = func(url string) ([]byte, error) {
+		if !strings.HasPrefix(path.Dir(url), "gs:/") {
+			return []byte{}, fmt.Errorf("url %s must start with gs:/", path.Dir(url))
+		}
+		gotVersionMapBucket = url
+		return []byte("1.2.3+abcde"), nil
+	}
+
+	oldGcloudGetImageName := gcloudGetImageName
+	defer func() { gcloudGetImageName = oldGcloudGetImageName }()
+	gcloudGetImageName = func(family string, project string) ([]byte, error) {
+		gotFamily = family
+		gotProject = project
+		return []byte("test-image"), nil
+	}
+
+	for _, tc := range cases {
+		if d, err := ioutil.TempDir("", "extract"); err != nil {
+			t.Fatal(err)
+		} else if err := os.Chdir(d); err != nil {
+			t.Fatal(err)
+		}
+
+		var es extractStrategies
+		if err := es.Set(tc.option); err != nil {
+			t.Errorf("extractStrategy.Set(%q) returned err: %q", tc.option, err)
+		}
+		if err := es.Extract("", "", "", false); err != nil {
+			t.Errorf("extractStrategy(%q).Extract() returned err: %q", tc.option, err)
+		}
+
+		if gotFamily != tc.expectFamily || gotProject != tc.expectProject {
+			t.Errorf("extractStrategies(%q).Extract() wanted setupGciVars(%q, %q), got setupGciVars(%q, %q)", tc.option, tc.expectFamily, tc.expectProject, gotFamily, gotProject)
+		}
+		if gotVersionMapBucket != tc.expectVersionMapBucket {
+			t.Errorf("extractStrategies(%q).Extract() wanted gsutilCat(%q), got gsutilCat(%q)", tc.option, tc.expectVersionMapBucket, gotVersionMapBucket)
+		}
 		if gotURL != tc.expectURL || gotVersion != tc.expectVersion {
 			t.Errorf("extractStrategy(%q).Extract() wanted getKube(%q, %q), got getKube(%q, %q)", tc.option, tc.expectURL, tc.expectVersion, gotURL, gotVersion)
 		}

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -38,7 +38,7 @@ func TestParseGciExtractOption(t *testing.T) {
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
 				"project":            "container-vm-image-staging",
-				"version-map-bucket": "container-vm-image-staging",
+				"k8s-map-bucket": "container-vm-image-staging",
 			},
 		},
 		{
@@ -46,23 +46,23 @@ func TestParseGciExtractOption(t *testing.T) {
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
 				"project":            "test-project",
-				"version-map-bucket": "container-vm-image-staging",
+				"k8s-map-bucket": "container-vm-image-staging",
 			},
 		},
 		{
-			option:       "gci-canary?version-map-bucket=test-bucket",
+			option:       "gci-canary?k8s-map-bucket=test-bucket",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
 				"project":            "container-vm-image-staging",
-				"version-map-bucket": "test-bucket",
+				"k8s-map-bucket": "test-bucket",
 			},
 		},
 		{
-			option:       "gci-canary?project=test-project:version-map-bucket=test-bucket",
+			option:       "gci-canary?project=test-project:k8s-map-bucket=test-bucket",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
 				"project":            "test-project",
-				"version-map-bucket": "test-bucket",
+				"k8s-map-bucket": "test-bucket",
 			},
 		},
 	}
@@ -297,7 +297,7 @@ func TestGciExtractStrategy(t *testing.T) {
 			"gs://container-vm-image-staging/k8s-version-map/test-image",
 		},
 		{
-			"gci/gci-canary?project=test-project:version-map-bucket=test-bucket",
+			"gci/gci-canary?project=test-project:k8s-map-bucket=test-bucket",
 			"https://storage.googleapis.com/kubernetes-release/release",
 			"v1.2.3+abcde",
 			"gci-canary",

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -37,7 +37,7 @@ func TestParseGciExtractOption(t *testing.T) {
 			option:       "gci-canary",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
-				"project":            "container-vm-image-staging",
+				"project":        "container-vm-image-staging",
 				"k8s-map-bucket": "container-vm-image-staging",
 			},
 		},
@@ -45,7 +45,7 @@ func TestParseGciExtractOption(t *testing.T) {
 			option:       "gci-canary?project=test-project",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
-				"project":            "test-project",
+				"project":        "test-project",
 				"k8s-map-bucket": "container-vm-image-staging",
 			},
 		},
@@ -53,7 +53,7 @@ func TestParseGciExtractOption(t *testing.T) {
 			option:       "gci-canary?k8s-map-bucket=test-bucket",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
-				"project":            "container-vm-image-staging",
+				"project":        "container-vm-image-staging",
 				"k8s-map-bucket": "test-bucket",
 			},
 		},
@@ -61,7 +61,7 @@ func TestParseGciExtractOption(t *testing.T) {
 			option:       "gci-canary?project=test-project:k8s-map-bucket=test-bucket",
 			expectFamily: "gci-canary",
 			expectParamsMap: map[string]string{
-				"project":            "test-project",
+				"project":        "test-project",
 				"k8s-map-bucket": "test-bucket",
 			},
 		},


### PR DESCRIPTION
By default, the --extract=gci/FAMILY flag will look at COS images in
the GCP project "container-vm-image-staging" and use the GCS bucket
"gs://container-vm-image-staging/k8s-version-map" to map the image name
to k8s version to be extracted. The COS team wants to run e2e tests on images found in other GCP projects. These values are hard-coded, and it
would be ideal to pass that information to the --extract flag instead.