### PR TITLE
Add job to push images from kubernetes-sigs/boskos

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-boskos.yaml
+++ b/config/jobs/image-pushing/k8s-staging-boskos.yaml
@@ -1,0 +1,24 @@
+postsubmits:
+  kubernetes-sigs/boskos:
+    - name: post-boskos-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-boskos
+        testgrid-tab-name: push-images
+        testgrid-alert-email: jgrafton@google.com
+      decorate: true
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-boskos
+              - --scratch-bucket=gs://k8s-staging-boskos-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - --build-dir=.
+              - images/
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"


### PR DESCRIPTION
Cloud Build configuration was added in https://github.com/kubernetes-sigs/boskos/pull/8 and has been tested manually.
Staging project was created in https://github.com/kubernetes/k8s.io/pull/890.

/assign @michelle192837 
cc @alvaroaleman 
/area boskos