### PR TITLE
Update node e2e OWNERS

### DIFF
--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -1,8 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
+reviewers:
+- bart0sh
+- derekwaynecarr
+- karan
+- MHBauer
+- vpickard
 approvers:
 - yujuhong
 - Random-Liu
 - dchen1107
+- derekwaynecarr
 labels:
 - sig/node

--- a/config/jobs/kubernetes/sig-node/OWNERS
+++ b/config/jobs/kubernetes/sig-node/OWNERS
@@ -1,9 +1,5 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-- yujuhong
-- Random-Liu
-- dchen1107
 approvers:
 - yujuhong
 - Random-Liu

--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -1,14 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- Random-Liu
-- yguo0905
-- yujuhong
 - tallclair
 - derekwaynecarr
 - ConnorDoyle
 - klueska
-- dchen1107
 - dims
 approvers:
 - Random-Liu
@@ -20,3 +16,5 @@ approvers:
 - klueska
 - dchen1107
 - dims
+labels:
+- sig/node

--- a/jobs/e2e_node/OWNERS
+++ b/jobs/e2e_node/OWNERS
@@ -1,11 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- tallclair
-- derekwaynecarr
+- bart0sh
 - ConnorDoyle
-- klueska
+- derekwaynecarr
 - dims
+- karan
+- klueska
+- MHBauer
+- tallclair
+- vpickard
 approvers:
 - Random-Liu
 - yguo0905


### PR DESCRIPTION
I've noticed an uptick in organized activity on taking ownership of and maintaining the node e2e tests

I'm proposing we drop reviewers that are known to be inactive, and add as reviewers some of the folks who have been putting in effort lately

Also added a sig/node label to jobs/e2e_node while I was there