### PR TITLE
config/testgrids/openshift: include e2e-metal-ipi informers

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
@@ -19,6 +19,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-release-master-ocp-4.4-e2e-metal-ipi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-release-master-ocp-4.4-e2e-metal-ipi
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: promote-release-openshift-machine-os-content-e2e-aws-4.4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1298,6 +1325,8 @@ dashboards:
     test_group_name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
   name: redhat-openshift-ocp-release-4.4-informing
 test_groups:
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.4-e2e-metal-ipi
+  name: periodic-ci-openshift-release-master-ocp-4.4-e2e-metal-ipi
 - gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.4
   name: promote-release-openshift-machine-os-content-e2e-aws-4.4
 - days_of_results: 33

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
@@ -46,6 +46,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-release-master-ocp-4.5-e2e-metal-ipi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-release-master-ocp-4.5-e2e-metal-ipi
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: promote-release-openshift-machine-os-content-e2e-aws-4.5
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1382,6 +1409,8 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.5-cnv
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.5-e2e-metal-ipi
+  name: periodic-ci-openshift-release-master-ocp-4.5-e2e-metal-ipi
 - gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.5
   name: promote-release-openshift-machine-os-content-e2e-aws-4.5
 - days_of_results: 60


### PR DESCRIPTION
This updates the OpenShift test grid to include the e2e-metal-ipi
informer jobs for 4.4 and 4.5.