### PR TITLE
changes project type on ci-kubernetes-e2e-gci-gce

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -353,7 +353,7 @@ periodics:
           - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
           - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
           - --env=KUBE_CONTAINER_RUNTIME=docker
-          - --gcp-project-type=k8s-infra-prow-build
+          - --gcp-project-type=k8s-infra-gce-project
           - --gcp-master-image=ubuntu
           - --gcp-node-image=ubuntu
           - --gcp-nodes=4


### PR DESCRIPTION
  from `--gcp-project-type=k8s-infra-prow-build`
  to   `--gcp-project-type=k8s-infra-gce-project`
 
In an attempt to resolve  https://github.com/kubernetes/kubernetes/issues/91947

