### PR TITLE
Deal better with docker server/client mismatch

### DIFF
--- a/kubetest/local.go
+++ b/kubetest/local.go
@@ -222,7 +222,7 @@ func (n localCluster) Down() error {
 		"kubelet",
 	}
 	// create docker client
-	cli, err := client.NewEnvClient()
+	cli, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
 	if err != nil {
 		log.Printf("Docker containers cleanup, unable to create Docker client: %v", err)
 	}


### PR DESCRIPTION
`pull-kubernetes-local-e2e` ends up failing because:

```
W0515 00:39:02.297] 2020/05/15 00:39:02 local.go:49: Failed to list containers: Error response from daemon: client version 1.41 is too new. Maximum supported API version is 1.40
```

So add version negotiation for better outcomes

Signed-off-by: Davanum Srinivas <davanum@gmail.com>