### PR TITLE
kops post-submit: Add --git-dir

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -13,7 +13,7 @@ postsubmits:
       spec:
         serviceAccountName: gcb-builder
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200422-c760048
+          - image: gcr.io/k8s-testimages/image-builder:v20200603-f2d2bf0
             command:
               - /run.sh
             args:
@@ -21,4 +21,5 @@ postsubmits:
               - --project=k8s-staging-kops
               - --scratch-bucket=gs://k8s-staging-kops-gcb
               - --env-passthrough=PULL_BASE_REF
+              - --with-git-dir
               - .


### PR DESCRIPTION
This should upload the .git directory to GCB, and allow the existing
git tag logic in the kops build to work.