### PR TITLE
Promote pull-kubernetes-e2e-gce-ubuntu-containerd to presubmit blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -158,8 +158,7 @@ presubmits:
             memory: "6Gi"
 
   - name: pull-kubernetes-e2e-gce-ubuntu-containerd
-    always_run: false
-    skip_report: false
+    always_run: true
     skip_branches:
       - release-\d+\.\d+ # per-release image
     annotations:
@@ -205,7 +204,6 @@ presubmits:
             - --gcp-zone=us-west1-b
             - --ginkgo-parallel=30
             - --provider=gce
-            - --runtime-config=batch/v2alpha1=true
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.


### PR DESCRIPTION
the corresponding CI job has been working well in release informing board for a while now. So time to promote the pull job to presubmit:
https://testgrid.k8s.io/google-gci#gce-ubuntu-master-containerd

Signed-off-by: Davanum Srinivas <davanum@gmail.com>