### PR TITLE
Fix issue-creator prowjob.

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -276,9 +276,9 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/issue-creator:v20200123-1ec7f94ed
+    - image: gcr.io/k8s-prow/issue-creator:v20200511-cdd819cd6
       command:
-      - /issue-creator
+      - /app/robots/issue-creator/app.binary
       args:
       - --dry-run=false
       - --alsologtostderr


### PR DESCRIPTION
I noticed this job was failing due to an invalid entrypoint. The image hosted at gcr.io/k8s-testimages appears to have been broken by a bad manual image push in January.  This switches to the version that is published automatically with Prow.

/assign @fejta 