### PR TITLE
bugzilla: truncate cloneBug description to 65535

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -295,6 +295,10 @@ func cloneBugStruct(bug *Bug, subcomponents map[string][]string, comments []Comm
 		newDesc.WriteString(comment.Text)
 	}
 	newBug.Description = newDesc.String()
+	// make sure comment isn't above maximum length
+	if len(newBug.Description) > 65535 {
+		newBug.Description = fmt.Sprint(newBug.Description[:65532], "...")
+	}
 	return newBug
 }
 

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -390,6 +390,18 @@ This is another comment.`,
 			t.Errorf("%s: Difference in expected BugCreate and actual: %s", testCase.name, cmp.Diff(testCase.expected, *newBug))
 		}
 	}
+	// test max length truncation
+	bug := Bug{}
+	baseComment := Comment{Text: "This is a test comment"}
+	comments := []Comment{}
+	// Make sure comments are at lest 65535 in total length
+	for i := 0; i < (65535 / len(baseComment.Text)); i++ {
+		comments = append(comments, baseComment)
+	}
+	newBug := cloneBugStruct(&bug, nil, comments)
+	if len(newBug.Description) != 65535 {
+		t.Errorf("Truncation error in cloneBug; expected description length of 65535, got %d", len(newBug.Description))
+	}
 }
 
 func TestUpdateBug(t *testing.T) {


### PR DESCRIPTION
The maximum length for a comment in bugzilla is 65535 characters. For bugs with many, long comments, we may exceed that during a clone. This truncates the description to 65535 characters, including a `...` at the end of the description if the description was too long.

/cc @stevekuznetsov 