### PR TITLE
Do not warning on ghproxy for mkpj

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -201,6 +201,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	o.kubernetes.AddFlags(fs)
 	o.github.AddFlags(fs)
 	o.github.AllowAnonymous = true
+	o.github.AllowDirectAccess = true
 	fs.Parse(args)
 	return o
 }

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -947,6 +947,7 @@ func Test_gatherOptions(t *testing.T) {
 		ghoptions := flagutil.GitHubOptions{}
 		ghoptions.AddFlags(fs)
 		ghoptions.AllowAnonymous = true
+		ghoptions.AllowDirectAccess = true
 		t.Run(tc.name, func(t *testing.T) {
 			expected := &options{
 				configPath:            "yo",

--- a/prow/cmd/mkpj/main.go
+++ b/prow/cmd/mkpj/main.go
@@ -54,7 +54,7 @@ type options struct {
 	pullRequest  *github.PullRequest
 }
 
-func (o *options) genJobSpec(conf *config.Config, name string) (config.JobBase, prowapi.ProwJobSpec) {
+func (o *options) genJobSpec(conf *config.Config) (config.JobBase, prowapi.ProwJobSpec) {
 	for fullRepoName, ps := range conf.PresubmitsStatic {
 		org, repo, err := splitRepoName(fullRepoName)
 		if err != nil {
@@ -206,6 +206,7 @@ func gatherOptions() options {
 	fs.StringVar(&o.pullAuthor, "pull-author", "", "Git pull author under test")
 	o.github.AddFlags(fs)
 	o.github.AllowAnonymous = true
+	o.github.AllowDirectAccess = true
 	fs.Parse(os.Args[1:])
 	return o
 }
@@ -232,7 +233,7 @@ func main() {
 	if err != nil {
 		logrus.WithError(err).Fatal("Failed to get GitHub client")
 	}
-	job, pjs := o.genJobSpec(conf, o.jobName)
+	job, pjs := o.genJobSpec(conf)
 	if job.Name == "" {
 		logrus.Fatalf("Job %s not found.", o.jobName)
 	}

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -65,6 +65,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 		group.AddFlags(fs)
 	}
 
+	o.github.AllowDirectAccess = true
 	fs.Parse(args)
 	return o
 }

--- a/prow/cmd/plank/main_test.go
+++ b/prow/cmd/plank/main_test.go
@@ -90,6 +90,7 @@ func Test_gatherOptions(t *testing.T) {
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)
 			expected.github.AllowAnonymous = true
+			expected.github.AllowDirectAccess = true
 			if tc.expected != nil {
 				tc.expected(expected)
 			}


### PR DESCRIPTION
`mkpj` does not need many accesses to the Github APIs, so it should not require ghproxy to be set. Adding an `AllowDirectAccess` field to allow suppressing the warning. And BTW removing one redundant argument from function `genJobSpec`.

Fixes #17549 

/cc @BenTheElder @cjwagner 