### PR TITLE
Kops - update verify-terraform presubmit to be required

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -445,7 +445,7 @@ presubmits:
   - name: pull-kops-verify-terraform
     branches:
     - master
-    optional: true
+    skip_report: false
     run_if_changed: '^tests\/integration\/update_cluster\/'
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
/hold for the `hack/verify-terraform.sh` changes in https://github.com/kubernetes/kops/pull/9340 to be merged

/cc @hakman