### PR TITLE
Prevent release note duplicate messages

### DIFF
--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -588,7 +588,7 @@ func TestGetReleaseNote(t *testing.T) {
 	}
 }
 
-func TestShouldIgnorePR(t *testing.T) {
+func TestShouldHandlePR(t *testing.T) {
 	tests := []struct {
 		name           string
 		action         github.PullRequestEventAction
@@ -599,25 +599,25 @@ func TestShouldIgnorePR(t *testing.T) {
 			name:           "Pull Request Action: Opened",
 			action:         github.PullRequestActionOpened,
 			label:          "",
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			name:           "Pull Request Action: Edited",
 			action:         github.PullRequestActionEdited,
 			label:          "",
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			name:           "Pull Request Action: Release Note label",
 			action:         github.PullRequestActionLabeled,
 			label:          ReleaseNoteLabelNeeded,
-			expectedResult: false,
+			expectedResult: true,
 		},
 		{
 			name:           "Pull Request Action: Non Release Note label",
 			action:         github.PullRequestActionLabeled,
 			label:          "do-not-merge/cherry-pick-not-approved",
-			expectedResult: true,
+			expectedResult: false,
 		},
 	}
 
@@ -628,7 +628,7 @@ func TestShouldIgnorePR(t *testing.T) {
 				Name: test.label,
 			},
 		}
-		result := shouldIgnorePR(&pr)
+		result := shouldHandlePR(&pr)
 
 		if test.expectedResult != result {
 			t.Errorf("(%s): Expected value to be: %t, but got %t.", test.name, test.expectedResult, result)

--- a/prow/plugins/releasenote/releasenote_test.go
+++ b/prow/plugins/releasenote/releasenote_test.go
@@ -587,3 +587,51 @@ func TestGetReleaseNote(t *testing.T) {
 		}
 	}
 }
+
+func TestShouldIgnorePR(t *testing.T) {
+	tests := []struct {
+		name           string
+		action         github.PullRequestEventAction
+		label          string
+		expectedResult bool
+	}{
+		{
+			name:           "Pull Request Action: Opened",
+			action:         github.PullRequestActionOpened,
+			label:          "",
+			expectedResult: false,
+		},
+		{
+			name:           "Pull Request Action: Edited",
+			action:         github.PullRequestActionEdited,
+			label:          "",
+			expectedResult: false,
+		},
+		{
+			name:           "Pull Request Action: Release Note label",
+			action:         github.PullRequestActionLabeled,
+			label:          ReleaseNoteLabelNeeded,
+			expectedResult: false,
+		},
+		{
+			name:           "Pull Request Action: Non Release Note label",
+			action:         github.PullRequestActionLabeled,
+			label:          "do-not-merge/cherry-pick-not-approved",
+			expectedResult: true,
+		},
+	}
+
+	for _, test := range tests {
+		pr := github.PullRequestEvent{
+			Action: test.action,
+			Label: github.Label{
+				Name: test.label,
+			},
+		}
+		result := shouldIgnorePR(&pr)
+
+		if test.expectedResult != result {
+			t.Errorf("(%s): Expected value to be: %t, but got %t.", test.name, test.expectedResult, result)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #16971

**Special notes for your reviewer**:
When you open a PR, multiple plugins add labels to the PR. Each label that is added, is triggering a call to handlePR in the release note plugin, adding a new release note comment to the issue.

The way I'm fixing this issue is by limiting the label add trigger to only labels related to release note plugin.

I added unit tests, and also tested the fix on a gke prow instance connected to a github repo.

/area prow/plugins

/assign @BenTheElder 

