### PR TITLE
Crier: Fix a bug where it waits for the wrong change

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -197,7 +197,7 @@ func (c *Controller) updateReportState(pj *v1.ProwJob, log *logrus.Entry, report
 			return false, err
 		}
 		if pj.Status.PrevReportStates != nil &&
-			newpj.Status.PrevReportStates[c.reporter.GetName()] == newpj.Status.State {
+			newpj.Status.PrevReportStates[c.reporter.GetName()] == reportedState {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/commit/01fd07142c61b3f89246cbad83a23ae4251e04f5#diff-0e4877bfa35d63bade3a386f20923299L168 crier was changed to set the `prevReportedStates` field to the state that was reported rather than the last state the job itself was in, as that could change in the meantime because we retry everything and within that retying we fetch the prowjob object again.

However, I forgot to also change the section that blocks until the change is in the cache to wait for the correct change, resulting in timeouts when the prowjob status got changed after it was reported and before the reported state was in the cache (the case where we silently claimed to have reported the current state before, even though we didn't).

Fixes https://github.com/kubernetes/test-infra/issues/17790
Fixes https://github.com/openshift/release/issues/9567