### PR TITLE
Update boskos pool dashboard to support same type, different instance

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -24,7 +24,7 @@ dashboard.new(
         aliasColors={'busy': '#ff0000', 'cleaning': '#00eeff', 'dirty': '#ff8000', 'free': '#00ff00', 'leased': '#ee00ff', 'other': '#aaaaff', 'toBeDeleted': '#fafa00', 'tombstone': '#cccccc'}
     )
     .addTarget(prometheus.target(
-        'sum(boskos_resources{type="%s"}) by (state)' % resource.type,
+        std.format('sum(boskos_resources{type="%s",instance="%s"}) by (state)', [resource.type, resource.instance]),
         legendFormat='{{state}}',
     ))
     {gridPos: {
@@ -34,15 +34,16 @@ dashboard.new(
         y: 0,
     }}
       for resource in [
-        {type: "aws-account", friendly: "AWS account"},
-        {type: "gce-project", friendly: "GCE project"},
-        {type: "gke-project", friendly: "GKE project"},
-        {type: "gpu-project", friendly: "GPU project"},
-        {type: "ingress-project", friendly: "Ingress project"},
-        {type: "k8s-infra-gce-project", friendly: "K8s Infra GCE project"},
-        {type: "node-e2e-project", friendly: "Node e2e project"},
-        {type: "scalability-project", friendly: "Scalability project"},
-        {type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+        {instance: "104.197.27.114:9090", type: "aws-account", friendly: "AWS account"},
+        {instance: "104.197.27.114:9090", type: "gce-project", friendly: "GCE project"},
+        {instance: "35.225.208.117:9090", type: "k8s-infra-gce-project", friendly: "GCE project (k8s-infra)"},
+        {instance: "104.197.27.114:9090", type: "gke-project", friendly: "GKE project"},
+        {instance: "104.197.27.114:9090", type: "gpu-project", friendly: "GPU project"},
+        {instance: "104.197.27.114:9090", type: "ingress-project", friendly: "Ingress project"},
+        {instance: "104.197.27.114:9090", type: "node-e2e-project", friendly: "Node e2e project"},
+        {instance: "104.197.27.114:9090", type: "scalability-project", friendly: "Scalability project"},
+        {instance: "35.225.208.117:9090", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
+        {instance: "104.197.27.114:9090", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
       ]
   ])
 + dashboardConfig


### PR DESCRIPTION
I would like to have pools named identically across prow-builds' boksos
and k8s-infra's boskos, so there's one less thing to change when
migrating a prowjob from one build cluster to the other.

k8s-infra-gce-project vs. gce-project was a mistake I'd like to undo

I also want to be able to display a panel per-instance for the same pool
type. This is the dumb hardcoded approach