### PR TITLE
Fix experimental scalability containerd correctness job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -202,9 +202,10 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-containerd: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
-    testgrid-tab-name: gce-cos-master-scalability-100-containerd-conformance
+    testgrid-tab-name: gce-cos-master-scalability-100-containerd-correctness
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200616-45495bd-master
@@ -226,7 +227,6 @@ periodics:
           - --test=true
           - --ginkgo-parallel=40
           - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
-          - --allowed-not-ready-nodes=1
           - --timeout=240m
           - --use-logexporter
         resources:


### PR DESCRIPTION
Previous job definition was lacking containerd preset, used unsupported flag and non-matching testgrid dashboard name.

/assign @wojtek-t 
Ref. #17903