### PR TITLE
add description text for containerd testgrid jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -57,7 +57,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build
-    description: "builds master branch of upstream containerd"
+    description: "builds development in progress branch of upstream containerd"
 - name: ci-containerd-build-1-2
   interval: 30m
   labels:
@@ -77,7 +77,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-1.2
-    description: "builds release/1.2 branch of upstream containerd"
+    description: "builds release/1.2 branch of upstream containerd as it is distributed with docker"
 - name: ci-containerd-build-1-3
   interval: 30m
   labels:

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -57,6 +57,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build
+    description: "builds master branch of upstream containerd"
 - name: ci-containerd-build-1-2
   interval: 30m
   labels:
@@ -76,6 +77,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-1.2
+    description: "builds release/1.2 branch of upstream containerd"
 - name: ci-containerd-build-1-3
   interval: 30m
   labels:
@@ -95,6 +97,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-1.3
+    description: "builds release/1.3 branch of upstream containerd"
 - interval: 1h
   name: ci-containerd-e2e-gci-gce
   labels:
@@ -445,6 +448,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: build
+    description: "builds master branch of upstream cri for containerd"
 - name: ci-cri-containerd-windows-build
   interval: 30m
   labels:


### PR DESCRIPTION
I think these run to ensure that our upstream dependencies still build, but I am not sure what would fail if one of these failed.

They are very quick, usually 3-5 minutes. 