### PR TITLE
Update cos-stable images to the latest versions

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -1,21 +1,21 @@
 ---
 images:
   cosstable2-resource1:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable2-resource2:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable2-resource3:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
@@ -23,52 +23,52 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   cosstable2-density1:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-2
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
-    image: cos-stable-77-12371-227-0 
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable1-resource2:
-    image: cos-stable-77-12371-227-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable1-resource3:
-    image: cos-stable-77-12371-227-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:
-    image_regex: cos-stable-73-11647-510-0
+    image_regex: cos-73-11647-534-0
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.2/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env"
   cos-stable:
-    image_regex: cos-stable-73-11647-510-0
+    image_regex: cos-73-11647-534-0
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-release-1.3/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env"
   cos-stable:
-    image_regex: cos-stable-73-11647-510-0
+    image_regex: cos-73-11647-534-0
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.3/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -1,21 +1,21 @@
 ---
 images:
   cosstable2-resource1:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable2-resource2:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable2-resource3:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
@@ -23,35 +23,35 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   cosstable2-density1:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
-    image: cos-stable-73-11647-510-0
+    image: cos-73-11647-534-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
@@ -59,21 +59,21 @@ images:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
-    image: cos-stable-77-12371-227-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable1-resource2:
-    image: cos-stable-77-12371-227-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable1-resource3:
-    image: cos-stable-77-12371-227-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:
-    image_regex: cos-stable-73-11647-510-0
+    image_regex: cos-73-11647-534-0
     project: cos-cloud
     metadata: "user-data</home/prow/go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/cri-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
   cos-stable:
-    image_regex: cos-stable-73-11647-510-0
+    image_regex: cos-73-11647-534-0
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/image-config-serial-cpu-manager.yaml
+++ b/jobs/e2e_node/image-config-serial-cpu-manager.yaml
@@ -8,7 +8,7 @@ images:
     # Using `n1-standard-4` to enable CPU manager node e2e tests.
     machine: n1-standard-4
   cos-stable1:
-    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19
+    image_regex: cos-73-11647-534-0 # docker v18.09.7, deprecated after 2020-06-19
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
     # Using `n1-standard-4` to enable CPU manager node e2e tests.

--- a/jobs/e2e_node/image-config-serial.yaml
+++ b/jobs/e2e_node/image-config-serial.yaml
@@ -6,7 +6,7 @@ images:
     image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable2:
-    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19
+    image_regex: cos-73-11647-534-0 # docker v18.09.7, deprecated after 2020-06-19
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/gci-init-gpu.yaml,gci-update-strategy=update_disabled"
     resources:
@@ -14,6 +14,6 @@ images:
         - type: nvidia-tesla-k80
           count: 2
   cos-stable1:
-    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17
+    image_regex: cos-77-12371-251-0 # docker v19.03.1, deprecated after 2020-12-17
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -6,10 +6,10 @@ images:
     image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable1:
-    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17
+    image_regex: cos-77-12371-251-0 # docker v19.03.1, deprecated after 2020-12-17
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
   cos-stable2:
-    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19
+    image_regex: cos-73-11647-534-0 # docker v18.09.7, deprecated after 2020-06-19
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
e2e node tests fail to find cos-stable images with this error:
    Error 400: Invalid value for field 'resource.disks[0].initializeParams.sourceImage':
        'projects/cos-cloud/global/images/cos-stable-73-11647-510-0'.
    The referenced image resource cannot be found., invalid

Updating to the latest cos-stable versions should fix this issue.

Here is an example of the failed build: https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance/1261760411095535627/build-log.txt