### PR TITLE
Fix updateconfig plugin bug: return nil when it could return error

### DIFF
--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -351,7 +351,7 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 	var msg string
 	switch n := len(updated); n {
 	case 0:
-		return nil
+		return utilerrors.NewAggregate(errs)
 	case 1:
 		msg = fmt.Sprintf("Updated the %s", updated[0])
 	default:

--- a/prow/plugins/updateconfig/updateconfig.go
+++ b/prow/plugins/updateconfig/updateconfig.go
@@ -339,6 +339,7 @@ func handle(gc githubClient, gitClient git.ClientFactory, kc corev1.ConfigMapsGe
 		configMapClient, err := GetConfigMapClient(kc, cm.Namespace, buildClusterCoreV1Clients, cm.Cluster)
 		if err != nil {
 			log.WithError(err).Errorf("Failed to find configMap client")
+			errs = append(errs, err)
 			continue
 		}
 		if err := Update(&OSFileGetter{Root: gitRepo.Directory()}, configMapClient, cm.Name, cm.Namespace, data, bootstrapMode, metrics, logger); err != nil {


### PR DESCRIPTION
updated could be 0 when all operations in previous for loop failed, thus it should return aggregated error instead of blind nil

/assign @alvaroaleman @matthyx 