### PR TITLE
delete docker conformance test group

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -235,21 +235,6 @@ test_groups:
 - name: cloud-provider-huaweicloud-e2e-conformance-release-v1.17
   gcs_prefix: k8s-conform-huaweicloud/cloud-provider-huaweicloud/e2e-conformance-release-v1.17
 
-# Docker node conformance test group
-- name: ce18.09-ubuntu16.04-k8s1.13.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ce18.09-ubuntu16.04-k8s1.13.x
-- name: ce19.03-ubuntu16.04-k8s1.14.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ce19.03-ubuntu16.04-k8s1.14.x
-- name: ee17.06-rhel7.5-k8s1.12.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ee17.06-rhel7.5-k8s1.12.x
-- name: ee17.06-ubuntu16.04-k8s1.12.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ee17.06-ubuntu16.04-k8s1.12.x
-- name: ee18.09-rhel7.5-k8s1.13.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ee18.09-rhel7.5-k8s1.13.x
-- name: ee18.09-ubuntu16.04-k8s1.14.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ee18.09-ubuntu16.04-k8s1.14.x
-- name: ee19.03-ubuntu16.04-k8s1.14.x-conformance
-  gcs_prefix: k8s-conformance-docker/ci-kube-node-e2e-docker/ee19.03-ubuntu16.04-k8s1.14.x
 
 # CEL Conformance Tests
 - name: cel-go-conformance-tests

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -11,11 +11,9 @@ dashboard_groups:
     - sig-node-cri-o
     - sig-node-cri
     - sig-node-arm64
-    - sig-node-docker
     - sig-node-node-feature-discovery
     - sig-node-node-problem-detector
     - sig-node-seccomp-operator
-
 
 dashboards:
 - name: sig-node-containerd-io
@@ -100,31 +98,6 @@ dashboards:
     - name: conformance-containerd-stable
       test_group_name: arm64-conformance-cntainerd-stable
       description: Runs conformance test by using kubetest against latest stable version of kubernetes with containerd on arm64
-
-  #Docker node conformance dashboard
-- name: sig-node-docker
-  dashboard_tab:
-    - name: ce18.09-node-ubuntu16.04-k8s1.13
-      test_group_name: ce18.09-ubuntu16.04-k8s1.13.x-conformance
-      description: k8s1.13.x node conformance test results for docker ce-18.09 on ubuntu16.04
-    - name: ce19.03-node-ubuntu16.04-k8s1.14
-      test_group_name: ce19.03-ubuntu16.04-k8s1.14.x-conformance
-      description: k8s1.14.x node conformance test results for ce-19.03 on ubuntu16.04
-    - name: ee17.06-node-rhel7.5-k8s1.12
-      test_group_name: ee17.06-rhel7.5-k8s1.12.x-conformance
-      description: k8s1.12.x node conformance test results for ee-17.06 on rhel7.5
-    - name: ee17.06-node-ubuntu16.04-k8s1.12
-      test_group_name: ee17.06-ubuntu16.04-k8s1.12.x-conformance
-      description: k8s1.12.x node conformance test results for ee-17.06 on ubuntu16.04
-    - name: ee18.09-node-rhel7.5-k8s1.13
-      test_group_name: ee18.09-rhel7.5-k8s1.13.x-conformance
-      description: k8s1.13.x node conformance test results for ee-18.09 on rhel7.5
-    - name: ee18.09-node-ubuntu16.04-k8s1.14
-      test_group_name: ee18.09-ubuntu16.04-k8s1.14.x-conformance
-      description: k8s1.14.x node conformance test results for ee-18.09 on ubuntu16.04
-    - name: ee19.03-node-ubuntu16.04-k8s1.14
-      test_group_name: ee19.03-ubuntu16.04-k8s1.14.x-conformance
-      description: k8s1.14.x node conformance test results for ee-19.03 on ubuntu16.04
 
 - name: sig-node-node-feature-discovery
 

--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -47,9 +47,6 @@ gs://k8s-conformance-openstack/:
 gs://k8s-conformance-gardener:
   contact: "OlegLoewen"
   prefix: "gardener:"
-gs://k8s-conformance-docker:
-  contact: "jeffqwb2017"
-  prefix: "docker:"
 gs://cel-conformance:
   contact: "JimLarson"
   prefix: "cel:"


### PR DESCRIPTION
no results for conformance after k8s-v1.14

no docker ce or ee results after v1.14 https://github.com/cncf/k8s-conformance

https://github.com/kubernetes/test-infra/blob/e3ac4d5f47937048cbb737dbe9e451abbf686fa6/kettle/buckets.yaml#L46-L48

If I check the bucket, the last results were uploaded about a year ago.

It's on the sig-node dashboard, but I think docker might be responsible party for updates, 
/cc @jeffqwb2017 