### PR TITLE
Trigger's TrustedUser returns a reason for untrusted. Consumed by verify-owners.

### DIFF
--- a/prow/plugins/dco/dco.go
+++ b/prow/plugins/dco/dco.go
@@ -113,11 +113,11 @@ func filterTrustedUsers(gc gitHubClient, l *logrus.Entry, skipDCOCheckForCollabo
 	untrustedCommits := make([]github.RepositoryCommit, 0, len(allCommits))
 
 	for _, commit := range allCommits {
-		trusted, err := trigger.TrustedUser(gc, !skipDCOCheckForCollaborators, trustedOrg, commit.Author.Login, org, repo)
+		trustedResponse, err := trigger.TrustedUser(gc, !skipDCOCheckForCollaborators, trustedOrg, commit.Author.Login, org, repo)
 		if err != nil {
 			return nil, fmt.Errorf("Error checking is member trusted: %v", err)
 		}
-		if !trusted {
+		if !trustedResponse.IsTrusted {
 			l.Debugf("Member %s is not trusted", commit.Author.Login)
 			untrustedCommits = append(untrustedCommits, commit)
 		}

--- a/prow/plugins/retitle/retitle.go
+++ b/prow/plugins/retitle/retitle.go
@@ -74,7 +74,8 @@ func handleGenericCommentEvent(pc plugins.Agent, e github.GenericCommentEvent) e
 	)
 	return handleGenericComment(pc.GitHubClient, func(user string) (bool, error) {
 		t := pc.PluginConfig.TriggerFor(org, repo)
-		return trigger.TrustedUser(pc.GitHubClient, t.OnlyOrgMembers, t.TrustedOrg, user, org, repo)
+		trustedResponse, err := trigger.TrustedUser(pc.GitHubClient, t.OnlyOrgMembers, t.TrustedOrg, user, org, repo)
+		return trustedResponse.IsTrusted, err
 	}, pc.PluginConfig.Retitle.AllowClosedIssues, pc.Logger, e)
 }
 

--- a/prow/plugins/trigger/generic-comment.go
+++ b/prow/plugins/trigger/generic-comment.go
@@ -94,10 +94,12 @@ func handleGenericComment(c Client, trigger plugins.Trigger, gc github.GenericCo
 	}
 
 	// Skip untrusted users comments.
-	trusted, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, commentAuthor, org, repo)
+	trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, commentAuthor, org, repo)
 	if err != nil {
 		return fmt.Errorf("error checking trust of %s: %v", commentAuthor, err)
 	}
+
+	trusted := trustedResponse.IsTrusted
 	var l []github.Label
 	if !trusted {
 		// Skip untrusted PRs.

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -71,7 +71,8 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		// When a PR is opened, if the author is in the org then build it.
 		// Otherwise, ask for "/ok-to-test". There's no need to look for previous
 		// "/ok-to-test" comments since the PR was just opened!
-		member, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo)
+		trustedResponse, err := TrustedUser(c.GitHubClient, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo)
+		member := trustedResponse.IsTrusted
 		if err != nil {
 			return fmt.Errorf("could not check membership: %s", err)
 		}
@@ -307,9 +308,9 @@ func draftMsg(ghc githubClient, pr github.PullRequest) error {
 // If already known, GitHub labels should be provided to save tokens. Otherwise, it fetches them.
 func TrustedPullRequest(tprc trustedPullRequestClient, trigger plugins.Trigger, author, org, repo string, num int, l []github.Label) ([]github.Label, bool, error) {
 	// First check if the author is a member of the org.
-	if orgMember, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo); err != nil {
+	if trustedResponse, err := TrustedUser(tprc, trigger.OnlyOrgMembers, trigger.TrustedOrg, author, org, repo); err != nil {
 		return l, false, fmt.Errorf("error checking %s for trust: %v", author, err)
-	} else if orgMember {
+	} else if trustedResponse.IsTrusted {
 		return l, true, nil
 	}
 	// Then check if PR has ok-to-test label

--- a/prow/plugins/trigger/trigger.go
+++ b/prow/plugins/trigger/trigger.go
@@ -48,17 +48,17 @@ const (
 	notSecondaryMember
 )
 
-// untrustedReasonString constructs a string explaining the reason for a user's denail of trust
+// String constructs a string explaining the reason for a user's denial of trust
 // from untrustedReason as described above.
-func untrustedReasonString(reasons untrustedReason) string {
+func (u untrustedReason) String() string {
 	var response string
-	if reasons&notMember != 0 {
+	if u&notMember != 0 {
 		response += "User is not a member of the org. "
 	}
-	if reasons&notCollaborator != 0 {
+	if u&notCollaborator != 0 {
 		response += "User is not a collaborator. "
 	}
-	if reasons&notSecondaryMember != 0 {
+	if u&notSecondaryMember != 0 {
 		response += "User is not a member of the trusted secondary org. "
 	}
 	response += "Satisfy at least one of these conditions to make the user trusted."
@@ -224,9 +224,9 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 	if trustedOrg == "" || trustedOrg == org {
 		// the if/else is only to improve error messaging
 		if onlyOrgMembers {
-			return TrustedUserResponse{IsTrusted: false, Reason: untrustedReasonString(notMember)}, nil // No trusted org and/or it is the same
+			return TrustedUserResponse{IsTrusted: false, Reason: notMember.String()}, nil // No trusted org and/or it is the same
 		}
-		return TrustedUserResponse{IsTrusted: false, Reason: untrustedReasonString(notMember | notCollaborator)}, nil // No trusted org and/or it is the same
+		return TrustedUserResponse{IsTrusted: false, Reason: (notMember | notCollaborator).String()}, nil // No trusted org and/or it is the same
 	}
 
 	// Check the second trusted org.
@@ -235,13 +235,13 @@ func TrustedUser(ghc trustedUserClient, onlyOrgMembers bool, trustedOrg, user, o
 		return errorResponse, fmt.Errorf("error in IsMember(%s): %v", trustedOrg, err)
 	} else if member {
 		return okResponse, nil
-	} else {
-		// the if/else is only to improve error messaging
-		if onlyOrgMembers {
-			return TrustedUserResponse{IsTrusted: false, Reason: untrustedReasonString(notMember | notSecondaryMember)}, nil
-		}
-		return TrustedUserResponse{IsTrusted: false, Reason: untrustedReasonString(notMember | notSecondaryMember | notCollaborator)}, nil
 	}
+
+	// the if/else is only to improve error messaging
+	if onlyOrgMembers {
+		return TrustedUserResponse{IsTrusted: false, Reason: (notMember | notSecondaryMember).String()}, nil
+	}
+	return TrustedUserResponse{IsTrusted: false, Reason: (notMember | notSecondaryMember | notCollaborator).String()}, nil
 }
 
 func skippedStatusFor(context string) github.Status {

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -303,7 +303,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  untrustedReasonString(notMember),
+			expectedReason:  (notMember).String(),
 		},
 		{
 			name:            "user is trusted org member",
@@ -321,7 +321,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  untrustedReasonString(notMember | notCollaborator),
+			expectedReason:  (notMember | notCollaborator).String(),
 		},
 		{
 			name:            "user is not org member or trusted org member",
@@ -331,7 +331,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  untrustedReasonString(notMember | notCollaborator | notSecondaryMember),
+			expectedReason:  (notMember | notCollaborator | notSecondaryMember).String(),
 		},
 		{
 			name:            "user is not org member or trusted org member, onlyOrgMembers true",
@@ -341,7 +341,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  untrustedReasonString(notMember | notSecondaryMember),
+			expectedReason:  (notMember | notSecondaryMember).String(),
 		},
 	}
 

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -303,7 +303,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  nonTrustedNotMember,
+			expectedReason:  untrustedReasonString(notMember),
 		},
 		{
 			name:            "user is trusted org member",
@@ -321,7 +321,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  nonTrustedNotMemberNotCollaborator,
+			expectedReason:  untrustedReasonString(notMember | notCollaborator),
 		},
 		{
 			name:            "user is not org member or trusted org member",
@@ -331,7 +331,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  nonTrustedNotMemberNotSecondaryMemberNotCollaborator,
+			expectedReason:  untrustedReasonString(notMember | notCollaborator | notSecondaryMember),
 		},
 		{
 			name:            "user is not org member or trusted org member, onlyOrgMembers true",
@@ -341,7 +341,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
-			expectedReason:  nonTrustedNotMemberNotSecondaryMember,
+			expectedReason:  untrustedReasonString(notMember | notSecondaryMember),
 		},
 	}
 

--- a/prow/plugins/trigger/trigger_test.go
+++ b/prow/plugins/trigger/trigger_test.go
@@ -270,6 +270,7 @@ func TestTrustedUser(t *testing.T) {
 		repo string
 
 		expectedTrusted bool
+		expectedReason  string
 	}{
 		{
 			name:            "user is member of trusted org",
@@ -302,6 +303,7 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
+			expectedReason:  nonTrustedNotMember,
 		},
 		{
 			name:            "user is trusted org member",
@@ -319,6 +321,27 @@ func TestTrustedUser(t *testing.T) {
 			org:             "kubernetes",
 			repo:            "kubernetes",
 			expectedTrusted: false,
+			expectedReason:  nonTrustedNotMemberNotCollaborator,
+		},
+		{
+			name:            "user is not org member or trusted org member",
+			onlyOrgMembers:  false,
+			trustedOrg:      "kubernetes-sigs",
+			user:            "test-2",
+			org:             "kubernetes",
+			repo:            "kubernetes",
+			expectedTrusted: false,
+			expectedReason:  nonTrustedNotMemberNotSecondaryMemberNotCollaborator,
+		},
+		{
+			name:            "user is not org member or trusted org member, onlyOrgMembers true",
+			onlyOrgMembers:  true,
+			trustedOrg:      "kubernetes-sigs",
+			user:            "test-2",
+			org:             "kubernetes",
+			repo:            "kubernetes",
+			expectedTrusted: false,
+			expectedReason:  nonTrustedNotMemberNotSecondaryMember,
 		},
 	}
 
@@ -331,12 +354,15 @@ func TestTrustedUser(t *testing.T) {
 				Collaborators: []string{"test-collaborator"},
 			}
 
-			trusted, err := TrustedUser(fc, tc.onlyOrgMembers, tc.trustedOrg, tc.user, tc.org, tc.repo)
+			trustedResponse, err := TrustedUser(fc, tc.onlyOrgMembers, tc.trustedOrg, tc.user, tc.org, tc.repo)
 			if err != nil {
 				t.Errorf("For case %s, didn't expect error from TrustedUser: %v", tc.name, err)
 			}
-			if trusted != tc.expectedTrusted {
-				t.Errorf("For case %s, expect result: %v, but got: %v", tc.name, tc.expectedTrusted, trusted)
+			if trustedResponse.IsTrusted != tc.expectedTrusted {
+				t.Errorf("For case %s, expect trusted: %v, but got: %v", tc.name, tc.expectedTrusted, trustedResponse.IsTrusted)
+			}
+			if trustedResponse.Reason != tc.expectedReason {
+				t.Errorf("For case %s, expect trusted reason: %v, but got: %v", tc.name, tc.expectedReason, trustedResponse.Reason)
 			}
 		})
 	}

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -41,13 +41,18 @@ import (
 
 const (
 	// PluginName defines this plugin's registered name.
-	PluginName                    = "verify-owners"
-	ownersFileName                = "OWNERS"
-	ownersAliasesFileName         = "OWNERS_ALIASES"
-	nonCollaboratorResponseFormat = `The following users are mentioned in %s file(s) but are not members of the %s org.
-
-Once all users have been added as [members](%s) of the org, you can trigger verification by writing ` + "`/verify-owners`" + ` in a comment.`
+	PluginName              = "verify-owners"
+	ownersFileName          = "OWNERS"
+	ownersAliasesFileName   = "OWNERS_ALIASES"
+	untrustedResponseFormat = `The following users are mentioned in %s file(s) but are untrusted for the following reasons. One way to make the user trusted is to add them as [members](%s) of the %s org. You can then trigger verification by writing ` + "`/verify-owners`" + ` in a comment.`
 )
+
+type nonTrustedReasons struct {
+	// files is a list of files they are being added in
+	files []string
+	// trigger is the reason that trigger's TrustedUser responds with for a failed trust check
+	trigger string
+}
 
 var (
 	verifyOwnersRe = regexp.MustCompile(`(?mi)^/verify-owners\s*$`)
@@ -324,7 +329,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 
 		// prune old comments before adding a new one
 		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org, triggerConfig.JoinOrgURL))
+			return strings.Contains(comment.Body, fmt.Sprintf(untrustedResponseFormat, ownersFileName, triggerConfig.JoinOrgURL, org))
 		})
 		if err := ghc.CreateComment(org, repo, number, markdownFriendlyComment(org, triggerConfig.JoinOrgURL, nonTrustedUsers)); err != nil {
 			log.WithError(err).Errorf("Could not create comment for listing non-collaborators in %s files", ownersFileName)
@@ -338,7 +343,7 @@ func handle(ghc githubClient, gc git.ClientFactory, roc repoownersClient, log *l
 			return fmt.Errorf("failed removing %s label: %v", labels.InvalidOwners, err)
 		}
 		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org, triggerConfig.JoinOrgURL))
+			return strings.Contains(comment.Body, fmt.Sprintf(untrustedResponseFormat, ownersFileName, triggerConfig.JoinOrgURL, org))
 		})
 	}
 
@@ -411,23 +416,24 @@ func parseOwnersFile(oc ownersClient, path string, c github.PullRequestChange, l
 	return nil, owners
 }
 
-func markdownFriendlyComment(org, joinOrgURL string, nonTrustedUsers map[string][]string) string {
+func markdownFriendlyComment(org, joinOrgURL string, nonTrustedUsers map[string]nonTrustedReasons) string {
 	var commentLines []string
-	commentLines = append(commentLines, fmt.Sprintf(nonCollaboratorResponseFormat, ownersFileName, org, joinOrgURL))
+	commentLines = append(commentLines, fmt.Sprintf(untrustedResponseFormat, ownersFileName, joinOrgURL, org))
 
-	for user, ownersFiles := range nonTrustedUsers {
+	for user, reasons := range nonTrustedUsers {
 		commentLines = append(commentLines, fmt.Sprintf("- %s", user))
-		for _, filename := range ownersFiles {
+		commentLines = append(commentLines, fmt.Sprintf("  - %s", reasons.trigger))
+		for _, filename := range reasons.files {
 			commentLines = append(commentLines, fmt.Sprintf("  - %s", filename))
 		}
 	}
 	return strings.Join(commentLines, "\n")
 }
 
-func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, dir, patch string, ownerAliasesModified, skipTrustedUserCheck bool) (map[string][]string, sets.String, repoowners.RepoAliases, error) {
+func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, dir, patch string, ownerAliasesModified, skipTrustedUserCheck bool) (map[string]nonTrustedReasons, sets.String, repoowners.RepoAliases, error) {
 	repoAliases := make(repoowners.RepoAliases)
-	// nonTrustedUsers is a map of non-trusted users to the list of files they are being added in
-	nonTrustedUsers := map[string][]string{}
+	// nonTrustedUsers is a map of non-trusted users to the reasons they were not trusted
+	nonTrustedUsers := map[string]nonTrustedReasons{}
 	trustedUsers := sets.String{}
 	var err error
 
@@ -458,7 +464,7 @@ func nonTrustedUsersInOwnersAliases(ghc githubClient, log *logrus.Entry, trigger
 	return nonTrustedUsers, trustedUsers, repoAliases, nil
 }
 
-func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, patch, fileName string, owners []string, nonTrustedUsers map[string][]string, trustedUsers sets.String, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
+func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, org, repo, patch, fileName string, owners []string, nonTrustedUsers map[string]nonTrustedReasons, trustedUsers sets.String, repoAliases repoowners.RepoAliases) (map[string]nonTrustedReasons, error) {
 	var err error
 	for _, owner := range owners {
 		// ignore if owner is an alias
@@ -476,7 +482,8 @@ func nonTrustedUsersInOwners(ghc githubClient, log *logrus.Entry, triggerConfig 
 
 // checkIfTrustedUser looks for newly addded owners by checking if they are in the patch
 // and then checks if the owner is a trusted user.
-func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, owner, patch, fileName, org, repo string, nonTrustedUsers map[string][]string, trustedUsers sets.String, repoAliases repoowners.RepoAliases) (map[string][]string, error) {
+// returns a map from user to reasons for not being trusted
+func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugins.Trigger, owner, patch, fileName, org, repo string, nonTrustedUsers map[string]nonTrustedReasons, trustedUsers sets.String, repoAliases repoowners.RepoAliases) (map[string]nonTrustedReasons, error) {
 	// cap the number of checks to avoid exhausting tokens in case of large OWNERS refactors.
 	if len(nonTrustedUsers)+trustedUsers.Len() > 50 {
 		return nonTrustedUsers, nil
@@ -488,33 +495,42 @@ func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugi
 	}
 
 	// if we already flagged the owner for the current file, return early
-	if ownersFiles, ok := nonTrustedUsers[owner]; ok {
-		for _, file := range ownersFiles {
+	if reasons, ok := nonTrustedUsers[owner]; ok {
+		for _, file := range reasons.files {
 			if file == fileName {
 				return nonTrustedUsers, nil
 			}
 		}
-		nonTrustedUsers[owner] = append(ownersFiles, fileName)
+		// have to separate assignment from map update due to map implementation (see "index expressions")
+		reasons.files = append(reasons.files, fileName)
+		nonTrustedUsers[owner] = reasons
 		return nonTrustedUsers, nil
 	}
 
-	isTrustedUser := trustedUsers.Has(owner)
-	if !isTrustedUser {
-		var err error
-		isTrustedUser, err = trigger.TrustedUser(ghc, triggerConfig.OnlyOrgMembers, triggerConfig.TrustedOrg, owner, org, repo)
+	isAlreadyTrusted := trustedUsers.Has(owner)
+	var err error
+	var triggerTrustedResponse trigger.TrustedUserResponse
+	if !isAlreadyTrusted {
+		triggerTrustedResponse, err = trigger.TrustedUser(ghc, triggerConfig.OnlyOrgMembers, triggerConfig.TrustedOrg, owner, org, repo)
 		if err != nil {
 			return nonTrustedUsers, err
 		}
 	}
 
-	if isTrustedUser {
+	if !isAlreadyTrusted && triggerTrustedResponse.IsTrusted {
 		trustedUsers.Insert(owner)
-	} else {
-		if ownersFiles, ok := nonTrustedUsers[owner]; ok {
-			nonTrustedUsers[owner] = append(ownersFiles, fileName)
+	} else if !isAlreadyTrusted && !triggerTrustedResponse.IsTrusted {
+		if reasons, ok := nonTrustedUsers[owner]; ok {
+			reasons.trigger = triggerTrustedResponse.Reason
+			nonTrustedUsers[owner] = reasons
 		} else {
-			nonTrustedUsers[owner] = []string{fileName}
+			nonTrustedUsers[owner] = nonTrustedReasons{
+				// ensure that files is initialized to avoid nil pointer
+				files:   []string{},
+				trigger: triggerTrustedResponse.Reason,
+			}
 		}
 	}
+
 	return nonTrustedUsers, nil
 }

--- a/prow/plugins/verify-owners/verify-owners.go
+++ b/prow/plugins/verify-owners/verify-owners.go
@@ -50,8 +50,8 @@ const (
 type nonTrustedReasons struct {
 	// files is a list of files they are being added in
 	files []string
-	// trigger is the reason that trigger's TrustedUser responds with for a failed trust check
-	trigger string
+	// triggerReason is the reason that trigger's TrustedUser responds with for a failed trust check
+	triggerReason string
 }
 
 var (
@@ -422,7 +422,7 @@ func markdownFriendlyComment(org, joinOrgURL string, nonTrustedUsers map[string]
 
 	for user, reasons := range nonTrustedUsers {
 		commentLines = append(commentLines, fmt.Sprintf("- %s", user))
-		commentLines = append(commentLines, fmt.Sprintf("  - %s", reasons.trigger))
+		commentLines = append(commentLines, fmt.Sprintf("  - %s", reasons.triggerReason))
 		for _, filename := range reasons.files {
 			commentLines = append(commentLines, fmt.Sprintf("  - %s", filename))
 		}
@@ -521,13 +521,13 @@ func checkIfTrustedUser(ghc githubClient, log *logrus.Entry, triggerConfig plugi
 		trustedUsers.Insert(owner)
 	} else if !isAlreadyTrusted && !triggerTrustedResponse.IsTrusted {
 		if reasons, ok := nonTrustedUsers[owner]; ok {
-			reasons.trigger = triggerTrustedResponse.Reason
+			reasons.triggerReason = triggerTrustedResponse.Reason
 			nonTrustedUsers[owner] = reasons
 		} else {
 			nonTrustedUsers[owner] = nonTrustedReasons{
 				// ensure that files is initialized to avoid nil pointer
-				files:   []string{},
-				trigger: triggerTrustedResponse.Reason,
+				files:         []string{},
+				triggerReason: triggerTrustedResponse.Reason,
 			}
 		}
 	}

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -837,7 +837,7 @@ func TestNonCollaboratorsV2(t *testing.T) {
 }
 
 func testNonCollaborators(clients localgit.Clients, t *testing.T) {
-	const nonTrustedNotMemberNotCollaborator = "User is not a member of the org and is not a collaborator."
+	const nonTrustedNotMemberNotCollaborator = "User is not a member of the org. User is not a collaborator."
 	var tests = []struct {
 		name                 string
 		filesChanged         []string

--- a/prow/plugins/welcome/welcome.go
+++ b/prow/plugins/welcome/welcome.go
@@ -103,11 +103,11 @@ func handlePR(c client, t plugins.Trigger, pre github.PullRequestEvent, welcomeT
 	repo := pre.PullRequest.Base.Repo.Name
 	user := pre.PullRequest.User.Login
 
-	trusted, err := trigger.TrustedUser(c.GitHubClient, t.OnlyOrgMembers, t.TrustedOrg, user, org, repo)
+	trustedResponse, err := trigger.TrustedUser(c.GitHubClient, t.OnlyOrgMembers, t.TrustedOrg, user, org, repo)
 	if err != nil {
 		return fmt.Errorf("check if user %s is trusted: %v", user, err)
 	}
-	if trusted {
+	if trustedResponse.IsTrusted {
 		return nil
 	}
 


### PR DESCRIPTION
Addresses https://github.com/kubernetes/test-infra/issues/14201

- Instead of a bool, Trigger's `TrustedUser` now returns a struct with the bool and the reason for a trust denial (if trust was denied).
- All calls to `TrustedUser` were updated to extract the bool from the struct.
- verify-owners's Github comment structure was updated to support the additional error messaging - the base comment pattern has more detail and the details include `TrustedUser`'s reason for denial. This addresses the ask in #14201