### PR TITLE
remove capi-e2e-test masters

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -116,32 +116,3 @@ periodics:
     testgrid-tab-name: unit tests-release-0-2
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-postsubmits:
-  kubernetes-sigs/cluster-api:
-  - name: postsubmit-cluster-api-e2e-tests-master
-    interval: 1h
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api
-    branches:
-    - master
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
-          args:
-            - runner.sh
-            - "./scripts/ci-e2e.sh"
-          # we need privileged mode in order to do docker in docker
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-            cpu: "6000m"
-            memory: "6Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: capi e2e tests-master
-      testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-      testgrid-num-failures-to-alert: "2"


### PR DESCRIPTION
Removing  the postsubmit-cluster-api-e2e-tests-master jobs, because changes on master are already tested by pre submits and periodic jobs

/assign @vincepri 