### PR TITLE
add metadata to cos-77 images

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -26,24 +26,28 @@ images:
     image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 35 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2:
     image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
     image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-1
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
     image: cos-77-12371-251-0
     project: cos-cloud
     machine: n1-standard-2
+    metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
       - 'create 105 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:


### PR DESCRIPTION
COS images have /tmp mounted with 'noexec' mount option.
This makes it impossible for run_remote to execute binaries
from its workspace.
This results in failed kubelet tests, e.g.
  ci-kubernetes-node-kubelet-benchmark and
  ci-kubernetes-node-kubelet-conformance test suites fail with
```
  "failed to run command './ginkgo': Permission denied" error
```
Adding metadata pointing to cloud-init(gci-init.yaml) should
solve this as cloud-init remounts /tmp with 'exec' mount option.

PS: This PR is similar to https://github.com/kubernetes/test-infra/pull/17656, just for another type of COS images