### PR TITLE
Fix bugs of hmac tool and add more logs

### DIFF
--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -872,15 +872,16 @@ func validateNeedsOkToTestLabel(cfg *config.Config) error {
 }
 
 func validateManagedWebhooks(cfg *config.Config) error {
+	mw := cfg.ManagedWebhooks
 	var errs []error
 	orgs := sets.String{}
-	for repo := range cfg.ManagedWebhooks {
+	for repo := range mw.OrgRepoConfig {
 		if !strings.Contains(repo, "/") {
 			org := repo
 			orgs.Insert(org)
 		}
 	}
-	for repo := range cfg.ManagedWebhooks {
+	for repo := range mw.OrgRepoConfig {
 		if strings.Contains(repo, "/") {
 			org := strings.SplitN(repo, "/", 2)[0]
 			if orgs.Has(org) {

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -918,39 +918,50 @@ func TestValidateManagedWebhooks(t *testing.T) {
 		{
 			name: "no duplicate webhooks",
 			config: config.ProwConfig{
-				ManagedWebhooks: map[string]config.ManagedWebhookInfo{
-					"foo1":     {TokenCreatedAfter: time.Now()},
-					"foo2":     {TokenCreatedAfter: time.Now()},
-					"foo/bar":  {TokenCreatedAfter: time.Now()},
-					"foo/bar1": {TokenCreatedAfter: time.Now()},
-					"foo/bar2": {TokenCreatedAfter: time.Now()},
-				}},
+				ManagedWebhooks: config.ManagedWebhooks{
+					RespectLegacyGlobalToken: false,
+					OrgRepoConfig: map[string]config.ManagedWebhookInfo{
+						"foo1":     {TokenCreatedAfter: time.Now()},
+						"foo2":     {TokenCreatedAfter: time.Now()},
+						"foo/bar":  {TokenCreatedAfter: time.Now()},
+						"foo/bar1": {TokenCreatedAfter: time.Now()},
+						"foo/bar2": {TokenCreatedAfter: time.Now()},
+					},
+				},
+			},
 			expectErr: false,
 		},
 		{
 			name: "has duplicate webhooks",
 			config: config.ProwConfig{
-				ManagedWebhooks: map[string]config.ManagedWebhookInfo{
-					"foo":      {TokenCreatedAfter: time.Now()},
-					"foo1":     {TokenCreatedAfter: time.Now()},
-					"foo2":     {TokenCreatedAfter: time.Now()},
-					"foo/bar":  {TokenCreatedAfter: time.Now()},
-					"foo/bar1": {TokenCreatedAfter: time.Now()},
-					"foo/bar2": {TokenCreatedAfter: time.Now()},
-				}},
+				ManagedWebhooks: config.ManagedWebhooks{
+					OrgRepoConfig: map[string]config.ManagedWebhookInfo{
+						"foo":      {TokenCreatedAfter: time.Now()},
+						"foo1":     {TokenCreatedAfter: time.Now()},
+						"foo2":     {TokenCreatedAfter: time.Now()},
+						"foo/bar":  {TokenCreatedAfter: time.Now()},
+						"foo/bar1": {TokenCreatedAfter: time.Now()},
+						"foo/bar2": {TokenCreatedAfter: time.Now()},
+					},
+				},
+			},
 			expectErr: true,
 		},
 		{
 			name: "has multiple duplicate webhooks",
 			config: config.ProwConfig{
-				ManagedWebhooks: map[string]config.ManagedWebhookInfo{
-					"foo":       {TokenCreatedAfter: time.Now()},
-					"foo1":      {TokenCreatedAfter: time.Now()},
-					"foo2":      {TokenCreatedAfter: time.Now()},
-					"foo/bar":   {TokenCreatedAfter: time.Now()},
-					"foo/bar1":  {TokenCreatedAfter: time.Now()},
-					"foo1/bar1": {TokenCreatedAfter: time.Now()},
-				}},
+				ManagedWebhooks: config.ManagedWebhooks{
+					RespectLegacyGlobalToken: true,
+					OrgRepoConfig: map[string]config.ManagedWebhookInfo{
+						"foo":       {TokenCreatedAfter: time.Now()},
+						"foo1":      {TokenCreatedAfter: time.Now()},
+						"foo2":      {TokenCreatedAfter: time.Now()},
+						"foo/bar":   {TokenCreatedAfter: time.Now()},
+						"foo/bar1":  {TokenCreatedAfter: time.Now()},
+						"foo1/bar1": {TokenCreatedAfter: time.Now()},
+					},
+				},
+			},
 			expectErr: true,
 		},
 	}

--- a/prow/cmd/hmac/README.md
+++ b/prow/cmd/hmac/README.md
@@ -37,33 +37,53 @@ configured for k8s Prow.
 
 ## How it works
 
-Given a new `managed_webhooks` configuration, the tool can reconcile the current
-state of HMAC tokens, secrets and webhooks to meet the new configuration.
+Given a new `managed_webhooks` configuration in the Prow core config file,
+the tool can reconcile the current state of HMAC tokens, secrets and
+webhooks to meet the new configuration.
 
-### Examples
+### Configuration example
 
-Suppose the current `managed_webhooks` configuration is
+Below is a typical example for the managed_webhooks configuration:
+
+```yaml
+managed_webhooks:
+  # Whether this tool should respect the legacy global token.
+  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.   
+  respect_legacy_global_token: true
+  # Config for orgs and repos that have been onboarded to this Prow instance.  
+  org_repo_config:
+    qux:
+      token_created_after: 2017-10-02T15:00:00Z
+    foo/bar:
+      token_created_after: 2018-10-02T15:00:00Z
+    foo/baz:
+      token_created_after: 2019-10-02T15:00:00Z
+```
+
+### Workflow example
+
+Suppose the current `org_repo_config` in the `managed_webhooks` configuration is
 ```yaml
 qux:
-  tokenCreatedAfter: 2017-10-02T15:00:00Z
+  token_created_after: 2017-10-02T15:00:00Z
 foo/bar:
-  tokenCreatedAfter: 2018-10-02T15:00:00Z
+  token_created_after: 2018-10-02T15:00:00Z
 foo/baz:
-  tokenCreatedAfter: 2019-10-02T15:00:00Z
+  token_created_after: 2019-10-02T15:00:00Z
 ``` 
 
 There can be 3 scenarios to modify the configuration, as explained below:
 
 #### Rotate an existing HMAC token
 
-User updates the `tokenCreatedAfter` for `foo/baz` to a later time, as shown below:
+User updates the `token_created_after` for `foo/baz` to a later time, as shown below:
 ```yaml
 qux:
-  tokenCreatedAfter: 2017-10-02T15:00:00Z
+  token_created_after: 2017-10-02T15:00:00Z
 foo/bar:
-  tokenCreatedAfter: 2018-10-02T15:00:00Z
+  token_created_after: 2018-10-02T15:00:00Z
 foo/baz:
-  tokenCreatedAfter: 2020-03-02T15:00:00Z
+  token_created_after: 2020-03-02T15:00:00Z
 ``` 
 
 The `hmac` tool will generate a new HMAC token for the `foo/baz` repo,
@@ -75,13 +95,13 @@ And after the update finishes, it will delete the old token.
 User adds a new repo `foo/bax` in the `managed_webhooks` configuration, as shown below:
 ```yaml
 qux:
-  tokenCreatedAfter: 2017-10-02T15:00:00Z
+  token_created_after: 2017-10-02T15:00:00Z
 foo/bar:
-  tokenCreatedAfter: 2018-10-02T15:00:00Z
+  token_created_after: 2018-10-02T15:00:00Z
 foo/baz:
-  tokenCreatedAfter: 2019-10-02T15:00:00Z
+  token_created_after: 2019-10-02T15:00:00Z
 foo/bax:
-  tokenCreatedAfter: 2020-03-02T15:00:00Z
+  token_created_after: 2020-03-02T15:00:00Z
 ``` 
 
 The `hmac` tool will generate an HMAC token for the `foo/bax` repo,
@@ -92,9 +112,9 @@ add the token to the secret, and add the webhook for the repo.
 User deletes the repo `foo/baz` from the `managed_webhooks` configuration, as shown below:
 ```yaml
 qux:
-  tokenCreatedAfter: 2017-10-02T15:00:00Z
+  token_created_after: 2017-10-02T15:00:00Z
 foo/bar:
-  tokenCreatedAfter: 2018-10-02T15:00:00Z
+  token_created_after: 2018-10-02T15:00:00Z
 ``` 
 
 The `hmac` tool will delete the HMAC token for the `foo/baz` repo from

--- a/prow/cmd/hmac/main_test.go
+++ b/prow/cmd/hmac/main_test.go
@@ -136,7 +136,7 @@ func TestPruneOldTokens(t *testing.T) {
 		{
 			name: "three hmacs, only the latest one is left after pruning",
 			current: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val1",
 						CreatedAt: time1,
@@ -153,7 +153,7 @@ func TestPruneOldTokens(t *testing.T) {
 			},
 			repo: "org1/repo1",
 			expected: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val3",
 						CreatedAt: time3,
@@ -164,7 +164,7 @@ func TestPruneOldTokens(t *testing.T) {
 		{
 			name: "two hmacs, only the latest one is left after pruning",
 			current: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val1",
 						CreatedAt: time1,
@@ -177,7 +177,7 @@ func TestPruneOldTokens(t *testing.T) {
 			},
 			repo: "org1/repo1",
 			expected: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val2",
 						CreatedAt: time2,
@@ -188,7 +188,7 @@ func TestPruneOldTokens(t *testing.T) {
 		{
 			name: "nothing will be changed if the repo is not in the map",
 			current: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val1",
 						CreatedAt: time1,
@@ -197,7 +197,7 @@ func TestPruneOldTokens(t *testing.T) {
 			},
 			repo: "org2/repo2",
 			expected: map[string]github.HMACsForRepo{
-				"org1/repo1": []github.HMACSecret{
+				"org1/repo1": []github.HMACToken{
 					{
 						Value:     "rand-val1",
 						CreatedAt: time1,
@@ -245,7 +245,7 @@ func TestHandleRemovedRepo(t *testing.T) {
 			toRemove: map[string]bool{"repo1": true},
 			expectedHMACs: map[string]github.HMACsForRepo{
 				"repo2": {
-					github.HMACSecret{
+					github.HMACToken{
 						Value: "val2",
 					},
 				},
@@ -274,7 +274,7 @@ func TestHandleRemovedRepo(t *testing.T) {
 			toRemove: map[string]bool{"repo1": true, "whatever-repo": true},
 			expectedHMACs: map[string]github.HMACsForRepo{
 				"repo2": {
-					github.HMACSecret{
+					github.HMACToken{
 						Value: "val2",
 					},
 				},
@@ -321,12 +321,12 @@ func TestHandleRemovedRepo(t *testing.T) {
 			c := &client{
 				currentHMACMap: map[string]github.HMACsForRepo{
 					"repo1": {
-						github.HMACSecret{
+						github.HMACToken{
 							Value: "val1",
 						},
 					},
 					"repo2": {
-						github.HMACSecret{
+						github.HMACToken{
 							Value: "val2",
 						},
 					},
@@ -348,7 +348,7 @@ func TestHandleRemovedRepo(t *testing.T) {
 }
 
 func TestHandleAddedRepo(t *testing.T) {
-	globalToken := []github.HMACSecret{
+	globalToken := []github.HMACToken{
 		{
 			Value:     "global-rand-val1",
 			CreatedAt: time.Now().Add(-time.Hour),
@@ -414,13 +414,13 @@ func TestHandleAddedRepo(t *testing.T) {
 func TestHandleRotatedRepo(t *testing.T) {
 	pastTime, _ := time.Parse(time.RFC3339Nano, "2020-01-01T00:00:50Z")
 
-	globalToken := []github.HMACSecret{
+	globalToken := []github.HMACToken{
 		{
 			Value:     "global-rand-val1",
 			CreatedAt: pastTime,
 		},
 	}
-	commonTokens := []github.HMACSecret{
+	commonTokens := []github.HMACToken{
 		{
 			Value:     "rand-val1",
 			CreatedAt: pastTime,
@@ -475,13 +475,13 @@ func TestHandleRotatedRepo(t *testing.T) {
 				"repo2": {TokenCreatedAfter: pastTime},
 			},
 			currentHMACs: map[string]github.HMACsForRepo{
-				"repo1": []github.HMACSecret{
+				"repo1": []github.HMACToken{
 					{
 						Value:     "rand-val1",
 						CreatedAt: pastTime.Add(-1 * time.Hour),
 					},
 				},
-				"repo2": []github.HMACSecret{
+				"repo2": []github.HMACToken{
 					{
 						Value:     "rand-val2",
 						CreatedAt: pastTime.Add(1 * time.Hour),

--- a/prow/cmd/hmac/main_test.go
+++ b/prow/cmd/hmac/main_test.go
@@ -24,7 +24,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
-	fakeghhook "k8s.io/test-infra/prow/cmd/hmac/fakeghhook"
+	"k8s.io/test-infra/prow/cmd/hmac/fakeghhook"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -731,11 +731,14 @@ type GitHubOptions struct {
 
 // ManagedWebhookInfo contains metadata about the repo/org which is onboarded.
 type ManagedWebhookInfo struct {
-	TokenCreatedAfter time.Time `json:"tokenCreatedAfter"`
+	TokenCreatedAfter time.Time `json:"token_created_after"`
 }
 
-// ManagedWebhooks contains information about all the repos/orgs which are onboarded with private tokens.
-type ManagedWebhooks map[string]ManagedWebhookInfo
+// ManagedWebhooks contains information about all the repos/orgs which are onboarded with auto-generated tokens.
+type ManagedWebhooks struct {
+	RespectLegacyGlobalToken bool                          `json:"respect_legacy_global_token"`
+	OrgRepoConfig            map[string]ManagedWebhookInfo `json:"org_repo_config"`
+}
 
 // SlackReporter represents the config for the Slack reporter. The channel can be overridden
 // on the job via the .reporter_config.slack.channel property
@@ -1195,10 +1198,10 @@ func (c *Config) validateComponentConfig() error {
 
 	var validationErrs []error
 
-	if c.ManagedWebhooks != nil {
-		for repoName, repoValue := range c.ManagedWebhooks {
+	if c.ManagedWebhooks.OrgRepoConfig != nil {
+		for repoName, repoValue := range c.ManagedWebhooks.OrgRepoConfig {
 			if repoValue.TokenCreatedAfter.After(time.Now()) {
-				validationErrs = append(validationErrs, fmt.Errorf("tokenCreatedAfter %s can be no later than current time for repo/org %s", repoValue.TokenCreatedAfter, repoName))
+				validationErrs = append(validationErrs, fmt.Errorf("token_created_after %s can be no later than current time for repo/org %s", repoValue.TokenCreatedAfter, repoName))
 			}
 		}
 		if len(validationErrs) > 0 {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3061,19 +3061,31 @@ func TestManagedHmacEntityValidation(t *testing.T) {
 	}{
 		{
 			name:       "Missing managed HmacEntities",
-			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: nil}},
+			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: ManagedWebhooks{}}},
 			shouldFail: false,
 		},
 		{
 			name: "Config with all valid dates",
-			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: map[string]ManagedWebhookInfo{"foo/bar": {TokenCreatedAfter: time.Now()},
-				"foo/baz": {TokenCreatedAfter: time.Now()}}}},
+			prowConfig: Config{ProwConfig: ProwConfig{
+				ManagedWebhooks: ManagedWebhooks{
+					OrgRepoConfig: map[string]ManagedWebhookInfo{
+						"foo/bar": {TokenCreatedAfter: time.Now()},
+						"foo/baz": {TokenCreatedAfter: time.Now()},
+					},
+				},
+			}},
 			shouldFail: false,
 		},
 		{
 			name: "Config with one invalid dates",
-			prowConfig: Config{ProwConfig: ProwConfig{ManagedWebhooks: map[string]ManagedWebhookInfo{"foo/bar": {TokenCreatedAfter: time.Now()},
-				"foo/baz": {TokenCreatedAfter: time.Now().Add(time.Hour)}}}},
+			prowConfig: Config{ProwConfig: ProwConfig{
+				ManagedWebhooks: ManagedWebhooks{
+					OrgRepoConfig: map[string]ManagedWebhookInfo{
+						"foo/bar": {TokenCreatedAfter: time.Now()},
+						"foo/baz": {TokenCreatedAfter: time.Now().Add(time.Hour)},
+					},
+				},
+			}},
 			shouldFail: true,
 		},
 	}

--- a/prow/github/hmac_test.go
+++ b/prow/github/hmac_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-var globalSecret = `
+var globalToken = `
 '*':
   - value: abc
     created_at: 2020-10-02T15:00:00Z
@@ -29,7 +29,7 @@ var globalSecret = `
 `
 
 var defaultTokenGenerator = func() []byte {
-	return []byte(globalSecret)
+	return []byte(globalToken)
 }
 
 // echo -n 'BODY' | openssl dgst -sha1 -hmac KEY

--- a/prow/github/hmac_test.go
+++ b/prow/github/hmac_test.go
@@ -20,54 +20,84 @@ import (
 	"testing"
 )
 
-var globalToken = `
+var tokens = `
 '*':
   - value: abc
+    created_at: 2020-10-02T15:00:00Z
+  - value: key
+    created_at: 2018-10-02T15:00:00Z
+'org1':
+  - value: abc1
+    created_at: 2020-10-02T15:00:00Z
+  - value: key1
+    created_at: 2018-10-02T15:00:00Z
+'org2/repo':
+  - value: abc2
     created_at: 2020-10-02T15:00:00Z
   - value: key2
     created_at: 2018-10-02T15:00:00Z
 `
 
 var defaultTokenGenerator = func() []byte {
-	return []byte(globalToken)
+	return []byte(tokens)
 }
 
 // echo -n 'BODY' | openssl dgst -sha1 -hmac KEY
 func TestValidatePayload(t *testing.T) {
 	var testcases = []struct {
+		name           string
 		payload        string
 		sig            string
 		tokenGenerator func() []byte
 		valid          bool
 	}{
 		{
+			"empty payload with a correct signature can pass the check",
 			"{}",
 			"sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580",
 			defaultTokenGenerator,
 			true,
 		},
 		{
+			"empty payload with a wrong formatted signature cannot pass the check",
 			"{}",
 			"db5c76f4264d0ad96cf21baec394964b4b8ce580",
 			defaultTokenGenerator,
 			false,
 		},
 		{
+			"empty signature is not valid",
 			"{}",
 			"",
 			defaultTokenGenerator,
 			false,
 		},
 		{
-			"{}",
-			"",
+			"org-level webhook event with a correct signature can pass the check",
+			`{"organization": {"login": "org1"}}`,
+			"sha1=cf2d7e20aa4863abe204a61a8adf53ddaef0b33b",
 			defaultTokenGenerator,
-			false,
+			true,
+		},
+		{
+			"repo-level webhook event with a correct signature can pass the check",
+			`{"repository": {"full_name": "org2/repo"}}`,
+			"sha1=0b5ea8bf5683e4bf89cf900271e1c8a021b4b0b3",
+			defaultTokenGenerator,
+			true,
+		},
+		{
+			"payload with both repository and organization is considered as a repo-level webhook event",
+			`{"repository": {"full_name": "org2/repo"}, "organization": {"login": "org2"}}`,
+			"sha1=db5ba00c9ed0153322d33decb7ad579401e917f6",
+			defaultTokenGenerator,
+			true,
 		},
 	}
 	for _, tc := range testcases {
-		if ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator) != tc.valid {
-			t.Errorf("Wrong validation for %+v", tc)
+		res := ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator)
+		if res != tc.valid {
+			t.Errorf("Wrong validation for the test %q: expected %t but got %t", tc.name, tc.valid, res)
 		}
 	}
 }

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -213,11 +213,13 @@ const (
 	PullRequestConvertedToDraft PullRequestEventAction = "converted_to_draft"
 )
 
-// GenericEvent is a lightweight struct containing just Sender and Repo as all events are expected to have this information.
-// https://developer.github.com/webhooks/#payloads
+// GenericEvent is a lightweight struct containing just Sender, Organization and Repo as
+// they are allWebhook payload object common properties:
+// https://developer.github.com/webhooks/event-payloads/#webhook-payload-object-common-properties
 type GenericEvent struct {
-	Sender User `json:"sender"`
-	Repo   Repo `json:"repository"`
+	Sender User         `json:"sender"`
+	Org    Organization `json:"organization"`
+	Repo   Repo         `json:"repository"`
 }
 
 // PullRequestEvent is what GitHub sends us when a PR is changed.
@@ -996,6 +998,9 @@ type Membership struct {
 
 // Organization stores metadata information about an organization
 type Organization struct {
+	// Login has the same meaning as Name, but it's more reliable to use as Name can sometimes be empty,
+	// see https://developer.github.com/v3/orgs/#list-organizations
+	Login string `json:"login"`
 	// BillingEmail holds private billing address
 	BillingEmail string `json:"billing_email"`
 	Company      string `json:"company"`


### PR DESCRIPTION
1. Fix some nil errors by initializing the map correctly

2. Skip the global token when collecting repos to be removed, as we never want to delete it

3. The global hmac token got from the secret in the old format can possibly have an extra `\n`, use `strings.TrimSpace` to remove it before writing the token back to the secret

4. Change the generated token length to 20 bytes (a string of length 40), to follow what we have in the manual deployment instruction - https://github.com/kubernetes/test-infra/blob/master/prow/getting_started_deploy.md#create-the-github-secrets

5. In the org level webhook events, the `Repo` field can be possibly empty, see https://developer.github.com/webhooks/event-payloads/#webhook-payload-object-common-properties. So fall back to the `Org` field if `event.Repo.FullName` is empty to have a better support for org level webhook events.

6. Add more debug logs in deleting/updating the webhooks

This time I tested it for all possible scenarios on my local with `--dry-run=false` and it works well.

/assign @cjwagner 
/cc @cjwagner 