### PR TITLE
Add a severity field to logrus JSON output by default

### DIFF
--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -63,7 +63,9 @@ func ComponentInit() {
 // map in order to not modify the caller's Entry, as that is not a thread
 // safe operation.
 func (f *DefaultFieldsFormatter) Format(entry *logrus.Entry) ([]byte, error) {
-	data := make(logrus.Fields, len(entry.Data)+len(f.DefaultFields))
+	data := make(logrus.Fields, len(entry.Data)+len(f.DefaultFields)+1)
+	// GCP's log collection expects a "severity" field instead of "level"
+	data["severity"] = entry.Level
 	for k, v := range f.DefaultFields {
 		data[k] = v
 	}


### PR DESCRIPTION
The GCP Cloud Logging agent expects a `severity` field instead of
`level`: https://cloud.google.com/logging/docs/agent/configuration#special-fields

Some processes already use `level`, so just export both.