### PR TITLE
kops e2e: only publish latest-ci-green from one test

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -22,7 +22,6 @@ periodics:
       - --extract=release/latest
       - --ginkgo-parallel
       - --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-central1-c
@@ -57,7 +56,6 @@ periodics:
       - --extract=ci/latest
       - --ginkgo-parallel
       - --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
-      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=us-central1-c

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -130,7 +130,6 @@ periodics:
       - --ginkgo-parallel
       - --kops-overrides=spec.kubeDNS.provider=CoreDNS
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
@@ -165,7 +164,6 @@ periodics:
       - --ginkgo-parallel
       - --kops-feature-flags=EnableLaunchTemplates
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-publish=gs://kops-ci/bin/latest-ci-green.txt
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
@@ -209,6 +207,8 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-newrunner
 
+# Verify the latest master branch of kops, with some of the simpler e2e tests
+# Publishes gs://kops-ci/bin/latest-ci-updown-green.txt
 - interval: 60m
   name: e2e-kops-aws-misc-updown
   labels:

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -1,5 +1,7 @@
 periodics:
 
+# Verify the latest-ci-updown-green version of kops, against most of the e2e tests
+# Publishes gs://kops-ci/bin/latest-ci-green.txt
 - interval: 1h
   name: e2e-kops-aws-k8s-latest
   labels:


### PR DESCRIPTION
There's a pipeline:

* kops CI passes => write latest-ci.txt
* updown smoketest passes => write latest-ci-updown-green.txt
* e2e passes => write latest-ci-green.txt

Most of our e2e tests rely on latest-ci-green.txt, so that we only
test kops versions that have passed e2e.