### PR TITLE
Move kops actions to master only

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -190,11 +190,15 @@ branch-protection:
         kops:
           required_status_checks:
             contexts:
-            - build (ubuntu-18.04, 1.13)
-            - build (ubuntu-18.04, 1.14)
-            - build (macos-10.15, 1.13)
-            - verify (ubuntu-18.04, 1.13)
             - continuous-integration/travis-ci/pr
+          branches:
+            master:
+              required_status_checks:
+                contexts:
+                - build (ubuntu-18.04, 1.13)
+                - build (ubuntu-18.04, 1.14)
+                - build (macos-10.15, 1.13)
+                - verify (ubuntu-18.04, 1.13)
         kubelet:
           restrictions:
             users: []
@@ -527,6 +531,8 @@ tide:
         repos:
           dashboard:
             skip-unknown-contexts: true
+            from-branch-protection: true
+          kops:
             from-branch-protection: true
       kubernetes-sigs:
         repos:


### PR DESCRIPTION
Follow up to #17857.  Only add new actions contexts to master.  We can decide if we want to add it to specific release branches in the future.  Leaving since it has been blocking for a long time.

/cc @hakman 