### PR TITLE
prow: change job url prefix format for multiple concurrent storage providers

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,11 @@
 ## New features
 
 New features added to each component:
+ - *July 13th, 2020* Configuring `job_url_prefix_config` with `gcs/` prefix is now deprecated. 
+    Please configure a job url prefix without the `gcs/` storage provider suffix. From now on the storage
+    provider is appended automatically so multiple storage providers can be used for builds of 
+    the same repository. For now we still handle the old configuration format, this will be removed 
+    in *September 2020*. To be clear handling of URLs with `/view/gcs` in Deck is not deprecated.
  - *June 23rd, 2020* An [hmac](/prow/cmd/hmac) tool was added to automatically reconcile webhooks and hmac
     tokens for the orgs and repos integrated with your prow instance.
  - *June 8th, 2020* A new informer-based Plank implementation was added. It can be used by deploying

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -2726,6 +2726,11 @@ func TestPlankJobURLPrefix(t *testing.T) {
 			refs:                 &prowapi.Refs{Org: "my-alternate-org", Repo: "my-second-repo"},
 			expectedJobURLPrefix: "https://my-prow",
 		},
+		{
+			name:                 "gcs/ suffix in JobURLPrefix will be automatically trimmed",
+			plank:                Plank{JobURLPrefixConfig: map[string]string{"*": "https://my-prow/view/gcs/"}},
+			expectedJobURLPrefix: "https://my-prow/view/",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/crier/reporters/pubsub/BUILD.bazel
+++ b/prow/crier/reporters/pubsub/BUILD.bazel
@@ -26,6 +26,8 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/io/providers:go_default_library",
+        "//prow/spyglass/api:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",
     ],
 )

--- a/prow/crier/reporters/pubsub/reporter_test.go
+++ b/prow/crier/reporters/pubsub/reporter_test.go
@@ -48,9 +48,11 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 	var testcases = []struct {
 		name            string
 		pj              *prowapi.ProwJob
+		jobURLPrefix    string
 		expectedMessage *ReportMessage
 		expectedError   error
 	}{
+		// tests with gubernator job URLs
 		{
 			name: "Prowjob with all information for presubmit jobs should work with no error",
 			pj: &prowapi.ProwJob{
@@ -74,6 +76,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 					},
 				},
 			},
+			jobURLPrefix: "guber/",
 			expectedMessage: &ReportMessage{
 				Project: testPubSubProjectName,
 				Topic:   testPubSubTopicName,
@@ -110,6 +113,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 					Job:  "test1",
 				},
 			},
+			jobURLPrefix: "guber/",
 			expectedMessage: &ReportMessage{
 				Project: testPubSubProjectName,
 				Topic:   testPubSubTopicName,
@@ -158,6 +162,7 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 					URL:   "guber/test1",
 				},
 			},
+			jobURLPrefix: "guber/",
 			expectedMessage: &ReportMessage{
 				Project: testPubSubProjectName,
 				Topic:   testPubSubTopicName,
@@ -188,23 +193,123 @@ func TestGenerateMessageFromPJ(t *testing.T) {
 				Status:  prowapi.SuccessState,
 			},
 		},
-	}
 
-	fca := &fca{
-		c: &config.Config{
-			ProwConfig: config.ProwConfig{
-				Plank: config.Plank{
-					JobURLPrefixConfig: map[string]string{"*": "guber/"},
+		// tests with regular job URLs
+		{
+			name: "Prowjob with all information for presubmit jobs should work with no error",
+			pj: &prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+					Labels: map[string]string{
+						PubSubProjectLabel: testPubSubProjectName,
+						PubSubTopicLabel:   testPubSubTopicName,
+						PubSubRunIDLabel:   testPubSubRunID,
+					},
 				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.SuccessState,
+					URL:   "https://prow.k8s.io/view/gcs/test1",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Type: prowapi.PresubmitJob,
+					Job:  "test1",
+					Refs: &prowapi.Refs{
+						Pulls: []prowapi.Pull{{Number: 123}},
+					},
+				},
+			},
+			jobURLPrefix: "https://prow.k8s.io/view/gcs/",
+			expectedMessage: &ReportMessage{
+				Project: testPubSubProjectName,
+				Topic:   testPubSubTopicName,
+				RunID:   testPubSubRunID,
+				Status:  prowapi.SuccessState,
+				URL:     "https://prow.k8s.io/view/gcs/test1",
+				GCSPath: "gs://test1",
+				Refs: []prowapi.Refs{
+					{
+						Pulls: []prowapi.Pull{{Number: 123}},
+					},
+				},
+				JobType: prowapi.PresubmitJob,
+				JobName: "test1",
+			},
+		},
+		{
+			name: "Prowjob with all information for periodic jobs should work with no error",
+			pj: &prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+					Labels: map[string]string{
+						PubSubProjectLabel: testPubSubProjectName,
+						PubSubTopicLabel:   testPubSubTopicName,
+						PubSubRunIDLabel:   testPubSubRunID,
+					},
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.SuccessState,
+					URL:   "https://prow.k8s.io/view/gcs/test1",
+				},
+				Spec: prowapi.ProwJobSpec{
+					Type: prowapi.PeriodicJob,
+					Job:  "test1",
+				},
+			},
+			jobURLPrefix: "https://prow.k8s.io/view/gcs/",
+			expectedMessage: &ReportMessage{
+				Project: testPubSubProjectName,
+				Topic:   testPubSubTopicName,
+				RunID:   testPubSubRunID,
+				Status:  prowapi.SuccessState,
+				URL:     "https://prow.k8s.io/view/gcs/test1",
+				GCSPath: "gs://test1",
+				JobType: prowapi.PeriodicJob,
+				JobName: "test1",
+			},
+		},
+		{
+			name: "Prowjob with all information annotations should work with no error",
+			pj: &prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test1",
+					Annotations: map[string]string{
+						PubSubProjectLabel: testPubSubProjectName,
+						PubSubTopicLabel:   testPubSubTopicName,
+						PubSubRunIDLabel:   testPubSubRunID,
+					},
+				},
+				Status: prowapi.ProwJobStatus{
+					State: prowapi.SuccessState,
+					URL:   "https://prow.k8s.io/view/gcs/test1",
+				},
+			},
+			jobURLPrefix: "https://prow.k8s.io/view/gcs/",
+			expectedMessage: &ReportMessage{
+				Project: testPubSubProjectName,
+				Topic:   testPubSubTopicName,
+				RunID:   testPubSubRunID,
+				Status:  prowapi.SuccessState,
+				URL:     "https://prow.k8s.io/view/gcs/test1",
+				GCSPath: "gs://test1",
 			},
 		},
 	}
 
-	c := &Client{
-		config: fca.Config,
-	}
-
 	for _, tc := range testcases {
+		fca := &fca{
+			c: &config.Config{
+				ProwConfig: config.ProwConfig{
+					Plank: config.Plank{
+						JobURLPrefixConfig: map[string]string{"*": tc.jobURLPrefix},
+					},
+				},
+			},
+		}
+
+		c := &Client{
+			config: fca.Config,
+		}
+
 		m := c.generateMessageFromPJ(tc.pj)
 
 		if !reflect.DeepEqual(m, tc.expectedMessage) {

--- a/prow/pjutil/pjutil.go
+++ b/prow/pjutil/pjutil.go
@@ -285,9 +285,13 @@ func JobURL(plank config.Plank, pj prowapi.ProwJob, log *logrus.Entry) (string, 
 		}
 
 		// Final path will be, e.g.:
-		// prefix.Path                   + bucketName         + gcsPath
-		// https://prow.k8s.io/view/gs/  + kubernetes-jenkins + pr-logs/pull/kubernetes-sigs_cluster-api-provider-openstack/541/pull-cluster-api-provider-openstack-test/1247344427123347459
-		prefix.Path = path.Join(prefix.Path, prowPath.FullPath(), gcsPath)
+		// prefix.Scheme + prefix.Host + prefix.Path + storageProvider + bucketName         + gcsPath
+		// https://prow.k8s.io/view/                 + gs/             + kubernetes-jenkins + pr-logs/pull/kubernetes-sigs_cluster-api-provider-openstack/541/pull-cluster-api-provider-openstack-test/1247344427123347459
+		if plank.JobURLPrefixDisableAppendStorageProvider {
+			prefix.Path = path.Join(prefix.Path, prowPath.FullPath(), gcsPath)
+		} else {
+			prefix.Path = path.Join(prefix.Path, prowPath.StorageProvider(), prowPath.FullPath(), gcsPath)
+		}
 		return prefix.String(), nil
 	}
 	var b bytes.Buffer

--- a/prow/pjutil/pjutil_test.go
+++ b/prow/pjutil/pjutil_test.go
@@ -736,7 +736,8 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcsupload",
 			plank: config.Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://gubernator.com/build"},
+				JobURLPrefixConfig:                       map[string]string{"*": "https://gubernator.com/build"},
+				JobURLPrefixDisableAppendStorageProvider: true,
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,
@@ -753,7 +754,7 @@ func TestJobURL(t *testing.T) {
 			expected: "https://gubernator.com/build/bucket/pr-logs/pull/org_repo/1",
 		},
 		{
-			name: "decorated job with prefix uses gcsupload and new bucket format with gcs",
+			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (deprecated job url format)",
 			plank: config.Plank{
 				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/gcs"},
 			},
@@ -769,12 +770,50 @@ func TestJobURL(t *testing.T) {
 					PathStrategy: prowapi.PathStrategyExplicit,
 				}},
 			}},
-			expected: "https://prow.k8s.io/view/gcs/bucket/pr-logs/pull/org_repo/1",
+			expected: "https://prow.k8s.io/view/gs/bucket/pr-logs/pull/org_repo/1",
+		},
+		{
+			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (deprecated job url format with trailing slash)",
+			plank: config.Plank{
+				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/gcs/"},
+			},
+			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
+				Type: prowapi.PresubmitJob,
+				Refs: &prowapi.Refs{
+					Org:   "org",
+					Repo:  "repo",
+					Pulls: []prowapi.Pull{{Number: 1}},
+				},
+				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{
+					Bucket:       "gs://bucket",
+					PathStrategy: prowapi.PathStrategyExplicit,
+				}},
+			}},
+			expected: "https://prow.k8s.io/view/gs/bucket/pr-logs/pull/org_repo/1",
+		},
+		{
+			name: "decorated job with prefix uses gcsupload and new bucket format with gcs (new job url format)",
+			plank: config.Plank{
+				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},
+			},
+			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
+				Type: prowapi.PresubmitJob,
+				Refs: &prowapi.Refs{
+					Org:   "org",
+					Repo:  "repo",
+					Pulls: []prowapi.Pull{{Number: 1}},
+				},
+				DecorationConfig: &prowapi.DecorationConfig{GCSConfiguration: &prowapi.GCSConfiguration{
+					Bucket:       "gs://bucket",
+					PathStrategy: prowapi.PathStrategyExplicit,
+				}},
+			}},
+			expected: "https://prow.k8s.io/view/gs/bucket/pr-logs/pull/org_repo/1",
 		},
 		{
 			name: "decorated job with prefix uses gcsupload and new bucket format with s3",
 			plank: config.Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/s3"},
+				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,
@@ -793,7 +832,7 @@ func TestJobURL(t *testing.T) {
 		{
 			name: "decorated job with prefix uses gcsupload with valid bucket with multiple separators",
 			plank: config.Plank{
-				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/s3"},
+				JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},
 			},
 			pj: prowapi.ProwJob{Spec: prowapi.ProwJobSpec{
 				Type: prowapi.PresubmitJob,
@@ -807,7 +846,7 @@ func TestJobURL(t *testing.T) {
 					PathStrategy: prowapi.PathStrategyExplicit,
 				}},
 			}},
-			expected: "https://prow.k8s.io/view/s3/my-floppy-backup/a:/doom2.wad.006/pr-logs/pull/org_repo/1",
+			expected: "https://prow.k8s.io/view/gs/my-floppy-backup/a:/doom2.wad.006/pr-logs/pull/org_repo/1",
 		},
 	}
 

--- a/prow/spyglass/lenses/common/common_test.go
+++ b/prow/spyglass/lenses/common/common_test.go
@@ -47,7 +47,7 @@ func TestProwToGCS(t *testing.T) {
 		wantErr             bool
 	}{
 		{
-			name: "legacy gs bucket, gcs status url and gcs job url prefix",
+			name: "legacy gs bucket, gcs status url and deprecated gcs job url prefix",
 			args: args{
 				fetcher: &fakeProwJobFetcher{
 					prowJob: prowapi.ProwJob{
@@ -81,7 +81,7 @@ func TestProwToGCS(t *testing.T) {
 			wantGCSKey:          "kubernetes-jenkins/logs/ci-benchmark-microbenchmarks/1258197944759226371",
 		},
 		{
-			name: "gs bucket, gcs status url and gcs job url prefix",
+			name: "gs bucket, gcs status url and deprecated gcs job url prefix",
 			args: args{
 				fetcher: &fakeProwJobFetcher{
 					prowJob: prowapi.ProwJob{
@@ -115,7 +115,7 @@ func TestProwToGCS(t *testing.T) {
 			wantGCSKey:          "kubernetes-jenkins/logs/ci-benchmark-microbenchmarks/1258197944759226371",
 		},
 		{
-			name: "gs bucket, gs status url and gs job url prefix",
+			name: "gs bucket, gs status url and new job url prefix format",
 			args: args{
 				fetcher: &fakeProwJobFetcher{
 					prowJob: prowapi.ProwJob{
@@ -138,7 +138,7 @@ func TestProwToGCS(t *testing.T) {
 					return &config.Config{
 						ProwConfig: config.ProwConfig{
 							Plank: config.Plank{
-								JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/gs/"},
+								JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},
 							},
 						},
 					}
@@ -149,7 +149,7 @@ func TestProwToGCS(t *testing.T) {
 			wantGCSKey:          "kubernetes-jenkins/logs/ci-benchmark-microbenchmarks/1258197944759226371",
 		},
 		{
-			name: "s3 bucket, s3 status url and s3 job url prefix",
+			name: "s3 bucket, s3 status url and new job url prefix format",
 			args: args{
 				fetcher: &fakeProwJobFetcher{
 					prowJob: prowapi.ProwJob{
@@ -172,7 +172,7 @@ func TestProwToGCS(t *testing.T) {
 					return &config.Config{
 						ProwConfig: config.ProwConfig{
 							Plank: config.Plank{
-								JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/s3/"},
+								JobURLPrefixConfig: map[string]string{"*": "https://prow.k8s.io/view/"},
 							},
 						},
 					}


### PR DESCRIPTION
Currently, it's only possible to use one storage provider per repository. This limitation is caused by `job_url_prefix_config`. The storage provider is suffixed to the job url prefix, e.g. `https://prow.k8s.io/view/gcs/`

This PR solves the issue by deprecating job url prefix with `gcs/` suffix. The storage provider is now appended automatically so a job url prefix like `https://prow.k8s.io/view/` can be used for e.g. `GS` and `S3`. Job url prefix with `gcs/` are still handled for now.

Open Issues:
* how should the old job url prefix be deprecated? I'm handling both formats for now and I added a note to the announcements. Should I add some warnings? If yes, in which component?

xref:
* issue was noticed in the [deck s3 support PR](https://github.com/kubernetes/test-infra/pull/17183#discussion_r421700277)
* s3 support issue: #11260