### PR TITLE
Adds docker as the container runtime for gcp-gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -45,7 +45,6 @@ presubmits:
         - --build=bazel
         - --cluster=
         - --extract=local
-        - --env=KUBE_CONTAINER_RUNTIME=docker
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
@@ -353,6 +352,7 @@ periodics:
           - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
           - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+          - --env=KUBE_CONTAINER_RUNTIME=docker
           - --gcp-project-type=k8s-infra-prow-build
           - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu


### PR DESCRIPTION
  kube-up now uses containerd by default. Jobs that depend on docker need
  to explicitly request docker by setting KUBE_CONTAINER_RUNTIME=docker