### PR TITLE
remove deprecated bots in approve plugin

### DIFF
--- a/prow/plugins/approve/approve.go
+++ b/prow/plugins/approve/approve.go
@@ -51,10 +51,6 @@ var (
 	commandRegex               = regexp.MustCompile(`(?m)^/([^\s]+)[\t ]*([^\n\r]*)`)
 	notificationRegex          = regexp.MustCompile(`(?is)^\[` + approvers.ApprovalNotificationName + `\] *?([^\n]*)(?:\n\n(.*))?`)
 
-	// deprecatedBotNames are the names of the bots that previously handled approvals.
-	// Each can be removed once every PR approved by the old bot has been merged or unapproved.
-	deprecatedBotNames = []string{"k8s-merge-robot", "openshift-merge-robot"}
-
 	// handleFunc is used to allow mocking out the behavior of 'handle' while testing.
 	handleFunc = handle
 )
@@ -517,7 +513,7 @@ func humanAddedApproved(ghc githubClient, log *logrus.Entry, org, repo string, n
 			lastAdded = event
 		}
 
-		if lastAdded.Actor.Login == "" || lastAdded.Actor.Login == botName || isDeprecatedBot(lastAdded.Actor.Login) {
+		if lastAdded.Actor.Login == "" || lastAdded.Actor.Login == botName {
 			return false
 		}
 		return true
@@ -540,7 +536,7 @@ func approvalMatcher(botName string, lgtmActsAsApprove, reviewActsAsApprove bool
 }
 
 func isApprovalCommand(botName string, lgtmActsAsApprove bool, c *comment) bool {
-	if c.Author == botName || isDeprecatedBot(c.Author) {
+	if c.Author == botName {
 		return false
 	}
 
@@ -554,7 +550,7 @@ func isApprovalCommand(botName string, lgtmActsAsApprove bool, c *comment) bool 
 }
 
 func isApprovalState(botName string, reviewActsAsApprove bool, c *comment) bool {
-	if c.Author == botName || isDeprecatedBot(c.Author) {
+	if c.Author == botName {
 		return false
 	}
 
@@ -578,7 +574,7 @@ func isApprovalState(botName string, reviewActsAsApprove bool, c *comment) bool 
 
 func notificationMatcher(botName string) func(*comment) bool {
 	return func(c *comment) bool {
-		if c.Author != botName && !isDeprecatedBot(c.Author) {
+		if c.Author != botName {
 			return false
 		}
 		match := notificationRegex.FindStringSubmatch(c.Body)
@@ -741,13 +737,4 @@ func getLast(cs []*comment) *comment {
 		return nil
 	}
 	return cs[len(cs)-1]
-}
-
-func isDeprecatedBot(login string) bool {
-	for _, deprecated := range deprecatedBotNames {
-		if deprecated == login {
-			return true
-		}
-	}
-	return false
 }

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -100,13 +100,7 @@ func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments 
 	if hasLabel {
 		labels = append(labels, fmt.Sprintf("org/repo#%v:approved", prNumber))
 	}
-	events := []github.ListedIssueEvent{
-		{
-			Event: github.IssueActionLabeled,
-			Label: github.Label{Name: "approved"},
-			Actor: github.User{Login: "k8s-merge-robot"},
-		},
-	}
+	events := []github.ListedIssueEvent{}
 	if humanApproved {
 		events = append(
 			events,


### PR DESCRIPTION
If those deprecated github names, will try to self-approve a PR, then the prow bot will remove the approve label.  

/cc @stevekuznetsov @alvaroaleman @petr-muller 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>