### PR TITLE
update sig-node testgrid OWNERS

### DIFF
--- a/config/testgrids/kubernetes/sig-node/OWNERS
+++ b/config/testgrids/kubernetes/sig-node/OWNERS
@@ -1,10 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- yujuhong
-- Random-Liu
+- bart0sh
 - dchen1107
+- derekwaynecarr
+- karan
+- MHBauer
+- Random-Liu
+- vpickard
 approvers:
 - yujuhong
 - Random-Liu
 - dchen1107
+- derekwaynecarr
+labels:
+- sig/node


### PR DESCRIPTION
Add some more active reviewers.
Remove some less active reviewers.

some recent changes in the same area
d570ef8af8adf4f71a0b8d252e46d5c9fbd985d9
5c4cfc8967b5eba59f60a238460ff5caa99779c7

If I may be so bold, I think this is similar to #17795, but maybe I'm overstepping. 

My understanding is that this specific OWNERS file is for configuring testgrid tabs for results uploaded outside of prow, and for how the output looks.

/assign @spiffxp 