### PR TITLE
add note about setting $HOME=/root for buildx

### DIFF
--- a/config/jobs/image-pushing/README.md
+++ b/config/jobs/image-pushing/README.md
@@ -59,6 +59,9 @@ steps:
     - --tag=gcr.io/$PROJECT_ID/some-image:$_GIT_TAG
     - --tag=gcr.io/$PROJECT_ID/some-image:latest
     - .
+    # default cloudbuild has HOME=/builder/home and docker buildx is in /root/.docker/cli-plugins/docker-buildx
+    # set the home to /root explicitly to if using docker buildx
+    # - HOME=/root
 substitutions:
   _GIT_TAG: '12345'
   _PULL_BASE_REF: 'master'


### PR DESCRIPTION
We ran into an issue while using `buildx` to build multi-arch images using cloudbuild. After some debugging figured out the `$HOME` dir need to be explicitly set to `/root` for using docker buildx (https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/219). Adding it to the docs for other users onboarding.