### PR TITLE
prow: sidecar: fix upload of empty files

### DIFF
--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/io:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
+        "@com_github_fsouza_fake_gcs_server//fakestorage:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_utils//pointer:go_default_library",
     ],

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -193,9 +193,7 @@ func (w *openerObjectWriter) Close() error {
 		// Always create a writer even if Write() was never called
 		// otherwise empty files are never created, because Write() is
 		// never called for them
-		var err error
-		w.writeCloser, err = w.Opener.Writer(w.Context, fmt.Sprintf("%s/%s", w.Bucket, w.Dest), w.opts...)
-		if err != nil {
+		if _, err := w.Write([]byte("")); err != nil {
 			return err
 		}
 	}

--- a/prow/pod-utils/gcs/upload_test.go
+++ b/prow/pod-utils/gcs/upload_test.go
@@ -17,10 +17,17 @@ limitations under the License.
 package gcs
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"sync"
 	"testing"
+
+	"github.com/fsouza/fake-gcs-server/fakestorage"
+
+	"k8s.io/test-infra/prow/io"
 )
 
 func TestUploadToGcs(t *testing.T) {
@@ -96,5 +103,75 @@ func TestUploadToGcs(t *testing.T) {
 		if count != (testCase.passingTargets + testCase.failingTargets) {
 			t.Errorf("%s: had %d passing and %d failing targets but only ran %d targets, not %d", testCase.name, testCase.passingTargets, testCase.failingTargets, count, testCase.passingTargets+testCase.failingTargets)
 		}
+	}
+}
+
+func Test_openerObjectWriter_Write(t *testing.T) {
+
+	fakeBucket := "test-bucket"
+	fakeGCSServer := fakestorage.NewServer([]fakestorage.Object{})
+	fakeGCSServer.CreateBucket(fakeBucket)
+	defer fakeGCSServer.Stop()
+	fakeGCSClient := fakeGCSServer.Client()
+
+	tests := []struct {
+		name          string
+		ObjectDest    string
+		ObjectContent []byte
+		wantN         int
+		wantErr       bool
+	}{
+		{
+			name:          "write regular file",
+			ObjectDest:    "build/log.text",
+			ObjectContent: []byte("Oh wow\nlogs\nthis is\ncrazy"),
+			wantN:         25,
+			wantErr:       false,
+		},
+		{
+			name:          "write empty file",
+			ObjectDest:    "build/marker",
+			ObjectContent: []byte(""),
+			wantN:         0,
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := &openerObjectWriter{
+				Opener:  io.NewGCSOpener(fakeGCSClient),
+				Context: context.Background(),
+				Bucket:  fmt.Sprintf("gs://%s", fakeBucket),
+				Dest:    tt.ObjectDest,
+			}
+			gotN, err := w.Write(tt.ObjectContent)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Write() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotN != tt.wantN {
+				t.Errorf("Write() gotN = %v, want %v", gotN, tt.wantN)
+			}
+
+			if err := w.Close(); (err != nil) != tt.wantErr {
+				t.Errorf("Close() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// read object back from bucket and compare with written object
+			reader, err := fakeGCSClient.Bucket(fakeBucket).Object(tt.ObjectDest).NewReader(context.Background())
+			if err != nil {
+				t.Errorf("Got unexpected error reading object %s: %v", tt.ObjectDest, err)
+			}
+
+			gotObjectContent, err := ioutil.ReadAll(reader)
+			if err != nil {
+				t.Errorf("Got unexpected error reading object %s: %v", tt.ObjectDest, err)
+			}
+
+			if bytes.Compare(tt.ObjectContent, gotObjectContent) != 0 {
+				t.Errorf("Write() gotObjectContent = %v, want %v", gotObjectContent, tt.ObjectContent)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Because for empty files (io.Reader) the Write call was never executed,
no files in GCS were created. Now we always create a Writer and therefore
even empty files are written (on Close())

See also: 
* bug report: https://kubernetes.slack.com/archives/CDECRSC5U/p1590603056330600
* context: https://github.com/kubernetes/test-infra/issues/11260