### PR TITLE
Update to latest alpine and git images

### DIFF
--- a/containers.bzl
+++ b/containers.bzl
@@ -25,10 +25,10 @@ def repositories():
 
     container_pull(
         name = "alpine-base",
-        digest = "sha256:bd327018b3effc802514b63cc90102bfcd92765f4486fc5abc28abf7eb9f1e4d",  # 2018/09/20
+        digest = "sha256:55a0c44a09ede57e3193fae6d0918865f2c4d7effe7a8f4dad72eef31f6f7841",
         registry = "gcr.io",
         repository = "k8s-prow/alpine",
-        tag = "0.1",  # TODO(fejta): update or replace
+        # tag = "v20200605-44f6c96",
     )
 
     container_pull(
@@ -49,10 +49,10 @@ def repositories():
 
     container_pull(
         name = "git-base",
-        digest = "sha256:01b0f83fe91b782ec7ddf1e742ab7cc9a2261894fd9ab0760ebfd39af2d6ab28",  # 2018/07/02
+        digest = "sha256:45a5255060b34151ec1fa913eb0bc18958c909fc088989dd84f0614a22fb1840",
         registry = "gcr.io",
         repository = "k8s-prow/git",
-        tag = "0.2",  # TODO(fejta): update or replace
+        # tag = "v20200605-44f6c96",
     )
 
     container_pull(

--- a/images/alpine-bash/Dockerfile
+++ b/images/alpine-bash/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Includes bash.
-FROM alpine:latest
+# Includes bash, see //containers.bzl
+FROM gcr.io/k8s-prow/alpine:v20200605-44f6c96
 
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG

--- a/images/git/Dockerfile
+++ b/images/git/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/k8s-prow/alpine:0.1
+FROM gcr.io/k8s-prow/alpine:v20200605-44f6c96
 
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}


### PR DESCRIPTION
Now that these images are in `gcr.io/k8s-prow` and have the `vYYYYMMDD-commit` format, it should cause them to get bumped automatically as new versions appear.