### PR TITLE
Fix wrong override locations

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -133,7 +133,7 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark/throughput_override.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_load_throughput.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=240m
       - --use-logexporter


### PR DESCRIPTION
Fix wrong kubemark 100 override location
Tests are failing: https://k8s-testgrid.appspot.com/sig-scalability-kubemark#kubemark-100

/cc wojtek-t mm4tt