### PR TITLE
Validate github tokens when reading and improve GitHub API error handling

### DIFF
--- a/prow/config/secret/BUILD.bazel
+++ b/prow/config/secret/BUILD.bazel
@@ -33,7 +33,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["agent_test.go"],
+    srcs = [
+        "agent_test.go",
+        "secret_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//prow/logrusutil:go_default_library",

--- a/prow/config/secret/secret.go
+++ b/prow/config/secret/secret.go
@@ -20,7 +20,12 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"regexp"
 )
+
+// base64token/token68 following RFC 6750
+var tokenRegex = regexp.MustCompile(`^[-\w._~+/]+$`)
+
 
 // LoadSecrets loads multiple paths of secrets and add them in a map.
 func LoadSecrets(paths []string) (map[string][]byte, error) {
@@ -42,5 +47,11 @@ func LoadSingleSecret(path string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s: %v", path, err)
 	}
-	return bytes.TrimSpace(b), nil
+
+	secret := bytes.TrimSpace(b)
+
+	if !tokenRegex.Match(secret) {
+		return nil, fmt.Errorf("error reading %s: invalid token format", path)
+	}
+	return secret, nil
 }

--- a/prow/config/secret/secret.go
+++ b/prow/config/secret/secret.go
@@ -26,7 +26,6 @@ import (
 // base64token/token68 following RFC 6750
 var tokenRegex = regexp.MustCompile(`^[-\w._~+/]+$`)
 
-
 // LoadSecrets loads multiple paths of secrets and add them in a map.
 func LoadSecrets(paths []string) (map[string][]byte, error) {
 	secretsMap := make(map[string][]byte, len(paths))
@@ -51,7 +50,7 @@ func LoadSingleSecret(path string) ([]byte, error) {
 	secret := bytes.TrimSpace(b)
 
 	if !tokenRegex.Match(secret) {
-		return nil, fmt.Errorf("error reading %s: invalid token format", path)
+		return nil, fmt.Errorf("error reading %s: invalid token format (does not match `%v`)", path, tokenRegex)
 	}
 	return secret, nil
 }

--- a/prow/config/secret/secret_test.go
+++ b/prow/config/secret/secret_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package secret
 
 import (
@@ -5,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -13,13 +30,13 @@ func TestLoadSingleSecret(t *testing.T) {
 		name    string
 		content string
 		want    []byte
-		wantErr bool
+		wantErr string
 	}{
-		{"valid token",  `121f3cb3e7f70feeb35f9204f5a988d7292c7ba1`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), false},
-		{"valid token with surrounding whitespace",  ` 121f3cb3e7f70feeb35f9204f5a988d7292c7ba1
-`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), false},
+		{"valid token", `121f3cb3e7f70feeb35f9204f5a988d7292c7ba1`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), ""},
+		{"valid token with surrounding whitespace", ` 121f3cb3e7f70feeb35f9204f5a988d7292c7ba1
+`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), ""},
 		{"token containing linesbreak", `121f3cb3e7f70feeb35f
-9204f5a988d7292c7ba1`, nil, true},
+9204f5a988d7292c7ba1`, nil, "invalid token format"},
 	}
 
 	// Creating a temporary directory.
@@ -28,7 +45,7 @@ func TestLoadSingleSecret(t *testing.T) {
 		t.Fatalf("fail to create a temporary directory: %v", err)
 	}
 	defer os.RemoveAll(secretDir)
- 	tempSecret := filepath.Join(secretDir, "tempSecret")
+	tempSecret := filepath.Join(secretDir, "tempSecret")
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,9 +53,8 @@ func TestLoadSingleSecret(t *testing.T) {
 				t.Fatalf("fail to write secret: %v", err)
 			}
 			got, err := LoadSingleSecret(tempSecret)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("LoadSingleSecret() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			if (err != nil) != (tt.wantErr != "") || err != nil && !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("LoadSingleSecret() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("LoadSingleSecret() got = %v, want %v", got, tt.want)

--- a/prow/config/secret/secret_test.go
+++ b/prow/config/secret/secret_test.go
@@ -1,0 +1,48 @@
+package secret
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestLoadSingleSecret(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    []byte
+		wantErr bool
+	}{
+		{"valid token",  `121f3cb3e7f70feeb35f9204f5a988d7292c7ba1`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), false},
+		{"valid token with surrounding whitespace",  ` 121f3cb3e7f70feeb35f9204f5a988d7292c7ba1
+`, []byte("121f3cb3e7f70feeb35f9204f5a988d7292c7ba1"), false},
+		{"token containing linesbreak", `121f3cb3e7f70feeb35f
+9204f5a988d7292c7ba1`, nil, true},
+	}
+
+	// Creating a temporary directory.
+	secretDir, err := ioutil.TempDir("", "secretDir")
+	if err != nil {
+		t.Fatalf("fail to create a temporary directory: %v", err)
+	}
+	defer os.RemoveAll(secretDir)
+ 	tempSecret := filepath.Join(secretDir, "tempSecret")
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ioutil.WriteFile(tempSecret, []byte(tt.content), 0666); err != nil {
+				t.Fatalf("fail to write secret: %v", err)
+			}
+			got, err := LoadSingleSecret(tempSecret)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadSingleSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("LoadSingleSecret() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -769,7 +769,7 @@ func (c *client) requestRetry(method, path, accept string, body interface{}) (*h
 				"backoff":      backoff.String(),
 				"old-endpoint": c.bases[oldHostIndex],
 				"new-endpoint": c.bases[hostIndex],
-			}).Debug("Retrying request due to connection problem")
+			}).Debugf("Retrying request due to connection problem: %v", err)
 			c.time.Sleep(backoff)
 			backoff *= 2
 		}


### PR DESCRIPTION
Per accident, I stored some YAML contents instead of a GitHub token to the secrets file, and got weird log messages reading like:

```
DEBU[0001] Retrying request due to connection problem    backoff=2s client=github new-endpoint="https://git.daimler.com/api/v3" old-endpoint="https://git.daimler.com/api/v3"
DEBU[0003] Retrying request due to connection problem    backoff=4s client=github new-endpoint="https://git.daimler.com/api/v3" old-endpoint="https://git.daimler.com/api/v3"
DEBU[0007] Retrying request due to connection problem    backoff=8s client=github new-endpoint="https://git.daimler.com/api/v3" old-endpoint="https://git.daimler.com/api/v3"
DEBU[0015] Retrying request due to connection problem    backoff=16s client=github new-endpoint="https://git.daimler.com/api/v3" old-endpoint="https://git.daimler.com/api/v3"
```

I started debugging networking issues, and only succeeded in determining the wrong file contents when analyzing request and error message in the go debugger. Just extending the error message also did not seem appropriate, since this exposes the file's content in plain text in the logs, so I also added basic input validation when reading the token from a file.

### validate secret token syntax

The secret token is directly passed through from file contents to HTTP
headers (with only sanitizing by trimming space). In my case, erronously
YAML contents in there resulted in weird client-side connection issues.

From my understanding [RFC 6750] has the most narrow definition of how a
token looks like. This commit will fail early if a token is syntactically
wrong.

[RFC 6750]: https://tools.ietf.org/html/rfc6750#section-2.1


### print details on connection issues

The code expects all connection issues to be a generic network or server
side issue that can be retried. Golang also returns an error here for
client-side issues like invalid header values, hiding the actual cause.
Pass-through the error message instead to help the operator debugging,
but keep the retry approach.
