### PR TITLE
remove duplicate image config for e2e_node benchmark

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -159,60 +159,21 @@ images:
     tests:
       - 'resource tracking for 90 pods per node \[Benchmark\]'
 
-  # NOTE: recommended versions of the ubuntu-gke images for GKE 1.14, 1.15 and 1.16 clusters
-  # were taken from https://cloud.google.com/kubernetes-engine/docs/release-notes
-  ubuntustable1-resource1:
-    image: ubuntu-gke-1804-1-16-v20200330
+# ubuntu gke image pre-configured to run kubernetes
+  ubuntu-gke-1804-resource1:
+    image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable1-resource2:
-    image: ubuntu-gke-1804-1-16-v20200330
+  ubuntu-gke-1804-resource2:
+    image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable1-resource3:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 90 pods per node \[Benchmark\]'
-
-  ubuntustable2-resource1:
-    image: ubuntu-gke-1804-1-15-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable2-resource2:
-    image: ubuntu-gke-1804-1-15-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable2-resource3:
-    image: ubuntu-gke-1804-1-15-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 90 pods per node \[Benchmark\]'
-
-  ubuntustable3-resource1:
-    image: ubuntu-gke-1804-1-14-v20200219
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable3-resource2:
-    image: ubuntu-gke-1804-1-14-v20200219
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable3-resource3:
-    image: ubuntu-gke-1804-1-14-v20200219
+  ubuntu-gke-1804-resource3:
+    image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -159,44 +159,23 @@ images:
     tests:
       - 'resource tracking for 90 pods per node \[Benchmark\]'
 
-  ubuntustable2-resource1:
-    image: ubuntu-gke-1804-1-16-v20200330
+# ubuntu gke image pre-configured to run kubernetes
+  ubuntu-gke-1804-resource1:
+    Image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable2-resource2:
-    image: ubuntu-gke-1804-1-16-v20200330
+  ubuntu-gke-1804-resource2:
+    image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable2-resource3:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
-    tests:
-      - 'resource tracking for 90 pods per node \[Benchmark\]'
-
-  ubuntustable1-resource1:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable1-resource2:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable1-resource3:
-    image: ubuntu-gke-1804-1-16-v20200330
+  ubuntu-gke-1804-resource3:
+    image: ubuntu-gke-1804-1-17-v20200729
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"


### PR DESCRIPTION
Updated with most recent image with most recent k8s version
```
$ gcloud compute images list --project ubuntu-os-gke-cloud --no-standard-images --sort-by=creationTimestamp
ubuntu-gke-1804-1-12-v20200617      ubuntu-os-gke-cloud                                     READY
ubuntu-gke-1804-1-17-v20200617      ubuntu-os-gke-cloud  pipeline-4                         READY
ubuntu-gke-1804-1-16-v20200617      ubuntu-os-gke-cloud  pipeline-3                         READY
ubuntu-gke-1804-1-15-v20200617      ubuntu-os-gke-cloud  pipeline-2                         READY
ubuntu-gke-1804-1-13-v20200617      ubuntu-os-gke-cloud                                     READY
ubuntu-gke-1804-1-14-v20200617      ubuntu-os-gke-cloud  pipeline-1                         READY
```

Alternatively could depend on `pipeline-4` image_family. 

After the previous update to these lines, the configuration was an exact duplicate. The original intent seemed to be to run against several versions of docker. Not sure we care about that anymore, and if we do we should probably manually be choosing which version of docker to install.