### PR TITLE
use cos image for containerd node-e2e tests

### DIFF
--- a/jobs/e2e_node/containerd/containerd-master/image-config.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config.yaml
@@ -4,6 +4,6 @@ images:
     project: ubuntu-os-gke-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env"
   cos-stable:
-    image: cos-77-12371-274-0
+    image_family: cos-81-lts
     project: cos-cloud
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
This should be fairly safe to experiment with. These both run successfully currently, and are not listed as blocking.

https://github.com/kubernetes/test-infra/blob/e3ac4d5f47937048cbb737dbe9e451abbf686fa6/config/jobs/kubernetes/sig-node/containerd.yaml#L219-L248

https://github.com/kubernetes/test-infra/blob/e3ac4d5f47937048cbb737dbe9e451abbf686fa6/config/jobs/kubernetes/sig-node/containerd.yaml#L309-L338

/cc @bart0sh @vpickard @bsdnet 