### PR TITLE
Migrate kind release-branch blocking jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -456,6 +456,7 @@ periodics:
     testgrid-dashboards: sig-release-1.15-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.15-parallel
+  cluster: k8s-infra-prow-build
   interval: 24h
   labels:
     preset-bazel-remote-cache-enabled: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -463,6 +463,7 @@ periodics:
     testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.16-parallel
+  cluster: k8s-infra-prow-build
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
@@ -502,6 +503,7 @@ periodics:
     testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-ipv6-1.16-parallel
+  cluster: k8s-infra-prow-build
   interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -517,6 +517,7 @@ periodics:
     testgrid-dashboards: sig-release-1.17-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.17-parallel
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-bazel-remote-cache-enabled: "true"
@@ -556,6 +557,7 @@ periodics:
     testgrid-dashboards: sig-release-1.17-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-ipv6-1.17-parallel
+  cluster: k8s-infra-prow-build
   interval: 2h
   labels:
     preset-bazel-remote-cache-enabled: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -561,6 +561,7 @@ periodics:
     testgrid-dashboards: sig-release-1.18-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.18-parallel
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 1h0m0s
@@ -606,6 +607,7 @@ periodics:
     testgrid-dashboards: sig-release-1.18-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-ipv6-1.18-parallel
+  cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 1h0m0s


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/17664

ref: https://github.com/kubernetes/k8s.io/issues/841