### PR TITLE
Added k8s-infra-dns-updater svcacct as trusted

### DIFF
--- a/config/prow/cluster/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/trusted_serviceaccounts.yaml
@@ -46,6 +46,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-dns-updater@kubernetes-public.iam.gserviceaccount.com
+  name: k8s-infra-dns-updater
+  namespace: test-pods
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above
 # * Config service account on job


### PR DESCRIPTION
This service account will be used to run dns updates using octodns when the config files under [k/k8s.io/dns/zone-configs/*.yaml](https://github.com/kubernetes/k8s.io/tree/8ab172615215f3e43fe455b5004c5a66d6df1105/dns/zone-configs) will change

More informations about whole process of automating this efforts: [k/k8s.io#786](https://github.com/kubernetes/k8s.io/issues/783)

/cc @spiffxp 

Signed-off-by: Bart Smykla <bsmykla@vmware.com>