### PR TITLE
prow: don't coerce draft conversions to comments

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -207,6 +207,8 @@ const (
 	PullRequestActionSynchronize PullRequestEventAction = "synchronize"
 	// PullRequestActionReadyForReview means the PR is no longer a draft PR.
 	PullRequestActionReadyForReview PullRequestEventAction = "ready_for_review"
+	// PullRequestConvertedToDraft means the PR is now a draft PR.
+	PullRequestConvertedToDraft PullRequestEventAction = "converted_to_draft"
 )
 
 // GenericEvent is a lightweight struct containing just Sender and Repo as all events are expected to have this information.

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -58,6 +58,7 @@ var (
 		github.PullRequestActionReopened:             true,
 		github.PullRequestActionSynchronize:          true,
 		github.PullRequestActionReadyForReview:       true,
+		github.PullRequestConvertedToDraft:           true,
 	}
 )
 


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 

fixes

```json
{
    "author": "djzager",
    "component": "hook",
    "event-GUID": "5795fc80-96d1-11ea-825c-9fa4882b8398",
    "event-type": "pull_request",
    "file": "prow/hook/events.go:206",
    "func": "k8s.io/test-infra/prow/hook.(*Server).handlePullRequestEvent",
    "level": "error",
    "msg": "Could not coerce pull_request event to a GenericCommentEvent. Unknown 'action': \"converted_to_draft\".",
    "org": "open-cluster-management",
    "pr": 125,
    "repo": "multicloud-operators-foundation",
    "time": "2020-05-15T17:27:25Z",
    "url": "https://github.com/open-cluster-management/multicloud-operators-foundation/pull/125"
}
```