### PR TITLE
kubernetes-sigs/boskos: configure prow plugins and jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/boskos/OWNERS
+++ b/config/jobs/kubernetes-sigs/boskos/OWNERS
@@ -1,0 +1,14 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- ixdy
+- alvaroaleman
+- stevekuznetsov
+
+reviewers:
+- ixdy
+- alvaroaleman
+- stevekuznetsov
+
+labels:
+- area/boskos

--- a/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-postsubmits.yaml
@@ -1,0 +1,23 @@
+postsubmits:
+  kubernetes-sigs/boskos:
+    - name: ci-boskos-build-test-verify
+      decorate: true
+      always_run: true
+      path_alias: sigs.k8s.io/boskos
+      spec:
+        containers:
+          - image: golang:1.14
+            imagePullPolicy: Always
+            command:
+              - make
+            args:
+              - build
+              - test
+              - verify
+            resources:
+              requests:
+                cpu: 4000m
+      annotations:
+        testgrid-dashboards: sig-testing-boskos
+        testgrid-tab-name: ci-build-test-verify
+        testgrid-alert-email: jgrafton@google.com

--- a/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/boskos/boskos-presubmits.yaml
@@ -1,0 +1,22 @@
+presubmits:
+  kubernetes-sigs/boskos:
+    - name: pull-boskos-build-test-verify
+      decorate: true
+      always_run: true
+      path_alias: sigs.k8s.io/boskos
+      spec:
+        containers:
+          - image: golang:1.14
+            imagePullPolicy: Always
+            command:
+              - make
+            args:
+              - build
+              - test
+              - verify
+            resources:
+              requests:
+                cpu: 4000m
+      annotations:
+        testgrid-dashboards: sig-testing-boskos
+        testgrid-tab-name: pull-build-test-verify

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -77,6 +77,7 @@ approve:
   require_self_approval: false
 - repos:
   - bazelbuild
+  - kubernetes-sigs/boskos
   - kubernetes-sigs/kind
   - kubernetes-sigs/slack-infra
   - kubernetes/community
@@ -126,6 +127,7 @@ lgtm:
 - repos:
   - bazelbuild
   - kubernetes/repo-infra
+  - kubernetes-sigs/boskos
   - kubernetes-sigs/kind
   - kubernetes/test-infra
   review_acts_as_lgtm: true
@@ -819,6 +821,9 @@ plugins:
 
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - release-note
+
+  kubernetes-sigs/boskos:
+  - override
 
   kubernetes-sigs/kind:
   - override

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -10,6 +10,7 @@ dashboard_groups:
   - sig-testing-maintenance
   - sig-testing-prow
   - sig-testing-images
+  - sig-testing-boskos
 
 # Dashboards
 
@@ -21,3 +22,4 @@ dashboards:
 - name: sig-testing-maintenance
 - name: sig-testing-prow
 - name: sig-testing-images
+- name: sig-testing-boskos


### PR DESCRIPTION
Configures the various plugins to support GitHub reviews, and also enable the overrides plugin (especially while getting CI set up).

I've created single presubmit and postsubmit jobs, since build/test/verify all run pretty quickly right now. I can separate these if we feel it's more appropriate.

Both the presubmit and postsubmit jobs have been tested locally with phaino and appear to work.

/area boskos
/assign @alvaroaleman @cjwagner 