### PR TITLE
match up test runs to image config for node-kubelet-features

### DIFF
--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -118,3 +118,10 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-features
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-features
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'


### PR DESCRIPTION
The output in testgrid jumps around depending on how many images
happen to be running. We can configure testgrid to match up the
context name being used from an image-config which will stabilize the
connection of a particular image used.

For example:
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [2]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [3]
should look like:
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [ubuntu]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [cos-stable1]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [cos-stable2]

I'm not 100% sure this is correct, but if it is, I intend to do it for most of the image-configs, some have 20+ images used, and the testgrid output is very unstable in terms of viewing what is failing on a particular image.
/cc @vpickard @bart0sh