### PR TITLE
Add ServiceCatalog tests against latest k8s version

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -37,12 +37,11 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-  - name: pull-service-catalog-test-e2e
+  - name: pull-service-catalog-test-e2e-k8s-1-16-9
     <<: *build_image_cfg
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    # Setting that job optional to check how it behaves
     optional: true
     spec:
       containers:
@@ -50,6 +49,55 @@ presubmits:
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
+          env:
+            - name: KUBERNETES_VERSION
+              value: "v1.16.9"
+          args:
+            - make
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-service-catalog-test-e2e-k8s-1-17-5
+    <<: *build_image_cfg
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    optional: true
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          env:
+            - name: KUBERNETES_VERSION
+              value: "v1.17.5"
+          args:
+            - make
+            - test-e2e
+          # docker-in-docker needs privileged mode
+          securityContext:
+            privileged: true
+  - name: pull-service-catalog-test-e2e-k8s-1-18-2
+    <<: *build_image_cfg
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    optional: true
+    # Run only on PR created to master branch. K8s in version 1.18 is not supported for
+    # legacy (v0.2.x) Service Catalog.
+    branches:
+      - master
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
+          command:
+            # generic runner script, handles DIND, bazelrc for caching, etc.
+            - runner.sh
+          env:
+            - name: KUBERNETES_VERSION
+              value: "v1.18.2"
           args:
             - make
             - test-e2e


### PR DESCRIPTION
**Description**

Add tests against 3 latest k8s versions.

Connected PR: https://github.com/kubernetes-sigs/service-catalog/pull/2803

Related Issue:
- https://github.com/kubernetes-sigs/service-catalog/issues/2793