### PR TITLE
update cos-73-lts to cos-81-lts

### DIFF
--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -266,7 +266,7 @@ periodics:
       - name: ZONE
         value: us-central1-a
       - name: IMAGE_FAMILY
-        value: cos-73-lts
+        value: cos-81-lts
       - name: IMAGE_PROJECT
         value: cos-cloud
       - name: BOSKOS_PROJECT_TYPE

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -257,7 +257,7 @@ presubmits:
         - name: ZONE
           value: us-central1-a
         - name: IMAGE_FAMILY
-          value: cos-73-lts
+          value: cos-81-lts
         - name: IMAGE_PROJECT
           value: cos-cloud
         - name: BOSKOS_PROJECT_TYPE

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -1099,7 +1099,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
-      - --image-family=cos-73-lts
+      - --image-family=cos-81-lts
       - --image-project=cos-cloud
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8


### PR DESCRIPTION
cos-73-lts scheduled for deprecation [2020-06-19](https://cloud.google.com/container-optimized-os/docs/release-notes/m73).

Most current lts is [cos-81-lts](https://cloud.google.com/container-optimized-os/docs/release-notes/).

Not sure if the image tags go *poof* on the deprecation date, but I know the remote_run will blow up if they are gone.

Seemed like image family was safe enough here, so I left it alone.

/cc @bsdnet 