### PR TITLE
Add Kops required status checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -187,6 +187,14 @@ branch-protection:
             - continuous-integration/travis-ci
           required_pull_request_reviews:
             required_approving_review_count: 1
+        kops:
+          required_status_checks:
+            contexts:
+            - build (ubuntu-18.04, 1.13)
+            - build (ubuntu-18.04, 1.14)
+            - build (macos-10.15, 1.13)
+            - verify (ubuntu-18.04, 1.13)
+            - continuous-integration/travis-ci/pr
         kubelet:
           restrictions:
             users: []


### PR DESCRIPTION
Adding kops to branch-protection for github actions, as discussed in https://github.com/kubernetes/kops/pull/9005.

I believe this will also remove the existing travis ci block so we'll need to add that here if we wish for it to continue to block.  

Thoughts @rifelpet, @hakman, @johngmyers ?

/hold