### PR TITLE
CAPZ: add storage-related periodic jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -22,7 +22,16 @@ periodics:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
         command:
           - "runner.sh"
-          - "./scripts/ci-conformance.sh"
+          - "./scripts/ci-entrypoint.sh"
+        env:
+          - name: FOCUS
+            value: "\\[Conformance\\]|\\[NodeConformance\\]"
+          - name: SKIP
+            value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
+          - name: PARALLEL
+            value: "true"
+          - name: USE_CI_ARTIFACTS
+            value: "true"
         securityContext:
           privileged: true
         resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -30,8 +30,6 @@ periodics:
             value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
           - name: PARALLEL
             value: "true"
-          - name: USE_CI_ARTIFACTS
-            value: "true"
         securityContext:
           privileged: true
         resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -371,3 +371,109 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-disk-1-16
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.16
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-disk # In-tree Azure disk storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-16-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-file-1-16
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azurefile-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.16
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.16
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-file # In-tree Azure file storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-file-1-16-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure File e2e test with Azure File in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -371,3 +371,109 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-disk-1-17
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.17
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.17
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-disk # In-tree Azure disk storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-17-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-file-1-17
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azurefile-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.17
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.17
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-file # In-tree Azure file storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-file-1-17-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure File e2e test with Azure File in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -371,3 +371,109 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-disk-1-18
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.18
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.18
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azuredisk-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-disk # In-tree Azure disk storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-disk-1-18-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'
+- interval: 3h
+  name: kubernetes-e2e-capz-azure-file-1-18
+  decorate: true
+  decoration_config:
+    timeout: 3h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api-provider-azure
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api-provider-azure
+  - org: kubernetes-sigs
+    repo: azurefile-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: release-1.18
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-1.18
+      command:
+      - runner.sh
+      - ./scripts/ci-entrypoint.sh
+      args:
+      - bash
+      - -c
+      - >-
+        cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
+        make e2e-test
+      env:
+      - name: SKIP_UPSTREAM_E2E_TESTS
+        value: "true"
+      - name: USE_CI_ARTIFACTS
+        value: "true"
+      - name: AZURE_STORAGE_DRIVER
+        value: kubernetes.io/azure-file # In-tree Azure file storage class
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 1
+          memory: "4Gi"
+  annotations:
+    testgrid-dashboards: provider-azure-upstream, provider-azure-periodic
+    testgrid-tab-name: k8s-e2e-azure-file-1-18-capz
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure File e2e test with Azure File in-tree volume plugin on a CAPZ cluster.
+    testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -294,12 +294,14 @@ periodics:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200513-7c0e31a-master
       command:
       - "runner.sh"
-      - "./scripts/ci-conformance.sh"
+      - "./scripts/ci-entrypoint.sh"
       env:
       - name: FOCUS
         value: "\\[Conformance\\]|\\[NodeConformance\\]"
       - name: SKIP
         value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
+      - name: PARALLEL
+        value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
       securityContext:


### PR DESCRIPTION
Setting all the new periodic jobs to 3h to get a faster test signal before changing it to 24h.

/assign @CecileRobertMichon
