### PR TITLE
Add a debug log in updateconfig plugin

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -309,6 +309,10 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 
 	// Are any of the changes files ones that define a configmap we want to update?
 	toUpdate := FilterChanges(config, changes, defaultNamespace, log)
+	log.WithFields(logrus.Fields{
+		"configmaps_to_update": len(toUpdate),
+		"changes":              len(changes),
+	}).Debug("Identified configmaps to update")
 
 	var updated []string
 	indent := " " // one space


### PR DESCRIPTION
When updateconfig plugin works it's obvious from both logs and Github comments, but when it doesn't work, i.e. filter error, the logs are not sufficient to identify. Add one more debug log to help with this