### PR TITLE
Kops - Use the release/stable marker until the next beta

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -82,10 +82,10 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --check-leaked-resources=false
         - --cluster=
-        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+        - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable.txt
         - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
         - --env=KOPS_RUN_TOO_NEW_VERSION=1
-        - --extract=release/latest
+        - --extract=release/stable
         - --ginkgo-parallel
         - --kops-build
         - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64


### PR DESCRIPTION
For https://github.com/kubernetes/kops/pull/9204 to work, a new 1.19 beta is needed.
Until then we should continue to use the `release/stable` marker.

/cc @rifelpet 