### PR TITLE
Use org variant of the bazel image.

### DIFF
--- a/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
+++ b/config/jobs/kubernetes/org/kubernetes-org-jobs.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.29.1
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200605-0202717-org
         command:
         - bazel
         args:
@@ -26,7 +26,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.29.1
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200605-0202717-org
         command:
         - ./hack/verify-all.sh
     annotations:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -6,10 +6,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: launcher.gcr.io/google/bazel:0.29.1
-        env:
-        - name: USE_BAZEL_VERSION
-          value: real  # Ignore .bazelversion
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200605-0202717-org
         command:
         - bazel
         args:


### PR DESCRIPTION
This has multiple versions of bazel installed, which will allow us to honor .bazelversion.
This will allow us to test the new version in presubmit and therefore safely upgrade bazel