### PR TITLE
prow: use flagutil for storageoptions in deck and gcsupload

### DIFF
--- a/prow/flagutil/storage.go
+++ b/prow/flagutil/storage.go
@@ -29,13 +29,13 @@ type StorageClientOptions struct {
 	// It's optional, if you want to write to local paths or GCS credentials auto-discovery is used.
 	// If set, this file is used to read/write to gs:// paths
 	// If not, credential auto-discovery is used
-	GCSCredentialsFile string
+	GCSCredentialsFile string `json:"gcs_credentials_file,omitempty"`
 	// S3CredentialsFile is used for reading/writing to s3 block storage.
 	// It's optional, if you want to write to local paths or S3 credentials auto-discovery is used.
 	// If set, this file is used to read/write to s3:// paths
 	// If not, go cloud credential auto-discovery is used
 	// For more details see the prow/io/providers pkg.
-	S3CredentialsFile string
+	S3CredentialsFile string `json:"s3_credentials_file,omitempty"`
 }
 
 // AddFlags injects status client options into the given FlagSet.

--- a/prow/gcsupload/BUILD.bazel
+++ b/prow/gcsupload/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "//prow/pod-utils/gcs:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",

--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -24,8 +24,10 @@ import (
 	"strings"
 
 	"github.com/GoogleCloudPlatform/testgrid/util/gcs"
+
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/flagutil"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 )
 
 // NewOptions returns an empty Options with no nil fields.
@@ -46,17 +48,7 @@ type Options struct {
 
 	*prowapi.GCSConfiguration
 
-	// GcsCredentialsFile is used for reading/writing to GCS block storage.
-	// It's optional, if you want to write to local paths or GCS credentials auto-discovery is used.
-	// If set, this file is used to read/write to gs:// paths
-	// If not, credential auto-discovery is used
-	GcsCredentialsFile string `json:"gcs_credentials_file,omitempty"`
-	// S3CredentialsFile is used for reading/writing to s3 block storage.
-	// It's optional, if you want to write to local paths or S3 credentials auto-discovery is used.
-	// If set, this file is used to read/write to s3:// paths
-	// If not, go cloud credential auto-discovery is used
-	// For more details see the prow/io/providers pkg.
-	S3CredentialsFile string `json:"s3_credentials_file,omitempty"`
+	prowflagutil.StorageClientOptions
 
 	DryRun bool `json:"dry_run"`
 
@@ -88,7 +80,7 @@ func (o *Options) Validate() error {
 			return errors.New("GCS upload was requested no GCS bucket was provided")
 		}
 
-		if o.GcsCredentialsFile == "" && o.S3CredentialsFile == "" {
+		if o.StorageClientOptions.GCSCredentialsFile == "" && o.StorageClientOptions.S3CredentialsFile == "" {
 			return errors.New("blob storage upload was requested but neither GCS nor S3 credentials file was provided")
 		}
 	}
@@ -135,13 +127,13 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.DefaultRepo, "default-repo", "", "optional default repo for GCS path encoding")
 
 	fs.Var(&o.gcsPath, "gcs-path", "GCS path to upload into")
-	fs.StringVar(&o.GcsCredentialsFile, "gcs-credentials-file", "", "file where Google Cloud authentication credentials are stored")
-	fs.StringVar(&o.S3CredentialsFile, "s3-credentials-file", "", "file where the S3 credentials are stored")
 	fs.BoolVar(&o.DryRun, "dry-run", true, "do not interact with GCS")
 
 	fs.Var(&o.mediaTypes, "media-type", "Optional comma-delimited set of extension media types.  Each entry is colon-delimited {extension}:{media-type}, for example, log:text/plain.")
 
 	fs.StringVar(&o.LocalOutputDir, "local-output-dir", "", "If specified, files are copied to this dir instead of uploading to GCS.")
+
+	o.StorageClientOptions.AddFlags(fs)
 }
 
 const (

--- a/prow/gcsupload/options_test.go
+++ b/prow/gcsupload/options_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/flagutil"
 )
 
 func TestOptions_Validate(t *testing.T) {
@@ -41,8 +42,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "push to GCS, ok",
 			input: Options{
-				DryRun:             false,
-				GcsCredentialsFile: "secrets",
+				DryRun: false,
+				StorageClientOptions: flagutil.StorageClientOptions{
+					GCSCredentialsFile: "secrets",
+				},
 				GCSConfiguration: &prowapi.GCSConfiguration{
 					Bucket:       "seal",
 					PathStrategy: prowapi.PathStrategyExplicit,
@@ -53,8 +56,10 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "push to GCS, missing bucket",
 			input: Options{
-				DryRun:             false,
-				GcsCredentialsFile: "secrets",
+				DryRun: false,
+				StorageClientOptions: flagutil.StorageClientOptions{
+					GCSCredentialsFile: "secrets",
+				},
 				GCSConfiguration: &prowapi.GCSConfiguration{
 					PathStrategy: prowapi.PathStrategyExplicit,
 				},

--- a/prow/gcsupload/run.go
+++ b/prow/gcsupload/run.go
@@ -57,7 +57,7 @@ func (o Options) Run(spec *downwardapi.JobSpec, extra map[string]gcs.UploadFunc)
 	}
 
 	if o.LocalOutputDir == "" {
-		if err := gcs.Upload(o.Bucket, o.GcsCredentialsFile, o.S3CredentialsFile, uploadTargets); err != nil {
+		if err := gcs.Upload(o.Bucket, o.StorageClientOptions.GCSCredentialsFile, o.StorageClientOptions.S3CredentialsFile, uploadTargets); err != nil {
 			return fmt.Errorf("failed to upload to blob storage: %w", err)
 		}
 		logrus.Info("Finished upload to blob storage")

--- a/prow/initupload/BUILD.bazel
+++ b/prow/initupload/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/gcsupload:go_default_library",
         "//prow/pod-utils/clone:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",

--- a/prow/initupload/options_test.go
+++ b/prow/initupload/options_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/gcsupload"
 )
 
@@ -107,8 +108,10 @@ func TestOptions_LoadConfig(t *testing.T) {
 						Bucket:       "prow-artifacts",
 						PathStrategy: "explicit",
 					},
-					GcsCredentialsFile: "/secrets/gcs/service-account.json",
-					DryRun:             false,
+					StorageClientOptions: flagutil.StorageClientOptions{
+						GCSCredentialsFile: "/secrets/gcs/service-account.json",
+					},
+					DryRun: false,
 				},
 				Log: "/logs/clone.json",
 			},
@@ -133,7 +136,9 @@ func TestOptions_LoadConfig(t *testing.T) {
 						Bucket:       "s3://prow-artifacts",
 						PathStrategy: "explicit",
 					},
-					S3CredentialsFile: "/secrets/s3-storage/service-account.json",
+					StorageClientOptions: flagutil.StorageClientOptions{
+						S3CredentialsFile: "/secrets/s3-storage/service-account.json",
+					},
 				},
 				Log: "/logs/clone.json",
 			},

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -533,7 +533,7 @@ func BlobStorageOptions(dc prowapi.DecorationConfig, localMode bool) ([]coreapi.
 			Name:      gcsCredentialsMountName,
 			MountPath: gcsCredentialsMountPath,
 		})
-		opt.GcsCredentialsFile = fmt.Sprintf("%s/service-account.json", gcsCredentialsMountPath)
+		opt.StorageClientOptions.GCSCredentialsFile = fmt.Sprintf("%s/service-account.json", gcsCredentialsMountPath)
 	}
 	if dc.S3CredentialsSecret != "" {
 		volumes = append(volumes, coreapi.Volume{
@@ -548,7 +548,7 @@ func BlobStorageOptions(dc prowapi.DecorationConfig, localMode bool) ([]coreapi.
 			Name:      s3CredentialsMountName,
 			MountPath: s3CredentialsMountPath,
 		})
-		opt.S3CredentialsFile = fmt.Sprintf("%s/service-account.json", s3CredentialsMountPath)
+		opt.StorageClientOptions.S3CredentialsFile = fmt.Sprintf("%s/service-account.json", s3CredentialsMountPath)
 	}
 
 	return volumes, mounts, opt

--- a/prow/sidecar/BUILD.bazel
+++ b/prow/sidecar/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/entrypoint:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/gcsupload:go_default_library",
         "//prow/pod-utils/wrapper:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/sidecar/options_test.go
+++ b/prow/sidecar/options_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/gcsupload"
 	"k8s.io/test-infra/prow/pod-utils/wrapper"
 )
@@ -70,9 +71,11 @@ func TestOptions_LoadConfig(t *testing.T) {
 						Bucket:       "prow-artifacts",
 						PathStrategy: "explicit",
 					},
-					GcsCredentialsFile: "/secrets/gcs/service-account.json",
-					DryRun:             false,
-					Items:              []string{"/logs/artifacts"},
+					StorageClientOptions: flagutil.StorageClientOptions{
+						GCSCredentialsFile: "/secrets/gcs/service-account.json",
+					},
+					DryRun: false,
+					Items:  []string{"/logs/artifacts"},
 				},
 				Entries: []wrapper.Options{
 					{
@@ -120,9 +123,11 @@ func TestOptions_LoadConfig(t *testing.T) {
 						Bucket:       "s3://prow-artifacts",
 						PathStrategy: "explicit",
 					},
-					S3CredentialsFile: "/secrets/s3-storage/service-account.json",
-					DryRun:            false,
-					Items:             []string{"/logs/artifacts"},
+					StorageClientOptions: flagutil.StorageClientOptions{
+						S3CredentialsFile: "/secrets/s3-storage/service-account.json",
+					},
+					DryRun: false,
+					Items:  []string{"/logs/artifacts"},
 				},
 				Entries: []wrapper.Options{
 					{


### PR DESCRIPTION
small cleanup PR in the context of https://github.com/kubernetes/test-infra/issues/11260

Might make sense to wait with merging until [prow: deck: add s3 support #17183](https://github.com/kubernetes/test-infra/pull/17183) has been rolled out successfully.