### PR TITLE
Set --selinux-enabled flag in periodic SELinux

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 24h
+- interval: 12h
   name: ci-kubernetes-e2e-storage-selinux
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -21,7 +21,7 @@ periodics:
       - --extract=ci/latest
       - --ginkgo-parallel
       - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-overrides=spec.docker.execOpt=--selinux-enabled
+      - --kops-overrides=spec.docker.selinuxEnabled=true
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=centos
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt


### PR DESCRIPTION
`--selinux-enabled` was added recently in https://github.com/kubernetes/kops/pull/9334/files.

Also, run periodic job twice a day (as per suggestion from @hakman).

CC @msau42 @hakman @rifelpet 