### PR TITLE
use image_family instead of static image reference

### DIFF
--- a/jobs/e2e_node/image-config.yaml
+++ b/jobs/e2e_node/image-config.yaml
@@ -3,13 +3,13 @@
 # `gcloud compute --project <to-project> images create <image-name> --source-disk=<image-name>`
 images:
   ubuntu:
-    image: ubuntu-gke-1804-1-16-v20200330 # docker 17.03
+    image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
   cos-stable1:
-    image: cos-81-12871-119-0 # docker v19.03.6
+    image_family: cos-81-lts
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"
   cos-stable2:
-    image: cos-77-12371-274-0 # docker v19.03.1, deprecated after 2020-12-17
+    image_family: cos-77-lts
     project: cos-cloud
     metadata: "user-data<test/e2e_node/jenkins/cos-init-live-restore.yaml,gci-update-strategy=update_disabled"


### PR DESCRIPTION
The intention here seems to be to test on the stable version of cos.

The history of this file shows many other environments, such as coroes, containervm, different versions of ubuntu with different versions of docker.

Given that it hasn't been running on cos for 6 weeks or so, I'm not sure there's much signal in running on multiple cos versions. cos-stable image_family should float as we like. Alternatively, we can go on an lts image family, such as cos-77-lts.

This would effect these jobs as they reference this file:
```
config/jobs/cadvisor/cadvisor.yaml
42:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml --test-suite=cadvisor
98:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml --test-suite=cadvisor

config/jobs/kubernetes/sig-node/node-docker.yaml
18:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
47:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
75:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
36:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
145:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/sig-node/node-kubelet.yaml
27:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
54:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
153:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
180:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
210:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
93:        "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=${EXTRA_ENVS}"

config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
90:          "--node-args=--image-config-file=/home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/image-config.yaml --extra-envs=${EXTRA_ENVS}"

config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
123:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
155:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
1052:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
86:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
118:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
757:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
86:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
118:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
804:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml

config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
123:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
155:      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
860:        - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
```