### PR TITLE
gubernator/README: 'name' and 'value' are attributes, not child elements

### DIFF
--- a/gubernator/README.md
+++ b/gubernator/README.md
@@ -92,14 +92,8 @@ The properties can be defined as:
 ```xml
 <testcase ...>
   <properties>
-    <property>
-        <name>key1</name>
-        <value>value1</value>
-    </property>
-    <property>
-        <name>key2</name>
-        <value>value2</value>
-    </property>
+    <property name="key1" value="value1"></property>
+    <property name="key2" value="value2"></property>
   </properties>
 </testcase>
 ```


### PR DESCRIPTION
These docs landed in 2f04de098e (#9182), but since we began vendoring the backing XML types in ce50d4c65c (#9887) they've been:

```go
type Property struct {
  Name  string `xml:"name,attr"`
  Value string `xml:"value,attr"`
}
```

The `attr` label gets these stored as attibutes instead of as child elements.