### PR TITLE
Migrate 100 node scalability release-blocking job to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -101,6 +101,7 @@ periodics:
           memory: "16Gi"
 
 - interval: 30m
+  cluster: k8s-infra-prow-build
   name: ci-kubernetes-e2e-gci-gce-scalability
   tags:
   - "perfDashPrefix: gce-100Nodes-master"


### PR DESCRIPTION
Demonstrate use of the scalability-project pool added to k8s-infra's boskos instance added via https://github.com/kubernetes/k8s.io/pull/898