### PR TITLE
Add a squash-merge-label plugin

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -270,6 +270,7 @@ type PullRequest struct {
 	Mergable *bool `json:"mergeable,omitempty"`
 	// If the PR doesn't have any milestone, `milestone` is null and is unmarshaled to nil.
 	Milestone *Milestone `json:"milestone,omitempty"`
+	Commits   int        `json:"commits"`
 }
 
 // PullRequestBranch contains information about a particular branch in a PR.

--- a/prow/hook/plugin-imports/BUILD.bazel
+++ b/prow/hook/plugin-imports/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//prow/plugins/label:go_default_library",
         "//prow/plugins/lgtm:go_default_library",
         "//prow/plugins/lifecycle:go_default_library",
+        "//prow/plugins/merge-method-comment:go_default_library",
         "//prow/plugins/mergecommitblocker:go_default_library",
         "//prow/plugins/milestone:go_default_library",
         "//prow/plugins/milestoneapplier:go_default_library",

--- a/prow/hook/plugin-imports/plugin-imports.go
+++ b/prow/hook/plugin-imports/plugin-imports.go
@@ -40,6 +40,7 @@ import (
 	_ "k8s.io/test-infra/prow/plugins/label"
 	_ "k8s.io/test-infra/prow/plugins/lgtm"
 	_ "k8s.io/test-infra/prow/plugins/lifecycle"
+	_ "k8s.io/test-infra/prow/plugins/merge-method-comment"
 	_ "k8s.io/test-infra/prow/plugins/mergecommitblocker"
 	_ "k8s.io/test-infra/prow/plugins/milestone"
 	_ "k8s.io/test-infra/prow/plugins/milestoneapplier"

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -91,6 +91,7 @@ filegroup(
         "//prow/plugins/label:all-srcs",
         "//prow/plugins/lgtm:all-srcs",
         "//prow/plugins/lifecycle:all-srcs",
+        "//prow/plugins/merge-method-comment:all-srcs",
         "//prow/plugins/mergecommitblocker:all-srcs",
         "//prow/plugins/milestone:all-srcs",
         "//prow/plugins/milestoneapplier:all-srcs",

--- a/prow/plugins/merge-method-comment/BUILD.bazel
+++ b/prow/plugins/merge-method-comment/BUILD.bazel
@@ -1,0 +1,44 @@
+package(default_visibility = ["//visibility:public"])
+
+licenses(["notice"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["merge-method-comment_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+    ],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["merge-method-comment.go"],
+    importpath = "k8s.io/test-infra/prow/plugins/merge-method-comment",
+    deps = [
+        "//prow/config:go_default_library",
+        "//prow/github:go_default_library",
+        "//prow/pluginhelp:go_default_library",
+        "//prow/plugins:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/prow/plugins/merge-method-comment/merge-method-comment.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package mergemethodcomment contains a Prow plugin which comments on PRs with
+// 2 or more commits, informing the user:
+// - How to request commits to be squashed if default merge method is merge,
+// - How to request commits to be merged if the repo squashes commits by default,
+// - That the commits will be merged/squashed if it is not possible to override
+// the default merge method.
+package mergemethodcomment
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pluginhelp"
+	"k8s.io/test-infra/prow/plugins"
+)
+
+const pluginName = "merge-method-comment"
+
+// Strict subset of github.Client methods.
+type githubClient interface {
+	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
+	CreateComment(org, repo string, number int, comment string) error
+	BotName() (string, error)
+}
+
+func init() {
+	plugins.RegisterPullRequestHandler(pluginName, handlePullRequest, helpProvider)
+}
+
+func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
+	return &pluginhelp.PluginHelp{
+			Description: "The merge-method-comment plugin adds a comment on how to request a different-from-default merge method to PRs with more than 1 commit",
+		},
+		nil
+}
+
+func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
+	return handlePR(pc.GitHubClient, pc.Config.ProwConfig.Tide, pe)
+}
+
+func handlePR(gc githubClient, c config.Tide, pe github.PullRequestEvent) error {
+	if !isPRChanged(pe) {
+		return nil
+	}
+
+	commentNeeded, comment := needsComment(c, pe)
+	if !commentNeeded {
+		return nil
+	}
+
+	owner := pe.PullRequest.Base.Repo.Owner.Login
+	repo := pe.PullRequest.Base.Repo.Name
+	num := pe.PullRequest.Number
+
+	hasComment, err := issueHasComment(gc, owner, repo, num, comment)
+	if err != nil {
+		return err
+	}
+	if hasComment {
+		return nil
+	}
+
+	return gc.CreateComment(owner, repo, num, plugins.FormatSimpleResponse(pe.PullRequest.User.Login, comment))
+}
+
+func needsComment(c config.Tide, pe github.PullRequestEvent) (bool, string) {
+	if pe.PullRequest.Commits <= 1 {
+		return false, ""
+	}
+
+	orgRepo := config.OrgRepo{
+		Org:  pe.PullRequest.Base.Repo.Owner.Login,
+		Repo: pe.PullRequest.Base.Repo.Name,
+	}
+	method := c.MergeMethod(orgRepo)
+	comment := fmt.Sprintf("This PR has multiple commits, and the default merge method is: %s.\n", method)
+
+	switch {
+	case method == github.MergeSquash && c.MergeLabel != "":
+		comment = fmt.Sprintf("%sYou can request commits to be merged using the label: %s", comment, c.MergeLabel)
+	case method == github.MergeSquash && c.MergeLabel == "":
+		comment = comment + "Commits will be squashed, as no merge labels are defined"
+	case method == github.MergeMerge && c.SquashLabel != "":
+		comment = fmt.Sprintf("%sYou can request commits to be squashed using the label: %s", comment, c.SquashLabel)
+	case method == github.MergeMerge && c.SquashLabel == "":
+		comment = comment + "Commits will be merged, as no squash labels are defined"
+	}
+
+	return true, comment
+}
+
+func issueHasComment(gc githubClient, org, repo string, number int, comment string) (bool, error) {
+	botName, err := gc.BotName()
+	if err != nil {
+		return false, err
+	}
+
+	comments, err := gc.ListIssueComments(org, repo, number)
+	if err != nil {
+		return false, fmt.Errorf("error listing issue comments: %v", err)
+	}
+
+	for _, c := range comments {
+		if c.User.Login == botName && strings.Contains(c.Body, comment) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// These are the only actions indicating the code diffs may have changed.
+func isPRChanged(pe github.PullRequestEvent) bool {
+	switch pe.Action {
+	case github.PullRequestActionOpened:
+		return true
+	case github.PullRequestActionReopened:
+		return true
+	case github.PullRequestActionSynchronize:
+		return true
+	case github.PullRequestActionEdited:
+		return true
+	default:
+		return false
+	}
+}

--- a/prow/plugins/merge-method-comment/merge-method-comment_test.go
+++ b/prow/plugins/merge-method-comment/merge-method-comment_test.go
@@ -1,0 +1,322 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mergemethodcomment
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"k8s.io/test-infra/prow/config"
+	"k8s.io/test-infra/prow/github"
+)
+
+type ghc struct {
+	*testing.T
+	comments         map[string][]github.IssueComment
+	createCommentErr error
+	listCommentsErr  error
+}
+
+func (c *ghc) CreateComment(org, repo string, num int, comment string) error {
+	c.T.Logf("CreateComment: %s/%s#%d: %s", org, repo, num, comment)
+	if c.createCommentErr != nil {
+		return c.createCommentErr
+	}
+	if len(c.comments) == 0 {
+		c.comments = make(map[string][]github.IssueComment)
+	}
+	botName, err := c.BotName()
+	if err != nil {
+		return err
+	}
+	orgRepoNum := fmt.Sprintf("%s/%s#%d", org, repo, num)
+	c.comments[orgRepoNum] = append(c.comments[orgRepoNum],
+		github.IssueComment{
+			Body: comment,
+			User: github.User{Login: botName},
+		},
+	)
+	return nil
+}
+
+func (c *ghc) ListIssueComments(org, repo string, num int) ([]github.IssueComment, error) {
+	c.T.Logf("ListIssueComments: %s/%s#%d", org, repo, num)
+	if c.listCommentsErr != nil {
+		return nil, c.listCommentsErr
+	}
+	return c.comments[fmt.Sprintf("%s/%s#%d", org, repo, num)], nil
+}
+
+func (c *ghc) BotName() (string, error) {
+	return "k8s-bot", nil
+}
+
+func TestHandlePR(t *testing.T) {
+	singleCommitPR := github.PullRequest{
+		Number: 101,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "kubernetes",
+				},
+				Name: "kubernetes",
+			},
+		},
+		Commits: 1,
+	}
+	multipleCommitsPR := github.PullRequest{
+		Number: 101,
+		Base: github.PullRequestBranch{
+			Repo: github.Repo{
+				Owner: github.User{
+					Login: "kubernetes",
+				},
+				Name: "kubernetes",
+			},
+		},
+		Commits: 2,
+	}
+
+	cases := []struct {
+		name               string
+		client             *ghc
+		event              github.PullRequestEvent
+		defaultMergeMethod github.PullRequestMergeType
+		squashLabel        string
+		mergeLabel         string
+		err                error
+		comments           []github.IssueComment
+	}{
+		{
+			name:   "single commit",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: singleCommitPR,
+			},
+			squashLabel:        "squash-label",
+			defaultMergeMethod: github.MergeSquash,
+		},
+		{
+			name:   "multiple commits, merge by-default, squash label configured",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			squashLabel:        "squash-label",
+			comments: []github.IssueComment{
+				{
+					Body: "You can request commits to be squashed using the label: squash-label",
+				},
+			},
+		},
+		{
+			name:   "multiple commits, merge by-default, squash label not configured",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be merged, as no squash labels are defined",
+				},
+			},
+		},
+		{
+			name:   "multiple commits, squash by-default, merge label configured",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeSquash,
+			mergeLabel:         "merge-label",
+			comments: []github.IssueComment{
+				{
+					Body: "You can request commits to be merged using the label: merge-label",
+				},
+			},
+		},
+		{
+			name:   "multiple commits, squash by-default, merge label not configured",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeSquash,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be squashed, as no merge labels are defined",
+				},
+			},
+		},
+		{
+			name: "do not create comment if already commented",
+			client: &ghc{
+				comments: map[string][]github.IssueComment{
+					"kubernetes/kubernetes#101": {
+						{
+							User: github.User{Login: "k8s-bot"},
+							Body: fmt.Sprintf("This PR has multiple commits, and the default merge method is: %s.\n%s",
+								github.MergeMerge,
+								"Commits will be merged, as no squash labels are defined"),
+						},
+					},
+				},
+			},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be merged, as no squash labels are defined",
+				},
+			},
+		},
+		{
+			name: "error listing issue comments",
+			client: &ghc{
+				listCommentsErr: fmt.Errorf("cannot list comments"),
+			},
+			defaultMergeMethod: github.MergeMerge,
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionOpened,
+				PullRequest: multipleCommitsPR,
+			},
+			err: fmt.Errorf("error listing issue comments: %s", "cannot list comments"),
+		},
+		{
+			name: "error creating comment",
+			client: &ghc{
+				createCommentErr: fmt.Errorf("cannot create comment"),
+			},
+			defaultMergeMethod: github.MergeMerge,
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionSynchronize,
+				PullRequest: multipleCommitsPR,
+			},
+			err: fmt.Errorf("cannot create comment"),
+		},
+		{
+			name:   "handle PR sync",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionSynchronize,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be merged, as no squash labels are defined",
+				},
+			},
+		},
+		{
+			name:   "handle PR reopen",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionReopened,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be merged, as no squash labels are defined",
+				},
+			},
+		},
+		{
+			name:   "handle PR edit",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionEdited,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+			comments: []github.IssueComment{
+				{
+					Body: "Commits will be merged, as no squash labels are defined",
+				},
+			},
+		},
+		{
+			name:   "ignore irrelevant events",
+			client: &ghc{},
+			event: github.PullRequestEvent{
+				Action:      github.PullRequestActionReviewRequested,
+				PullRequest: multipleCommitsPR,
+			},
+			defaultMergeMethod: github.MergeMerge,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if c.client == nil {
+				t.Fatalf("test case can not have nil github client")
+			}
+
+			// Set up test logging.
+			c.client.T = t
+
+			c.event.Number = 101
+			config := config.Tide{
+				MergeType: map[string]github.PullRequestMergeType{
+					"kubernetes/kubernetes": c.defaultMergeMethod,
+				},
+				SquashLabel: c.squashLabel,
+				MergeLabel:  c.mergeLabel,
+			}
+			err := handlePR(c.client, config, c.event)
+
+			if err != nil && c.err == nil {
+				t.Fatalf("handlePR error: %v", err)
+			}
+
+			if err == nil && c.err != nil {
+				t.Fatalf("handlePR wanted error %v, got nil", err)
+			}
+
+			if got, want := err, c.err; got != nil && got.Error() != want.Error() {
+				t.Fatalf("handlePR errors mismatch: got %v, want %v", got, want)
+			}
+
+			if c.err != nil {
+				return
+			}
+
+			if got, want := len(c.client.comments["kubernetes/kubernetes#101"]), len(c.comments); got != want {
+				t.Logf("github client comments: got %v; want %v", c.client.comments, c.comments)
+				t.Fatalf("issue comments count mismatch: got %d, want %d", got, want)
+			}
+
+			for i, comment := range c.comments {
+				if !strings.Contains(c.client.comments["kubernetes/kubernetes#101"][i].Body, comment.Body) {
+					t.Fatalf("github client comment: got %s, expected it to contain: %s", c.client.comments["kubernetes/kubernetes#101"][i].Body, comment.Body)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
A new plugin is added which applies a squash merge label on PullRequests
with more than 1 commit, if tide has a configured squash merge label and
the repo is not configured to automatically squash commits. Closes #17841 