### PR TITLE
GHProxy: log token usage

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -398,13 +398,21 @@ func (t *throttler) Do(req *http.Request) (*http.Response, error) {
 		if ghcache.CacheModeIsFree(cacheMode) {
 			// This request was fulfilled by ghcache without using an API token.
 			// Refund the throttling token we preemptively consumed.
-			log := logrus.WithFields(logrus.Fields{
+			logrus.WithFields(logrus.Fields{
 				"client":     "github",
 				"throttled":  true,
 				"cache-mode": string(cacheMode),
-			})
-			log.Debug("Throttler refunding token for free response from ghcache.")
+			}).Debug("Throttler refunding token for free response from ghcache.")
 			t.Refund()
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"client":     "github",
+				"throttled":  true,
+				"cache-mode": string(cacheMode),
+				"path":       req.URL.Path,
+				"method":     req.Method,
+			}).Debug("Used token for request")
+
 		}
 	}
 	return resp, err


### PR DESCRIPTION
Right now we only log free tokens but we do not log when we use tokens. Having logs about when tokens were used might be super useful for debugging issues there.