### PR TITLE
add missing scenario flag to ci-docker-node-legacy job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -69,6 +69,7 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
       - --root=/go/src
+      - --scenario=kubernetes_e2e
       - --
       - --deployment=node
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
This job has been failing for all visible history, complaining of `ValueError: ('cannot find scenario for job', 'ci-docker-node-legacy')`

https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-docker-node-legacy?buildId=1235667000813948931

All the other jobs in this config have it, so looks like it hasn't been running for a while.

If fixed it'll make the https://testgrid.k8s.io/sig-node-cri tab blue on testgrid.
