### PR TITLE
Added testgrid alert email annotation to containerd jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -57,6 +57,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-build-1-2
   interval: 30m
   labels:
@@ -76,6 +77,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-1.2
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-build-1-3
   interval: 30m
   labels:
@@ -95,6 +97,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-build-1.3
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-containerd-e2e-gci-gce
   labels:
@@ -125,6 +128,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-2
   labels:
@@ -155,6 +159,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.2
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-containerd-e2e-gci-gce-1-3
   labels:
@@ -185,6 +190,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.3
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 
 - interval: 1h
   name: ci-containerd-e2e-ubuntu-gce
@@ -216,6 +222,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e
   interval: 1h
   labels:
@@ -246,6 +253,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cri
     testgrid-tab-name: containerd-node-conformance
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-1-2
   interval: 1h
   labels:
@@ -276,6 +284,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-1.2
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-1-3
   interval: 1h
   labels:
@@ -306,6 +315,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-1.3
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -336,6 +346,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd, sig-node-cri
     testgrid-tab-name: containerd-node-features
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-features-1-2
   interval: 1h
   labels:
@@ -366,6 +377,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.2
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-containerd-node-e2e-features-1-3
   interval: 1h
   labels:
@@ -396,6 +408,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-node-e2e-features-1.3
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 12h
   name: ci-containerd-soak-gci-gce
   labels:
@@ -428,6 +441,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: soak-gci-gce
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-build
   interval: 30m
   labels:
@@ -445,6 +459,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: build
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-windows-build
   interval: 30m
   labels:
@@ -462,6 +477,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: windows-build
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-e2e-gce-device-plugin-gpu
   cron: "30 1-23/3 * * *"
   labels:
@@ -491,6 +507,7 @@ periodics:
     testgrid-tab-name: e2e-gci-device-plugin-gpu
     testgrid-num-failures-to-alert: '8'
     testgrid-alert-stale-results-hours: '24'
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-multizone
   labels:
@@ -521,6 +538,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-multizone
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gce-stackdriver
   labels:
@@ -549,6 +567,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-stackdriver
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce
   labels:
@@ -577,6 +596,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-alpha-features
   labels:
@@ -606,6 +626,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-alpha-features
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-es-logging
   labels:
@@ -633,6 +654,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-es-logging
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-flaky
   labels:
@@ -658,6 +680,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-flaky
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ingress
   labels:
@@ -686,7 +709,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-containerd
     testgrid-tab-name: e2e-gci-ingress
-    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com, kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-ip-alias
   labels:
@@ -716,6 +739,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-ip-alias
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-proto
   labels:
@@ -743,6 +767,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-proto
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-reboot
   labels:
@@ -768,6 +793,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-reboot
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging
   labels:
@@ -795,6 +821,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-sd-logging-k8s-resources
   labels:
@@ -826,6 +853,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging-k8s-resources
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-serial
   labels:
@@ -851,6 +879,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-serial
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cri-containerd-e2e-gci-gce-slow
   labels:
@@ -877,6 +906,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-slow
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 2h
   name: ci-cri-containerd-e2e-gci-gce-statefulset
   labels:
@@ -901,6 +931,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-statefulset
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cri-containerd-e2e-ubuntu-gce
   labels:
@@ -929,6 +960,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-node-e2e
   interval: 1h
   labels:
@@ -959,6 +991,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-node-e2e-benchmark
   interval: 2h
   labels:
@@ -989,6 +1022,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-benchmark
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -1019,6 +1053,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-features
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-node-e2e-flaky
   interval: 2h
   labels:
@@ -1049,6 +1084,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-flaky
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-node-e2e-serial
   interval: 4h30m
   labels:
@@ -1079,6 +1115,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: node-e2e-serial
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cos-containerd-e2e-gci-gce
   labels:
@@ -1108,6 +1145,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - interval: 1h
   name: ci-cos-containerd-e2e-ubuntu-gce
   labels:
@@ -1135,6 +1173,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cos-containerd-node-e2e
   interval: 1h
   labels:
@@ -1164,6 +1203,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-node-e2e
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cos-containerd-node-e2e-features
   interval: 1h
   labels:
@@ -1193,6 +1233,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-node-features
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com
 - name: ci-cri-containerd-cri-validation-windows
   interval: 1h
   decorate: true
@@ -1216,3 +1257,4 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: cri-validation-windows
+    testgrid-alert-email: kubernetes-sig-node-test-failures@googlegroups.com


### PR DESCRIPTION
This is the first patch to update all SIG Node-owned prow jobs with an annotation
to send email alerts to the kubernetes-sig-node-test-failures@googlegroups.com
mailing list.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>