### PR TITLE
Improve tide status update error message

### DIFF
--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -384,7 +384,8 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 			wantDesc = fmt.Sprintf("%s...", wantDesc[0:(maxStatusDescriptionLength-3)])
 			log.WithField("original-desc", original).Warn("GitHub status description needed to be truncated to fit GH API limit")
 		}
-		if wantState != strings.ToLower(string(actualState)) || wantDesc != actualDesc {
+		actualState = githubql.StatusState(strings.ToLower(string(actualState)))
+		if wantState != string(actualState) || wantDesc != actualDesc {
 			if err := sc.ghc.CreateStatus(
 				org,
 				repo,
@@ -396,9 +397,11 @@ func (sc *statusController) setStatuses(all []PullRequest, pool map[string]PullR
 					TargetURL:   targetURL(c, pr, log),
 				}); err != nil {
 				log.WithError(err).Errorf(
-					"Failed to set status context from %q to %q.",
-					string(actualState),
+					"Failed to set status context from %q to %q and description from %q to %q",
+					actualState,
 					wantState,
+					actualDesc,
+					wantDesc,
 				)
 			}
 		}


### PR DESCRIPTION
Currently we are seeing errors like this one:
```
{"branch":"master","component":"tide","controller":"status-update","error":"status code 502 not one of [201], body: {\n  \"message\": \"Server Error\"\n}\n","file":"prow/tide/status.go:398","func":"k8s.io/test-infra/prow/tide.(*statusController).setStatuses.func1","level":"error","msg":"Failed to set status context from \"PENDING\" to \"pending\".","org":"openshift","pr":170,"repo":"ovn-kubernetes","sha":"0edae21e2d77a94d186ff01433368247f5b6c8b8","time":"2020-05-22T16:12:33Z"}
```

This is confusing because it looks like we would be changing the casing
of the status, which we don't actually do. Instead we presumably tried
to update the description.

This PR updates the log message to use the correct casing and include
the old and new description.

/assign @stevekuznetsov 