### PR TITLE
Stop publishing latest-green.txt and migrate to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -301,6 +301,7 @@ presubmits:
 periodics:
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -314,14 +315,13 @@ periodics:
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest
+      - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce
-      # TODO: cannot migrate over to k8s-infra-prow-build until this writes to another bucket
-      - --publish=gs://kubernetes-release-dev/ci/latest-green.txt
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200519-d13d3ca-master


### PR DESCRIPTION
This migrates ci-kubernetes-e2e-gci-gce over to the k8s-infra owned
prow build cluster. The release branch variants of this job have
already been moved over. What was preventing this from moving over
was the --publish flag, implying that this job needed write access
to a bucket that won't allow non-google.com access.

I have looked using cs.k8s.io and can't find any code that actually
relies on the existence of latest-green.txt. I could have sworn that
it was at one time used by tooling in kubernetes/release (eg: as part
of find_green_build), but I haven't found it in history there either.

I've looked in this repo's history, and publishing to this path has
been present since inception, but I still can't find what might actually
be looking for this file.

It's referenced in docs in a few places, which I will PR to remove if
those are the only references.

/cc @fejta @ixdy
maybe you remember the history of this file?