### PR TITLE
Update containerd related tests using latest kubekins image

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -143,7 +143,7 @@ periodics:
       - --env=KUBE_MASTER_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/master.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=KUBE_NODE_EXTRA_METADATA=user-data=/workspace/github.com/containerd/cri/test/e2e/node.yaml,containerd-configure-sh=/workspace/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env=/workspace/test-infra/jobs/e2e_node/containerd/containerd-release-1.2/env
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest-1.13
+      - --extract=ci/latest-1.15
       - --gcp-node-image=gci
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
@@ -151,7 +151,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200521-100609e-1.15
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.2
@@ -253,10 +253,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200521-100609e-1.15
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.13
+      - --repo=k8s.io/kubernetes=release-1.15
       - --repo=github.com/containerd/cri=release/1.2
       - --timeout=90
       - --scenario=kubernetes_e2e
@@ -343,10 +343,10 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20191029-3656cc1-1.13
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200521-100609e-1.15
       args:
       - --root=/go/src
-      - --repo=k8s.io/kubernetes=release-1.13
+      - --repo=k8s.io/kubernetes=release-1.15
       - --repo=github.com/containerd/cri=release/1.2
       - --timeout=90
       - --scenario=kubernetes_e2e


### PR DESCRIPTION
Signed-off-by: Roy Yang <royyang@google.com>

What happened:

The following tests failed continuously in the past:
https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-gci-1.2
https://testgrid.k8s.io/sig-node-containerd#containerd-node-e2e-1.2
https://testgrid.k8s.io/sig-node-containerd#containerd-node-e2e-features-1.2

What you expected to happen:
They should succeed.

How to reproduce it (as minimally and precisely as possible):
See https://testgrid.k8s.io/sig-node-containerd

Please provide links to example occurrences, if any:
See https://testgrid.k8s.io/sig-node-containerd

Anything else we need to know?:
From the log of https://testgrid.k8s.io/sig-node-containerd#containerd-e2e-gci-1.2, it mentioned that failing to get k8s image 1.3, which is removed from https://github.com/kubernetes/test-infra/blob/master/images/kubekins-e2e/variants.yaml. Also, kubekins container is out of date.

Ideally, we should use the latest stable kubekins image. Also, the reason bumping to 1.15 is that it is using the same golang version with latest containered.