### PR TITLE
Add Release Branches To Descheduler Push Job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -11,6 +11,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
+        - ^release-.*
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:


### PR DESCRIPTION
The k8s descheduler recently added release branches. Container images
now need to be automatically built for release branches.