### PR TITLE
Update bazel-base to latest test-infra variant

### DIFF
--- a/containers.bzl
+++ b/containers.bzl
@@ -73,8 +73,8 @@ def repositories():
 
     container_pull(
         name = "bazel-base",
-        digest = "sha256:cefc822f93bb3dcf272ce3e4c5162b179d5c165584ace13856afed99662b87cd",
+        digest = "sha256:2e8163b61f3759f6ff0e4df43c40d092dae331b1c2d5326f05f78e72a68d3203",
         registry = "gcr.io",
         repository = "k8s-testimages/launcher.gcr.io/google/bazel",
-        tag = "2.2.0-from-2.0.0",  # TODO(fejta): switch to test-infra tag once it exists
+        tag = "v20200609-e7bfd25-test-infra",
     )

--- a/images/README.md
+++ b/images/README.md
@@ -26,6 +26,9 @@ We have bazel images that have two versions of bazel installed. The upgrade proc
   - This should postsubmits to create the `bazel` and `bazelbuild` images.
   - Run the `push.sh` script in `images/gcloud-bazel` to push the new image.
 * Update usage to these new images
+  - Manually update the [`bazel-base`] digtest in `containers.bzl` to the new image.
+    - NOTE: must update the digest (the tag param is just documentation)
+    - `TODO(fejta):` this should be done automatically like the others
   - The periodic prow autobump job should make a PR to start using these images an hour later.
   - The next day oncall should merge this PR, at which point they will start getting used.
 * Create a PR to change [`.bazelversion`] to the target version.
@@ -48,6 +51,7 @@ There is no automated testing pipeline for images:
 1. You are done. If more breaks happen later, [test-infra oncall](go.k8s.io/oncall) will take care of it.
 
 
+[`bazel-base`]: /containers.bzl
 [`.bazelversion`]: /.bazelversion
 [`images/bazel`]: /images/bazel/variants.yaml
 [`images/bazelbuild`]: /images/bazelbuild/variants.yaml


### PR DESCRIPTION
Document the need to do this.


This is the one we are currently using: https://github.com/kubernetes/test-infra/blob/47fde963491bba2175a497960e677cbef338b75b/config/jobs/kubernetes/test-infra/test-infra-postsubmits.yaml#L12