### PR TITLE
kops build-grid: stop the autobumper getting confused

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -155,7 +155,9 @@ def build_test(cloud='aws', distro=None, networking=None, k8s_version=None):
     else:
         extract = expand("release/stable-{k8s_version}")
         k8s_deploy_url = expand("https://storage.googleapis.com/kubernetes-release/release/stable-{k8s_version}.txt") # pylint: disable=line-too-long
-        e2e_image = expand("gcr.io/k8s-testimages/kubekins-e2e:v20171002-6e8d729f-{k8s_version}")
+        # Hack to stop the autobumper getting confused
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-1.18"
+        e2e_image = e2e_image[:-4] + k8s_version
 
     kops_args = ""
     if networking:


### PR DESCRIPTION
We use a static image, and then rewrite to the correct k8s version.