### PR TITLE
*: Fix "jUnit" -> "JUnit" typos

### DIFF
--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -43,13 +43,13 @@ are laid out in a specific manner relative to each other.
 ## Job Artifact GCS Layout
 
 Every run should upload `started.json`, `finished.json`, and `build-log.txt`, and
-can optionally upload jUnit XML and/or other files to the `artifacts/` directory.
+can optionally upload JUnit XML and/or other files to the `artifacts/` directory.
 For a single build of a job, Gubernator expects the following layout in GCS:
 
 ```
 .
 ├── artifacts         # all artifacts must be placed under this directory
-│   └── junit_00.xml  # jUnit XML reports from the build
+│   └── junit_00.xml  # JUnit XML reports from the build
 ├── build-log.txt     # std{out,err} from the build
 ├── finished.json     # metadata uploaded once the build finishes
 └── started.json      # metadata uploaded once the build starts
@@ -77,7 +77,7 @@ The following fields in `finished.json` are honored:
 }
 ```
 
-Any artifacts from the build should be placed under `./artifacts/`. Any jUnit
+Any artifacts from the build should be placed under `./artifacts/`. Any JUnit
 XML reports should be named `junit_*.xml` and placed under `./artifacts` as well.
 
 ## Test Properties [Optional]

--- a/robots/coverage/docs/design.md
+++ b/robots/coverage/docs/design.md
@@ -72,7 +72,7 @@ The tool produces & stores coverage profile for later presubmit jobs to compare 
       An example of how these git attribute is used can be found [here](https://github.com/knative/serving/blob/master/.gitattributes)
     - Stores in the XML format, that is used by TestGrid, and dump it in artifacts directory
       - The XML should be a valid JUnit XML file. See [JUnit XML format](https://www.ibm.com/support/knowledgecenter/en/SSQ2R2_14.1.0/com.ibm.rsar.analysis.codereview.cobol.doc/topics/cac_useresults_junit.html)
-      - In addition to being a valid jUnit XML file, the file needs to have the properties specified [here](https://github.com/kubernetes/test-infra/tree/master/gubernator#gcs-layout) to be readable by TestGrid
+      - In addition to being a valid JUnit XML file, the file needs to have the properties specified [here](https://github.com/kubernetes/test-infra/tree/master/gubernator#gcs-layout) to be readable by TestGrid
       - For each file that has a coverage level lower than the threshold, the corresponding entry in the XML should have a \<failure\> tag
 
 ## Pre-submit workflow


### PR DESCRIPTION
`JUnit` is [the canonical casing][1].

Generated with:

```console
$ sed -i 's/jUnit/JUnit/g' $(git grep -l jUnit)
```

[1]: https://junit.org/