### PR TITLE
PlankV2: Couple of small bugs

### DIFF
--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -67,7 +67,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.StringVar(&o.jobConfigPath, "job-config-path", "", "Path to prow job configs.")
 	fs.StringVar(&o.selector, "label-selector", labels.Everything().String(), "Label selector to be applied in prowjobs. See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors for constructing a label selector.")
-	flag.Var(&o.enabledControllers, "enable-controller", fmt.Sprintf("Controllers to enable. Can be passed multiple times. Defaults to all controllers (%v)", allControllers.List()))
+	fs.Var(&o.enabledControllers, "enable-controller", fmt.Sprintf("Controllers to enable. Can be passed multiple times. Defaults to all controllers (%v)", allControllers.List()))
 
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Whether or not to make mutating API calls to GitHub.")
 	for _, group := range []flagutil.OptionGroup{&o.kubernetes, &o.github} {

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -239,22 +239,24 @@ func (r *reconciler) terminateDupes(pj *prowv1.ProwJob) error {
 		return fmt.Errorf("failed to list prowjobs: %v", err)
 	}
 
-	return pjutil.TerminateOlderJobs(r.pjClient, r.log, pjs.Items, func(toCancel prowv1.ProwJob) error {
-		client, ok := r.buildClients[pj.ClusterAlias()]
-		if !ok {
-			return fmt.Errorf("no client for cluster %q present", pj.ClusterAlias())
-		}
-		podToDelete := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: r.config().PodNamespace,
-				Name:      toCancel.Name,
-			},
-		}
-		if err := client.Delete(r.ctx, podToDelete); err != nil {
-			return fmt.Errorf("failed to delete pod %s/%s: %w", podToDelete.Namespace, podToDelete.Name, err)
-		}
-		return nil
-	})
+	return pjutil.TerminateOlderJobs(r.pjClient, r.log, pjs.Items, r.terminateDupesCleanup)
+}
+
+func (r *reconciler) terminateDupesCleanup(pj prowv1.ProwJob) error {
+	client, ok := r.buildClients[pj.ClusterAlias()]
+	if !ok {
+		return fmt.Errorf("no client for cluster %q present", pj.ClusterAlias())
+	}
+	podToDelete := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: r.config().PodNamespace,
+			Name:      pj.Name,
+		},
+	}
+	if err := client.Delete(r.ctx, podToDelete); err != nil && !kerrors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete pod %s/%s in cluster %s: %w", podToDelete.Namespace, podToDelete.Name, pj.ClusterAlias(), err)
+	}
+	return nil
 }
 
 // syncPendingJob syncs jobs for which we already created the test workload

--- a/prow/plank/reconciler_test.go
+++ b/prow/plank/reconciler_test.go
@@ -438,3 +438,13 @@ func (ecpc *eventuallyConsistentlyPatchingClient) Patch(ctx context.Context, obj
 
 	return nil
 }
+
+func TestTerminateDupesToleratesNotFound(t *testing.T) {
+	r := &reconciler{
+		buildClients: map[string]ctrlruntimeclient.Client{"default": fakectrlruntimeclient.NewFakeClient()},
+		config:       func() *config.Config { return &config.Config{} },
+	}
+	if err := r.terminateDupesCleanup(prowv1.ProwJob{}); err != nil {
+		t.Errorf("expected no error when deleting absent pod, got %v", err)
+	}
+}


### PR DESCRIPTION
* Flag registered on the wrong flagset
* TerminateDupes logs an error when the pod is already gone and might use the wrong cluster if the cluster for the prowjob got changed
* startPod didn't block until the pod is in the cache, which might result in aborting the prowjob if a new reconcile request came in that tries to create it as well and fails with IsAlreadyExists