### PR TITLE
Specified instance size for flaky kubelet e2e tests to run on

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -177,6 +177,7 @@ periodics:
       - --deployment=node
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
+      - --gcp-node-size=n1-standard-32
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
       - --node-test-args= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true


### PR DESCRIPTION
kubelet e2e tests labeled as "flaky" require workloads that request at
least 15 cpus and at least 16 Gi of memory.
A n1-standard-32 instance offers 32 cpus and 120 GB of ram, enough for
all e2e tests to run.

xref: https://github.com/kubernetes/kubernetes/issues/91263

Signed-off-by: alejandrox1 <alarcj137@gmail.com>