### PR TITLE
correct grace period config and match bootstrap

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-presubmits.yaml
@@ -64,7 +64,7 @@ presubmits:
     path_alias: sigs.k8s.io/kind
     decoration_config:
       timeout: 40m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master
@@ -166,7 +166,7 @@ presubmits:
     path_alias: sigs.k8s.io/kind
     decoration_config:
       timeout: 40m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-master
@@ -215,7 +215,7 @@ presubmits:
     path_alias: sigs.k8s.io/kind
     decoration_config:
       timeout: 40m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     spec:
       containers:
       - image: gcr.io/k8s-testimages/krte:v20200430-04773e2-1.18

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -64,7 +64,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -115,7 +115,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -170,7 +170,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -226,7 +226,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 2h # allow plenty of time for a serial conformance run
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -270,7 +270,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     decoration_config:
       timeout: 60m
-      terminationGracePeriodSeconds: 300
+      grace_period: 15m
     path_alias: k8s.io/kubernetes
     spec:
       containers:


### PR DESCRIPTION
the previous key was a bad copy paste, i'm surprised it passed validation, I guess we don't have strict key checking still

this also updates the value to match bootstrap, I did some thorough digging this time and i'm pretty certain that bootstrap jobs get a 15m grace period if the timeout actually is triggered (which is very buggy in bootstrap).

/cc @aojea @amwat 