### PR TITLE
Remove CAPI pr-integration presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -103,30 +103,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-test
-  - name: pull-cluster-api-integration
-    labels:
-      preset-dind-enabled: "true"
-      preset-service-account: "true"
-      preset-kind-volume-mounts: "true"
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api
-    always_run: true
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-master
-        command:
-        - runner.sh
-        - ./scripts/ci-integration.sh
-        # we need privileged mode in order to do docker in docker
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: "4000m"
-            memory: "6Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-integration
   - name: pull-cluster-api-e2e
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Most of the integration tests are now run as part of the pr-test presubmit job. We also added pr-e2e that cover a different set of scenarios, including some from the one being removed here.

/assign @detiber