### PR TITLE
Provide the job for e2e-node hugepages tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -341,3 +341,34 @@ periodics:
     testgrid-dashboards: wg-resource-management, sig-node-kubelet
     testgrid-tab-name: kubelet-serial-gce-e2e-topology-manager
     testgrid-alert-email: vpickard@redhat.com, klueska@gmail.com
+
+- name: ci-kubernetes-node-kubelet-serial-hugepages
+  interval: 4h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
+        args:
+          - --repo=k8s.io/kubernetes=master
+          - --timeout=240
+          - --root=/go/src
+          - --scenario=kubernetes_e2e
+          - --
+          - --deployment=node
+          - --gcp-project-type=node-e2e-project
+          - --gcp-zone=us-west1-b
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-hugepages.yaml
+          - --node-test-args=--feature-gates=HugePageStorageMediumSize=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+          - --node-tests=true
+          - --provider=gce
+          - --test_args=--nodes=1 --focus="\[Feature:HugePages\]"
+          - --timeout=180m
+        env:
+          - name: GOPATH
+            value: /go
+  annotations:
+    testgrid-dashboards: wg-resource-management, sig-node-kubelet
+    testgrid-tab-name: kubelet-serial-gce-e2e-hugepages
+    testgrid-alert-email: alukiano@redhat.com, eduard.bartosh@intel.com

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -216,3 +216,37 @@ presubmits:
           env:
             - name: GOPATH
               value: /go
+  - name: pull-kubernetes-node-kubelet-serial-hugepages
+    always_run: false
+    optional: true
+    skip_report: false
+    skip_branches:
+      - release-\d+\.\d+  # per-release image
+    annotations:
+      testgrid-dashboards: wg-resource-management
+      testgrid-tab-name: pr-kubelet-serial-gce-e2e-hugepages
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
+          args:
+            - --repo=k8s.io/kubernetes=$(PULL_REFS)
+            - --repo=k8s.io/release
+            - --timeout=240
+            - --root=/go/src
+            - --scenario=kubernetes_e2e
+            - --
+            - --deployment=node
+            - --gcp-project=k8s-jkns-pr-node-e2e
+            - --gcp-zone=us-west1-b
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-hugepages.yaml
+            - --node-test-args=--feature-gates=HugePageStorageMediumSize=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+            - --node-tests=true
+            - --provider=gce
+            - --test_args=--nodes=1 --skip="" --focus="\[Feature:HugePages\]"
+            - --timeout=180m
+          env:
+            - name: GOPATH
+              value: /go

--- a/jobs/e2e_node/image-config-serial-hugepages.yaml
+++ b/jobs/e2e_node/image-config-serial-hugepages.yaml
@@ -1,0 +1,10 @@
+# To copy an image between projects:
+# `gcloud compute --project <to-project> disks create <image name> --image=https://www.googleapis.com/compute/v1/projects/<from-project>/global/images/<image-name>`
+# `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
+images:
+  ubuntu:
+    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</workspace/test-infra/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml"
+    # Using `n1-standard-2` to have enough memory for 1Gb huge pages allocation
+    machine: n1-standard-2

--- a/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml
+++ b/jobs/e2e_node/ubuntu-hugepages-1G-allocation.yaml
@@ -1,0 +1,4 @@
+#cloud-config
+
+runcmd:
+  - echo 1 > /sys/kernel/mm/hugepages/hugepages-1048576kB/nr_hugepages


### PR DESCRIPTION
Using multiple hugepages with different page size is an alpha feature under the k8s 1.18,
to promote it to the beta, e2e tests were provided, but these tests can not run under the serial
lane, because the feature gate should be enabled and the instance that will run tests, should
have 1Gb hugepage allocated. To satisfy these requests new jobs should be introduced.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>