### PR TITLE
Add kops e2e test for the legacy etcd provider

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -179,6 +179,43 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-launchtemplates
 
+- interval: 4h
+  name: e2e-kops-aws-misc-legacy-etcd
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+    preset-e2e-platform-aws: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-legacy-etcd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-feature-flags=SpecOverrideFlag
+      - --kops-args=--override="cluster.spec.etcdClusters[*].provider"=Legacy
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e::v20200602-05eeaff-1.17
+      imagePullPolicy: Always
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
+    testgrid-tab-name: kops-aws-legacy-etcd
+
 - interval: 1h
   name: e2e-kops-aws-misc-newrunner
   labels:


### PR DESCRIPTION
Since the k8s-1.11 caught a bug in the legacy etcd provider code
and k8s 1.11 won't be supported by kops 1.20+, make sure we have
signal on the legacy etcd provider on the latest kops version that
supports it.

/cc @rifelpet 