### PR TITLE
enable nfs on IPv6 kind canary job

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -182,7 +182,7 @@ presubmits:
           value: "."
         # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE


### PR DESCRIPTION
we should be able to use nfs tests on IPv6 jobs
https://github.com/kubernetes/kubernetes/pull/90689
Let's run it first with the canary job
