### PR TITLE
Comment accordingly if /test all cant run any jobs

### DIFF
--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -37,9 +37,10 @@ var (
 	retestWithTargetRe  = regexp.MustCompile(`(?m)^/retest[ \t]+\S+`)
 	testWithAnyTargetRe = regexp.MustCompile(`(?m)^/test[ \t]+\S+`)
 
-	testWithoutTargetNote = "The `/test` command needs one or more targets.\n"
-	retestWithTargetNote  = "The `/retest` command does not accept any targets.\n"
-	targetNotFoundNote    = "The specified target(s) for `/test` were not found.\n"
+	testWithoutTargetNote     = "The `/test` command needs one or more targets.\n"
+	retestWithTargetNote      = "The `/retest` command does not accept any targets.\n"
+	targetNotFoundNote        = "The specified target(s) for `/test` were not found.\n"
+	thereAreNoTestAllJobsNote = "No jobs can be run with `/test all`.\n"
 )
 
 func mayNeedHelpComment(body string) bool {
@@ -197,20 +198,36 @@ func FilterPresubmits(honorOkToTest bool, gitHubClient GitHubClient, body string
 	return pjutil.FilterPresubmits(filter, changes, branch, presubmits, logger)
 }
 
-func availablePresubmits(githubClient GitHubClient, body, org, repo, branch string, number int, presubmits []config.Presubmit, logger *logrus.Entry) ([]string, error) {
+// availablePresubmits returns 2 sets of presubmits:
+// 1. presubmits that can be run with '/test all' command.
+// 2. presubmits that can be run with their trigger, e.g. '/test job'
+func availablePresubmits(githubClient GitHubClient, body, org, repo, branch string, number int, presubmits []config.Presubmit, logger *logrus.Entry) ([]string, []string, error) {
 	changes := config.NewGitHubDeferredChangedFilesProvider(githubClient, org, repo, number)
-	all := func(p config.Presubmit) (bool, bool, bool) {
-		return true, true, true
-	}
-	toTest, err := pjutil.FilterPresubmits(all, changes, branch, presubmits, logger)
+
+	runWithTestAll, err := pjutil.FilterPresubmits(pjutil.TestAllFilter(), changes, branch, presubmits, logger)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	var available []string
-	for _, pre := range toTest {
-		available = append(available, pre.RerunCommand)
+
+	var triggerFilters []pjutil.Filter
+	for _, ps := range presubmits {
+		triggerFilters = append(triggerFilters, pjutil.CommandFilter(ps.RerunCommand))
 	}
-	return available, nil
+	runWithTrigger, err := pjutil.FilterPresubmits(pjutil.AggregateFilter(triggerFilters), changes, branch, presubmits, logger)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var runWithTestAllNames []string
+	for _, ps := range runWithTestAll {
+		runWithTestAllNames = append(runWithTestAllNames, ps.Name)
+	}
+	var runWithTriggerNames []string
+	for _, ps := range runWithTrigger {
+		runWithTriggerNames = append(runWithTriggerNames, ps.RerunCommand)
+	}
+
+	return runWithTestAllNames, runWithTriggerNames, nil
 }
 
 func getContexts(combinedStatus *github.CombinedStatus) (sets.String, sets.String) {
@@ -228,18 +245,30 @@ func getContexts(combinedStatus *github.CombinedStatus) (sets.String, sets.Strin
 }
 
 func addHelpComment(githubClient githubClient, body, org, repo, branch string, number int, presubmits []config.Presubmit, HTMLURL, user, note string, logger *logrus.Entry) error {
-	available, err := availablePresubmits(githubClient, body, org, repo, branch, number, presubmits, logger)
+	testAllNames, testCommands, err := availablePresubmits(githubClient, body, org, repo, branch, number, presubmits, logger)
 	if err != nil {
 		return err
 	}
+
 	var resp string
-	if len(available) > 0 {
-		var listBuilder strings.Builder
-		for _, name := range available {
-			listBuilder.WriteString(fmt.Sprintf("\n* `%s`", name))
+	if len(testAllNames)+len(testCommands) > 0 {
+		listBuilder := func(names []string) string {
+			var list strings.Builder
+			for _, name := range names {
+				list.WriteString(fmt.Sprintf("\n* `%s`", name))
+			}
+			return list.String()
 		}
-		resp = fmt.Sprintf("%sThe following commands are available to trigger jobs:%s\n\nUse `/test all` to run all jobs.",
-			note, listBuilder.String())
+
+		var testAllNote string
+		if len(testAllNames) == len(testCommands) {
+			testAllNote = "Use `/test all` to run all jobs.\n"
+		} else if len(testAllNames) > 0 {
+			testAllNote = fmt.Sprintf("Use `/test all` to run the following jobs:%s\n\n", listBuilder(testAllNames))
+		}
+
+		resp = fmt.Sprintf("%sThe following commands are available to trigger jobs:%s\n\n%s",
+			note, listBuilder(testCommands), testAllNote)
 	} else {
 		resp = fmt.Sprintf("No presubmit jobs available for %s/%s@%s", org, repo, branch)
 	}
@@ -254,6 +283,8 @@ func shouldRespondWithHelp(body string, toRunOrSkip int) (bool, string) {
 		return true, testWithoutTargetNote
 	case retestWithTargetRe.MatchString(body):
 		return true, retestWithTargetNote
+	case toRunOrSkip == 0 && pjutil.TestAllRe.MatchString(body):
+		return true, thereAreNoTestAllJobsNote
 	case toRunOrSkip == 0 && testWithAnyTargetRe.MatchString(body):
 		return true, targetNotFoundNote
 	default:


### PR DESCRIPTION
If no jobs can be run with `/test all` command, the trigger plugin
responds accordingly in the help comment. Closes #17580 

