### PR TITLE
kubeadm: increase job timeout to 60 minutes

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -16,7 +16,7 @@ periodics:
     testgrid-num-failures-to-alert: "8"
     testgrid-alert-stale-results-hours: "16"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -56,7 +56,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -96,7 +96,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -136,7 +136,7 @@ periodics:
     testgrid-num-failures-to-alert: "4"
     testgrid-alert-stale-results-hours: "48"
   decoration_config:
-    timeout: 40m
+    timeout: 60m
   extra_refs:
   - org: kubernetes
     repo: kubernetes


### PR DESCRIPTION
Attempt to resolve recent, occasional flakes where the overall job
runtime of 40 minutes is not sufficient.

xref https://github.com/kubernetes/kubernetes/issues/90761#issuecomment-638877266

/sig cluster-lifecycle
/kind bug
/priority important-soon