### PR TITLE
roll cos-stable-73 -> cos-stable-81 in image-config

### DIFF
--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -6,10 +6,10 @@ images:
     image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
     project: ubuntu-os-gke-cloud
   cos-stable1:
-    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17
+    image_regex: cos-stable-81-12871-103-0 # docker v19.03.6
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
   cos-stable2:
-    image_regex: cos-stable-73-11647-510-0 # docker v18.09.7, deprecated after 2020-06-19
+    image_regex: cos-stable-77-12371-227-0 # docker v19.03.1, deprecated after 2020-12-17
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This should fix ci-kubernetes-node-kubelet Summary API
test failure:

```
[91mTimed out after 60.001s.
I0520 06:49:56.332]     Expected
I0520 06:49:56.332]         <string>: Summary
I0520 06:49:56.332]     to match fields: {
I0520 06:49:56.332]     [.Pods:
I0520 06:49:56.332]     	missing expected element summary-test-1998::stats-busybox-1, .Pods:
I0520 06:49:56.333]     	missing expected element summary-test-1998::stats-busybox-0]
I0520 06:49:56.333]     }
```