### PR TITLE
Kops - update milestone applier settings for release-1.18 branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -318,7 +318,8 @@ milestone_applier:
   kubernetes/test-infra:
     master: v1.19
   kubernetes/kops:
-    master: v1.18
+    master: v1.19
+    release-1.18: v1.18
     release-1.17: v1.17
     release-1.16: v1.16
     release-1.15: v1.15


### PR DESCRIPTION
The release-1.18 branch [has been created](https://github.com/kubernetes/kops/tree/release-1.18) so this updates the milestone versions for master and the new branch.

Step 4 of [these instructions](https://github.com/kubernetes/kops/blob/master/docs/development/release.md#new-kubernetes-versions-and-release-branches).