### PR TITLE
use standard image-config for conformance testing

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -112,7 +112,7 @@ periodics:
       - --deployment=node
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/benchmark-config.yaml --test-suite=conformance
+      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml --test-suite=conformance
       - --node-test-args=--feature-gates=DynamicKubeletConfig=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce


### PR DESCRIPTION
The prow job overrides the test definitions in benchmark-config
resulting in the same tests running on the same images over and over
again, way too many times.

This seems to have been a mistake when transferring into test-infra.

There are also duplicate images defined in benchmark-config which I'll make another PR to fixup.