### PR TITLE
prow: configurable metrics and pprof port

### DIFF
--- a/ghproxy/BUILD.bazel
+++ b/ghproxy/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//ghproxy/ghcache:go_default_library",
         "//greenhouse/diskutil:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/metrics:go_default_library",

--- a/prow/cmd/admission/BUILD.bazel
+++ b/prow/cmd/admission/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/scheme:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",
@@ -48,6 +49,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "//prow/flagutil:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],

--- a/prow/cmd/admission/main.go
+++ b/prow/cmd/admission/main.go
@@ -26,14 +26,17 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
 )
 
 type options struct {
-	cert       string
-	privateKey string
+	cert                   string
+	privateKey             string
+	instrumentationOptions prowflagutil.InstrumentationOptions
 }
 
 func parseOptions() options {
@@ -47,6 +50,7 @@ func parseOptions() options {
 func (o *options) parse(flags *flag.FlagSet, args []string) error {
 	flags.StringVar(&o.cert, "tls-cert-file", "", "Path to x509 certificate for HTTPS")
 	flags.StringVar(&o.privateKey, "tls-private-key-file", "", "Path to matching x509 private key.")
+	o.instrumentationOptions.AddFlags(flags)
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("parse flags: %v", err)
 	}
@@ -63,7 +67,7 @@ func main() {
 
 	defer interrupts.WaitForGracefulShutdown()
 
-	pjutil.ServePProf()
+	pjutil.ServePProf(o.instrumentationOptions.PProfPort)
 	health := pjutil.NewHealth()
 
 	http.HandleFunc("/validate", handle)

--- a/prow/cmd/admission/main_test.go
+++ b/prow/cmd/admission/main_test.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"reflect"
 	"testing"
+
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 )
 
 func TestOptions(t *testing.T) {
@@ -41,6 +43,10 @@ func TestOptions(t *testing.T) {
 			expected: &options{
 				cert:       "c",
 				privateKey: "k",
+				instrumentationOptions: prowflagutil.InstrumentationOptions{
+					MetricsPort: prowflagutil.DefaultMetricsPort,
+					PProfPort:   prowflagutil.DefaultPProfPort,
+				},
 			},
 		},
 		{

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -32,6 +32,10 @@ func TestOptions(t *testing.T) {
 
 	defaultGerritProjects := make(map[string][]string, 0)
 
+	defaultInstrumentationOptions := flagutil.InstrumentationOptions{
+		MetricsPort: prowflagutil.DefaultMetricsPort,
+		PProfPort:   prowflagutil.DefaultPProfPort,
+	}
 	cases := []struct {
 		name     string
 		args     []string
@@ -56,9 +60,10 @@ func TestOptions(t *testing.T) {
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
 				},
-				configPath:        "foo",
-				github:            defaultGitHubOptions,
-				k8sReportFraction: 1.0,
+				configPath:             "foo",
+				github:                 defaultGitHubOptions,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{
@@ -73,9 +78,10 @@ func TestOptions(t *testing.T) {
 				gerritProjects: map[string][]string{
 					"foo": {"bar"},
 				},
-				configPath:        "foo",
-				github:            defaultGitHubOptions,
-				k8sReportFraction: 1.0,
+				configPath:             "foo",
+				github:                 defaultGitHubOptions,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		//PubSub Reporter
@@ -83,11 +89,12 @@ func TestOptions(t *testing.T) {
 			name: "pubsub workers, sets workers",
 			args: []string{"--pubsub-workers=7", "--config-path=baz"},
 			expected: &options{
-				pubsubWorkers:     7,
-				configPath:        "baz",
-				github:            defaultGitHubOptions,
-				gerritProjects:    defaultGerritProjects,
-				k8sReportFraction: 1.0,
+				pubsubWorkers:          7,
+				configPath:             "baz",
+				github:                 defaultGitHubOptions,
+				gerritProjects:         defaultGerritProjects,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{
@@ -99,12 +106,13 @@ func TestOptions(t *testing.T) {
 			name: "slack workers, sets workers",
 			args: []string{"--slack-workers=13", "--slack-token-file=/bar/baz", "--config-path=foo"},
 			expected: &options{
-				slackWorkers:      13,
-				slackTokenFile:    "/bar/baz",
-				configPath:        "foo",
-				github:            defaultGitHubOptions,
-				gerritProjects:    defaultGerritProjects,
-				k8sReportFraction: 1.0,
+				slackWorkers:           13,
+				slackTokenFile:         "/bar/baz",
+				configPath:             "foo",
+				github:                 defaultGitHubOptions,
+				gerritProjects:         defaultGerritProjects,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{
@@ -122,9 +130,10 @@ func TestOptions(t *testing.T) {
 				client: prowflagutil.KubernetesOptions{
 					DeckURI: "http://www.example.com",
 				},
-				github:            defaultGitHubOptions,
-				gerritProjects:    defaultGerritProjects,
-				k8sReportFraction: 1.0,
+				github:                 defaultGitHubOptions,
+				gerritProjects:         defaultGerritProjects,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{
@@ -135,22 +144,24 @@ func TestOptions(t *testing.T) {
 			name: "k8s-gcs enables k8s-gcs",
 			args: []string{"--kubernetes-blob-storage-workers=3", "--config-path=foo"},
 			expected: &options{
-				k8sBlobStorageWorkers: 3,
-				configPath:            "foo",
-				github:                defaultGitHubOptions,
-				gerritProjects:        defaultGerritProjects,
-				k8sReportFraction:     1.0,
+				k8sBlobStorageWorkers:  3,
+				configPath:             "foo",
+				github:                 defaultGitHubOptions,
+				gerritProjects:         defaultGerritProjects,
+				k8sReportFraction:      1.0,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{
 			name: "k8s-gcs with report fraction sets report fraction",
 			args: []string{"--kubernetes-blob-storage-workers=3", "--config-path=foo", "--kubernetes-report-fraction=0.5"},
 			expected: &options{
-				k8sBlobStorageWorkers: 3,
-				configPath:            "foo",
-				github:                defaultGitHubOptions,
-				gerritProjects:        defaultGerritProjects,
-				k8sReportFraction:     0.5,
+				k8sBlobStorageWorkers:  3,
+				configPath:             "foo",
+				github:                 defaultGitHubOptions,
+				gerritProjects:         defaultGerritProjects,
+				k8sReportFraction:      0.5,
+				instrumentationOptions: defaultInstrumentationOptions,
 			},
 		},
 		{

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -101,7 +101,7 @@ const (
 type options struct {
 	configPath            string
 	jobConfigPath         string
-	common                prowflagutil.CommonOptions
+	instrumentation       prowflagutil.InstrumentationOptions
 	kubernetes            prowflagutil.KubernetesOptions
 	github                prowflagutil.GitHubOptions
 	tideURL               string
@@ -195,7 +195,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for CSRF and GitHub oauth.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether or not to make mutating API calls to GitHub.")
 	fs.StringVar(&o.pluginConfig, "plugin-config", "", "Path to plugin config file, probably /etc/plugins/plugins.yaml")
-	o.common.AddFlags(fs)
+	o.instrumentation.AddFlags(fs)
 	o.kubernetes.AddFlags(fs)
 	o.github.AddFlags(fs)
 	o.github.AllowAnonymous = true
@@ -279,7 +279,7 @@ func main() {
 	}
 
 	defer interrupts.WaitForGracefulShutdown()
-	pjutil.ServePProf(o.common.PProfPort)
+	pjutil.ServePProf(o.instrumentation.PProfPort)
 
 	// setup config agent, pod log clients etc.
 	configAgent := &config.Agent{}
@@ -297,7 +297,7 @@ func main() {
 	} else {
 		logrus.Info("No plugins configuration was provided to deck. You must provide one to reuse /test checks for rerun")
 	}
-	metrics.ExposeMetrics("deck", cfg().PushGateway, o.common.MetricsPort)
+	metrics.ExposeMetrics("deck", cfg().PushGateway, o.instrumentation.MetricsPort)
 
 	// signal to the world that we are healthy
 	// this needs to be in a separate port as we don't start the

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -101,6 +101,7 @@ const (
 type options struct {
 	configPath            string
 	jobConfigPath         string
+	common                prowflagutil.CommonOptions
 	kubernetes            prowflagutil.KubernetesOptions
 	github                prowflagutil.GitHubOptions
 	tideURL               string
@@ -194,6 +195,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.allowInsecure, "allow-insecure", false, "Allows insecure requests for CSRF and GitHub oauth.")
 	fs.BoolVar(&o.dryRun, "dry-run", false, "Whether or not to make mutating API calls to GitHub.")
 	fs.StringVar(&o.pluginConfig, "plugin-config", "", "Path to plugin config file, probably /etc/plugins/plugins.yaml")
+	o.common.AddFlags(fs)
 	o.kubernetes.AddFlags(fs)
 	o.github.AddFlags(fs)
 	o.github.AllowAnonymous = true
@@ -277,7 +279,7 @@ func main() {
 	}
 
 	defer interrupts.WaitForGracefulShutdown()
-	pjutil.ServePProf()
+	pjutil.ServePProf(o.common.PProfPort)
 
 	// setup config agent, pod log clients etc.
 	configAgent := &config.Agent{}
@@ -295,8 +297,7 @@ func main() {
 	} else {
 		logrus.Info("No plugins configuration was provided to deck. You must provide one to reuse /test checks for rerun")
 	}
-
-	metrics.ExposeMetrics("deck", cfg().PushGateway)
+	metrics.ExposeMetrics("deck", cfg().PushGateway, o.common.MetricsPort)
 
 	// signal to the world that we are healthy
 	// this needs to be in a separate port as we don't start the

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -36,11 +36,6 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
-
-	"k8s.io/test-infra/prow/github/fakegithub"
-	"k8s.io/test-infra/prow/githuboauth"
-	"k8s.io/test-infra/prow/plugins"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/yaml"
@@ -49,7 +44,10 @@ import (
 	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/github/fakegithub"
+	"k8s.io/test-infra/prow/githuboauth"
 	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/buildlog"
 	"k8s.io/test-infra/prow/spyglass/lenses/common"
 	_ "k8s.io/test-infra/prow/spyglass/lenses/junit"
@@ -694,6 +692,10 @@ func Test_gatherOptions(t *testing.T) {
 				spyglassFilesLocation: "/lenses",
 				kubernetes:            flagutil.KubernetesOptions{},
 				github:                ghoptions,
+				instrumentation: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			if tc.expected != nil {
 				tc.expected(expected)

--- a/prow/cmd/gerrit/BUILD.bazel
+++ b/prow/cmd/gerrit/BUILD.bazel
@@ -56,6 +56,7 @@ go_test(
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/flagutil:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/io:go_default_library",
         "@com_google_cloud_go//storage:go_default_library",

--- a/prow/cmd/gerrit/main_test.go
+++ b/prow/cmd/gerrit/main_test.go
@@ -31,6 +31,7 @@ import (
 	"cloud.google.com/go/storage"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/io"
 )
@@ -106,6 +107,10 @@ func TestFlags(t *testing.T) {
 				lastSyncFallback: "gs://path",
 				configPath:       "yo",
 				dryRun:           false,
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expected.projects.Set("foo=bar")
 			if tc.expected != nil {

--- a/prow/cmd/hook/main.go
+++ b/prow/cmd/hook/main.go
@@ -24,15 +24,15 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/bugzilla"
-	"k8s.io/test-infra/prow/interrupts"
 
 	"k8s.io/test-infra/pkg/flagutil"
+	"k8s.io/test-infra/prow/bugzilla"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/hook"
+	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/metrics"
 	"k8s.io/test-infra/prow/pjutil"
@@ -50,11 +50,12 @@ type options struct {
 	jobConfigPath string
 	pluginConfig  string
 
-	dryRun      bool
-	gracePeriod time.Duration
-	kubernetes  prowflagutil.KubernetesOptions
-	github      prowflagutil.GitHubOptions
-	bugzilla    prowflagutil.BugzillaOptions
+	dryRun                 bool
+	gracePeriod            time.Duration
+	kubernetes             prowflagutil.KubernetesOptions
+	github                 prowflagutil.GitHubOptions
+	bugzilla               prowflagutil.BugzillaOptions
+	instrumentationOptions prowflagutil.InstrumentationOptions
 
 	webhookSecretFile string
 	slackTokenFile    string
@@ -80,7 +81,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 	fs.DurationVar(&o.gracePeriod, "grace-period", 180*time.Second, "On shutdown, try to handle remaining events for the specified duration. ")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.bugzilla} {
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.bugzilla, &o.instrumentationOptions} {
 		group.AddFlags(fs)
 	}
 
@@ -198,8 +199,8 @@ func main() {
 	defer interrupts.WaitForGracefulShutdown()
 
 	// Expose prometheus metrics
-	metrics.ExposeMetrics("hook", configAgent.Config().PushGateway)
-	pjutil.ServePProf()
+	metrics.ExposeMetrics("hook", configAgent.Config().PushGateway, o.instrumentationOptions.MetricsPort)
+	pjutil.ServePProf(o.instrumentationOptions.PProfPort)
 
 	server := &hook.Server{
 		ClientAgent:    clientAgent,

--- a/prow/cmd/hook/main_test.go
+++ b/prow/cmd/hook/main_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -92,6 +93,10 @@ func Test_gatherOptions(t *testing.T) {
 				gracePeriod:       180 * time.Second,
 				kubernetes:        flagutil.KubernetesOptions{DeckURI: "http://whatever"},
 				webhookSecretFile: "/etc/webhook/hmac",
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)

--- a/prow/cmd/horologium/BUILD.bazel
+++ b/prow/cmd/horologium/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/cmd/horologium/main_test.go
+++ b/prow/cmd/horologium/main_test.go
@@ -30,6 +30,7 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 )
 
 type fakeCron struct {
@@ -300,6 +301,10 @@ func TestFlags(t *testing.T) {
 			expected := &options{
 				configPath: "yo",
 				dryRun:     true,
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expected.kubernetes.DeckURI = "http://whatever"
 			if tc.expected != nil {

--- a/prow/cmd/pipeline/BUILD.bazel
+++ b/prow/cmd/pipeline/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//prow/client/informers/externalversions/prowjobs/v1:go_default_library",
         "//prow/client/listers/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/logrusutil:go_default_library",
@@ -70,6 +71,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",

--- a/prow/cmd/pipeline/main_test.go
+++ b/prow/cmd/pipeline/main_test.go
@@ -20,9 +20,16 @@ import (
 	"flag"
 	"reflect"
 	"testing"
+
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
 )
 
 func TestOptions(t *testing.T) {
+
+	defaultInstrumentationOptions := prowflagutil.InstrumentationOptions{
+		MetricsPort: prowflagutil.DefaultMetricsPort,
+		PProfPort:   prowflagutil.DefaultPProfPort,
+	}
 	cases := []struct {
 		name     string
 		args     []string
@@ -36,7 +43,8 @@ func TestOptions(t *testing.T) {
 		name: "only config works",
 		args: []string{"--config=/etc/config.yaml"},
 		expected: &options{
-			configPath: "/etc/config.yaml",
+			configPath:             "/etc/config.yaml",
+			instrumentationOptions: defaultInstrumentationOptions,
 		},
 	}, {
 		name: "error when providing both kubeconfig and build-cluter options ",
@@ -44,11 +52,12 @@ func TestOptions(t *testing.T) {
 			"--kubeconfig=/root/kubeconfig", "--config=/etc/config.yaml",
 			"--build-cluster=/etc/build-cluster.yaml"},
 		expected: &options{
-			allContexts:  true,
-			totURL:       "https://tot",
-			kubeconfig:   "/root/kubeconfig",
-			configPath:   "/etc/config.yaml",
-			buildCluster: "/etc/build-cluster.yaml",
+			allContexts:            true,
+			totURL:                 "https://tot",
+			kubeconfig:             "/root/kubeconfig",
+			configPath:             "/etc/config.yaml",
+			buildCluster:           "/etc/build-cluster.yaml",
+			instrumentationOptions: defaultInstrumentationOptions,
 		},
 		err: true,
 	}, {
@@ -56,10 +65,11 @@ func TestOptions(t *testing.T) {
 		args: []string{"--all-contexts=true", "--tot-url=https://tot",
 			"--kubeconfig=/root/kubeconfig", "--config=/etc/config.yaml"},
 		expected: &options{
-			allContexts: true,
-			totURL:      "https://tot",
-			kubeconfig:  "/root/kubeconfig",
-			configPath:  "/etc/config.yaml",
+			allContexts:            true,
+			totURL:                 "https://tot",
+			kubeconfig:             "/root/kubeconfig",
+			configPath:             "/etc/config.yaml",
+			instrumentationOptions: defaultInstrumentationOptions,
 		},
 	}}
 	for _, tc := range cases {

--- a/prow/cmd/plank/main_test.go
+++ b/prow/cmd/plank/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/test-infra/prow/flagutil"
 )
 
@@ -86,6 +87,10 @@ func Test_gatherOptions(t *testing.T) {
 				configPath: "yo",
 				dryRun:     true,
 				kubernetes: flagutil.KubernetesOptions{DeckURI: "http://whatever"},
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -763,6 +763,10 @@ func TestFlags(t *testing.T) {
 				dryRun: flagutil.Bool{
 					Explicit: true,
 				},
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			if tc.expected != nil {
 				tc.expected(expected)

--- a/prow/cmd/status-reconciler/main.go
+++ b/prow/cmd/status-reconciler/main.go
@@ -52,6 +52,7 @@ type options struct {
 	kubernetes              prowflagutil.KubernetesOptions
 	github                  prowflagutil.GitHubOptions
 	storage                 prowflagutil.StorageClientOptions
+	instrumentationOptions  prowflagutil.InstrumentationOptions
 
 	tokenBurst    int
 	tokensPerHour int
@@ -76,7 +77,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
 	fs.IntVar(&o.tokensPerHour, "tokens", defaultTokens, "Throttle hourly token consumption (0 to disable)")
 	fs.IntVar(&o.tokenBurst, "token-burst", defaultBurst, "Allow consuming a subset of hourly tokens in a short burst")
-	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage} {
+	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github, &o.storage, &o.instrumentationOptions} {
 		group.AddFlags(fs)
 	}
 	fs.Parse(args)
@@ -103,7 +104,7 @@ func main() {
 
 	defer interrupts.WaitForGracefulShutdown()
 
-	pjutil.ServePProf()
+	pjutil.ServePProf(o.instrumentationOptions.PProfPort)
 
 	configAgent := &config.Agent{}
 	if err := configAgent.Start(o.configPath, o.jobConfigPath); err != nil {

--- a/prow/cmd/status-reconciler/main_test.go
+++ b/prow/cmd/status-reconciler/main_test.go
@@ -66,6 +66,10 @@ func TestGatherOptions(t *testing.T) {
 				kubernetes:    flagutil.KubernetesOptions{DeckURI: "http://whatever"},
 				tokenBurst:    100,
 				tokensPerHour: 300,
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)

--- a/prow/cmd/tide/main_test.go
+++ b/prow/cmd/tide/main_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+
 	"k8s.io/test-infra/prow/flagutil"
 )
 
@@ -97,6 +98,10 @@ func Test_gatherOptions(t *testing.T) {
 				statusThrottle:    400,
 				maxRecordsPerPool: 1000,
 				kubernetes:        flagutil.KubernetesOptions{DeckURI: "http://whatever"},
+				instrumentationOptions: flagutil.InstrumentationOptions{
+					MetricsPort: flagutil.DefaultMetricsPort,
+					PProfPort:   flagutil.DefaultPProfPort,
+				},
 			}
 			expectedfs := flag.NewFlagSet("fake-flags", flag.PanicOnError)
 			expected.github.AddFlags(expectedfs)

--- a/prow/cmd/tot/BUILD.bazel
+++ b/prow/cmd/tot/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/cmd/tot",
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/pjutil:go_default_library",

--- a/prow/cmd/tot/main.go
+++ b/prow/cmd/tot/main.go
@@ -32,9 +32,10 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/test-infra/prow/interrupts"
 
 	"k8s.io/test-infra/prow/config"
+	prowflagutil "k8s.io/test-infra/prow/flagutil"
+	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pod-utils/downwardapi"
@@ -48,9 +49,10 @@ type options struct {
 	useFallback bool
 	fallbackURI string
 
-	configPath     string
-	jobConfigPath  string
-	fallbackBucket string
+	configPath             string
+	jobConfigPath          string
+	fallbackBucket         string
+	instrumentationOptions prowflagutil.InstrumentationOptions
 }
 
 func gatherOptions() options {
@@ -69,7 +71,7 @@ func gatherOptions() options {
 	flag.StringVar(&o.fallbackBucket, "fallback-bucket", "",
 		"Fallback to top-level bucket for jobs that lack a last vended build number. The bucket layout is expected to follow https://github.com/kubernetes/test-infra/tree/master/gubernator#gcs-bucket-layout",
 	)
-
+	o.instrumentationOptions.AddFlags(flag.CommandLine)
 	flag.Parse()
 	return o
 }
@@ -279,7 +281,7 @@ func main() {
 
 	defer interrupts.WaitForGracefulShutdown()
 
-	pjutil.ServePProf()
+	pjutil.ServePProf(o.instrumentationOptions.PProfPort)
 	health := pjutil.NewHealth()
 
 	s, err := newStore(o.storagePath)

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "bool.go",
         "bugzilla.go",
+        "common.go",
         "doc.go",
         "git.go",
         "github.go",

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -5,10 +5,10 @@ go_library(
     srcs = [
         "bool.go",
         "bugzilla.go",
-        "common.go",
         "doc.go",
         "git.go",
         "github.go",
+        "instrumentation.go",
         "k8s_client.go",
         "kubernetes_cluster_clients.go",
         "storage.go",

--- a/prow/flagutil/common.go
+++ b/prow/flagutil/common.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+)
+
+// CommonOptions holds common options which are used across Prow components
+type CommonOptions struct {
+	// MetricsPort is the port which is used to serve metrics
+	MetricsPort int
+	// PProfPort is the port which is used to serve pprof
+	PProfPort int
+}
+
+// AddFlags injects common options into the given FlagSet.
+func (o *CommonOptions) AddFlags(fs *flag.FlagSet) {
+	fs.IntVar(&o.MetricsPort, "metrics-port", 9090, "port to serve metrics")
+	fs.IntVar(&o.PProfPort, "pprof-port", 6060, "port to serve pprof")
+}

--- a/prow/flagutil/instrumentation.go
+++ b/prow/flagutil/instrumentation.go
@@ -20,8 +20,13 @@ import (
 	"flag"
 )
 
-// CommonOptions holds common options which are used across Prow components
-type CommonOptions struct {
+const (
+	DefaultMetricsPort = 9090
+	DefaultPProfPort   = 6060
+)
+
+// InstrumentationOptions holds common options which are used across Prow components
+type InstrumentationOptions struct {
 	// MetricsPort is the port which is used to serve metrics
 	MetricsPort int
 	// PProfPort is the port which is used to serve pprof
@@ -29,7 +34,11 @@ type CommonOptions struct {
 }
 
 // AddFlags injects common options into the given FlagSet.
-func (o *CommonOptions) AddFlags(fs *flag.FlagSet) {
-	fs.IntVar(&o.MetricsPort, "metrics-port", 9090, "port to serve metrics")
-	fs.IntVar(&o.PProfPort, "pprof-port", 6060, "port to serve pprof")
+func (o *InstrumentationOptions) AddFlags(fs *flag.FlagSet) {
+	fs.IntVar(&o.MetricsPort, "metrics-port", DefaultMetricsPort, "port to serve metrics")
+	fs.IntVar(&o.PProfPort, "pprof-port", DefaultPProfPort, "port to serve pprof")
+}
+
+func (o *InstrumentationOptions) Validate(_ bool) error {
+	return nil
 }

--- a/prow/metrics/BUILD.bazel
+++ b/prow/metrics/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/config:go_default_library",
+        "//prow/flagutil:go_default_library",
         "//prow/interrupts:go_default_library",
         "@io_k8s_utils//diff:go_default_library",
     ],

--- a/prow/metrics/metrics.go
+++ b/prow/metrics/metrics.go
@@ -31,12 +31,12 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 )
 
-const metricsPort = 9090
+const defaultMetricsPort = 9090
 
 type CreateServer func(http.Handler) interrupts.ListenAndServer
 
 // ExposeMetricsWithRegistry chooses whether to serve or push metrics for the service with the registry
-func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway, reg prometheus.Gatherer, createServer CreateServer) {
+func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway, port int, reg prometheus.Gatherer, createServer CreateServer) {
 	if pushGateway.Endpoint != "" {
 		pushMetrics(component, pushGateway.Endpoint, pushGateway.Interval.Duration)
 		if !pushGateway.ServeMetrics {
@@ -44,7 +44,7 @@ func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway,
 		}
 	}
 
-	// These get regsitered in controller-runtimes registry via an init in the internal/controller/metrics package. if
+	// These get registered in controller-runtimes registry via an init in the internal/controller/metrics package. if
 	// we dont unregister them, metrics break if that package is somehow imported.
 	// Setting the default prometheus registry in controller-runtime is unfortunately not an option, because that would
 	// result in all metrics that got registered in controller-runtime via an init to vanish, as inits of dependencies
@@ -63,7 +63,10 @@ func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway,
 	metricsMux.Handle("/metrics", handler)
 	var server interrupts.ListenAndServer
 	if createServer == nil {
-		server = &http.Server{Addr: ":" + strconv.Itoa(metricsPort), Handler: metricsMux}
+		if port == 0 {
+			port = defaultMetricsPort
+		}
+		server = &http.Server{Addr: ":" + strconv.Itoa(port), Handler: metricsMux}
 	} else {
 		server = createServer(handler)
 	}
@@ -71,8 +74,8 @@ func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway,
 }
 
 // ExposeMetrics chooses whether to serve or push metrics for the service
-func ExposeMetrics(component string, pushGateway config.PushGateway) {
-	ExposeMetricsWithRegistry(component, pushGateway, nil, nil)
+func ExposeMetrics(component string, pushGateway config.PushGateway, port int) {
+	ExposeMetricsWithRegistry(component, pushGateway, port, nil, nil)
 }
 
 // pushMetrics is meant to run in a goroutine and continuously push

--- a/prow/metrics/metrics.go
+++ b/prow/metrics/metrics.go
@@ -31,8 +31,6 @@ import (
 	"k8s.io/test-infra/prow/interrupts"
 )
 
-const defaultMetricsPort = 9090
-
 type CreateServer func(http.Handler) interrupts.ListenAndServer
 
 // ExposeMetricsWithRegistry chooses whether to serve or push metrics for the service with the registry
@@ -63,9 +61,6 @@ func ExposeMetricsWithRegistry(component string, pushGateway config.PushGateway,
 	metricsMux.Handle("/metrics", handler)
 	var server interrupts.ListenAndServer
 	if createServer == nil {
-		if port == 0 {
-			port = defaultMetricsPort
-		}
 		server = &http.Server{Addr: ":" + strconv.Itoa(port), Handler: metricsMux}
 	} else {
 		server = createServer(handler)

--- a/prow/metrics/metrics_test.go
+++ b/prow/metrics/metrics_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/interrupts"
 )
 
@@ -52,7 +53,7 @@ func TestExposeMetrics(t *testing.T) {
 	defer cancel()
 	fls := fakeListenAndServer{ctx: ctx}
 
-	ExposeMetricsWithRegistry("my-component", config.PushGateway{}, 9090, nil, fls.CreateServer)
+	ExposeMetricsWithRegistry("my-component", config.PushGateway{}, flagutil.DefaultMetricsPort, nil, fls.CreateServer)
 	resp, err := http.Get(fls.server.URL + "/metrics")
 	if err != nil {
 		t.Fatalf("failed getting metrics: %v", err)

--- a/prow/metrics/metrics_test.go
+++ b/prow/metrics/metrics_test.go
@@ -52,7 +52,7 @@ func TestExposeMetrics(t *testing.T) {
 	defer cancel()
 	fls := fakeListenAndServer{ctx: ctx}
 
-	ExposeMetricsWithRegistry("my-component", config.PushGateway{}, nil, fls.CreateServer)
+	ExposeMetricsWithRegistry("my-component", config.PushGateway{}, 9090, nil, fls.CreateServer)
 	resp, err := http.Get(fls.server.URL + "/metrics")
 	if err != nil {
 		t.Fatalf("failed getting metrics: %v", err)

--- a/prow/pjutil/pprof.go
+++ b/prow/pjutil/pprof.go
@@ -20,6 +20,7 @@ package pjutil
 import (
 	"net/http"
 	"net/http/pprof"
+	"strconv"
 	"time"
 
 	"k8s.io/test-infra/prow/interrupts"
@@ -29,13 +30,13 @@ import (
 // The contents of this function are identical to what the `net/http/pprof` package does on import for
 // the simple case where the default mux is to be used, but with a custom mux to ensure we don't serve
 // this data from an exposed port.
-func ServePProf() {
+func ServePProf(port int) {
 	pprofMux := http.NewServeMux()
 	pprofMux.HandleFunc("/debug/pprof/", pprof.Index)
 	pprofMux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
 	pprofMux.HandleFunc("/debug/pprof/profile", pprof.Profile)
 	pprofMux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
 	pprofMux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	server := &http.Server{Addr: ":6060", Handler: pprofMux}
+	server := &http.Server{Addr: ":" + strconv.Itoa(port), Handler: pprofMux}
 	interrupts.ListenAndServe(server, 5*time.Second)
 }


### PR DESCRIPTION
I only implemented it for Deck for now. After we agreed on how to implement it, I would apply this change to all callers of `ServePProf` and `ExposeMetrics`

* Implementation variants:
  * I would use a flagutil to avoid code duplication, but I'm not sure if `CommonOptions` is a good name. Alternatives:
    * `DebugOptions`
    * `ObservabilityOptions`
    * separate `MetricsOptions` and `PProfOptions`
* Should we force callers of `ServePProf` and `ExposeMetrics` to handover a port or should I add an additional func for each which allows handing over the port
* Is defaulting to the old port in flagutil enough or should we also default to the old port when port `0` is handed over?

Fixed #17033 