### PR TITLE
Migrate ci-kubernetes-e2e-ubuntu-gce jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -332,6 +332,7 @@ periodics:
 
 - interval: 120m
   name: ci-kubernetes-e2e-ubuntu-gce
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -351,6 +352,7 @@ periodics:
           - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
           - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+          - --gcp-project-type=k8s-infra-prow-build
           - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu
           - --gcp-nodes=4
@@ -369,6 +371,7 @@ periodics:
 
 - interval: 120m
   name: ci-kubernetes-e2e-ubuntu-gce-containerd
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -393,6 +396,7 @@ periodics:
           - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
           - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+          - --gcp-project-type=k8s-infra-gce-project
           - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu
           - --gcp-nodes=4


### PR DESCRIPTION
Migrate ci-kubernetes-e2e-ubuntu-gce-containerd because it's on
sig-release-master-blocking

Migrate ci-kubernetes-e2e-ubuntu-gce while we're here since it's on
sig-release-master-informing, and we don't have people trying to nitpick
differences between one cluster and the other when comparing these jobs
to each other

ref: https://github.com/kubernetes/k8s.io/issues/841