### PR TITLE
Add capdo e2e job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -56,3 +56,30 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
       testgrid-tab-name: pr-lint
+  - name: pull-cluster-api-provider-digitalocean-e2e
+    always_run: false
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
+    decoration_config:
+      timeout: 5h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-do-credential: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
+        command:
+          - "runner.sh"
+          - "./scripts/ci-e2e.sh"
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 1
+            memory: "4Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-digitalocean
+      testgrid-tab-name: pr-e2e


### PR DESCRIPTION
Add prow job config for e2e kubernetes/sigs/cluster-api-provider-digitalocean

/hold 
depends on https://github.com/kubernetes-sigs/cluster-api-provider-digitalocean/pull/156

/cc @xmudrii @cpanato @MorrisLaw 