### PR TITLE
CAPZ: add conformance presubmit job on MachinePool cluster

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -170,7 +170,7 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: verify-boilerplate
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-conformance-v1alpha3-master
+  - name: pull-cluster-api-provider-azure-conformance-v1alpha3
     always_run: false
     optional: true
     decorate: true
@@ -209,8 +209,8 @@ presubmits:
               memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: pull-conformance-v1alpha3-master
-  - name: pull-cluster-api-provider-azure-conformance-v1alpha3-1-18
+      testgrid-tab-name: pull-conformance-v1alpha3
+  - name: pull-cluster-api-provider-azure-conformance-machine-pool-v1alpha3
     always_run: false
     optional: true
     decorate: true
@@ -224,11 +224,11 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: release-1.18
+      base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200527-e50e8f5-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200527-e50e8f5-master
           command:
             - "runner.sh"
             - "./scripts/ci-entrypoint.sh"
@@ -241,6 +241,10 @@ presubmits:
               value: "true"
             - name: USE_CI_ARTIFACTS
               value: "true"
+            - name: FEATURE_GATE_MACHINE_POOL
+              value: "true"
+            - name: USE_MACHINE_POOL
+              value: "true"
           securityContext:
             privileged: true
           resources:
@@ -249,7 +253,7 @@ presubmits:
               memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: pull-conformance-v1alpha3-k8s-1-18
+      testgrid-tab-name: pull-conformance-machine-pool-v1alpha3
   - name: pull-cluster-api-provider-azure-apidiff
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -243,8 +243,6 @@ presubmits:
               value: "true"
             - name: FEATURE_GATE_MACHINE_POOL
               value: "true"
-            - name: USE_MACHINE_POOL
-              value: "true"
           securityContext:
             privileged: true
           resources:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -371,7 +371,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-disk-1-16
   decorate: true
   decoration_config:
@@ -424,7 +424,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-file-1-16
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -371,7 +371,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-disk-1-17
   decorate: true
   decoration_config:
@@ -424,7 +424,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-file-1-17
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -371,7 +371,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-disk-1-18
   decorate: true
   decoration_config:
@@ -424,7 +424,7 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin on a CAPZ cluster.
     testgrid-num-columns-recent: '30'
-- interval: 3h
+- interval: 24h
   name: kubernetes-e2e-capz-azure-file-1-18
   decorate: true
   decoration_config:


### PR DESCRIPTION
Creating a presubmit job to test https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/659. Removing `pull-cluster-api-provider-azure-conformance-v1alpha3-1-18` since we already have some coverages in terms of using built K8s artifacts from a release branch from jobs such as https://testgrid.k8s.io/provider-azure-upstream#k8s-e2e-azure-disk-1-16-capz.

Also reducing the frequency of jobs created in https://github.com/kubernetes/test-infra/pull/17655 from 3h to 24h

/assign @CecileRobertMichon 