### PR TITLE
Migrate 100 node release-branch blocking jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -164,6 +164,7 @@ periodics:
     testgrid-dashboards: sig-release-1.15-blocking, sig-scalability-gce, google-gce
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: gce-cos-1.15-scalability-100
+  cluster: k8s-infra-prow-build
   cron: 0 8-20/12 * * *
   labels:
     preset-e2e-scalability-common: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -165,6 +165,7 @@ periodics:
       google-gci
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.16-scalability-100
+  cluster: k8s-infra-prow-build
   cron: 0 4-16/12 * * *
   labels:
     preset-e2e-scalability-common: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -202,6 +202,7 @@ periodics:
       google-gci
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.17-scalability-100
+  cluster: k8s-infra-prow-build
   cron: 0 0/12 * * *
   labels:
     preset-e2e-scalability-common: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -267,6 +267,7 @@ periodics:
       google-gci
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.18-scalability-100
+  cluster: k8s-infra-prow-build
   cron: 0 */6 * * *
   labels:
     preset-e2e-scalability-common: "true"


### PR DESCRIPTION
Followup to #17725 which migrated just the master branch job

ref: https://github.com/kubernetes/k8s.io/issues/841