### PR TITLE
Rollout containerd to remaining jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -195,60 +195,44 @@ periodics:
           - --timeout=120m
           - --use-logexporter
 
-# This is a fork of ci-kubernetes-e2e-gci-gce-scalability job (as of 2020-02-18) with enabled containerd.
-- interval: 1h
-  name: ci-kubernetes-e2e-gci-gce-scalability-containerd
-  tags:
-    - "perfDashPrefix: gce-100Nodes-master-containerd"
-    - "perfDashJobType: performance"
-    - "perfDashBuildsCount: 500"
+  # Experimental job providing visibility into state of containerd.
+- interval: 6h
+  name: ci-kubernetes-e2e-gci-gce-scalability-containerd-correctness
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
-    preset-e2e-scalability-containerd: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
-    testgrid-tab-name: gce-cos-master-scalability-100-containerd
+    testgrid-tab-name: gce-cos-master-scalability-100-containerd-conformance
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-master
         args:
-          - --timeout=140
           - --repo=k8s.io/kubernetes=master
-          - --repo=k8s.io/perf-tests=master
           - --root=/go/src
           - --scenario=kubernetes_e2e
+          - --timeout=270
           - --
           - --check-leaked-resources
-          - --cluster=e2e-big-containerd
-          # TODO(oxddr): remove once debugging is finished
-          - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
+          - --cluster=e2e-containerd-conformance
           - --extract=ci/latest
           - --gcp-node-image=gci
           - --gcp-nodes=100
           - --gcp-project-type=scalability-project
+          - --gcp-ssh-proxy-instance-name=gce-cluster-master
           - --gcp-zone=us-east1-b
           - --provider=gce
-          - --test=false
-          - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
-          - --test-cmd-args=cluster-loader2
-          - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
-          - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}
-          - --test-cmd-args=--nodes=100
-          - --test-cmd-args=--prometheus-scrape-node-exporter
-          - --test-cmd-args=--provider=gce
-          - --test-cmd-args=--report-dir=/workspace/_artifacts
-          - --test-cmd-args=--testconfig=testing/density/config.yaml
-          - --test-cmd-args=--testconfig=testing/load/config.yaml
-          - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-          - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
-          - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
-          - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-          - --test-cmd-args=--testoverrides=./testing/overrides/load_throughput.yaml
-          - --test-cmd-name=ClusterLoaderV2
-          - --timeout=120m
+          - --test=true
+          - --ginkgo-parallel=40
+          - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
+          - --allowed-not-ready-nodes=1
+          - --timeout=240m
           - --use-logexporter
+        resources:
+          requests:
+            cpu: 2
+            memory: "6Gi"
 
   # Experimental job confirming that node killer works. Fork of ci-kubernetes-e2e-gci-gce-scalability.
   # To be removed after Chaos Monkey flags are enabled in ci-kubernetes-e2e-gci-gce-scalability

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -163,6 +163,7 @@ presubmits:
       preset-k8s-ssh: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -52,6 +52,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-containerd: "true"
   annotations:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-master-informing, sig-scalability-gce, google-gce


### PR DESCRIPTION
Continue rollout for kubernetes/perf-tests#1110

/sig scalability
/assign @mm4tt

Final rollout, as discussed, kubemark will not be updated.