### PR TITLE
Cherrypicker: add support for conditional labels

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -11,6 +11,8 @@ go_library(
         "k8s_client.go",
         "kubernetes_cluster_clients.go",
         "storage.go",
+        "string_slice.go",
+        "string_to_strings.go",
         "strings.go",
     ],
     importpath = "k8s.io/test-infra/prow/flagutil",
@@ -50,7 +52,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["kubernetes_cluster_clients_test.go"],
+    srcs = [
+        "kubernetes_cluster_clients_test.go",
+        "string_slice_test.go",
+        "string_to_strings_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//pkg/flagutil:go_default_library"],
+    deps = [
+        "//pkg/flagutil:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
 )

--- a/prow/flagutil/string_slice.go
+++ b/prow/flagutil/string_slice.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"strings"
+)
+
+// StringSlice is a generic command-line flag for a []string.
+// The flag is specified using the format: value1,value2,value3
+type StringSlice struct {
+	value []string
+}
+
+// NewStringSlice creates a new instance of StringSlice.
+func NewStringSlice(value []string) *StringSlice {
+	return &StringSlice{
+		value: value,
+	}
+}
+
+// Set returns the string representation of the StringSlice.
+func (s *StringSlice) String() string {
+	return strings.Join(s.value, ",")
+}
+
+// Strings gets the value of the StringSlice.
+func (s *StringSlice) Get() []string {
+	return s.value
+}
+
+// Set sets the value of the StringSlice.
+func (s *StringSlice) Set(value string) error {
+	s.value = strings.Split(value, ",")
+	return nil
+}

--- a/prow/flagutil/string_slice_test.go
+++ b/prow/flagutil/string_slice_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStringSlice(t *testing.T) {
+	testCases := []struct {
+		name        string
+		value       string
+		expectedErr bool
+		expected    *StringSlice
+	}{
+		{
+			value:    "a,b,c,z",
+			expected: NewStringSlice([]string{"a", "b", "c", "z"}),
+		},
+		{
+			value:    "cla: yes,approved",
+			expected: NewStringSlice([]string{"cla: yes", "approved"}),
+		},
+		{
+			value:    "key",
+			expected: NewStringSlice([]string{"key"}),
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := NewStringSlice([]string{})
+		err := actual.Set(tc.value)
+
+		if err == nil && tc.expectedErr {
+			t.Fatal("error expected")
+		}
+		if err != nil && !tc.expectedErr {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cmp.Equal(tc.expected.Get(), actual.Get(), cmp.AllowUnexported(StringSlice{})) {
+			t.Fatalf("expected and actual are not equal: %v", cmp.Diff(tc.expected.Get(), actual.Get()))
+		}
+		if !cmp.Equal(tc.expected, actual, cmp.AllowUnexported(StringSlice{})) {
+			t.Fatalf("expected and actual string representations are not equal: %v", cmp.Diff(tc.expected, actual))
+		}
+	}
+}

--- a/prow/flagutil/string_to_strings.go
+++ b/prow/flagutil/string_to_strings.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StringToStringSlice is a generic command-line flag for a map[string][]string.
+// The flag is specified using the format: key1=value1,value2;key2=value1,value2
+type StringToStringSlice struct {
+	value map[string][]string
+}
+
+// NewStringToStringSlice creates a new instance of StringToStringSlice.
+func NewStringToStringSlice(value map[string][]string) *StringToStringSlice {
+	return &StringToStringSlice{
+		value: value,
+	}
+}
+
+// Set returns the string representation of the StringToStringSlice.
+func (s *StringToStringSlice) String() string {
+	var valuesList []string
+	for key, values := range s.value {
+		valuesList = append(valuesList, key+"="+strings.Join(values, ","))
+	}
+	return strings.Join(valuesList, ";")
+}
+
+// Strings gets the value of the StringToStringSlice.
+func (s *StringToStringSlice) Get() map[string][]string {
+	return s.value
+}
+
+// Set sets the value of the StringToStringSlice.
+func (s *StringToStringSlice) Set(value string) error {
+	s.value = make(map[string][]string)
+
+	parts := strings.Split(value, ";")
+	for _, part := range parts {
+		subparts := strings.Split(part, "=")
+		if len(subparts) != 2 {
+			return fmt.Errorf("%s not in the form of key1=value1,value2;key2=value1,value2", value)
+		}
+		key := subparts[0]
+		if _, ok := s.value[key]; ok {
+			return fmt.Errorf("duplicate key: %s", key)
+		}
+		values := strings.Split(subparts[1], ",")
+		s.value[key] = append(s.value[key], values...)
+	}
+
+	return nil
+}

--- a/prow/flagutil/string_to_strings_test.go
+++ b/prow/flagutil/string_to_strings_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestStringToStringSlice(t *testing.T) {
+	testCases := []struct {
+		name        string
+		value       string
+		expectedErr bool
+		expected    *StringToStringSlice
+	}{
+		{
+			value: "a=1,2,3,4;b=5,2,3,7;c=5,8,9,7;z=1,3,2,1",
+			expected: NewStringToStringSlice(map[string][]string{
+				"a": {"1", "2", "3", "4"},
+				"b": {"5", "2", "3", "7"},
+				"c": {"5", "8", "9", "7"},
+				"z": {"1", "3", "2", "1"},
+			}),
+		},
+		{
+			value: "cla: no=cla: yes,automerge;approved=automerge,lgtm",
+			expected: NewStringToStringSlice(map[string][]string{
+				"cla: no":  {"cla: yes", "automerge"},
+				"approved": {"automerge", "lgtm"},
+			}),
+		},
+		{
+			value: "key=Value",
+			expected: NewStringToStringSlice(map[string][]string{
+				"key": {"Value"},
+			}),
+		},
+		{
+			value:       "a;b=c",
+			expected:    NewStringToStringSlice(map[string][]string{}),
+			expectedErr: true,
+		},
+		{
+			value:       "a=b=c=d",
+			expected:    NewStringToStringSlice(map[string][]string{}),
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := NewStringToStringSlice(map[string][]string{})
+		err := actual.Set(tc.value)
+
+		if err == nil && tc.expectedErr {
+			t.Fatal("error expected")
+		}
+		if err != nil && !tc.expectedErr {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !cmp.Equal(tc.expected.Get(), actual.Get(), cmp.AllowUnexported(StringToStringSlice{})) {
+			t.Fatalf("expected and actual are not equal: %v", cmp.Diff(tc.expected.Get(), actual.Get()))
+		}
+		if !cmp.Equal(tc.expected, actual, cmp.AllowUnexported(StringToStringSlice{})) {
+			t.Fatalf("expected and actual string representations are not equal: %v", cmp.Diff(tc.expected, actual))
+		}
+	}
+}


### PR DESCRIPTION
* Add `--conditional-labels` option to the **cherrypicker** plugin to specify labels to conditionally apply to the cherrypicked PR when another label is present.
* Add new `StringToStringSlice` flag for `map[string][]string`
* Add new `StringSlice` flag for `[]string`

https://github.com/istio/istio.io/issues/6333