### PR TITLE
use latest kind binaries for ci jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -40,10 +40,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -53,7 +49,7 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       # don't retry conformance tests
       - name: GINKGO_TOLERATE_FLAKES
@@ -91,10 +87,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -104,7 +96,7 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       env:
       # enable IPV6 in bootstrap image
       - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -149,10 +141,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -171,7 +159,7 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -203,10 +191,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  - org: kubernetes-sigs
-    repo: kind
-    base_ref: master
-    path_alias: sigs.k8s.io/kind
   decoration_config:
     timeout: 40m
   spec:
@@ -231,7 +215,7 @@ periodics:
         - wrapper.sh
         - bash
         - -c
-        - cd ./../../k8s.io/kubernetes && ./../../sigs.k8s.io/kind/hack/ci/e2e.sh
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -40,8 +40,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  decoration_config:
-    timeout: 40m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master
@@ -87,8 +85,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  decoration_config:
-    timeout: 40m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master
@@ -141,8 +137,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  decoration_config:
-    timeout: 40m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master
@@ -191,8 +185,6 @@ periodics:
     repo: kubernetes
     base_ref: master
     path_alias: k8s.io/kubernetes
-  decoration_config:
-    timeout: 40m
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master


### PR DESCRIPTION
> The CI jobs should be using the latest binaries and e2e-k8s.sh like kubernetes presubmits. More clones and building is slower, flakier, etc.

Also, remove the timeout decorations, it's a leftover from the presubmit jobs that are causing these jobs to fail