### PR TITLE
Roll COS images to the latest available versions

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -1,21 +1,21 @@
 ---
 images:
   cosstable2-resource1:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable2-resource2:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable2-resource3:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
@@ -23,52 +23,52 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   cosstable2-density1:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-2
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     tests:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
-    image: cos-stable-77-12371-227-0 
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable1-resource2:
-    image: cos-stable-77-12371-227-0
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable1-resource3:
-    image: cos-stable-77-12371-227-0
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -1,21 +1,21 @@
 ---
 images:
   cosstable2-resource1:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable2-resource2:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable2-resource3:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
@@ -23,35 +23,35 @@ images:
       - 'resource tracking for 105 pods per node \[Benchmark\]'
 
   cosstable2-density1:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
-    image: cos-stable-73-11647-510-0
+    image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
@@ -59,21 +59,21 @@ images:
       - 'create 105 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
-    image: cos-stable-77-12371-227-0
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
   cosstable1-resource2:
-    image: cos-stable-77-12371-227-0
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   cosstable1-resource3:
-    image: cos-stable-77-12371-227-0
+    image: cos-stable-81-12871-103-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Roll COS images to the latest available versions
    
COS images are outdated in the benchmark configs.
    
This causes e2e node kubelet tests failures like this:
        Error 400: Invalid value for field 'resource.disks[0].initializeParams.sourceImage':
        'projects/cos-cloud/global/images/cos-stable-73-11647-510-0'.
        The referenced image resource cannot be found., invalid
    
Rolled cos-stable-73 -> cos-77 and cos-stable-77 -> cos-stable-81 to
get rid of non-existent images and to use latest available image versions.