### PR TITLE
Fixing doc for --github-workers for crier

### DIFF
--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -40,7 +40,7 @@ You can check the reported result by [list the pubsub topic](https://cloud.googl
 
 ### [GitHub reporter](/prow/crier/reporters/github)
 
-You can enable github reporter in crier by specifying `--github-workers=N` flag.
+You can enable github reporter in crier by specifying `--github-workers=N` flag (N>0).
 
 You also need to mount a github oauth token by specifying `--github-token-path` flag, which defaults to `/etc/github/oauth`.
 

--- a/prow/cmd/crier/README.md
+++ b/prow/cmd/crier/README.md
@@ -40,7 +40,7 @@ You can check the reported result by [list the pubsub topic](https://cloud.googl
 
 ### [GitHub reporter](/prow/crier/reporters/github)
 
-You can enable github reporter in crier by specifying `--github-workers=1` flag. (We only support single worker for github, due to [#13306](https://github.com/kubernetes/test-infra/issues/13306))
+You can enable github reporter in crier by specifying `--github-workers=N` flag.
 
 You also need to mount a github oauth token by specifying `--github-token-path` flag, which defaults to `/etc/github/oauth`.
 


### PR DESCRIPTION
Parallel workers fixed in
https://github.com/kubernetes/test-infra/pull/16316

/cc @cjwagner 