### PR TITLE
Fix ubuntu image name for iSCSI tests

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -228,7 +228,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-family=ubuntu-gke-1804-1-16-v20200330
         - --image-project=ubuntu-os-gke-cloud
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -269,7 +269,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-lts-1
+        - --image-family=ubuntu-gke-1804-1-16-v20200330
         - --image-project=ubuntu-os-gke-cloud
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -336,7 +336,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-lts-1
+      - --image-family=ubuntu-gke-1804-1-16-v20200330
       - --image-project=ubuntu-os-gke-cloud
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -361,7 +361,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-lts-1
+      - --image-family=ubuntu-gke-1804-1-16-v20200330
       - --image-project=ubuntu-os-gke-cloud
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
ubuntu-gke-1804-lts-1 does not start kubelet any longer.
See https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-iscsi/1272786812674248704

```
Jun 16 07:10:10.453360 bootstrap-e2e-minion-group-75hw systemd[1]: Starting Download and install k8s binaries and configurations...
Jun 16 07:10:10.575059 bootstrap-e2e-minion-group-75hw configure.sh[1894]: Start to install kubernetes files
Jun 16 07:10:10.598886 bootstrap-e2e-minion-group-75hw configure.sh[1894]: Version :  Python 2.7.15rc1
Jun 16 07:10:10.799823 bootstrap-e2e-minion-group-75hw configure.sh[1894]: Downloading Kubelet config file, if it exists
Jun 16 07:10:10.815851 bootstrap-e2e-minion-group-75hw configure.sh[1894]: ERROR ctr not found. Aborting.
```

Tested with `KUBE_GCE_NODE_IMAGE=ubuntu-gke-1804-1-16-v20200330 KUBE_GCE_NODE_PROJECT=ubuntu-os-gke-cloud KUBE_NODE_OS_DISTRIBUTION=ubuntu kube-up.sh`