### PR TITLE
Honor .bazelversion in trusted jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -72,9 +72,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/alpine-bash/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-git
     cluster: test-infra-trusted
     run_if_changed: '^images/git/'
@@ -109,9 +106,6 @@ postsubmits:
         - prow/deploy.sh
         args:
         - --confirm
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: deploy-prow
@@ -128,9 +122,6 @@ postsubmits:
       - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - experiment/resultstore/push.sh
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: push-resultstore
@@ -148,9 +139,6 @@ postsubmits:
       - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - prow/push.sh
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
     annotations:
       testgrid-dashboards: sig-testing-prow
       testgrid-tab-name: push-prow
@@ -180,9 +168,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - velodrome/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-kettle
     cluster: test-infra-trusted
     annotations:
@@ -206,9 +191,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - kettle/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-triage
     cluster: test-infra-trusted
     run_if_changed: '^triage/'
@@ -232,9 +214,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - triage/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bazel
     cluster: test-infra-trusted
     run_if_changed: '^images/bazel/'
@@ -257,9 +236,6 @@ postsubmits:
         - --scratch-bucket=gs://k8s-testimages-scratch
         - --project=k8s-testimages
         - images/bazel/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bazelbuild
     cluster: test-infra-trusted
     run_if_changed: '^images/bazelbuild/'
@@ -283,9 +259,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/bazelbuild/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bazel-krte
     cluster: test-infra-trusted
     run_if_changed: '^images/bazel-krte/'
@@ -309,9 +282,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/bazel-krte/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bigquery
     cluster: test-infra-trusted
     run_if_changed: '^images/bigquery/'
@@ -335,9 +305,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/bigquery/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-bootstrap
     cluster: test-infra-trusted
     run_if_changed: '^(images/bootstrap|scenarios)/'
@@ -361,9 +328,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/bootstrap/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-cluster-api
     cluster: test-infra-trusted
     run_if_changed: '^images/cluster-api/'
@@ -387,9 +351,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/cluster-api/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-gcb-docker-gcloud
     cluster: test-infra-trusted
     run_if_changed: '^images/gcb-docker-gcloud/'
@@ -413,9 +374,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/gcb-docker-gcloud/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-gcloud
     cluster: test-infra-trusted
     run_if_changed: '^images/gcloud/'
@@ -439,9 +397,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/gcloud/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-kubekins-e2e
     cluster: test-infra-trusted
     run_if_changed: '^(images/kubekins-e2e|kubetest|boskos)/'
@@ -465,9 +420,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/kubekins-e2e/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-krte
     cluster: test-infra-trusted
     run_if_changed: '^images/krte/'
@@ -491,9 +443,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/krte/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-kubemci
     cluster: test-infra-trusted
     run_if_changed: '^images/kubemci/'
@@ -517,9 +466,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/kubemci/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-test-gubernator
     cluster: test-infra-trusted
     run_if_changed: '^images/pull-test-infra-gubernator/'
@@ -543,9 +489,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/pull-test-infra-gubernator/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-image-builder
     cluster: test-infra-trusted
     run_if_changed: '^images/builder/'
@@ -569,9 +512,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - images/builder/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-image-benchmarkjunit
     cluster: test-infra-trusted
     run_if_changed: '^pkg/benchmarkjunit/'
@@ -595,9 +535,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - pkg/benchmarkjunit/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-push-gencred
     cluster: test-infra-trusted
     run_if_changed: '^gencred/'
@@ -621,9 +558,6 @@ postsubmits:
         - --project=k8s-testimages
         - --build-dir=.
         - gencred/
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
   - name: post-test-infra-upload-testgrid-config
     cluster: test-infra-trusted
     branches:
@@ -636,9 +570,6 @@ postsubmits:
       serviceAccountName: testgrid-config-updater
       containers:
       - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
         command:
         - ./testgrid/config-upload.sh
         resources:
@@ -662,9 +593,6 @@ postsubmits:
       - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
         command:
         - ./boskos/update_prow_config.sh
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
     annotations:
       testgrid-dashboards: sig-testing-maintenance
       testgrid-tab-name: boskos-config-upload
@@ -803,9 +731,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
-      env:
-      - name: USE_BAZEL_VERSION
-        value: real  # Ignore .bazelversion
       command:
       - hack/autodeps.sh
       args:
@@ -843,9 +768,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
-      env:
-      - name: USE_BAZEL_VERSION
-        value: real  # Ignore .bazelversion
       command:
       - hack/autodeps.sh
       args:
@@ -883,9 +805,6 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/bazelbuild:v20200421-b889179-test-infra
-      env:
-      - name: USE_BAZEL_VERSION
-        value: real  # Ignore .bazelversion
       command:
       - bazel
       - run


### PR DESCRIPTION
These images now install multiple versions of bazel. We should use
the version specified in .bazelversion.