### PR TITLE
ci-kubernetes-e2e-gce-device-plugin-gpu needs docker as default runtime

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -35,6 +35,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
A recent change in kube-up switched us to using `containerd` as default, so we need to fix up CI jobs that depend on docker. (see https://github.com/kubernetes/kubernetes/pull/91684)

Fix for https://github.com/kubernetes/kubernetes/issues/91990