### PR TITLE
Migrate kind release-blocking ga-only job to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -187,6 +187,7 @@ periodics:
     testgrid-num-columns-recent: '3'
 
 - name: ci-kubernetes-conformance-kind-ga-only
+  cluster: k8s-infra-prow-build
   interval: 12h
   decorate: true
   skip_branches:


### PR DESCRIPTION
Followup to #17664

ref: kubernetes/k8s.io#841