### PR TITLE
Update Prow Deck Job badges display order

### DIFF
--- a/prow/cmd/deck/badge.go
+++ b/prow/cmd/deck/badge.go
@@ -85,10 +85,10 @@ func makeShield(subject, status, color string) []byte {
 
 // pickLatestJobs returns the most recent run of each job matching the selector,
 // which is comma-separated list of globs, for example "ci-ti-*,ci-other".
-// jobs will be sorted
+// jobs will be sorted by StartTime in reverse order to display recent jobs first
 func pickLatestJobs(jobs []prowapi.ProwJob, selector string) []prowapi.ProwJob {
 	sort.Slice(jobs, func(i, j int) bool {
-		return jobs[i].Status.StartTime.Before(&jobs[j].Status.StartTime)
+		return jobs[j].Status.StartTime.Before(&jobs[i].Status.StartTime)
 	})
 	var out []prowapi.ProwJob
 	have := make(map[string]bool)

--- a/prow/cmd/deck/badge_test.go
+++ b/prow/cmd/deck/badge_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestPickLatest(t *testing.T) {
-	// timestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2020-05-29T15:55:41Z")
 	earliest := metav1.Now()
 	time.Sleep(100 * time.Millisecond)
 	earlier := metav1.Now()

--- a/prow/cmd/deck/badge_test.go
+++ b/prow/cmd/deck/badge_test.go
@@ -20,33 +20,40 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 func TestPickLatest(t *testing.T) {
+	// timestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2020-05-29T15:55:41Z")
+	earliest := metav1.Now()
+	time.Sleep(100 * time.Millisecond)
+	earlier := metav1.Now()
 	jobs := []prowapi.ProwJob{
 		// We're using Cluster as a simple way to distinguish runs
-		{Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "1"}},
-		{Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "2"}},
-		{Spec: prowapi.ProwJobSpec{Job: "glob-2", Cluster: "1"}},
-		{Spec: prowapi.ProwJobSpec{Job: "job-a", Cluster: "1"}},
-		{Spec: prowapi.ProwJobSpec{Job: "job-ab", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earliest}, Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "2"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "glob-2", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earliest}, Spec: prowapi.ProwJobSpec{Job: "job-a", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "job-a", Cluster: "2"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "job-ab", Cluster: "1"}},
 	}
 	expected := []prowapi.ProwJob{
-		{Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "1"}},
-		{Spec: prowapi.ProwJobSpec{Job: "glob-2", Cluster: "1"}},
-		{Spec: prowapi.ProwJobSpec{Job: "job-a", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "glob-1", Cluster: "2"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "glob-2", Cluster: "1"}},
+		{Status: prowapi.ProwJobStatus{StartTime: earlier}, Spec: prowapi.ProwJobSpec{Job: "job-a", Cluster: "2"}},
 	}
 	result := pickLatestJobs(jobs, "glob-*,job-a")
 	if !reflect.DeepEqual(result, expected) {
 		fmt.Println("expected:")
 		for _, job := range expected {
-			fmt.Printf("  job: %s cluster: %s,", job.Spec.Job, job.Spec.Cluster)
+			fmt.Printf("  job: %s cluster: %s, timestamp %s", job.Spec.Job, job.Spec.Cluster, earlier)
 		}
 		fmt.Println("got:")
 		for _, job := range result {
-			fmt.Printf("  job: %s cluster: %s,", job.Spec.Job, job.Spec.Cluster)
+			fmt.Printf("  job: %s cluster: %s, timestamp %s", job.Spec.Job, job.Spec.Cluster, earlier)
 		}
 	}
 }

--- a/prow/cmd/deck/badge_test.go
+++ b/prow/cmd/deck/badge_test.go
@@ -27,8 +27,7 @@ import (
 )
 
 func TestPickLatest(t *testing.T) {
-	earliest := metav1.Now()
-	time.Sleep(100 * time.Millisecond)
+	earliest := metav1.Time{}
 	earlier := metav1.Now()
 	jobs := []prowapi.ProwJob{
 		// We're using Cluster as a simple way to distinguish runs

--- a/prow/cmd/deck/badge_test.go
+++ b/prow/cmd/deck/badge_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"


### PR DESCRIPTION
Prow Jobs on line 91 were being ordered in the Slice with the lowest StartTime as element 0. This caused the appended job on like 103 to be the first glob matching job, and not the latest glob matching job. By reverse ordering the Slice it will perform the intended function.