### PR TITLE
Kops - Make pull-kops-verify-hashes pre-submit mandatory

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -415,7 +415,6 @@ presubmits:
   - name: pull-kops-verify-hashes
     branches:
     - master
-    optional: true
     run_if_changed: '^nodeup\/pkg\/'
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
This should be enough to always run the job when a file from `nodeup/pkg/` is changed.

/cc @rifelpet 