### PR TITLE
hook only unmarshals the hmac token secret when it's changed

### DIFF
--- a/prow/cmd/hook/BUILD.bazel
+++ b/prow/cmd/hook/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//prow/config/secret:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/git/v2:go_default_library",
+        "//prow/github:go_default_library",
         "//prow/githubeventserver:go_default_library",
         "//prow/hook:go_default_library",
         "//prow/interrupts:go_default_library",

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/test-infra/prow/config/secret"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git/v2"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/interrupts"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 )
@@ -119,9 +120,11 @@ func main() {
 	}
 
 	server := &Server{
-		tokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
-		botName:        botName,
-		email:          email,
+		tokenResolver: github.HMACTokenResolver{
+			TokenGenerator: secretAgent.GetTokenGeneratorWithRevision(o.webhookSecretFile),
+		},
+		botName: botName,
+		email:   email,
 
 		gc:  git.ClientFactoryFrom(gitClient),
 		ghc: githubClient,

--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -79,9 +79,9 @@ func HelpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 // Server implements http.Handler. It validates incoming GitHub webhooks and
 // then dispatches them to the appropriate plugins.
 type Server struct {
-	tokenGenerator func() []byte
-	botName        string
-	email          string
+	tokenResolver github.HMACTokenResolver
+	botName       string
+	email         string
 
 	gc git.ClientFactory
 	// Used for unit testing
@@ -107,7 +107,7 @@ type Server struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenResolver.Get())
 	if !ok {
 		return
 	}

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -285,18 +285,20 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	expectedLabels := []string{}
 	expected := fmt.Sprintf(expectedFmt, expectedTitle, expectedBody, expectedHead, expectedBase, expectedLabels)
 
-	getSecret := func() []byte {
-		return []byte("sha=abcdefg")
+	getSecret := func() ([]byte, uint32) {
+		return []byte("sha=abcdefg"), 1
 	}
 
 	s := &Server{
-		botName:        botName,
-		gc:             c,
-		push:           func(newBranch string, force bool) error { return nil },
-		ghc:            ghc,
-		tokenGenerator: getSecret,
-		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+		botName: botName,
+		gc:      c,
+		push:    func(newBranch string, force bool) error { return nil },
+		ghc:     ghc,
+		tokenResolver: github.HMACTokenResolver{
+			TokenGenerator: getSecret,
+		},
+		log:   logrus.StandardLogger().WithField("client", "cherrypicker"),
+		repos: []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 		prowAssignments: true,
 	}
@@ -430,18 +432,20 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 
 	botName := "ci-robot"
 
-	getSecret := func() []byte {
-		return []byte("sha=abcdefg")
+	getSecret := func() ([]byte, uint32) {
+		return []byte("sha=abcdefg"), 1
 	}
 
 	s := &Server{
-		botName:        botName,
-		gc:             c,
-		push:           func(newBranch string, force bool) error { return nil },
-		ghc:            ghc,
-		tokenGenerator: getSecret,
-		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+		botName: botName,
+		gc:      c,
+		push:    func(newBranch string, force bool) error { return nil },
+		ghc:     ghc,
+		tokenResolver: github.HMACTokenResolver{
+			TokenGenerator: getSecret,
+		},
+		log:   logrus.StandardLogger().WithField("client", "cherrypicker"),
+		repos: []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 		prowAssignments: false,
 	}
@@ -543,8 +547,8 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 
 	botName := "ci-robot"
 
-	getSecret := func() []byte {
-		return []byte("sha=abcdefg")
+	getSecret := func() ([]byte, uint32) {
+		return []byte("sha=abcdefg"), 1
 	}
 
 	for _, evt := range events {
@@ -584,13 +588,15 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 		}
 
 		s := &Server{
-			botName:        botName,
-			gc:             c,
-			push:           func(newBranch string, force bool) error { return nil },
-			ghc:            ghc,
-			tokenGenerator: getSecret,
-			log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-			repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+			botName: botName,
+			gc:      c,
+			push:    func(newBranch string, force bool) error { return nil },
+			ghc:     ghc,
+			tokenResolver: github.HMACTokenResolver{
+				TokenGenerator: getSecret,
+			},
+			log:   logrus.StandardLogger().WithField("client", "cherrypicker"),
+			repos: []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 
 			labels:          []string{"cla: yes"},
 			prowAssignments: false,

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/interrupts"
 
 	"k8s.io/test-infra/pkg/flagutil"
@@ -103,11 +104,13 @@ func main() {
 	}
 
 	serv := &server{
-		tokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
-		prowURL:        o.prowURL,
-		configAgent:    configAgent,
-		ghc:            githubClient,
-		log:            log,
+		tokenResolver: github.HMACTokenResolver{
+			TokenGenerator: secretAgent.GetTokenGeneratorWithRevision(o.webhookSecretFile),
+		},
+		prowURL:     o.prowURL,
+		configAgent: configAgent,
+		ghc:         githubClient,
+		log:         log,
 	}
 
 	mux := http.NewServeMux()

--- a/prow/external-plugins/refresh/server.go
+++ b/prow/external-plugins/refresh/server.go
@@ -53,15 +53,15 @@ func helpProvider(_ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 }
 
 type server struct {
-	tokenGenerator func() []byte
-	prowURL        string
-	configAgent    *config.Agent
-	ghc            github.Client
-	log            *logrus.Entry
+	tokenResolver github.HMACTokenResolver
+	prowURL       string
+	configAgent   *config.Agent
+	ghc           github.Client
+	log           *logrus.Entry
 }
 
 func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenGenerator)
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.tokenResolver.Get())
 	if !ok {
 		return
 	}

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
         "@io_k8s_utils//diff:go_default_library",
     ],
 )

--- a/prow/github/hmac_test.go
+++ b/prow/github/hmac_test.go
@@ -18,6 +18,8 @@ package github
 
 import (
 	"testing"
+
+	"sigs.k8s.io/yaml"
 )
 
 var tokens = `
@@ -38,64 +40,56 @@ var tokens = `
     created_at: 2018-10-02T15:00:00Z
 `
 
-var defaultTokenGenerator = func() []byte {
-	return []byte(tokens)
-}
-
 // echo -n 'BODY' | openssl dgst -sha1 -hmac KEY
 func TestValidatePayload(t *testing.T) {
 	var testcases = []struct {
-		name           string
-		payload        string
-		sig            string
-		tokenGenerator func() []byte
-		valid          bool
+		name    string
+		payload string
+		sig     string
+		valid   bool
 	}{
 		{
 			"empty payload with a correct signature can pass the check",
 			"{}",
 			"sha1=db5c76f4264d0ad96cf21baec394964b4b8ce580",
-			defaultTokenGenerator,
 			true,
 		},
 		{
 			"empty payload with a wrong formatted signature cannot pass the check",
 			"{}",
 			"db5c76f4264d0ad96cf21baec394964b4b8ce580",
-			defaultTokenGenerator,
 			false,
 		},
 		{
 			"empty signature is not valid",
 			"{}",
 			"",
-			defaultTokenGenerator,
 			false,
 		},
 		{
 			"org-level webhook event with a correct signature can pass the check",
 			`{"organization": {"login": "org1"}}`,
 			"sha1=cf2d7e20aa4863abe204a61a8adf53ddaef0b33b",
-			defaultTokenGenerator,
 			true,
 		},
 		{
 			"repo-level webhook event with a correct signature can pass the check",
 			`{"repository": {"full_name": "org2/repo"}}`,
 			"sha1=0b5ea8bf5683e4bf89cf900271e1c8a021b4b0b3",
-			defaultTokenGenerator,
 			true,
 		},
 		{
 			"payload with both repository and organization is considered as a repo-level webhook event",
 			`{"repository": {"full_name": "org2/repo"}, "organization": {"login": "org2"}}`,
 			"sha1=db5ba00c9ed0153322d33decb7ad579401e917f6",
-			defaultTokenGenerator,
 			true,
 		},
 	}
+	repoTokenMap := map[string]HMACsForRepo{}
+
+	yaml.Unmarshal([]byte(tokens), &repoTokenMap)
 	for _, tc := range testcases {
-		res := ValidatePayload([]byte(tc.payload), tc.sig, tc.tokenGenerator)
+		res := ValidatePayload([]byte(tc.payload), tc.sig, repoTokenMap)
 		if res != tc.valid {
 			t.Errorf("Wrong validation for the test %q: expected %t but got %t", tc.name, tc.valid, res)
 		}

--- a/prow/github/webhooks.go
+++ b/prow/github/webhooks.go
@@ -28,7 +28,7 @@ import (
 // the provided hmac secret. It returns the event type, the event guid,
 // the payload of the request, whether the webhook is valid or not,
 // and finally the resultant HTTP status code
-func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func() []byte) (string, string, []byte, bool, int) {
+func ValidateWebhook(w http.ResponseWriter, r *http.Request, repoTokenMap map[string]HMACsForRepo) (string, string, []byte, bool, int) {
 	defer r.Body.Close()
 
 	// Header checks: It must be a POST with an event type and a signature.
@@ -62,7 +62,7 @@ func ValidateWebhook(w http.ResponseWriter, r *http.Request, tokenGenerator func
 		return "", "", nil, false, http.StatusInternalServerError
 	}
 	// Validate the payload with our HMAC secret.
-	if !ValidatePayload(payload, sig, tokenGenerator) {
+	if !ValidatePayload(payload, sig, repoTokenMap) {
 		responseHTTPError(w, http.StatusForbidden, "403 Forbidden: Invalid X-Hub-Signature")
 		return "", "", nil, false, http.StatusForbidden
 	}

--- a/prow/githubeventserver/BUILD.bazel
+++ b/prow/githubeventserver/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     srcs = ["githubeventserver_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//prow/github:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/prow/githubeventserver/options.go
+++ b/prow/githubeventserver/options.go
@@ -29,7 +29,7 @@ import (
 type Options struct {
 	// HmacTokenGenerator is a function that holds a hmac token that will be used
 	// in a github event server
-	HmacTokenGenerator func() []byte
+	HmacTokenGenerator func() ([]byte, uint32)
 
 	// Metrics will be used to expose prometheus metrics from the
 	// github event server operations.
@@ -51,7 +51,7 @@ func (o *Options) DefaultAndValidate() error {
 	}
 
 	if o.HmacTokenGenerator == nil {
-		o.HmacTokenGenerator = func() []byte { return []byte("") }
+		o.HmacTokenGenerator = func() ([]byte, uint32) { return []byte(""), 1 }
 	}
 
 	if o.Metrics == nil {

--- a/prow/hook/server_test.go
+++ b/prow/hook/server_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/githubeventserver"
 	"k8s.io/test-infra/prow/plugins"
 )
@@ -32,7 +33,7 @@ func TestServeHTTPErrors(t *testing.T) {
 	pa := &plugins.ConfigAgent{}
 	pa.Set(&plugins.Configuration{})
 
-	getSecret := func() []byte {
+	getSecret := func() ([]byte, uint32) {
 		var repoLevelSecret = `
 '*':
   - value: abc
@@ -45,13 +46,15 @@ foo/bar:
   - value: key6
     created_at: 2020-10-02T15:00:00Z
 `
-		return []byte(repoLevelSecret)
+		return []byte(repoLevelSecret), 1
 	}
 
 	s := &Server{
-		Metrics:        metrics,
-		Plugins:        pa,
-		TokenGenerator: getSecret,
+		Metrics: metrics,
+		Plugins: pa,
+		HMACTokenResolver: &github.HMACTokenResolver{
+			TokenGenerator: getSecret,
+		},
 	}
 	// This is the SHA1 signature for payload "{}" and signature "abc"
 	// echo -n '{}' | openssl dgst -sha1 -hmac abc


### PR DESCRIPTION
As discussed in https://kubernetes.slack.com/archives/CDECRSC5U/p1589893627262700 and synced offline with @fejta:

1. Adding a map named `secretRevisionsMap` in the secret Agent to keep track of the revisions for each secret, and increment the revision by 1 for the secret when it's reloaded.

2. hook maintains the current revision of the hmac token map. In each http request, comparing the current and latest revision, and only reloading and unmarshalling the secret if they are not the same. This will reduce the frequency we unmarshal the secret string into the map.

/assign @fejta @alvaroaleman 

(BTW sorry for the delayed response to this issue.)