### PR TITLE
Changes in k8sio-dns-update prow job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -44,7 +44,7 @@ postsubmits:
         args:
         - -c
         - "cd groups && make run -- --confirm"
-  - name: k8sio-dns-update
+  - name: post-k8sio-dns-update
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     run_if_changed: "^dns/zone-configs/"
@@ -59,9 +59,9 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-dns-updater
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200612-d4db040
+      - image: us.gcr.io/k8s-artifacts-prod/infra-tools/octodns:v20200616-67ce585
         command:
         - bash
         args:
         - -c
-        - "cd dns && ./push.sh --dry-run"
+        - "cd dns && make dry-run-local"


### PR DESCRIPTION
- Changed the name of postsubmit job which is updating the dnses from
  `k8sio-dns-update` to `post-k8sio-dns-update` which is more consistent
  with other jobs
- Updated the version of octodns image in `k8sio-dns-update` (now
  `post-k8sio-dns-update`) job for the one with `make` inside
- Updated the `k8sio-dns-update` (now `post-k8sio-dns-update`) job to
  use `make` instead of directly calling the bash scripts, which is more
  consistent with the commands used by dns-admins

/assign @spiffxp 

ref. [`k/k8s.io#961`](https://github.com/kubernetes/k8s.io/issues/961)

Signed-off-by: Bart Smykla <bsmykla@vmware.com>