### PR TITLE
Skip the periodic SCTP related NetworkPolicy test

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -473,6 +473,6 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:SCTP\]
+      - --test_args=--ginkgo.focus=\[Feature:SCTP\] --ginkgo.skip=\[Feature:NetworkPolicy\]
       - --timeout=300m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200527-e50e8f5-master


### PR DESCRIPTION
The GCP environment of the periodic test execution does not support SCTP in NetworkPolicy. So we should skip that testcase, but execute all other SCTP related tests - it makes no sense to test that in such an environment, we know that it will fail.