### PR TITLE
prow/spyglass/lenses/junit/template: Render <properties>

### DIFF
--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -784,24 +784,13 @@ func TestBody(t *testing.T) {
 				</testsuites>
 				`),
 			},
-			expected: `
-
-
-
-
-
-<div id="junit-container">
+			expected: `<div id="junit-container">
   <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
-  
   <tr id="failed-theader" class="header section-expander">
     <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>2/3 Tests Failed.</h6></td>
     <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="failed-tbody">
-    
-      
-      
-      
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
@@ -816,17 +805,11 @@ func TestBody(t *testing.T) {
                   <dd>b</dd>
                 </dl>
                 <div> failure message 0 </div>
-                
               </td>
             </tr>
           </table>
         </td>
       </tr>
-      
-    
-      
-      
-      
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
@@ -836,7 +819,6 @@ func TestBody(t *testing.T) {
             <tr class="hidden">
               <td>
                 <table  class="failed-layout">
-                  
                   <tr  class="failure-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="failed-layout">
@@ -851,13 +833,11 @@ func TestBody(t *testing.T) {
                               <dd>b</dd>
                             </dl>
                             <div> failure message 0 </div>
-                            
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  
                   <tr  class="failure-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="failed-layout">
@@ -872,31 +852,23 @@ func TestBody(t *testing.T) {
                               <dd>d</dd>
                             </dl>
                             <div> failure message 1 </div>
-                            
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  
                 </table>
               </td>
             </tr>
           </table>
         </td>
       </tr>
-      
-    
   </tbody>
-  
-  
   <tr id="flaky-theader" class="header section-expander">
     <td class="mdl-data-table__cell--non-numeric expander flaky" colspan="1"><h6>1/3 Tests Flaky.</h6></td>
     <td class="mdl-data-table__cell--non-numeric expander"><i id="flaky-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="flaky-tbody">
-    
-      
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="flaky-layout">
@@ -906,7 +878,6 @@ func TestBody(t *testing.T) {
             <tr class="hidden">
               <td>
                 <table class="flaky-layout">
-                  
                   <tr  class="flaky-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="flaky-layout">
@@ -921,13 +892,11 @@ func TestBody(t *testing.T) {
                               <dd>b</dd>
                             </dl>
                             <div> failure message 0 </div>
-                            
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  
                   <tr  class="flaky-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="flaky-layout">
@@ -942,28 +911,20 @@ func TestBody(t *testing.T) {
                               <dd>d</dd>
                             </dl>
                             <div>&lt;nil&gt;</div>
-                            
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  
                 </table>
               </td>
             </tr>
           </table>
         </td>
       </tr>
-    
   </tbody>
-  
-  
-  
   </table>
-</div>
-
-`,
+</div>`,
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/prow/spyglass/lenses/junit/lens_test.go
+++ b/prow/spyglass/lenses/junit/lens_test.go
@@ -617,6 +617,107 @@ func TestGetJvd(t *testing.T) {
 				Flaky:   nil,
 			},
 		},
+		{
+			"Test-cases with properties",
+			[][]byte{
+				[]byte(`
+				<testsuites>
+					<testsuite>
+						<testcase classname="fake_class_0" name="fake_test_0">
+							<failure message="Failed once" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_1">
+							<failure message="Failed twice" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_1">
+							<failure message="Failed twice" type=""> failure message 1 </failure>
+							<properties>
+								<property name="c" value="d"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_2">
+							<failure message="Flaked once" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_2">
+							<properties>
+								<property name="c" value="d"/>
+							</properties>
+						</testcase>
+					</testsuite>
+				</testsuites>
+				`),
+			},
+			JVD{
+				NumTests: 3,
+				Failed: []TestResult{
+					{
+						Junit: []JunitResult{
+							{
+								junit.Result{
+									Name:       "fake_test_0",
+									ClassName:  "fake_class_0",
+									Failure:    &failureMsgs[0],
+									Properties: &junit.Properties{PropertyList: []junit.Property{{Name: "a", Value: "b"}}},
+								},
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+					{
+						Junit: []JunitResult{
+							{
+								Result: junit.Result{
+									Name:       "fake_test_1",
+									ClassName:  "fake_class_0",
+									Failure:    &failureMsgs[0],
+									Properties: &junit.Properties{PropertyList: []junit.Property{{Name: "a", Value: "b"}}},
+								},
+							},
+							{
+								Result: junit.Result{
+									Name:       "fake_test_1",
+									ClassName:  "fake_class_0",
+									Failure:    &failureMsgs[1],
+									Properties: &junit.Properties{PropertyList: []junit.Property{{Name: "c", Value: "d"}}},
+								},
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+				},
+				Flaky: []TestResult{
+					{
+						Junit: []JunitResult{
+							{
+								junit.Result{
+									Name:       "fake_test_2",
+									ClassName:  "fake_class_0",
+									Failure:    &failureMsgs[0],
+									Properties: &junit.Properties{PropertyList: []junit.Property{{Name: "a", Value: "b"}}},
+								},
+							},
+							{
+								Result: junit.Result{
+									Name:       "fake_test_2",
+									ClassName:  "fake_class_0",
+									Properties: &junit.Properties{PropertyList: []junit.Property{{Name: "c", Value: "d"}}},
+								},
+							},
+						},
+						Link: "linknotfound.io/404",
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -633,6 +734,251 @@ func TestGetJvd(t *testing.T) {
 			got := l.getJvd(artifacts)
 			if diff := cmp.Diff(tt.exp, got); diff != "" {
 				t.Fatalf("JVD mismatch, want(-), got(+): \n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBody(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		artifacts [][]byte
+		expected  string
+	}{
+		{
+			name: "Test-cases with properties",
+			artifacts: [][]byte{
+				[]byte(`
+				<testsuites>
+					<testsuite>
+						<testcase classname="fake_class_0" name="fake_test_0">
+							<failure message="Failed once" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_1">
+							<failure message="Failed twice" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_1">
+							<failure message="Failed twice" type=""> failure message 1 </failure>
+							<properties>
+								<property name="c" value="d"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_2">
+							<failure message="Flaked once" type=""> failure message 0 </failure>
+							<properties>
+								<property name="a" value="b"/>
+							</properties>
+						</testcase>
+						<testcase classname="fake_class_0" name="fake_test_2">
+							<properties>
+								<property name="c" value="d"/>
+							</properties>
+						</testcase>
+					</testsuite>
+				</testsuites>
+				`),
+			},
+			expected: `
+
+
+
+
+
+<div id="junit-container">
+  <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
+  
+  <tr id="failed-theader" class="header section-expander">
+    <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>2/3 Tests Failed.</h6></td>
+    <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+  </tr>
+  <tbody id="failed-tbody">
+    
+      
+      
+      
+      <tr>
+        <td colspan="2" style="padding: 0;">
+          <table class="failed-layout">
+            <tr class="failure-name">
+              <td class="mdl-data-table__cell--non-numeric test-name">fake_test_0&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+              <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">0s</td>
+            </tr>
+            <tr class="hidden failure-text">
+              <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                <dl>
+                  <dt>a</dt>
+                  <dd>b</dd>
+                </dl>
+                <div> failure message 0 </div>
+                
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      
+    
+      
+      
+      
+      <tr>
+        <td colspan="2" style="padding: 0;">
+          <table class="failed-layout">
+            <tr class="failure-name">
+              <td class="mdl-data-table__cell--non-numeric test-name">fake_test_1&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+            </tr>
+            <tr class="hidden">
+              <td>
+                <table  class="failed-layout">
+                  
+                  <tr  class="failure-text">
+                    <td colspan="2" style="padding: 0;">
+                      <table class="failed-layout">
+                        <tr class="failure-name">
+                          <td class="mdl-data-table__cell--non-numeric test-name">Run #0: Failed&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">0s</td>
+                        </tr>
+                        <tr class="hidden failure-text">
+                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            <dl>
+                              <dt>a</dt>
+                              <dd>b</dd>
+                            </dl>
+                            <div> failure message 0 </div>
+                            
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  
+                  <tr  class="failure-text">
+                    <td colspan="2" style="padding: 0;">
+                      <table class="failed-layout">
+                        <tr class="failure-name">
+                          <td class="mdl-data-table__cell--non-numeric test-name">Run #1: Failed&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">0s</td>
+                        </tr>
+                        <tr class="hidden failure-text">
+                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            <dl>
+                              <dt>c</dt>
+                              <dd>d</dd>
+                            </dl>
+                            <div> failure message 1 </div>
+                            
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      
+    
+  </tbody>
+  
+  
+  <tr id="flaky-theader" class="header section-expander">
+    <td class="mdl-data-table__cell--non-numeric expander flaky" colspan="1"><h6>1/3 Tests Flaky.</h6></td>
+    <td class="mdl-data-table__cell--non-numeric expander"><i id="flaky-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
+  </tr>
+  <tbody id="flaky-tbody">
+    
+      
+      <tr>
+        <td colspan="2" style="padding: 0;">
+          <table class="flaky-layout">
+            <tr class="flaky-name">
+              <td class="mdl-data-table__cell--non-numeric test-name">fake_test_2&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+            </tr>
+            <tr class="hidden">
+              <td>
+                <table class="flaky-layout">
+                  
+                  <tr  class="flaky-text">
+                    <td colspan="2" style="padding: 0;">
+                      <table class="flaky-layout">
+                        <tr class="flaky-name">
+                          <td class="mdl-data-table__cell--non-numeric test-name">Run #0: Failed&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">0s</td>
+                        </tr>
+                        <tr class="hidden flaky-text">
+                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            <dl>
+                              <dt>a</dt>
+                              <dd>b</dd>
+                            </dl>
+                            <div> failure message 0 </div>
+                            
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  
+                  <tr  class="flaky-text">
+                    <td colspan="2" style="padding: 0;">
+                      <table class="flaky-layout">
+                        <tr class="flaky-name">
+                          <td class="mdl-data-table__cell--non-numeric test-name">Run #1: Passed&nbsp;<i class="icon-button material-icons arrow-icon">expand_more</i></td>
+                          <td class="mdl-data-table__cell--non-numeric" style="text-align: right;">0s</td>
+                        </tr>
+                        <tr class="hidden flaky-text">
+                          <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            <dl>
+                              <dt>c</dt>
+                              <dd>d</dd>
+                            </dl>
+                            <div>&lt;nil&gt;</div>
+                            
+                          </td>
+                        </tr>
+                      </table>
+                    </td>
+                  </tr>
+                  
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    
+  </tbody>
+  
+  
+  
+  </table>
+</div>
+
+`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			artifacts := make([]api.Artifact, 0)
+			for _, artifact := range test.artifacts {
+				artifacts = append(artifacts, &FakeArtifact{
+					path:      "log.txt",
+					content:   artifact,
+					sizeLimit: 500e6,
+				})
+			}
+			lens := Lens{}
+			got := lens.Body(artifacts, ".", "data", nil)
+			if diff := cmp.Diff(test.expected, got); diff != "" {
+				t.Fatalf("Body mismatch, want(-), got(+): \n%s", diff)
 			}
 		})
 	}

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -34,6 +34,15 @@
             </tr>
             <tr class="hidden failure-text">
               <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                {{- $numProperties := len $firstTest.Properties.PropertyList}}
+                {{- if gt $numProperties 0}}
+                <dl>
+                  {{- range $ixp, $property := $firstTest.Properties.PropertyList}}
+                  <dt>{{$property.Name}}</dt>
+                  <dd>{{$property.Value}}</dd>
+                  {{- end}}
+                </dl>
+                {{- end}}
                 <div>{{$firstTest.Failure}}</div>
                 {{if $firstTest.Output}}
                 <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
@@ -64,6 +73,15 @@
                         </tr>
                         <tr class="hidden failure-text">
                           <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            {{- $numProperties := len $indTest.Properties.PropertyList}}
+                            {{- if gt $numProperties 0}}
+                            <dl>
+                              {{- range $ixp, $property := $indTest.Properties.PropertyList}}
+                              <dt>{{$property.Name}}</dt>
+                              <dd>{{$property.Value}}</dd>
+                              {{- end}}
+                            </dl>
+                            {{- end}}
                             <div>{{$indTest.Failure}}</div>
                             {{if $indTest.Output}}
                             <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
@@ -112,6 +130,15 @@
                         </tr>
                         <tr class="hidden flaky-text">
                           <td colspan="2" class="mdl-data-table__cell--non-numeric">
+                            {{- $numProperties := len $indTest.Properties.PropertyList}}
+                            {{- if gt $numProperties 0}}
+                            <dl>
+                              {{- range $ixp, $property := $indTest.Properties.PropertyList}}
+                              <dt>{{$property.Name}}</dt>
+                              <dd>{{$property.Value}}</dd>
+                              {{- end}}
+                            </dl>
+                            {{- end}}
                             <div>{{$indTest.Failure}}</div>
                             {{if $indTest.Output}}
                             <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>

--- a/prow/spyglass/lenses/junit/template.html
+++ b/prow/spyglass/lenses/junit/template.html
@@ -4,27 +4,27 @@
 {{end}}
 
 {{define "body"}}
-{{$numF := len .Failed}}
-{{$numFlk := len .Flaky}}
-{{$numP := len .Passed}}
-{{$numS := len .Skipped}}
-{{if eq .NumTests 0}}
+{{- $numF := len .Failed}}
+{{- $numFlk := len .Flaky}}
+{{- $numP := len .Passed}}
+{{- $numS := len .Skipped}}
+{{- if eq .NumTests 0}}
   <div id="empty-junit-container">
     No tests were recorded.
   </div>
-{{else}}
+{{- else -}}
 <div id="junit-container">
   <table id="junit-table" class="mdl-data-table mdl-js-data-table mdl-shadow--2dp">
-  {{if gt $numF 0}}
+  {{- if gt $numF 0}}
   <tr id="failed-theader" class="header section-expander">
     <td class="mdl-data-table__cell--non-numeric expander failed" colspan="1"><h6>{{len .Failed}}/{{.NumTests}} Tests Failed.</h6></td>
     <td class="mdl-data-table__cell--non-numeric expander"><i id="failed-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="failed-tbody">
-    {{range $ix, $test := .Failed}}
-      {{$numTest := len $test.Junit}}
-      {{$firstTest := index $test.Junit 0}}
-      {{if eq $numTest 1}}
+    {{- range $ix, $test := .Failed}}
+      {{- $numTest := len $test.Junit}}
+      {{- $firstTest := index $test.Junit 0}}
+      {{- if eq $numTest 1}}
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
@@ -44,16 +44,16 @@
                 </dl>
                 {{- end}}
                 <div>{{$firstTest.Failure}}</div>
-                {{if $firstTest.Output}}
+                {{- if $firstTest.Output}}
                 <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                 <pre style="display: none;">{{$firstTest.Output}}</pre>
-                {{end}}
+                {{- end}}
               </td>
             </tr>
           </table>
         </td>
       </tr>
-      {{else}}
+      {{- else}}
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="failed-layout">
@@ -63,7 +63,7 @@
             <tr class="hidden">
               <td>
                 <table  class="failed-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
+                  {{- range $ixt, $indTest := $test.Junit}}
                   <tr  class="failure-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="failed-layout">
@@ -83,34 +83,34 @@
                             </dl>
                             {{- end}}
                             <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
+                            {{- if $indTest.Output}}
                             <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                             <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
+                            {{- end}}
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  {{end}}
+                  {{- end}}
                 </table>
               </td>
             </tr>
           </table>
         </td>
       </tr>
-      {{end}}
-    {{end}}
+      {{- end}}
+    {{- end}}
   </tbody>
-  {{end}}
-  {{if gt $numFlk 0}}
+  {{- end}}
+  {{- if gt $numFlk 0}}
   <tr id="flaky-theader" class="header section-expander">
     <td class="mdl-data-table__cell--non-numeric expander flaky" colspan="1"><h6>{{len .Flaky}}/{{.NumTests}} Tests Flaky.</h6></td>
     <td class="mdl-data-table__cell--non-numeric expander"><i id="flaky-expander" class="icon-button material-icons arrow-icon noselect">expand_less</i></td>
   </tr>
   <tbody id="flaky-tbody">
-    {{range $ix, $test := .Flaky}}
-      {{$firstTest := index $test.Junit 0}}
+    {{- range $ix, $test := .Flaky}}
+      {{- $firstTest := index $test.Junit 0}}
       <tr>
         <td colspan="2" style="padding: 0;">
           <table class="flaky-layout">
@@ -120,7 +120,7 @@
             <tr class="hidden">
               <td>
                 <table class="flaky-layout">
-                  {{range $ixt, $indTest := $test.Junit}}
+                  {{- range $ixt, $indTest := $test.Junit}}
                   <tr  class="flaky-text">
                     <td colspan="2" style="padding: 0;">
                       <table class="flaky-layout">
@@ -140,56 +140,56 @@
                             </dl>
                             {{- end}}
                             <div>{{$indTest.Failure}}</div>
-                            {{if $indTest.Output}}
+                            {{- if $indTest.Output}}
                             <a href="#" class="open-stdout">open stdout<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
                             <pre style="display: none;">{{$indTest.Output}}</pre>
-                            {{end}}
+                            {{- end}}
                           </td>
                         </tr>
                       </table>
                     </td>
                   </tr>
-                  {{end}}
+                  {{- end}}
                 </table>
               </td>
             </tr>
           </table>
         </td>
       </tr>
-    {{end}}
+    {{- end}}
   </tbody>
-  {{end}}
-  {{if gt $numP 0}}
+  {{- end}}
+  {{- if gt $numP 0}}
     <tr id="passed-theader" class="header section-expander">
       <td class="mdl-data-table__cell--non-numeric expander passed" colspan="1"><h6>{{len .Passed}}/{{.NumTests}} Tests Passed!</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="passed-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     <tbody id="passed-tbody" class="hidden-tests">
-      {{range .Passed}}
+      {{- range .Passed}}
         {{$firstTest := index .Junit 0}}
         <tr>
           <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.Name}}</td>
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
-      {{end}}
+      {{- end}}
     </tbody>
-  {{end}}
-  {{if gt $numS 0}}
+  {{- end}}
+  {{- if gt $numS 0}}
     <tr id="skipped-theader" class="header section-expander">
       <td class="mdl-data-table__cell--non-numeric expander skipped" colspan="1"><h6>{{len .Skipped}}/{{.NumTests}} Tests Skipped.</h6></td>
       <td class="mdl-data-table__cell--non-numeric expander"><i id="skipped-expander" class="icon-button material-icons arrow-icon noselect">expand_more</i></td>
     </tr>
     <tbody id="skipped-tbody" class="hidden-tests">
-      {{range .Skipped}}
-        {{$firstTest := index .Junit 0}}
+      {{- range .Skipped}}
+        {{- $firstTest := index .Junit 0}}
         <tr>
           <td class="mdl-data-table__cell--non-numeric test-name">{{$firstTest.Name}}</td>
           <td class="mdl-data-table__cell--non-numeric">{{$firstTest.Duration}}</td>
         </tr>
-      {{end}}
+      {{- end}}
     </tbody>
-  {{end}}
+  {{- end}}
   </table>
 </div>
-{{end}}
-{{end}}
+{{- end}}
+{{- end}}


### PR DESCRIPTION
Our JUnit typing has supported test-case properties since ce50d4c65c (#9887). If the ingested JUnit includes them, display those properties for failing/flaky tests as a description list.

This implementation does not currently support properties for passing/skipped tests, since those don't currently have an expanding section to hold these additional details.

openshift/origin#25044 would be an example of content feeding into this display.