### PR TITLE
Specify redundant version when autobump.sh fails

### DIFF
--- a/prow/cmd/autobump/autobump.sh
+++ b/prow/cmd/autobump/autobump.sh
@@ -44,7 +44,7 @@ main() {
 	version=$(cat "${PLANK_DEPLOYMENT_FILE}" | extract-version)
 
 	if [[ "${old_version}" == "${version}" ]]; then
-		echo "Bump did not change the Prow version. Aborting no-op bump." >&2
+		echo "Bump did not change the Prow version: it's still ${version}. Aborting no-op bump." >&2
 		exit 0
 	fi
 


### PR DESCRIPTION
When autobump.sh does nothing due to "no change", and the person debugging isn't sure why that is, listing the redundant version the script thinks is a useful signal.

For example, from this log example:
```
Bumping prow to upstream (prow.k8s.io) version...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100  3400  100  3400    0     0  45709      0 --:--:-- --:--:-- --:--:-- 45945
Bumping: 'gcr.io/k8s-prow/' images to v20200609-2d17640dc1 ...
Attempting to bump the following files:
prow/config.yaml
prow/config/jobs/test-infra.yaml
Checking the existence of gcr.io/k8s-prow/clonerefs:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/initupload:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/entrypoint:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/sidecar:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/clonerefs:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/initupload:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/entrypoint:v20200601-4efada0619
Checking the existence of gcr.io/k8s-prow/sidecar:v20200601-4efada0619
bump.sh completed successfully!
Bump did not change the Prow version. Aborting no-op bump.
```

...it's clear that `${old_version}" == "${version}`, but not whether that version is v20200601 or v20200609.