### PR TITLE
releng: Update bot comment for patch releases

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -215,17 +215,17 @@ aliases:
   # copied from git.k8s.io/kubernetes/OWNERS_ALIASES
   release-engineering-approvers:
     - calebamiles # subproject owner
-    - justaugustus # subproject owner / Patch Release Team
-    - tpepper # subproject owner / Patch Release Team
+    - justaugustus # subproject owner / Release Manager
+    - tpepper # subproject owner / Release Manager
   release-engineering-reviewers:
     - calebamiles # subproject owner
-    - cpanato # Branch Manager
-    - feiskyer # Patch Release Team
-    - hasheddan # Branch Manager
-    - hoegaarden # Patch Release Team
-    - justaugustus # subproject owner / Patch Release Team
-    - saschagrunert # Branch Manager
-    - tpepper # subproject owner / Patch Release Team
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager
+    - hoegaarden # Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - saschagrunert # Release Manager
+    - tpepper # subproject owner / Release Manager
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES
   enhancements-approvers:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -537,11 +537,14 @@ retitle:
 
 cherry_pick_unapproved:
   comment: |
-    This cherry pick PR is for a release branch and has not yet been approved by the Patch Release Team.
+    This cherry pick PR is for a release branch and has not yet been approved by [Release Managers](https://git.k8s.io/sig-release/release-managers.md).
     Adding the `do-not-merge/cherry-pick-not-approved` label.
 
-    To merge this cherry pick, please ping the **kubernetes/patch-release-team** in a comment, *after* it has been approved by the relevant OWNERS.
-    For details on the patch release process and schedule, see the [Patch Releases](https://git.k8s.io/sig-release/releases/patch-releases.md) page.
+    To merge this cherry pick, it must first be approved (`/lgtm` + `/approve`) by the relevant OWNERS.
+
+    **AFTER** it has been approved by code owners, please ping the **kubernetes/release-managers** team in a comment to request a cherry pick review.
+
+    (For details on the patch release process and schedule, see the [Patch Releases](https://git.k8s.io/sig-release/releases/patch-releases.md) page.)
 
 plugins:
   # Enable the following for any bazelbuild repo (rules_k8s, rules_docker) that sends prow webhooks


### PR DESCRIPTION
Update patch release bot comment to reference @kubernetes/release-managers, as we'll be consolidating the Patch Release Team and Branch Managers into one team.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold until https://github.com/kubernetes/sig-release/pull/1106 merges
/assign @tpepper 
cc: @kubernetes/release-engineering 