### PR TITLE
Process latest report for each label separately.

### DIFF
--- a/prow/crier/reporters/gerrit/BUILD.bazel
+++ b/prow/crier/reporters/gerrit/BUILD.bazel
@@ -38,7 +38,9 @@ go_test(
         "//prow/client/listers/prowjobs/v1:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
     ],
 )

--- a/prow/gerrit/adapter/BUILD.bazel
+++ b/prow/gerrit/adapter/BUILD.bazel
@@ -23,16 +23,22 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["adapter_test.go"],
+    srcs = [
+        "adapter_test.go",
+        "trigger_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/gerrit:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "@com_github_andygrunwald_go_gerrit//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
     ],
 )

--- a/prow/gerrit/adapter/trigger.go
+++ b/prow/gerrit/adapter/trigger.go
@@ -17,55 +17,57 @@ limitations under the License.
 package adapter
 
 import (
-	"strings"
 	"time"
 
+	"github.com/andygrunwald/go-gerrit"
 	"github.com/sirupsen/logrus"
-
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/test-infra/prow/apis/prowjobs/v1"
+
 	"k8s.io/test-infra/prow/config"
-	reporter "k8s.io/test-infra/prow/crier/reporters/gerrit"
-	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/pjutil"
 )
 
-// messageFilter builds a filter for jobs based on the messageBody matching the trigger regex of the jobs.
-func messageFilter(lastUpdate time.Time, change client.ChangeInfo, presubmits []config.Presubmit, latestReport *reporter.JobReport, logger *logrus.Entry) (pjutil.Filter, error) {
-	var filters []pjutil.Filter
-	currentRevision := change.Revisions[change.CurrentRevision].Number
-
-	contextGetter := func() (sets.String, sets.String, error) {
-		allContexts := sets.String{}
-		failedContexts := sets.String{}
-		for _, presubmit := range presubmits {
-			allContexts.Insert(presubmit.Name)
-		}
-		if latestReport != nil {
-			jobs := map[string]*reporter.Job{}
-			for _, job := range latestReport.Jobs {
-				jobs[job.Name] = job
-			}
-			for _, presubmit := range presubmits {
-				j, ok := jobs[presubmit.Name]
-				if ok && (strings.ToLower(j.State) == string(v1.FailureState) || strings.ToLower(j.State) == string(v1.ErrorState)) {
-					failedContexts.Insert(presubmit.Name)
-				}
-			}
-		}
-		return failedContexts, allContexts, nil
+// presubmitContexts returns the set of failing and all job names contained in the reports.
+func presubmitContexts(failed sets.String, presubmits []config.Presubmit, logger *logrus.Entry) (sets.String, sets.String) {
+	allContexts := sets.String{}
+	for _, presubmit := range presubmits {
+		allContexts.Insert(presubmit.Name) // TODO(fejta): context, not name
 	}
-	for _, message := range change.Messages {
-		messageTime := message.Date.Time
-		if message.RevisionNumber != currentRevision || !messageTime.After(lastUpdate) {
+	failedContexts := allContexts.Intersection(failed)
+	return failedContexts, allContexts
+}
+
+// currentMessages returns messages on the current revision after the specified time.
+func currentMessages(change gerrit.ChangeInfo, since time.Time) []string {
+	var messages []string
+	want := change.Revisions[change.CurrentRevision].Number
+	for _, have := range change.Messages {
+		if have.RevisionNumber != want {
 			continue
 		}
-		filter, err := pjutil.PresubmitFilter(false, contextGetter, message.Message, logger)
-		if err != nil || filter == nil {
-			logger.Warnf("failed to create filter for %s", message.Message)
+		if !have.Date.Time.After(since) {
+			continue
+		}
+		messages = append(messages, have.Message)
+	}
+	return messages
+}
+
+// messageFilter returns filter that matches all /test all, /test foo, /retest comments since lastUpdate.
+//
+// The behavior of each message matches the behavior of pjutil.PresubmitFilter.
+func messageFilter(messages []string, failingContexts, allContexts sets.String, logger *logrus.Entry) pjutil.Filter {
+	var filters []pjutil.Filter
+	contextGetter := func() (sets.String, sets.String, error) {
+		return failingContexts, allContexts, nil
+	}
+	for _, message := range messages {
+		filter, err := pjutil.PresubmitFilter(false, contextGetter, message, logger)
+		if err != nil {
+			logger.WithError(err).WithField("message", message).Warn("failed to create presubmit filter")
 			continue
 		}
 		filters = append(filters, filter)
 	}
-	return pjutil.AggregateFilter(filters), nil
+	return pjutil.AggregateFilter(filters)
 }

--- a/prow/gerrit/adapter/trigger_test.go
+++ b/prow/gerrit/adapter/trigger_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapter
+
+import (
+	"testing"
+	"time"
+
+	"github.com/andygrunwald/go-gerrit"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
+
+	"k8s.io/test-infra/prow/config"
+)
+
+func TestPresubmitContexts(t *testing.T) {
+	jobs := func(names ...string) []config.Presubmit {
+		var presubmits []config.Presubmit
+		for _, n := range names {
+			var p config.Presubmit
+			p.Name = n
+			presubmits = append(presubmits, p)
+		}
+		return presubmits
+	}
+	cases := []struct {
+		name       string
+		presubmits []config.Presubmit
+		failing    sets.String
+		failed     sets.String
+		all        sets.String
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:       "simple case works",
+			presubmits: jobs("hello-fail", "world"),
+			failing:    sets.NewString("world"),
+			failed:     sets.NewString("world"),
+			all:        sets.NewString("hello-fail", "world"),
+		},
+		{
+			name:       "ignore failures from deleted jobs",
+			presubmits: jobs("failing", "passing"),
+			failing:    sets.NewString("failing", "deleted"),
+			failed:     sets.NewString("failing"),
+			all:        sets.NewString("failing", "passing"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotFailed, gotAll := presubmitContexts(tc.failing, tc.presubmits, logrus.WithField("case", tc.name))
+			if !equality.Semantic.DeepEqual(tc.failed, gotFailed) {
+				t.Errorf("wrong failures:%s", diff.ObjectReflectDiff(tc.failed, gotFailed))
+			}
+			if !equality.Semantic.DeepEqual(tc.all, gotAll) {
+				t.Errorf("wrong all contexts:%s", diff.ObjectReflectDiff(tc.all, gotAll))
+			}
+		})
+	}
+}
+
+func stamp(t time.Time) gerrit.Timestamp {
+	return gerrit.Timestamp{Time: t}
+}
+
+func TestCurrentMessages(t *testing.T) {
+	now := time.Now()
+	before := now.Add(-time.Minute)
+	after := now.Add(time.Hour)
+	later := after.Add(time.Hour)
+	cases := []struct {
+		name   string
+		change gerrit.ChangeInfo
+		since  time.Time
+		want   []string
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:  "simple case",
+			since: before,
+			change: gerrit.ChangeInfo{
+				Revisions: map[string]gerrit.RevisionInfo{
+					"3": {
+						Number: 3,
+					},
+				},
+				CurrentRevision: "3",
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						RevisionNumber: 3,
+						Date:           stamp(now),
+						Message:        "now",
+					},
+					{
+						RevisionNumber: 3,
+						Date:           stamp(after),
+						Message:        "after",
+					},
+					{
+						RevisionNumber: 3,
+						Date:           stamp(later),
+						Message:        "later",
+					},
+				},
+			},
+			want: []string{"now", "after", "later"},
+		},
+		{
+			name:  "reject old messages",
+			since: now,
+			change: gerrit.ChangeInfo{
+				Revisions: map[string]gerrit.RevisionInfo{
+					"3": {
+						Number: 3,
+					},
+				},
+				CurrentRevision: "3",
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						RevisionNumber: 3,
+						Date:           stamp(now),
+						Message:        "now",
+					},
+					{
+						RevisionNumber: 3,
+						Date:           stamp(after),
+						Message:        "after",
+					},
+					{
+						RevisionNumber: 3,
+						Date:           stamp(later),
+						Message:        "later",
+					},
+				},
+			},
+			want: []string{"after", "later"},
+		},
+		{
+			name:  "reject message from other revisions",
+			since: before,
+			change: gerrit.ChangeInfo{
+				Revisions: map[string]gerrit.RevisionInfo{
+					"3": {
+						Number: 3,
+					},
+				},
+				CurrentRevision: "3",
+				Messages: []gerrit.ChangeMessageInfo{
+					{
+						RevisionNumber: 3,
+						Date:           stamp(now),
+						Message:        "3-now",
+					},
+					{
+						RevisionNumber: 4,
+						Date:           stamp(after),
+						Message:        "4-after",
+					},
+					{
+						RevisionNumber: 3,
+						Date:           stamp(later),
+						Message:        "3-later",
+					},
+				},
+			},
+			want: []string{"3-now", "3-later"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := currentMessages(tc.change, tc.since)
+			if !equality.Semantic.DeepEqual(got, tc.want) {
+				t.Errorf("wrong messages:%s", diff.ObjectReflectDiff(got, tc.want))
+			}
+		})
+	}
+}
+
+func TestMessageFilter(t *testing.T) {
+	job := func(name string, patch func(j *config.Presubmit)) config.Presubmit {
+		var presubmit config.Presubmit
+		presubmit.Name = name
+		presubmit.Context = name
+		presubmit.Trigger = config.DefaultTriggerFor(name)
+		presubmit.RerunCommand = config.DefaultRerunCommandFor(name)
+		presubmit.AlwaysRun = true
+		if patch != nil {
+			patch(&presubmit)
+		}
+		return presubmit
+	}
+	type check struct {
+		job             config.Presubmit
+		shouldRun       bool
+		forcedToRun     bool
+		defaultBehavior bool
+	}
+	cases := []struct {
+		name     string
+		messages []string
+		failed   sets.String
+		all      sets.String
+		checks   []check
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name:     "/test foo works",
+			messages: []string{"/test foo", "/test bar"},
+			all:      sets.NewString("foo", "bar", "ignored"),
+			checks: []check{
+				{
+					job:             job("foo", nil),
+					shouldRun:       true,
+					forcedToRun:     true,
+					defaultBehavior: true,
+				},
+				{
+					job:             job("bar", nil),
+					shouldRun:       true,
+					forcedToRun:     true,
+					defaultBehavior: true,
+				},
+				{
+					job:             job("ignored", nil),
+					shouldRun:       false,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+			},
+		},
+		{
+			name:     "/test all triggers multiple",
+			messages: []string{"/test all"},
+			all:      sets.NewString("foo", "bar"),
+			checks: []check{
+				{
+					job:             job("foo", nil),
+					shouldRun:       true,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+				{
+					job:             job("bar", nil),
+					shouldRun:       true,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+			},
+		},
+		{
+			name:     "/retest triggers failures",
+			messages: []string{"/retest"},
+			failed:   sets.NewString("failed"),
+			all:      sets.NewString("foo", "bar", "failed"),
+			checks: []check{
+				{
+					job:             job("foo", nil),
+					shouldRun:       false,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+				{
+					job:             job("failed", nil),
+					shouldRun:       true,
+					forcedToRun:     false,
+					defaultBehavior: true,
+				},
+				{
+					job:             job("bar", nil),
+					shouldRun:       false,
+					forcedToRun:     false,
+					defaultBehavior: false,
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, check := range tc.checks {
+				t.Run(check.job.Name, func(t *testing.T) {
+					fixed := []config.Presubmit{check.job}
+					config.SetPresubmitRegexes(fixed)
+					check.job = fixed[0]
+					logger := logrus.WithField("case", tc.name).WithField("job", check.job.Name)
+					filt := messageFilter(tc.messages, tc.failed, tc.all, logger)
+					shouldRun, forcedToRun, defaultBehavior := filt(check.job)
+					if got, want := shouldRun, check.shouldRun; got != want {
+						t.Errorf("shouldRun: got %t, want %t", got, want)
+					}
+					if got, want := forcedToRun, check.forcedToRun; got != want {
+						t.Errorf("forcedToRun: got %t, want %t", got, want)
+					}
+					if got, want := defaultBehavior, check.defaultBehavior; got != want {
+						t.Errorf("defaultBehavior: got %t, want %t", got, want)
+					}
+				})
+			}
+		})
+	}
+}

--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -114,7 +114,7 @@ func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body strin
 	var filters []Filter
 	filters = append(filters, CommandFilter(body))
 	if RetestRe.MatchString(body) {
-		logger.Debug("Using retest filter.")
+		logger.Info("Using retest filter.")
 		failedContexts, allContexts, err := contextGetter()
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The /retest command handling in gerrit relies on parsing the messages it leaves.
When it was written prow would only ever write to one label. Now users can and do
have different sets of tests (blocking vs informing) report on different labels.

This PR changes the adapter to look for the latest report on each label,
rather than the single latest report on each label. Thus /retest should retest
jobs more correctly now.

Also involves refactoring the reporter to make Generating/Parsing reports reversible
(currently the parsed report differs from the string output of a generated report).

Added a variety of unit tests, which also included some refactoring towards this end.