### PR TITLE
Kops - Update to latest image for Flatcar

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -126,7 +126,7 @@ def build_test(cloud='aws', distro=None, networking=None, k8s_version=None):
         kops_image = '136693071363/debian-10-amd64-20200511-260'
     elif distro == 'flatcar':
         kops_ssh_user = 'core'
-        kops_image = '075585003325/Flatcar-stable-2345.3.1-hvm'
+        kops_image = '075585003325/Flatcar-stable-2512.2.0-hvm'
     elif distro == 'u1604':
         kops_ssh_user = 'ubuntu'
         kops_image = '099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429'

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -347,7 +347,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable
       - --ginkgo-parallel
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -762,7 +762,7 @@ periodics:
       - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -799,7 +799,7 @@ periodics:
       - --extract=release/stable-1.16
       - --ginkgo-parallel
       - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -836,7 +836,7 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -873,7 +873,7 @@ periodics:
       - --extract=release/stable-1.18
       - --ginkgo-parallel
       - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2386,7 +2386,7 @@ periodics:
       - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2423,7 +2423,7 @@ periodics:
       - --extract=release/stable-1.16
       - --ginkgo-parallel
       - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2460,7 +2460,7 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -2497,7 +2497,7 @@ periodics:
       - --extract=release/stable-1.18
       - --ginkgo-parallel
       - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4010,7 +4010,7 @@ periodics:
       - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4047,7 +4047,7 @@ periodics:
       - --extract=release/stable-1.16
       - --ginkgo-parallel
       - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4084,7 +4084,7 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -4121,7 +4121,7 @@ periodics:
       - --extract=release/stable-1.18
       - --ginkgo-parallel
       - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5634,7 +5634,7 @@ periodics:
       - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5671,7 +5671,7 @@ periodics:
       - --extract=release/stable-1.16
       - --ginkgo-parallel
       - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5708,7 +5708,7 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -5745,7 +5745,7 @@ periodics:
       - --extract=release/stable-1.18
       - --ginkgo-parallel
       - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7258,7 +7258,7 @@ periodics:
       - --extract=release/stable
       - --ginkgo-parallel
       - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7295,7 +7295,7 @@ periodics:
       - --extract=release/stable-1.16
       - --ginkgo-parallel
       - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7332,7 +7332,7 @@ periodics:
       - --extract=release/stable-1.17
       - --ginkgo-parallel
       - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
@@ -7369,7 +7369,7 @@ periodics:
       - --extract=release/stable-1.18
       - --ginkgo-parallel
       - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2345.3.1-hvm
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=core
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt


### PR DESCRIPTION
New Flatcar version that includes the `conntrack` binaries:
https://github.com/flatcar-linux/manifest/releases/tag/v2512.2.0