### PR TITLE
Add --yes to kops create cluster

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -470,7 +470,7 @@ func (k kops) Up() error {
 	}
 
 	// TODO: Once this gets support for N checks in a row, it can replace the above node readiness check
-	if err := control.FinishRunning(exec.Command(k.path, "validate", "cluster", k.cluster, "--wait", "5m")); err != nil {
+	if err := control.FinishRunning(exec.Command(k.path, "validate", "cluster", k.cluster, "--wait", "15m")); err != nil {
 		return fmt.Errorf("kops validate cluster failed: %v", err)
 	}
 

--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -462,11 +462,11 @@ func (k kops) Up() error {
 	if len(featureFlags) != 0 {
 		os.Setenv("KOPS_FEATURE_FLAGS", strings.Join(featureFlags, ","))
 	}
+
+	createArgs = append(createArgs, "--yes")
+
 	if err := control.FinishRunning(exec.Command(k.path, createArgs...)); err != nil {
 		return fmt.Errorf("kops create cluster failed: %v", err)
-	}
-	if err := control.FinishRunning(exec.Command(k.path, "update", "cluster", k.cluster, "--yes")); err != nil {
-		return fmt.Errorf("kops update cluster failed: %v", err)
 	}
 
 	// We require repeated successes, so we know that the cluster is stable


### PR DESCRIPTION
Instead of first running kops create cluster, then kops update cluster,
we should add --yes to kops create cluster so that the cluster is
created directly.
This allows us to implement some breaking changes to the kops update
cluster interface without affecting tests. Since we cannot add args to
kops update cluster, it also opens up for further changes later on.