### PR TITLE
Update root OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- fejta # lead
+- BenTheElder # lead
 - spiffxp # lead
 - stevekuznetsov # lead
 - test-infra-oncall # oncall
 approvers:
-- fejta # lead
+- BenTheElder # lead
 - spiffxp # lead
 - stevekuznetsov # lead
 - test-infra-oncall # oncall

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,8 +9,9 @@ aliases:
   - Katharine
   - michelle192837
 
-  # kubernetes.io org admins
   wg-k8s-infra-oncall:
+  - BenTheElder
+  # kubernetes.io org admins
   - cblecker
   - dims
   - spiffxp


### PR DESCRIPTION
Followup to https://github.com/kubernetes/community/pull/4791

In practice root /approve doesn't change, since both BenTheElder and
fejta are in the test-infra-oncall alias.