### PR TITLE
Alert earlier on ci-kubernetes-e2e-gce-device-plugin-gpu failures

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -24,7 +24,7 @@ periodics:
     testgrid-tab-name: gce-device-plugin-gpu-master
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     description: "Uses kubetest to run e2e tests (+Feature:GPUDevicePlugin) against a cluster created with cluster/kube-up.sh"
-    testgrid-num-failures-to-alert: '12'
+    testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
   spec:
     containers:


### PR DESCRIPTION
ci-kubernetes-e2e-gce-device-plugin-gpu is fairly stable release-blocking job
that runs hourly. Testgrid should not wait 24 hours before alerting of failure.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>