### PR TITLE
Implement kubetest2 GCE Up() for cloud-provider-gcp

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "build.go",
         "deployer.go",
+        "up.go",
     ],
     importpath = "k8s.io/test-infra/kubetest2/kubetest2-gce/deployer",
     visibility = ["//visibility:public"],

--- a/kubetest2/kubetest2-gce/deployer/build.go
+++ b/kubetest2/kubetest2-gce/deployer/build.go
@@ -20,10 +20,13 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/klog"
 	"k8s.io/test-infra/kubetest2/pkg/exec"
 )
 
 func (d *deployer) Build() error {
+	klog.Info("GCE deployer starting Build()")
+
 	if err := d.verifyBuildFlags(); err != nil {
 		return fmt.Errorf("Build() failed to verify build-specific flags: %s", err)
 	}
@@ -54,6 +57,7 @@ func (d *deployer) setRepoPathIfNotSet() error {
 	if err != nil {
 		return fmt.Errorf("Failed to get current working directory for setting Kubernetes root path: %s", err)
 	}
+	klog.Infof("defaulting repo root to the current directory: %s", path)
 	d.RepoRoot = path
 
 	return nil

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/exec"
+)
+
+func (d *deployer) Up() error {
+	klog.Info("GCE deployer starting Up()")
+
+	if err := d.verifyFlags(); err != nil {
+		return fmt.Errorf("up failed to verify flags: %s", err)
+	}
+
+	if err := enableComputeAPI(d.GCPProject); err != nil {
+		return fmt.Errorf("up couldn't enable compute API: %s", err)
+	}
+
+	env := d.buildEnv()
+	script := filepath.Join(d.RepoRoot, "cluster", "kube-up.sh")
+	klog.Infof("About to run script at: %s", script)
+
+	cmd := exec.Command(script)
+	cmd.SetEnv(env...)
+	exec.InheritOutput(cmd)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error encountered during %s: %s", script, err)
+	}
+
+	return nil
+}
+
+func (d *deployer) buildEnv() []string {
+	// The base env currently does not inherit the current os env (except for PATH)
+	// because (for now) it doesn't have to. In future, this may have to change when
+	// support is added for k/k's kube-up.sh and kube-down.sh which support a wide
+	// variety of environment variables. Before doing so, it is worth investigating
+	// inheriting the os env vs. adding flags to this deployer on a case-by-case
+	// basis to support individual environment configurations.
+	var env []string
+
+	// path is necessary for scripts to find gsutil, gcloud, etc
+	env = append(env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+
+	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter for all gcloud commands
+	env = append(env, fmt.Sprintf("PROJECT=%s", d.GCPProject))
+
+	// kubeconfig is set to tell kube-up.sh where to generate the kubeconfig
+	// we don't want this to be the default because this kubeconfig "belongs" to
+	// the run of kubetest2 and so should be placed in the artifacts directory
+	env = append(env, fmt.Sprintf("KUBECONFIG=%s", d.kubeconfigPath))
+
+	return env
+}
+
+func (d *deployer) verifyFlags() error {
+	if err := d.setRepoPathIfNotSet(); err != nil {
+		return err
+	}
+
+	if d.GCPProject == "" {
+		return fmt.Errorf("gcp project must be set")
+	}
+
+	return nil
+}
+
+func enableComputeAPI(project string) error {
+	// In freshly created GCP projects, the compute API is
+	// not enabled. We need it. Enabling it after it has
+	// already been enabled is a relatively fast no-op,
+	// so this can be called without consequence.
+
+	env := os.Environ()
+	cmd := exec.Command(
+		"gcloud",
+		"services",
+		"enable",
+		"compute.googleapis.com",
+		"--project="+project,
+	)
+	cmd.SetEnv(env...)
+	exec.InheritOutput(cmd)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to enable compute API: %s", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
Implements the Up() method for the kubetest2 GCE deployer. This version of Up() only supports the kube-up.sh in k/cloud-provider-gcp for POC/MVP. Also sets path for kubeconfig to be in the kubetest2 artifacts directory. Chose to start with empty environment rather than inheriting from the OS to guarantee functionality on minimal information.

Relies on:
* https://github.com/kubernetes/cloud-provider-gcp/pull/153
* https://github.com/kubernetes/cloud-provider-gcp/pull/154

Tested against fresh GCP projects. If doing the same, make sure to ignore errors from the gsutil ACL command, as it will fail and does not matter.
https://github.com/kubernetes/cloud-provider-gcp/blob/bf905db434d3cfbdc345b19429a6c3a1180016b9/cluster/gce/util.sh#L244

Change:
```
gsutil -m acl ch -g all:R "${gs_url}" "${gs_url}.sha512" >/dev/null 2>&1
```
to
```
gsutil -m acl ch -g all:R "${gs_url}" "${gs_url}.sha512" >/dev/null 2>&1 || :
```
