### PR TITLE
ci-kubernetes-e2e-gce-device-plugin-gpu-beta needs docker as default runtime

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -89,6 +89,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest
+      - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
       - --gcp-zone=us-west1-b


### PR DESCRIPTION
A recent change in kube-up switched us to using `containerd` as default,
so we need to fix up CI jobs that depend on docker.

Same as https://github.com/kubernetes/test-infra/pull/17905

Fixes failures on https://testgrid.k8s.io/sig-release-1.18-blocking#gce-device-plugin-gpu-1.18

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>