### PR TITLE
Add new job to run sig-storage tests with SELinux enabled

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -1,0 +1,35 @@
+periodics:
+- interval: 24h
+  name: ci-kubernetes-e2e-storage-selinux
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-k8s-storage-selinux.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=ci/latest
+      - --ginkgo-parallel
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-ssh-user=centos
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200527-e50e8f5-master
+      imagePullPolicy: Always
+  annotations:
+    testgrid-num-columns-recent: '20'
+    testgrid-num-failures-to-alert: '6'
+    testgrid-alert-email: kubernetes-sig-storage-test-failures@googlegroups.com

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -84,6 +84,12 @@ dashboards:
       description: storage snapshot e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
+    - name: kops-selinux
+      test_group_name: ci-kubernetes-e2e-storage-selinux
+      base_options: include-filter-by-regex=Volume%7Cstorage
+      description: storage selinux e2e tests for master branch
+      alert_options:
+        alert_mail_to_addresses: kubernetes-sig-storage-test-failures@googlegroups.com
 
 - name: sig-storage-local-static-provisioner
   dashboard_tab:


### PR DESCRIPTION
We want a periodic job that runs sig-storage tests on a host with SELinux enabled.

@hakman could you take a look at this, please?

CC @msau42 @jsafrane 