### PR TITLE
Update test grids for OpenShift informers

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.4-informing.yaml
@@ -667,6 +667,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-ocp-installer-e2e-openstack-ppc64le-4.4
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-ocp-installer-e2e-openstack-ppc64le-4.4
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-ocp-installer-e2e-openstack-serial-4.4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1342,6 +1369,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.4
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.4
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1414,11 +1468,12 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.4
   name: release-openshift-ocp-installer-e2e-metal-serial-4.4
-- days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.4
   name: release-openshift-ocp-installer-e2e-openstack-4.4
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4
+  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-ppc64le-4.4
+  name: release-openshift-ocp-installer-e2e-openstack-ppc64le-4.4
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.4
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.4
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-ovirt-4.4
@@ -1492,6 +1547,9 @@ test_groups:
 - days_of_results: 50
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.4
   name: release-openshift-origin-installer-e2e-remote-libvirt-ppc64le-4.4
+- days_of_results: 50
+  gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.4
+  name: release-openshift-origin-installer-e2e-remote-libvirt-s390x-4.4
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-origin-installer-old-rhcos-e2e-aws-4.4
   name: release-openshift-origin-installer-old-rhcos-e2e-aws-4.4

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.5-informing.yaml
@@ -1477,11 +1477,9 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-metal-serial-4.5
   name: release-openshift-ocp-installer-e2e-metal-serial-4.5
-- days_of_results: 25
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.5
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-4.5
   name: release-openshift-ocp-installer-e2e-openstack-4.5
-- days_of_results: 25
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.5
+- gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-openstack-serial-4.5
   name: release-openshift-ocp-installer-e2e-openstack-serial-4.5
 - days_of_results: 17
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-e2e-ovirt-4.5

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
@@ -46,6 +46,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: periodic-ci-openshift-release-master-ocp-4.6-e2e-metal-ipi
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: periodic-ci-openshift-release-master-ocp-4.6-e2e-metal-ipi
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: promote-release-openshift-machine-os-content-e2e-aws-4.6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -1436,6 +1463,8 @@ test_groups:
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/canary-release-openshift-origin-installer-e2e-aws-4.6-cnv
   name: canary-release-openshift-origin-installer-e2e-aws-4.6-cnv
+- gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.6-e2e-metal-ipi
+  name: periodic-ci-openshift-release-master-ocp-4.6-e2e-metal-ipi
 - gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.6
   name: promote-release-openshift-machine-os-content-e2e-aws-4.6
 - days_of_results: 60

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.4-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.4-informing.yaml
@@ -56,7 +56,7 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.4
   name: redhat-openshift-okd-release-4.4-informing
 test_groups:
-- days_of_results: 8
+- days_of_results: 60
   gcs_prefix: origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.4
   name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.4
 - days_of_results: 60

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.5-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.5-informing.yaml
@@ -19,6 +19,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.5
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.5
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-okd-installer-e2e-aws-4.5
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -29,6 +56,9 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.5
   name: redhat-openshift-okd-release-4.5-informing
 test_groups:
+- days_of_results: 8
+  gcs_prefix: origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.5
+  name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.5
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.5
   name: release-openshift-okd-installer-e2e-aws-4.5

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.6-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.6-informing.yaml
@@ -19,6 +19,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.6
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.6
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-okd-installer-e2e-aws-4.6
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -29,6 +56,9 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.6
   name: redhat-openshift-okd-release-4.6-informing
 test_groups:
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.6
+  name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.6
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.6
   name: release-openshift-okd-installer-e2e-aws-4.6

--- a/config/testgrids/openshift/redhat-openshift-okd-release-4.7-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-okd-release-4.7-informing.yaml
@@ -19,6 +19,33 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
+    name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.7
+    open_bug_template:
+      url: https://github.com/openshift/origin/issues/
+    open_test_template:
+      url: https://prow.svc.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
+    results_url_template:
+      url: https://prow.svc.ci.openshift.org/job-history/<gcs_prefix>
+    test_group_name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.7
+  - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
+    code_search_path: https://github.com/openshift/origin/search
+    code_search_url_template:
+      url: https://github.com/openshift/origin/compare/<start-custom-0>...<end-custom-0>
+    file_bug_template:
+      options:
+      - key: classification
+        value: Red Hat
+      - key: product
+        value: OpenShift Container Platform
+      - key: cf_internal_whiteboard
+        value: buildcop
+      - key: short_desc
+        value: 'test: <test-name>'
+      - key: cf_environment
+        value: 'test: <test-name>'
+      - key: comment
+        value: 'test: <test-name> failed, see job: <link>'
+      url: https://bugzilla.redhat.com/enter_bug.cgi
     name: release-openshift-okd-installer-e2e-aws-4.7
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
@@ -29,6 +56,9 @@ dashboards:
     test_group_name: release-openshift-okd-installer-e2e-aws-4.7
   name: redhat-openshift-okd-release-4.7-informing
 test_groups:
+- days_of_results: 60
+  gcs_prefix: origin-ci-test/logs/promote-release-openshift-okd-machine-os-content-e2e-aws-4.7
+  name: promote-release-openshift-okd-machine-os-content-e2e-aws-4.7
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-okd-installer-e2e-aws-4.7
   name: release-openshift-okd-installer-e2e-aws-4.7


### PR DESCRIPTION
I want metal-ipi to show up for 4.6, but looks like there's some other
synced changes as well.

Updated as per https://github.com/openshift/ci-tools/tree/59bd6f89a7e44d3ef4a1d733bba13739a98fe02f/cmd/testgrid-config-generator.