### PR TITLE
Put image builder messages to console

### DIFF
--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -38,6 +38,42 @@ const (
 	gcsLogsDir   = "/logs"
 )
 
+type Step struct {
+	Name string `yaml:"name"`
+	Args []string
+}
+
+type CloudBuildYAMLFile struct {
+	Steps         []Step `yaml:"steps"`
+	Substitutions map[string]string
+	Images        []string
+}
+
+func getProjectId() (string, error) {
+	cmd := exec.Command("gcloud", "config", "get-value", "project")
+	projectId, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project_id: %v", err)
+	}
+	return string(projectId), nil
+}
+
+func getImageName(o options, tag string, config string) (string, error) {
+	var cloudbuildyamlFile CloudBuildYAMLFile
+	buf, _ := ioutil.ReadFile(o.cloudbuildFile)
+	if err := yaml.Unmarshal(buf, &cloudbuildyamlFile); err != nil {
+		return "", fmt.Errorf("failed to get image name: %v", err)
+	}
+	var projectId, _ = getProjectId()
+	var imageNames = cloudbuildyamlFile.Images
+	r := strings.NewReplacer("$PROJECT_ID", strings.TrimSpace(projectId), "$_GIT_TAG", tag, "$_CONFIG", config)
+	var result string
+	for _, name := range imageNames {
+		result = result + r.Replace(name) + " "
+	}
+	return result, nil
+}
+
 func runCmd(command string, args ...string) error {
 	cmd := exec.Command(command, args...)
 	cmd.Stderr = os.Stderr
@@ -150,8 +186,9 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 
 	cmd := exec.Command("gcloud", args...)
 
+	var p string
 	if o.logDir != "" {
-		p := path.Join(o.logDir, strings.Replace(jobName, "/", "-", -1)+".log")
+		p = path.Join(o.logDir, strings.Replace(jobName, "/", "-", -1)+".log")
 		f, err := os.Create(p)
 
 		if err != nil {
@@ -169,6 +206,10 @@ func runSingleJob(o options, jobName, uploaded, version string, subs map[string]
 	}
 
 	if err := cmd.Run(); err != nil {
+		if o.logDir != "" {
+			buildLog, _ := ioutil.ReadFile(p)
+			fmt.Println(string(buildLog))
+		}
 		return fmt.Errorf("error running %s: %v", cmd.Args, err)
 	}
 
@@ -232,11 +273,14 @@ func runBuildJobs(o options) []error {
 	if err != nil {
 		return []error{err}
 	}
+
 	if len(vs) == 0 {
 		log.Println("No variants.yaml, starting single build job...")
 		if err := runSingleJob(o, "build", uploaded, tag, getExtraSubs(o)); err != nil {
 			return []error{err}
 		}
+		var imageName, _ = getImageName(o, tag, "")
+		log.Printf("Successfully built image: %v \n", imageName)
 		return nil
 	}
 
@@ -254,6 +298,8 @@ func runBuildJobs(o options) []error {
 				errors = append(errors, fmt.Errorf("job %q failed: %v", job, err))
 				log.Printf("Job %q failed: %v\n", job, err)
 			} else {
+				var imageName, _ = getImageName(o, tag, job)
+				log.Printf("Successfully built image: %v \n", imageName)
 				log.Printf("Job %q completed.\n", job)
 			}
 		}(k, v)


### PR DESCRIPTION
This PR is to fix: https://github.com/kubernetes/test-infra/issues/17862

The PR is basically adding some useful information for bazel build operations, like `bazel run //images/builder -- --log-dir=/tmp --allow-dirty images/alpine`:
1. If the job fails, pulling all of this build log into the console log (aka print it to stdout)
2. Print the resolved images it created if it passes, aka

In the example below, the line started with `Successfully built image` is newly added: 
```
bazel run //images/builder -- --log-dir=/tmp --allow-dirty images/alpine 
INFO: Analyzed target //images/builder:builder (1 packages loaded, 8 targets configured).
INFO: Found 1 target...
Target //images/builder:builder up-to-date:
  bazel-bin/images/builder/linux_amd64_stripped/builder
INFO: Elapsed time: 0.408s, Critical Path: 0.26s
INFO: 2 processes: 2 linux-sandbox.
INFO: Build completed successfully, 3 total actions
INFO: Build completed successfully, 3 total actions
2020/06/09 14:37:31 Build directory: images/alpine
2020/06/09 14:37:31 Config directory: /home/zhi/os_k8s/go/src/k8s.io/test-infra/images/alpine
2020/06/09 14:37:31 cd-ing to build directory: images/alpine
2020/06/09 14:37:31 Skipping advance upload and relying on gcloud...
2020/06/09 14:37:31 Running build jobs...
2020/06/09 14:37:31 No variants.yaml, starting single build job...
2020/06/09 14:37:52 Successfully built image: gcr.io/arcane-glow-279118/alpine:v20200609-4572dc3bf9-dirty gcr.io/arcane-glow-279118/alpine:latest  
2020/06/09 14:37:52 Finished.
```
Similarly for multiple variants, the images for each job will be printed to console too:
```
bazel run //images/builder -- --log-dir=/tmp --allow-dirty images/bazel
INFO: Analyzed target //images/builder:builder (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //images/builder:builder up-to-date:
  bazel-bin/images/builder/linux_amd64_stripped/builder
INFO: Elapsed time: 0.277s, Critical Path: 0.20s
INFO: 0 processes.
INFO: Build completed successfully, 1 total action
INFO: Build completed successfully, 1 total action
2020/06/09 14:37:58 Build directory: images/bazel
2020/06/09 14:37:58 Config directory: /home/zhi/os_k8s/go/src/k8s.io/test-infra/images/bazel
2020/06/09 14:37:58 cd-ing to build directory: images/bazel
2020/06/09 14:37:58 Skipping advance upload and relying on gcloud...
2020/06/09 14:37:58 Running build jobs...
2020/06/09 14:37:58 Found variants.yaml, starting 3 build jobs...
2020/06/09 14:37:58 Starting job "org"...
2020/06/09 14:37:58 Starting job "test-infra"...
2020/06/09 14:37:58 Starting job "kubernetes"...
2020/06/09 14:38:53 Successfully built image: gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:v20200609-4572dc3bf9-dirty-test-infra gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:latest-test-infra  
2020/06/09 14:38:53 Job "test-infra" completed.
2020/06/09 14:39:31 Successfully built image: gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:v20200609-4572dc3bf9-dirty-kubernetes gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:latest-kubernetes  
2020/06/09 14:39:31 Job "kubernetes" completed.
2020/06/09 14:39:42 Successfully built image: gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:v20200609-4572dc3bf9-dirty-org gcr.io/arcane-glow-279118/launcher.gcr.io/google/bazel:latest-org  
2020/06/09 14:39:42 Job "org" completed.
2020/06/09 14:39:42 Finished.
```

If the image build fails, the builder will read from log file and print it to the console. 