### PR TITLE
Make svcat e2e test required on pipeline

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -42,7 +42,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    optional: true
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20200520-95b3c72-master
@@ -63,7 +62,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    optional: true
     spec:
       containers:
         - image: gcr.io/k8s-testimages/kubekins-e2e:v20200520-95b3c72-master
@@ -84,7 +82,6 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-    optional: true
     # Run only on PR created to master branch. K8s in version 1.18 is not supported for
     # legacy (v0.2.x) Service Catalog.
     branches:


### PR DESCRIPTION
**Description**

In the first phase, the e2e tests were optional but e2e test proved that it is stable and should be required before merging any functionality to master