### PR TITLE
Adds prow jobs for new e2e test flow

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -37,6 +37,46 @@ periodics:
     testgrid-tab-name: periodic-e2e-v1alpha3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-provider-aws-e2e-new-v1alpha3
+  decorate: true
+  decoration_config:
+    timeout: 5h
+  interval: 6h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-aws
+      base_ref: master
+      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200511-cdd819c-master
+        command:
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: BOSKOS_HOST
+            value: "boskos.test-pods.svc.cluster.local"
+          - name: AWS_REGION
+            value: "us-west-2"
+          - name: NEW_E2E_FLOW
+            value: "1"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+    testgrid-tab-name: periodic-e2e-new-v1alpha3
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-v1alpha2
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -34,6 +34,42 @@ postsubmits:
         testgrid-tab-name: ci-e2e
         testgrid-num-columns-recent: '20'
         testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    - name: ci-cluster-api-provider-aws-e2e-new
+      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+      decorate: true
+      decoration_config:
+        timeout: 5h
+      max_concurrency: 1
+      labels:
+        preset-dind-enabled: "true"
+        preset-kind-volume-mounts: "true"
+        preset-service-account: "true"
+        preset-aws-ssh: "true"
+        preset-aws-credential: "true"
+      spec:
+        containers:
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200511-cdd819c-master
+            command:
+              - "runner.sh"
+              - "./scripts/ci-e2e.sh"
+            env:
+              - name: BOSKOS_HOST
+                value: "boskos.test-pods.svc.cluster.local"
+              - name: AWS_REGION
+                value: "us-west-2"
+              - name: NEW_E2E_FLOW
+                value: "1"
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                cpu: 1
+                memory: "4Gi"
+      annotations:
+        testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+        testgrid-tab-name: ci-e2e-new
+        testgrid-num-columns-recent: '20'
+        testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     - name: ci-cluster-api-provider-aws-e2e-conformance
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
       decorate: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -147,6 +147,43 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-e2e
       testgrid-num-columns-recent: '20'
+  - name: pull-cluster-api-provider-aws-e2e-new
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200511-cdd819c-master
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            - name: NEW_E2E_FLOW
+              value: "1"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1
+              memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-e2e-new
+      testgrid-num-columns-recent: '20'
   - name: pull-cluster-api-provider-aws-e2e-conformance
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     always_run: false


### PR DESCRIPTION
cluster-api-aws-provider is moving its e2e tests to use the new cluster-api testing [framework](https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/1701). The tests will be moved incrementally so setting up a new set of prow jobs to exercise the e2e tests through the new flow. Once we're confident in the new tests, a new PR will be created to revert back to a single set of e2e jobs.