### PR TITLE
Fixes 14718 implements FindConfigFileForLabel on Repoowners

### DIFF
--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1192,6 +1192,10 @@ type fakeRepoOwners struct {
 	fakeRepo
 }
 
+func (fro fakeRepoOwners) FindConfigFileForLabel(label string) string {
+	return "" 
+}
+
 func (fro fakeRepoOwners) FindLabelsForFile(path string) sets.String {
 	return sets.NewString()
 }

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1193,7 +1193,7 @@ type fakeRepoOwners struct {
 }
 
 func (fro fakeRepoOwners) FindConfigFileForLabel(label string) string {
-	return "" 
+	return ""
 }
 
 func (fro fakeRepoOwners) FindLabelsForFile(path string) sets.String {

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -110,7 +110,20 @@ type fakeOwnersClient struct {
 	reviewers         map[string]sets.String
 	requiredReviewers map[string]sets.String
 	leafReviewers     map[string]sets.String
+	configSources     map[string]sets.String
 	dirBlacklist      []*regexp.Regexp
+}
+
+func (foc *fakeOwnersClient) FindConfigFileForFile(path string) sets.String {
+	return sets.String{}
+}
+
+func (foc *fakeOwnersClient) FindConfigFileForLabel(path string) string {
+	return "OWNERS"
+}
+
+func (foc *fakeOwnersClient) FindOwnersConfigForFile(path string) map[string]map[*regexp.Regexp]sets.String {
+	return nil
 }
 
 func (foc *fakeOwnersClient) Approvers(path string) sets.String {

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -61,6 +61,10 @@ func (f *fakeOwnersClient) WithGitHubClient(client github.Client) repoowners.Int
 	return f
 }
 
+func (fro fakeRepoOwners) FindConfigFileForLabel(label string) string {
+	return ""
+}
+
 type fakeRepoOwners struct {
 	approvers    map[string]sets.String
 	reviewers    map[string]sets.String

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -102,6 +102,10 @@ func (foc *fakeOwnersClient) ParseFullConfig(path string) (repoowners.FullConfig
 	return repoowners.FullConfig{}, nil
 }
 
+func (fro *fakeOwnersClient) FindConfigFileForLabel(label string) string {
+	return ""
+}
+
 type fakeClient struct {
 	comments []string
 	statuses map[string]github.Status

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
+	"fmt"
 )
 
 const (
@@ -113,7 +114,11 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 			continue
 		}
 		if err := ghc.AddLabel(org, repo, number, labelToAdd); err != nil {
-			log.WithError(err).Errorf("GitHub failed to add label: %s found in %s", labelToAdd, oc.FindConfigFileForLabel(labelToAdd))
+			log.WithError(err).WithFields(
+				logrus.Fields{
+					"label":        labelToAdd,
+					"config-files": oc.FindConfigFileForLabel(labelToAdd),
+				}).Error("Failed to add label found in config-file(s)")
 		}
 	}
 

--- a/prow/plugins/owners-label/owners-label.go
+++ b/prow/plugins/owners-label/owners-label.go
@@ -46,6 +46,7 @@ func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhel
 
 type ownersClient interface {
 	FindLabelsForFile(path string) sets.String
+	FindConfigFileForLabel(label string) string
 }
 
 type githubClient interface {
@@ -112,7 +113,7 @@ func handle(ghc githubClient, oc ownersClient, log *logrus.Entry, pre *github.Pu
 			continue
 		}
 		if err := ghc.AddLabel(org, repo, number, labelToAdd); err != nil {
-			log.WithError(err).Errorf("GitHub failed to add the following label: %s", labelToAdd)
+			log.WithError(err).Errorf("GitHub failed to add label: %s found in %s", labelToAdd, oc.FindConfigFileForLabel(labelToAdd))
 		}
 	}
 

--- a/prow/plugins/owners-label/owners-label_test.go
+++ b/prow/plugins/owners-label/owners-label_test.go
@@ -50,7 +50,7 @@ func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
 }
 
 func (foc *fakeOwnersClient) FindConfigFileForLabel(path string) string {
-	return "" 
+	return ""
 }
 
 // TestHandle tests that the handle function requests reviews from the correct number of unique users.

--- a/prow/plugins/owners-label/owners-label_test.go
+++ b/prow/plugins/owners-label/owners-label_test.go
@@ -49,6 +49,10 @@ func (foc *fakeOwnersClient) FindLabelsForFile(path string) sets.String {
 	return foc.labels[path]
 }
 
+func (foc *fakeOwnersClient) FindConfigFileForLabel(path string) string {
+	return "" 
+}
+
 // TestHandle tests that the handle function requests reviews from the correct number of unique users.
 func TestHandle(t *testing.T) {
 	foc := &fakeOwnersClient{

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -248,6 +248,10 @@ func (foc *fakeOwnersClient) TopLevelApprovers() sets.String {
 	return sets.String{}
 }
 
+func (foc *fakeOwnersClient) FindConfigFileForLabel(path string) string {
+	return "OWNERS"
+}
+
 func makeFakeRepoOwnersClient() fakeRepoownersClient {
 	return fakeRepoownersClient{
 		foc: &fakeOwnersClient{},

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -36,6 +36,8 @@ import (
 	prowConf "k8s.io/test-infra/prow/config"
 )
 
+// Implements https://go.k8s.io/owners
+
 const (
 	ownersFileName  = "OWNERS"
 	aliasesFileName = "OWNERS_ALIASES"
@@ -216,7 +218,6 @@ type RepoOwner interface {
 	FindApproverOwnersForFile(path string) string
 	FindReviewersOwnersForFile(path string) string
 	FindLabelsForFile(path string) sets.String
-	FindConfigFileForFile(path string) sets.String
 	FindConfigFileForLabel(label string) string
 	IsNoParentOwners(path string) bool
 	LeafApprovers(path string) sets.String
@@ -894,12 +895,6 @@ func (o *RepoOwners) TopLevelApprovers() sets.String {
 	return o.entriesForFile(".", o.approvers, false)
 }
 
-
-// FindConfigFileForFile returns set of config files used to be configure
-// the RepoOwners struct for the repo file specified in path
-func (o *RepoOwners) FindConfigFileForFile(path string) sets.String {
-	return o.configSources[path][nil]
-}
 
 // FindConfigFileForLabel returns set of config files used to configure
 // the RepoOwners struct for the repo file specified in path

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -693,7 +693,7 @@ func NormLogins(logins []string) sets.String {
 	return normed
 }
 
-var defaultDirOptions = dirOptions{}
+var defaultDirOptions dirOptions
 
 // applyConfigToPath takes a parsed Config for a path and sets up fields in RepoOwners
 func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *Config) {

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -499,8 +499,9 @@ func canonicalize(path string) string {
 func (o *RepoOwners) walkFunc(path string, info os.FileInfo, err error) error {
 	log := o.log.WithField("path", path)
 	log.Debugf("walkFunc(%q, %q,  %q)", path, info, err)
+
 	if err != nil {
-		log.WithError(err).Errorf("Error while walking OWNERS files while processing %q", path)
+		log.WithError(err).Error("Error while walking OWNERS files")
 		return nil
 	}
 	filename := filepath.Base(path)

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -56,7 +56,7 @@ type Config struct {
 	Reviewers         []string `json:"reviewers,omitempty"`
 	RequiredReviewers []string `json:"required_reviewers,omitempty"`
 	Labels            []string `json:"labels,omitempty"`
-	SourcePath        string   `json:"-"`
+	sourcePath        string
 }
 
 // SimpleConfig holds options and Config applied to everything under the containing directory
@@ -531,7 +531,7 @@ func (o *RepoOwners) walkFunc(path string, info os.FileInfo, err error) error {
 			log.WithError(err).Infof("Error decoding OWNERS config from %q", filename)
 			return nil
 		}
-		simple.SourcePath = filename
+		simple.sourcePath = filename
 		// Set owners for this file (not the directory) using the relative path if they were found
 		o.applyConfigToPath(relPath, nil, &simple.Config)
 		o.applyOptionsToPath(relPath, simple.Options)
@@ -612,7 +612,7 @@ func (o *RepoOwners) ParseSimpleConfig(path string) (SimpleConfig, error) {
 	}
 
 	simple, err := LoadSimpleConfig(b)
-	simple.SourcePath = path
+	simple.sourcePath = path
 	return simple, err
 }
 
@@ -720,17 +720,17 @@ func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *C
 		}
 		o.labels[path][re] = sets.NewString(config.Labels...)
 	}
-	if len(config.SourcePath) > 0 {
+	if len(config.sourcePath) > 0 {
 		if o.configSources[path] == nil {
-			o.configSources[path] = make(map[*regexp.Regexp]sets.String)
+			o.configSources[path] = map[*regexp.Regexp]sets.String{}
 		}
-		o.configSources[path][re] = sets.NewString(config.SourcePath)
+		o.configSources[path][re] = sets.NewString(config.sourcePath)
 		if len(config.Labels) > 0 {
 			if o.configSourceByLabel == nil {
 				o.configSourceByLabel = make(map[string]string)
 			}
 			for _, label := range config.Labels {
-				o.configSourceByLabel[label] = config.SourcePath
+				o.configSourceByLabel[label] = config.sourcePath
 			}
 		}
 	}

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -216,7 +216,6 @@ type RepoOwner interface {
 	FindApproverOwnersForFile(path string) string
 	FindReviewersOwnersForFile(path string) string
 	FindLabelsForFile(path string) sets.String
-	FindOwnersConfigForFile(path string) map[string]map[*regexp.Regexp]sets.String
 	FindConfigFileForFile(path string) sets.String
 	FindConfigFileForLabel(label string) string
 	IsNoParentOwners(path string) bool
@@ -819,9 +818,6 @@ func (o *RepoOwners) IsNoParentOwners(path string) bool {
 //            when false retrieve all entries in all OWNERS file
 func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.Regexp]sets.String, leafOnly bool) sets.String {
 	d := path
-	fmt.Printf("entriesForFile : path %30v=\n", path)
-	fmt.Printf("entriesForFile : entries %v\n", people)
-	fmt.Printf("entriesForFile : %q\n", o.FindOwnersConfigForFile(path))
 	if !o.enableMDYAML || !strings.HasSuffix(path, ".md") {
 		// if path is a directory, this will remove the leaf directory, and returns "." for topmost dir
 		d = filepath.Dir(d)
@@ -898,11 +894,6 @@ func (o *RepoOwners) TopLevelApprovers() sets.String {
 	return o.entriesForFile(".", o.approvers, false)
 }
 
-// FindOwnersConfigForFile returns the config file as a map (OWNERS, OWNERS_ALIAS, that md file thing that I can't find out anything about)
-// that applies to the specified path
-func (o *RepoOwners) FindOwnersConfigForFile(path string) map[string]map[*regexp.Regexp]sets.String {
-	return o.configSources
-}
 
 // FindConfigFileForFile returns set of config files used to be configure
 // the RepoOwners struct for the repo file specified in path

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -699,25 +699,25 @@ var defaultDirOptions dirOptions
 func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *Config) {
 	if len(config.Approvers) > 0 {
 		if o.approvers[path] == nil {
-			o.approvers[path] = make(map[*regexp.Regexp]sets.String)
+			o.approvers[path] = map[*regexp.Regexp]sets.String{}
 		}
 		o.approvers[path][re] = o.ExpandAliases(NormLogins(config.Approvers))
 	}
 	if len(config.Reviewers) > 0 {
 		if o.reviewers[path] == nil {
-			o.reviewers[path] = make(map[*regexp.Regexp]sets.String)
+			o.reviewers[path] = map[*regexp.Regexp]sets.String{}
 		}
 		o.reviewers[path][re] = o.ExpandAliases(NormLogins(config.Reviewers))
 	}
 	if len(config.RequiredReviewers) > 0 {
 		if o.requiredReviewers[path] == nil {
-			o.requiredReviewers[path] = make(map[*regexp.Regexp]sets.String)
+			o.requiredReviewers[path] = map[*regexp.Regexp]sets.String{}
 		}
 		o.requiredReviewers[path][re] = o.ExpandAliases(NormLogins(config.RequiredReviewers))
 	}
 	if len(config.Labels) > 0 {
 		if o.labels[path] == nil {
-			o.labels[path] = make(map[*regexp.Regexp]sets.String)
+			o.labels[path] = map[*regexp.Regexp]sets.String{}
 		}
 		o.labels[path][re] = sets.NewString(config.Labels...)
 	}
@@ -728,7 +728,7 @@ func (o *RepoOwners) applyConfigToPath(path string, re *regexp.Regexp, config *C
 		o.configSources[path][re] = sets.NewString(config.sourcePath)
 		if len(config.Labels) > 0 {
 			if o.configSourceByLabel == nil {
-				o.configSourceByLabel = make(map[string]string)
+				o.configSourceByLabel = map[string]string{}
 			}
 			for _, label := range config.Labels {
 				o.configSourceByLabel[label] = config.sourcePath
@@ -750,9 +750,9 @@ func (o *RepoOwners) filterCollaborators(toKeep []github.User) *RepoOwners {
 	}
 
 	filter := func(ownerMap map[string]map[*regexp.Regexp]sets.String) map[string]map[*regexp.Regexp]sets.String {
-		filtered := make(map[string]map[*regexp.Regexp]sets.String)
+		filtered := map[string]map[*regexp.Regexp]sets.String{}
 		for path, reMap := range ownerMap {
-			filtered[path] = make(map[*regexp.Regexp]sets.String)
+			filtered[path] = map[*regexp.Regexp]sets.String{}
 			for re, unfiltered := range reMap {
 				filtered[path][re] = unfiltered.Intersection(collabs)
 			}

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -895,7 +895,6 @@ func (o *RepoOwners) TopLevelApprovers() sets.String {
 	return o.entriesForFile(".", o.approvers, false)
 }
 
-
 // FindConfigFileForLabel returns set of config files used to configure
 // the RepoOwners struct for the repo file specified in path
 func (o *RepoOwners) FindConfigFileForLabel(label string) string {

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -39,7 +39,8 @@ var (
 	testFiles = map[string][]byte{
 		"foo": []byte(`approvers:
 - bob`),
-		"OWNERS": []byte(`approvers:
+		"OWNERS": []byte(
+			`approvers:
 - cjwagner
 reviewers:
 - Alice
@@ -1192,9 +1193,9 @@ func TestFindConfigFileByLabel(t *testing.T) {
 			"a/b/c/foo.txt": regexpAll("./OWNERS", "a/b/c/OWNERS"),
 		},
 		configSourceByLabel: map[string]string{
-			"sig/hg2tg": "./OWNERS",
+			"sig/hg2tg":                 "./OWNERS",
 			"sig/hg2tg-secondary-phase": "a/b/c/OWNERS",
-			"wg/towel":  "./OWNERS",
+			"wg/towel":                  "./OWNERS",
 		},
 	}
 	for i, test := range tests {

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1166,7 +1166,7 @@ func TestFindConfigFileByLabel(t *testing.T) {
 			label:                "sig/hg2tg",
 			expectedConfigSource: "./OWNERS",
 		}, {
-			name: "OWNERS in ROOT and LEAF",
+			name:                 "OWNERS in ROOT and LEAF",
 			path:                 leafDir,
 			label:                "sig/hg2tg",
 			expectedConfigSource: "./OWNERS",
@@ -1197,7 +1197,7 @@ func TestFindConfigFileByLabel(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		gotConfigSource:= testOwners.FindConfigFileForLabel(test.label)
+		gotConfigSource := testOwners.FindConfigFileForLabel(test.label)
 		if !(gotConfigSource == test.expectedConfigSource) {
 			t.Errorf("%d [%s] for %q", i, test.name, test.path)
 			t.Errorf("  expected config(s) %q", test.expectedConfigSource)

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1173,8 +1173,8 @@ func TestFindConfigFileByLabel(t *testing.T) {
 		}, {
 			name:                 "OWNERS in ROOT and LEAF",
 			path:                 "a/b/c/foo.txt",
-			label:                "sig/hg2tg",
-			expectedConfigSource: "./OWNERS",
+			label:                "sig/hg2tg-secondary-phase",
+			expectedConfigSource: "a/b/c/OWNERS",
 		},
 	}
 
@@ -1193,6 +1193,7 @@ func TestFindConfigFileByLabel(t *testing.T) {
 		},
 		configSourceByLabel: map[string]string{
 			"sig/hg2tg": "./OWNERS",
+			"sig/hg2tg-secondary-phase": "a/b/c/OWNERS",
 			"wg/towel":  "./OWNERS",
 		},
 	}

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1141,41 +1141,40 @@ func TestFindConfigFileByLabel(t *testing.T) {
 	tests := []struct {
 		name                 string
 		path                 string
-		expectedLabels       sets.String
-		expectedConfigSource sets.String
+		label                string
+		expectedConfigSource string
 	}{
 		{
 			name:                 "OWNERS in root only",
 			path:                 "foo.txt",
-			expectedLabels:       sets.NewString("sig/hg2tg"),
-			expectedConfigSource: sets.NewString("./OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		},
 		{ // Should I accomdate this use case (relative path to a root file??)
 			name:                 "OWNERS in root only",
 			path:                 "./foo.txt",
-			expectedLabels:       sets.NewString("sig/hg2tg"),
-			expectedConfigSource: sets.NewString("./OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		}, {
 			name:                 "OWNERS in root only",
 			path:                 "",
-			expectedLabels:       sets.NewString("sig/hg2tg"),
-			expectedConfigSource: sets.NewString("./OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		}, {
 			name:                 "OWNERS in root only",
 			path:                 ".",
-			expectedLabels:       sets.NewString("sig/hg2tg"),
-			expectedConfigSource: sets.NewString("./OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		}, {
 			name: "OWNERS in ROOT and LEAF",
-			// path:                 "a/b/c/",
 			path:                 leafDir,
-			expectedLabels:       sets.NewString("sig/hg2tg", "wg/towel"),
-			expectedConfigSource: sets.NewString("./OWNERS", "a/b/c/OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		}, {
 			name:                 "OWNERS in ROOT and LEAF",
 			path:                 "a/b/c/foo.txt",
-			expectedLabels:       sets.NewString("sig/hg2tg"),
-			expectedConfigSource: sets.NewString("./OWNERS", "a/b/c/OWNERS"),
+			label:                "sig/hg2tg",
+			expectedConfigSource: "./OWNERS",
 		},
 	}
 
@@ -1198,15 +1197,11 @@ func TestFindConfigFileByLabel(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		gotConfigSource := testOwners.FindConfigFileForFile(test.path)
-		gotLabels := testOwners.FindLabelsForFile(test.path)
-		if !gotConfigSource.Equal(test.expectedConfigSource) {
+		gotConfigSource:= testOwners.FindConfigFileForLabel(test.label)
+		if !(gotConfigSource == test.expectedConfigSource) {
 			t.Errorf("%d [%s] for %q", i, test.name, test.path)
-			t.Errorf("  expected config(s) %q", test.expectedConfigSource.List())
-			t.Errorf("  but got  config(s) %q", gotConfigSource.List())
-			t.Errorf("  expected labels(s) %q", test.expectedLabels.List())
-			t.Errorf("  but got  labels(s) %q", gotLabels.List())
-
+			t.Errorf("  expected config(s) %q", test.expectedConfigSource)
+			t.Errorf("  but got  config(s) %q", gotConfigSource)
 		}
 	}
 }

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1150,7 +1150,7 @@ func TestFindConfigFileByLabel(t *testing.T) {
 			label:                "sig/hg2tg",
 			expectedConfigSource: "./OWNERS",
 		},
-		{ // Should I accomdate this use case (relative path to a root file??)
+		{
 			name:                 "OWNERS in root only",
 			path:                 "./foo.txt",
 			label:                "sig/hg2tg",

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"github.com/davecgh/go-spew/spew"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
 	prowConf "k8s.io/test-infra/prow/config"
@@ -1124,7 +1123,6 @@ func TestFindLabelsForPath(t *testing.T) {
 			leafDir: regexpAll("wg/save-tokyo"),
 		},
 	}
-	spew.Dump(testOwners)
 	for _, test := range tests {
 		got := testOwners.FindLabelsForFile(test.path)
 		if !got.Equal(test.expectedLabels) {
@@ -1199,14 +1197,6 @@ func TestFindConfigFileByLabel(t *testing.T) {
 			"wg/towel":  "./OWNERS",
 		},
 	}
-	/*
-		        spew.Dump(testOwners)
-			t.Errorf("testOwners.labels[%s] %v", baseDir, testOwners.labels[baseDir])
-			t.Errorf("testOwners.labels[%s] %v", leafDir, testOwners.labels[leafDir])
-			t.Errorf("testOwners.configSources[%s] %v", baseDir, testOwners.configSources[baseDir])
-			t.Errorf("testOwners.configSources[%s] %v", leafDir, testOwners.configSources[leafDir])
-			t.Errorf("testOwners.configSources[%s] %v", noParentsDir, testOwners.configSources[noParentsDir])
-	*/
 	for i, test := range tests {
 		gotConfigSource := testOwners.FindConfigFileForFile(test.path)
 		gotLabels := testOwners.FindLabelsForFile(test.path)


### PR DESCRIPTION
Implements #14718 

When there is a problem adding a label to an issue, the logged error can report which OWNERS file contained the label that could not be added. 

`log.WithError(err).Errorf("GitHub failed to add label: %s found in %s", labelToAdd, oc.FindConfigFileForLabel(labelToAdd))`

This is implemented by mapping labels to the CONFIG files where they were found in repoowners.go