### PR TITLE
gcsupload: Don't force optional credentials file to be provided

### DIFF
--- a/prow/gcsupload/options.go
+++ b/prow/gcsupload/options.go
@@ -79,10 +79,6 @@ func (o *Options) Validate() error {
 		if o.Bucket == "" {
 			return errors.New("GCS upload was requested no GCS bucket was provided")
 		}
-
-		if o.StorageClientOptions.GCSCredentialsFile == "" && o.StorageClientOptions.S3CredentialsFile == "" {
-			return errors.New("blob storage upload was requested but neither GCS nor S3 credentials file was provided")
-		}
 	}
 
 	return o.GCSConfiguration.Validate()

--- a/prow/gcsupload/options_test.go
+++ b/prow/gcsupload/options_test.go
@@ -66,17 +66,6 @@ func TestOptions_Validate(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-		{
-			name: "push to GCS, missing credentials",
-			input: Options{
-				DryRun: false,
-				GCSConfiguration: &prowapi.GCSConfiguration{
-					Bucket:       "seal",
-					PathStrategy: prowapi.PathStrategyExplicit,
-				},
-			},
-			expectedErr: true,
-		},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
These 2 options are in fact optional as documented at https://github.com/kubernetes/test-infra/blob/master/prow/flagutil/storage.go#L27
```
type StorageClientOptions struct {
	// GCSCredentialsFile is used for reading/writing to GCS block storage.
	// It's optional, if you want to write to local paths or GCS credentials auto-discovery is used.
	// If set, this file is used to read/write to gs:// paths
	// If not, credential auto-discovery is used
	GCSCredentialsFile string `json:"gcs_credentials_file,omitempty"`
	// S3CredentialsFile is used for reading/writing to s3 block storage.
	// It's optional, if you want to write to local paths or S3 credentials auto-discovery is used.
	// If set, this file is used to read/write to s3:// paths
	// If not, go cloud credential auto-discovery is used
	// For more details see the prow/io/providers pkg.
	S3CredentialsFile string `json:"s3_credentials_file,omitempty"`
}
```