### PR TITLE
bugzilla: unlink PRs that are closed without being merged

### DIFF
--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -608,6 +608,136 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 	}
 }
 
+func TestRemovePullRequestAsExternalBug(t *testing.T) {
+	var testCases = []struct {
+		name            string
+		id              int
+		expectedPayload string
+		response        string
+		expectedError   bool
+		expectedChanged bool
+	}{
+		{
+			name:            "update succeeds, makes a change",
+			id:              1705243,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.remove_external_bug","params":[{"api_key":"api-key","bug_ids":[1705243],"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}}`,
+			expectedError:   false,
+			expectedChanged: true,
+		},
+		{
+			name:            "update succeeds, makes a change as part of multiple changes reported",
+			id:              1705244,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.remove_external_bug","params":[{"api_key":"api-key","bug_ids":[1705244],"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"},{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/2"}]}}`,
+			expectedError:   false,
+			expectedChanged: true,
+		},
+		{
+			name:            "update succeeds, makes no change",
+			id:              1705245,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.remove_external_bug","params":[{"api_key":"api-key","bug_ids":[1705245],"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"external_bugs":[]}}`,
+			expectedError:   false,
+			expectedChanged: false,
+		},
+		{
+			name:            "update fails, makes no change",
+			id:              1705246,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.remove_external_bug","params":[{"api_key":"api-key","bug_ids":[1705246],"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}],"id":"identifier"}`,
+			response:        `{"error":{"code": 100400,"message":"Invalid params for JSONRPC 1.0."},"id":"identifier","result":null}`,
+			expectedError:   true,
+			expectedChanged: false,
+		},
+		{
+			name:            "get unrelated JSONRPC response",
+			id:              1705247,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.remove_external_bug","params":[{"api_key":"api-key","bug_ids":[1705247],"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"oops","result":{"external_bugs":[]}}`,
+			expectedError:   true,
+			expectedChanged: false,
+		},
+	}
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Error("did not correctly set content-type header for JSON")
+			http.Error(w, "403 Forbidden", http.StatusForbidden)
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("incorrect method to use the JSONRPC API: %s", r.Method)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		if r.URL.Path != "/jsonrpc.cgi" {
+			t.Errorf("incorrect path to use the JSONRPC API: %s", r.URL.Path)
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		var payload struct {
+			// Version is the version of JSONRPC to use. All Bugzilla servers
+			// support 1.0. Some support 1.1 and some support 2.0
+			Version string `json:"jsonrpc"`
+			Method  string `json:"method"`
+			// Parameters must be specified in JSONRPC 1.0 as a structure in the first
+			// index of this slice
+			Parameters []RemoveExternalBugParameters `json:"params"`
+			ID         string                        `json:"id"`
+		}
+		raw, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			http.Error(w, "500 Server Error", http.StatusInternalServerError)
+			return
+		}
+		if err := json.Unmarshal(raw, &payload); err != nil {
+			t.Errorf("malformed JSONRPC payload: %s", string(raw))
+			http.Error(w, "400 Bad Request", http.StatusBadRequest)
+			return
+		}
+		for _, testCase := range testCases {
+			if payload.Parameters[0].BugIDs[0] == testCase.id {
+				if actual, expected := string(raw), testCase.expectedPayload; actual != expected {
+					t.Errorf("%s: got incorrect JSONRPC payload: %v", testCase.name, diff.ObjectReflectDiff(expected, actual))
+				}
+				if _, err := w.Write([]byte(testCase.response)); err != nil {
+					t.Fatalf("%s: failed to send JSONRPC response: %v", testCase.name, err)
+				}
+				return
+			}
+		}
+		http.Error(w, "404 Not Found", http.StatusNotFound)
+	}))
+	defer testServer.Close()
+	client := clientForUrl(testServer.URL)
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			changed, err := client.RemovePullRequestAsExternalBug(testCase.id, "org", "repo", 1)
+			if !testCase.expectedError && err != nil {
+				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)
+			}
+			if testCase.expectedError && err == nil {
+				t.Errorf("%s: expected an error, but got none", testCase.name)
+			}
+			if testCase.expectedChanged != changed {
+				t.Errorf("%s: got incorrect state change", testCase.name)
+			}
+		})
+	}
+
+	// this should 404
+	changed, err := client.AddPullRequestAsExternalBug(1, "org", "repo", 1)
+	if err == nil {
+		t.Error("expected an error, but got none")
+	} else if !IsNotFound(err) {
+		t.Errorf("expected a not found error, got %v", err)
+	}
+	if changed {
+		t.Error("expected not to change state, but did")
+	}
+}
+
 func TestIdentifierForPull(t *testing.T) {
 	var testCases = []struct {
 		name      string

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -265,19 +265,19 @@ type ExternalBugType struct {
 }
 
 // AddExternalBugParameters are the parameters required to add an external
-// tracker bug to a Bugtzilla bug
+// tracker bug to a Bugzilla bug
 type AddExternalBugParameters struct {
 	// APIKey is the API key to use when authenticating with Bugzilla
 	APIKey string `json:"api_key"`
 	// BugIDs are the IDs of Bugzilla bugs to update
 	BugIDs []int `json:"bug_ids"`
 	// ExternalBugs are the external bugs to add
-	ExternalBugs []NewExternalBugIdentifier `json:"external_bugs"`
+	ExternalBugs []ExternalBugIdentifier `json:"external_bugs"`
 }
 
-// NewExternalBugIdentifier holds fields used to identify new external bugs when
-// adding them using the JSONRPC API
-type NewExternalBugIdentifier struct {
+// ExternalBugIdentifier holds fields used to identify external bugs when
+// modifying them using the JSONRPC API
+type ExternalBugIdentifier struct {
 	// Type is the URL prefix that identifies the external bug tracker type.
 	// For GitHub, this is commonly https://github.com/
 	Type string `json:"ext_type_url"`
@@ -285,4 +285,15 @@ type NewExternalBugIdentifier struct {
 	// For GitHub issues and pull requests, this ID is commonly the path
 	// like `org/repo/pull/number` or `org/repo/issue/number`.
 	ID string `json:"ext_bz_bug_id"`
+}
+
+// RemoveExternalBugParameters are the parameters required to remove an external
+// tracker bug from a Bugzilla bug
+type RemoveExternalBugParameters struct {
+	// APIKey is the API key to use when authenticating with Bugzilla
+	APIKey string `json:"api_key"`
+	// BugIDs are the IDs of Bugzilla bugs to update
+	BugIDs []int `json:"bug_ids"`
+	// The inline identifier for which external bug to remove
+	ExternalBugIdentifier
 }


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Currently won't be functional until https://bugzilla.redhat.com/show_bug.cgi?id=1839609 is fixed but should be good to review

/assign @AlexNPavel @petr-muller 