### PR TITLE
add metadata to cos beta images

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -100,30 +100,35 @@ images:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosbeta-density2:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosbeta-density2-qps60:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosbeta-density3:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-2
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosbeta-density4:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
 


### PR DESCRIPTION
COS beta images have /tmp mounted with 'noexec' mount option.
This makes it impossible for run_remote to execute binaries
from its workspace. This results in failed kubelet tests,
e.g. ci-kubernetes-node-kubelet-benchmark and
ci-kubernetes-node-kubelet-conformance test suites fail with
"failed to run command './ginkgo': Permission denied" error

Adding metadata pointing to cloud-init(gci-init.yaml) should solve
this as cloud-init remounts /tmp with 'exec' mount option.