### PR TITLE
fix kind periodic jobs migration

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -40,7 +40,10 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  path_alias: sigs.k8s.io/kind
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -88,7 +91,10 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  path_alias: sigs.k8s.io/kind
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -143,7 +149,10 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  path_alias: sigs.k8s.io/kind
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -194,7 +203,10 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  path_alias: sigs.k8s.io/kind
+  - org: kubernetes-sigs
+    repo: kind
+    base_ref: master
+    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:


### PR DESCRIPTION
kind periodic jobs started to fail after the migration to podutils.
The problem is that I copy-pasted blindly the job config from the PR jobs, and it was not cloning the kind repo