### PR TITLE
match up test-runs for sig-node-kubelet dashboard tabs

### DIFF
--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -111,8 +111,29 @@ dashboards:
 - name: sig-node-node-problem-detector
 
 test_groups:
-- name: ci-kubernetes-node-kubelet-serial-alpha
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-alpha
+- name: ci-kubernetes-node-kubelet-alpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-alpha
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-benchmark
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-benchmark
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-conformance
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-conformance
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-flaky
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-flaky
   test_name_config:
     name_elements:
     - target_config: Tests name
@@ -120,6 +141,41 @@ test_groups:
     name_format: '%s [%s]'
 - name: ci-kubernetes-node-kubelet-features
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-features
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-orphans
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-orphans
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-serial
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-serial-alpha
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-alpha
+  test_name_config:
+    name_elements:
+    - target_config: Tests name
+    - target_config: Context
+    name_format: '%s [%s]'
+- name: ci-kubernetes-node-kubelet-serial-topology-manager
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-topology-manager
   test_name_config:
     name_elements:
     - target_config: Tests name


### PR DESCRIPTION
Configure most tabs for the sig-note-kubelet test-group on testgrid to
match up the context name being used from an image-config which will
stabilize the correspondence of test-results to the particular image
used.

Alphabetized the existing list.

For example:
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [2]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [3]
should look like:
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [ubuntu]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [cos-stable1]
[k8s.io] Sysctls [LinuxOnly] [NodeFeature:Sysctls] should support sysctls [cos-stable2]


 https://github.com/kubernetes/test-infra/pull/17745 didn't blow up, so I'd try not blowing up some additional output.

In order to not rock the boat, I didn't get fancy with the titles, mostly because I'm not 100% sure of the code path that leads to the Context key getting filled in that way, but here's some ideas from a comment:
https://github.com/kubernetes/test-infra/pull/17745/files#r432058730
