### PR TITLE
update crier flags.

### DIFF
--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -35,16 +35,17 @@ spec:
       - name: crier
         image: gcr.io/k8s-prow/crier:v20200602-f3683752b8
         args:
-        - --github-workers=5
+        - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml
-        - --job-config-path=/etc/job-config
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
-        - --slack-workers=1
-        - --slack-token-file=/etc/slack/token
-        - --gcs-workers=1
-        - --kubernetes-gcs-workers=1
+        - --github-token-path=/etc/github/oauth
+        - --github-workers=5
+        - --job-config-path=/etc/job-config
         - --kubeconfig=/etc/kubeconfig/config
+        - --kubernetes-blob-storage-workers=1
+        - --slack-token-file=/etc/slack/token
+        - --slack-workers=1
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig


### PR DESCRIPTION
Set -github-token-path explicitly.
Use blob-storage prefix instead of gcs.

fixes https://github.com/kubernetes/test-infra/issues/17730

/assign @michelle192837 