### PR TITLE
promote ci-kubernetes-e2e-ubuntu-gce-containerd to release blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -405,10 +405,10 @@ periodics:
           - --timeout=50m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200602-c1964ea-master
   annotations:
-    testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
+    testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
     testgrid-tab-name: gce-ubuntu-master-containerd
     testgrid-num-failures-to-alert: '6'
-    testgrid-alert-email: kubernetes-release-team@googlegroups.com
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, kubernetes-release-team@googlegroups.com
     description: Uses kubetest to run e2e tests (-Slow|Serial|Disruptive|Flaky|Feature) against a cluster (ubuntu based and uses containerd) created with cluster/kube-up.sh
 
 - interval: 30m


### PR DESCRIPTION
this job has served us well, please promote it to release blocking.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>