### PR TITLE
fix post-k8sio-groups

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -13,8 +13,7 @@ postsubmits:
       - name: groups
         image: golang:1.13
         command:
-        - go
+        - bash
         args:
-        - run
-        - ./groups/reconcile.go
-        - --confirm
+        - -c
+        - "cd groups && make run -- --confirm"


### PR DESCRIPTION
apparently I was overzealous in my desire to excise bash from invocations
that boil down to `go run` or `go test`

followup to https://github.com/kubernetes/test-infra/pull/17760