### PR TITLE
run sig-windows tests on windows file change too

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -72,7 +72,7 @@ presubmits:
       timeout: 2h
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$'
     path_alias: k8s.io/kubernetes
     branches:
     - master
@@ -134,7 +134,7 @@ presubmits:
       timeout: 2h
     always_run: false
     optional: true
-    run_if_changed: 'azure.*\.go'
+    run_if_changed: 'azure.*\.go$|.*windows\.go$'
     path_alias: k8s.io/kubernetes
     branches:
     - master


### PR DESCRIPTION
run following tests on windows file change:
 - pull-kubernetes-e2e-azure-disk-windows
 - pull-kubernetes-e2e-azure-file-windows

per requirements from https://github.com/kubernetes/kubernetes/pull/91468#issuecomment-636257357, let's only run tests on azure or windows related changes, otherwise it may exceed Azure testing quota easily.

/assign @chewong @liggitt @jingxu97 
The regex in this PR should be correct, right?