### PR TITLE
Add kubeflow-pipeline-multiuser-test as optional

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -550,6 +550,24 @@ presubmits:
         command:
         - ./test/presubmit-backend-visualization.sh
 
+  - name: kubeflow-pipeline-multiuser-test
+    cluster: kubeflow
+    always_run: false
+    decorate: true
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-master
+        command:
+        - ./test/multiuser-tests.sh
+        args:
+        - --workflow_file
+        - multiuser_test.yaml
+        - --test_result_folder
+        - multiuser_test
+
   kubeflow/xgboost-operator:
   - name: kubeflow-xgboost-operator-presubmit
     cluster: kubeflow


### PR DESCRIPTION
Configure kubeflow-pipeline-multiuser-test as optional, so that we can trigger the test when needed. 

Related to https://github.com/kubeflow/pipelines/pull/3673
/cc @jlewi @Bobgy 