### PR TITLE
Deck: supporting restrictions on buckets/folders

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -13,11 +13,11 @@ New features added to each component:
     in *September 2020*. To be clear handling of URLs with `/view/gcs` in Deck is not deprecated.
  - *June 23rd, 2020* An [hmac](/prow/cmd/hmac) tool was added to automatically reconcile webhooks and hmac
     tokens for the orgs and repos integrated with your prow instance.
-- *June 12, 2020* Added _bucket_ and _folder_ whitelisting to Deck in order to restrict artifact requests to 
-     specific storage locations. This feature can be enabled by setting `deck.enable_whitelist` in the Prow config.
-     By default, _buckets_ specified in the `plank.decoration_config[*].gcs_configuration.bucket` are whitelisted and 
-     the `pr-logs` and `logs` _folders_ are whitelisted. Additional _buckets_ can be whitelisted by adding them to 
-     `deck.additional_buckets`. Additional _folders_ can be whitelisted by adding them to `deck.additional_folders`.
+- *June 12, 2020* Added _bucket_ and _folder_ validation features to Deck to restrict artifact requests to only
+     specific storage locations. This feature can be enabled by setting `deck.restrict_storage_paths` in the Prow config.
+     By default, _buckets_ specified in the `plank.decoration_config[*].gcs_configuration.bucket` and 
+     the `pr-logs` and `logs` _folders_ are allowed allowed. _Additional buckets_ can be allowed by adding them to 
+     `deck.additional_allowed_buckets`. _Additional folders_ can be allowed by adding them to `deck.additional_allowed_folders`.
  - *June 8th, 2020* A new informer-based Plank implementation was added. It can be used by deploying
     the new [prow-controller-manager](/config/prow/experimental/controller_manager.yaml) binary.
     We plan to gradually move all our controllers into that binary, see https://github.com/kubernetes/test-infra/issues/17024

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -13,6 +13,11 @@ New features added to each component:
     in *September 2020*. To be clear handling of URLs with `/view/gcs` in Deck is not deprecated.
  - *June 23rd, 2020* An [hmac](/prow/cmd/hmac) tool was added to automatically reconcile webhooks and hmac
     tokens for the orgs and repos integrated with your prow instance.
+- *June 12, 2020* Added _bucket_ and _folder_ whitelisting to Deck in order to restrict artifact requests to 
+     specific storage locations. This feature can be enabled by setting `deck.enable_whitelist` in the Prow config.
+     By default, _buckets_ specified in the `plank.decoration_config[*].gcs_configuration.bucket` are whitelisted and 
+     the `pr-logs` and `logs` _folders_ are whitelisted. Additional _buckets_ can be whitelisted by adding them to 
+     `deck.additional_buckets`. Additional _folders_ can be whitelisted by adding them to `deck.additional_folders`.
  - *June 8th, 2020* A new informer-based Plank implementation was added. It can be used by deploying
     the new [prow-controller-manager](/config/prow/experimental/controller_manager.yaml) binary.
     We plan to gradually move all our controllers into that binary, see https://github.com/kubernetes/test-infra/issues/17024

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,12 @@
 ## New features
 
 New features added to each component:
+  - *September 15, 2020* Added validation to Deck that will restrict artifact requests based on storage buckets.
+    Opt-out by setting `deck.skip_storage_path_validation` in your Prow config.
+    Buckets specified in job configs (`<job>.gcs_configuration.bucket`) and 
+    plank configs (`plank.default_decoration_configs[*].gcs_configuration.bucket`) are automatically allowed access.
+    Additional buckets can be allowed by adding them to the `deck.additional_allowed_buckets` list.
+    (This feature will be enabled by default ~Jan 2021. For now, you will begin to notice violation warnings in your logs.)
  - *August 31th, 2020* Added `gcs_browser_prefixes` field in spyglass configuration. `gcs_browser_prefix` will
     be deprecated in February 2021. You can now specify different values for different repositories. The
     format should be in org, org/repo or '\*' which is the default value.
@@ -13,11 +19,6 @@ New features added to each component:
     in *September 2020*. To be clear handling of URLs with `/view/gcs` in Deck is not deprecated.
  - *June 23rd, 2020* An [hmac](/prow/cmd/hmac) tool was added to automatically reconcile webhooks and hmac
     tokens for the orgs and repos integrated with your prow instance.
-- *June 12, 2020* Added _bucket_ and _folder_ validation features to Deck to restrict artifact requests to only
-     specific storage locations. This feature can be enabled by setting `deck.restrict_storage_paths` in the Prow config.
-     By default, _buckets_ specified in the `plank.decoration_config[*].gcs_configuration.bucket` and 
-     the `pr-logs` and `logs` _folders_ are allowed allowed. _Additional buckets_ can be allowed by adding them to 
-     `deck.additional_allowed_buckets`. _Additional folders_ can be allowed by adding them to `deck.additional_allowed_folders`.
  - *June 8th, 2020* A new informer-based Plank implementation was added. It can be used by deploying
     the new [prow-controller-manager](/config/prow/experimental/controller_manager.yaml) binary.
     We plan to gradually move all our controllers into that binary, see https://github.com/kubernetes/test-infra/issues/17024

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -401,7 +401,7 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 	if err != nil {
 		return tmpl, fmt.Errorf("invalid url %s: %v", url.String(), err)
 	}
-	if err := ValidateStoragePath(cfg, strings.Join([]string{storageProvider, bucketName, root}, "/")); err != nil {
+	if err := validateStorageBucket(cfg, strings.Join([]string{storageProvider, bucketName, root}, "/")); err != nil {
 		return tmpl, err
 	}
 	tmpl.Name = root

--- a/prow/cmd/deck/job_history.go
+++ b/prow/cmd/deck/job_history.go
@@ -32,8 +32,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 
-	"k8s.io/test-infra/prow/config"
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
 	pkgio "k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/io/providers"
 	"k8s.io/test-infra/prow/pod-utils/gcs"
@@ -401,7 +401,7 @@ func getJobHistory(ctx context.Context, url *url.URL, cfg config.Getter, opener 
 	if err != nil {
 		return tmpl, fmt.Errorf("invalid url %s: %v", url.String(), err)
 	}
-	if err := ValidatePath(cfg, strings.Join([]string{storageProvider, bucketName, root}, "/")); err != nil {
+	if err := ValidateStoragePath(cfg, strings.Join([]string{storageProvider, bucketName, root}, "/")); err != nil {
 		return tmpl, err
 	}
 	tmpl.Name = root

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -344,10 +344,13 @@ func Test_getJobHistory(t *testing.T) {
 
 	fakeGCSClient := gcsServer.Client()
 
+	boolTrue := true
 	ca := &config.Agent{}
 	ca.Set(&config.Config{
 		ProwConfig: config.ProwConfig{
-			Deck: config.Deck{},
+			Deck: config.Deck{
+				SkipStoragePathValidation: &boolTrue,
+			},
 		},
 	})
 

--- a/prow/cmd/deck/job_history_test.go
+++ b/prow/cmd/deck/job_history_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/io/providers"
 )
@@ -343,6 +344,13 @@ func Test_getJobHistory(t *testing.T) {
 
 	fakeGCSClient := gcsServer.Client()
 
+	ca := &config.Agent{}
+	ca.Set(&config.Config{
+		ProwConfig: config.ProwConfig{
+			Deck: config.Deck{},
+		},
+	})
+
 	tests := []struct {
 		name    string
 		url     string
@@ -374,7 +382,7 @@ func Test_getJobHistory(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			jobURL, _ := url.Parse(tt.url)
-			got, err := getJobHistory(context.Background(), jobURL, io.NewGCSOpener(fakeGCSClient))
+			got, err := getJobHistory(context.Background(), jobURL, ca.Config, io.NewGCSOpener(fakeGCSClient))
 			var actualErr string
 			if err != nil {
 				actualErr = err.Error()

--- a/prow/cmd/deck/main_test.go
+++ b/prow/cmd/deck/main_test.go
@@ -1167,7 +1167,7 @@ func TestCanTriggerJob(t *testing.T) {
 	}
 }
 
-func TestValidatePath(t *testing.T) {
+func TestValidateStoragePath(t *testing.T) {
 	testCases := []struct {
 		name        string
 		config      config.ProwConfig
@@ -1175,21 +1175,21 @@ func TestValidatePath(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			name:        "whitelist disabled",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: false}},
+			name:        "validation disabled",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: false}},
 			path:        "to/some/wild/location",
 			expectedErr: false,
 		},
 		{
-			name:        "whitelist enabled",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true}},
+			name:        "validation enabled",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true}},
 			path:        "to/some/wild/location",
 			expectedErr: true,
 		},
 		{
-			name: "decoration config whitelisted bucket",
+			name: "DecorationConfig allowed bucket",
 			config: config.ProwConfig{
-				Deck: config.Deck{EnableWhitelist: true},
+				Deck: config.Deck{RestrictStoragePaths: true},
 				Plank: config.Plank{
 					DefaultDecorationConfigs: map[string]*prowapi.DecorationConfig{
 						"*": {
@@ -1204,32 +1204,32 @@ func TestValidatePath(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			name:        "custom whitelisted bucket",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true, AdditionalBuckets: []string{"kubernetes-prow"}}},
+			name:        "custom allowed bucket",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true, AdditionalAllowedBuckets: []string{"kubernetes-prow"}}},
 			path:        "gs/kubernetes-prow/pr-logs/directory/pull-echo",
 			expectedErr: false,
 		},
 		{
-			name:        "non-whitelisted bucket",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true}},
+			name:        "unknown bucket path",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true}},
 			path:        "gs/istio-prow/pr-logs/directory/post-check",
 			expectedErr: true,
 		},
 		{
-			name:        "default whitelisted folder",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true, AdditionalBuckets: []string{"kubernetes-jenkins"}}},
+			name:        "default allowed folder",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true, AdditionalAllowedBuckets: []string{"kubernetes-jenkins"}}},
 			path:        "gs/kubernetes-jenkins/pr-logs/directory/pull-capi",
 			expectedErr: false,
 		},
 		{
-			name:        "custom whitelisted folder",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true, AdditionalBuckets: []string{"kubernetes-jenkins"}, AdditionalFolders: []string{"custom"}}},
+			name:        "custom allowed folder",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true, AdditionalAllowedBuckets: []string{"kubernetes-jenkins"}, AdditionalAllowedFolders: []string{"custom"}}},
 			path:        "gs/kubernetes-jenkins/custom/directory/pull-echo",
 			expectedErr: false,
 		},
 		{
-			name:        "non-whitelisted folder",
-			config:      config.ProwConfig{Deck: config.Deck{EnableWhitelist: true, AdditionalBuckets: []string{"kubernetes-jenkins"}}},
+			name:        "unknown folder path",
+			config:      config.ProwConfig{Deck: config.Deck{RestrictStoragePaths: true, AdditionalAllowedBuckets: []string{"kubernetes-jenkins"}}},
 			path:        "gs/kubernetes-jenkins/invalid/directory/post-check",
 			expectedErr: true,
 		},
@@ -1240,7 +1240,7 @@ func TestValidatePath(t *testing.T) {
 		ca := config.Agent{}
 		ca.Set(&cfg)
 
-		err := ValidatePath(ca.Config, tc.path)
+		err := ValidateStoragePath(ca.Config, tc.path)
 
 		if err == nil && tc.expectedErr {
 			t.Fatal("error expected")

--- a/prow/cmd/deck/pr_history.go
+++ b/prow/cmd/deck/pr_history.go
@@ -283,7 +283,10 @@ func getPRHistory(ctx context.Context, prHistoryURL *url.URL, config *config.Con
 		}
 		bucketName := parsedBucket.Host
 		storageProvider := parsedBucket.Scheme
-		bucket := blobStorageBucket{bucketName, storageProvider, opener}
+		bucket, err := newBlobStorageBucket(bucketName, storageProvider, config, opener)
+		if err != nil {
+			return template, err
+		}
 		for storagePath := range storagePaths {
 			jobPrefixes, err := bucket.listSubDirs(ctx, storagePath)
 			if err != nil {

--- a/prow/cmd/deck/pr_history_test.go
+++ b/prow/cmd/deck/pr_history_test.go
@@ -499,6 +499,9 @@ func Test_getPRHistory(t *testing.T) {
 					},
 				},
 			},
+			Deck: config.Deck{
+				AllKnownStorageBuckets: sets.NewString("kubernetes-jenkins"),
+			},
 		},
 	}
 	objects := []fakestorage.Object{

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -61,6 +61,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/kube:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
         "//prow/pod-utils/downwardapi:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -740,17 +740,11 @@ func (d *Deck) Validate() error {
 var warnInRepoStorageBucketValidation time.Time
 
 // ValidateStorageBucket validates a storage bucket (unless the `Deck.SkipStoragePathValidation` field is true).
-// The given storage path should match "<key-type>/<bucket>/<folders...>".
 // The bucket name must be included in any of the following:
 //    1) Any job's `.DecorationConfig.GCSConfiguration.Bucket` (except jobs defined externally via InRepoConfig)
 //    2) `Plank.DefaultDecorationConfigs.GCSConfiguration.Bucket`
 //    3) `Deck.AdditionalAllowedBuckets`
-func (c *Config) ValidateStorageBucket(path string) error {
-	parts := strings.Split(path, "/")
-	if len(parts) < 3 {
-		return fmt.Errorf("invalid path: %s expected <key-type>/<bucket>/<folders...>", path)
-	}
-
+func (c *Config) ValidateStorageBucket(bucketName string) error {
 	if len(c.InRepoConfig.Enabled) > 0 && len(c.Deck.AdditionalAllowedBuckets) == 0 {
 		logrusutil.ThrottledWarnf(&warnInRepoStorageBucketValidation, 1*time.Hour,
 			"skipping storage-path validation because `in_repo_config` is enabled, but `deck.additional_allowed_buckets` empty. "+
@@ -764,9 +758,8 @@ func (c *Config) ValidateStorageBucket(path string) error {
 		return nil
 	}
 
-	bucket := parts[1]
-	if !c.Deck.AllKnownStorageBuckets.Has(bucket) {
-		return fmt.Errorf("bucket %q not in allowed list (%v); you may allow it by including it in `deck.additional_allowed_buckets`", bucket, c.Deck.AllKnownStorageBuckets.List())
+	if !c.Deck.AllKnownStorageBuckets.Has(bucketName) {
+		return fmt.Errorf("bucket %q not in allowed list (%v); you may allow it by including it in `deck.additional_allowed_buckets`", bucketName, c.Deck.AllKnownStorageBuckets.List())
 	}
 	return nil
 }

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -693,6 +693,13 @@ type Deck struct {
 	// accepts a key of: `org/repo`, `org` or `*` (wildcard) to define what GitHub org (or repo) a particular
 	// config applies to and a value of: `RerunAuthConfig` struct to define the users/groups authorized to rerun jobs.
 	RerunAuthConfigs RerunAuthConfigs `json:"rerun_auth_configs,omitempty"`
+	// EnableWhitelist restricts artifact requests to the list of whitelisted buckets and folders.
+	// Buckets listed in the GCSConfiguration are automatically whitelisted.
+	EnableWhitelist bool `json:"enable_whitelist,omitempty"`
+	// AdditionalBuckets is a list of additional storage buckets to whitelist.
+	AdditionalBuckets []string `json:"additional_buckets,omitempty"`
+	// AdditionalFolders is a list of additional top-level storage folders to whitelist.
+	AdditionalFolders []string `json:"additional_folders,omitempty"`
 }
 
 // ExternalAgentLog ensures an external agent like Jenkins can expose

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -3045,6 +3045,78 @@ func TestValidateComponentConfig(t *testing.T) {
 			}}},
 			errExpected: true,
 		},
+		{
+			name: "RestrictStoragePaths false and AdditionalAllowedBuckets/Folders empty, no err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths:     false,
+				AdditionalAllowedBuckets: []string{},
+				AdditionalAllowedFolders: []string{},
+			}}},
+			errExpected: false,
+		},
+		{
+			name: "RestrictStoragePaths false and AdditionalAllowedBuckets non-empty, err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths: false,
+				AdditionalAllowedBuckets: []string{
+					"foo",
+					"bar",
+				},
+				AdditionalAllowedFolders: []string{},
+			}}},
+			errExpected: true,
+		},
+		{
+			name: "RestrictStoragePaths false and AdditionalAllowedFolders non-empty, err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths:     false,
+				AdditionalAllowedBuckets: []string{},
+				AdditionalAllowedFolders: []string{
+					"batz",
+					"quux",
+				},
+			}}},
+			errExpected: true,
+		},
+		{
+			name: "RestrictStoragePaths true and AdditionalAllowedBuckets non-empty, no err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths: true,
+				AdditionalAllowedBuckets: []string{
+					"foo",
+					"bar",
+				},
+				AdditionalAllowedFolders: []string{},
+			}}},
+			errExpected: false,
+		},
+		{
+			name: "RestrictStoragePaths true and AdditionalAllowedFolders non-empty, no err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths:     true,
+				AdditionalAllowedBuckets: []string{},
+				AdditionalAllowedFolders: []string{
+					"batz",
+					"quux",
+				},
+			}}},
+			errExpected: false,
+		},
+		{
+			name: "RestrictStoragePaths true and both AdditionalAllowedBuckers/Folders non-empty, no err",
+			config: &Config{ProwConfig: ProwConfig{Deck: Deck{
+				RestrictStoragePaths: true,
+				AdditionalAllowedBuckets: []string{
+					"foo",
+					"bar",
+				},
+				AdditionalAllowedFolders: []string{
+					"batz",
+					"quux",
+				},
+			}}},
+			errExpected: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/prow/inrepoconfig.md
+++ b/prow/inrepoconfig.md
@@ -24,7 +24,9 @@ in_repo_config:
 
 Additionally, `Deck` must be configured with an oauth token if that is not already the case. To do
 so, the `--github-token-path=` flag must be set and point to a valid token file that has permissions
-to read all your repositories.
+to read all your repositories. Also, in order for Deck to serve content from storage locations not
+defined in the default locations or centrally-defined jobs, those buckets must be listed 
+in `deck.additional_allowed_buckets`.
 
 Afterwards, you need to add a config verification job to make sure people people get told about
 mistakes in their `.prow.yaml` rather than the PR being stuck. It makes sense to define this

--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -20,6 +20,8 @@ package logrusutil
 import (
 	"bytes"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -128,4 +130,34 @@ func NewCensoringFormatter(f logrus.Formatter, getSecrets func() sets.String) Ce
 		getSecrets: getSecrets,
 		delegate:   f,
 	}
+}
+
+// ThrottledWarnf prints a warning the first time called and if at most `period` has elapsed since the last time.
+func ThrottledWarnf(last *time.Time, period time.Duration, format string, args ...interface{}) {
+	if throttleCheck(last, period) {
+		logrus.Warnf(format, args...)
+	}
+}
+
+var throttleLock sync.RWMutex // Rare updates and concurrent readers, so reuse the same lock
+
+// throttleCheck returns true when first called or if
+// at least `period` has elapsed since the last time it returned true.
+func throttleCheck(last *time.Time, period time.Duration) bool {
+	// has it been at least `period` since we won the race?
+	throttleLock.RLock()
+	fresh := time.Now().Sub(*last) <= period
+	throttleLock.RUnlock()
+	if fresh { // event occurred too recently
+		return false
+	}
+	// Event is stale, will we win the race?
+	throttleLock.Lock()
+	defer throttleLock.Unlock()
+	now := time.Now()             // Recalculate now, we might wait awhile for the lock
+	if now.Sub(*last) <= period { // Nope, we lost
+		return false
+	}
+	*last = now
+	return true
 }

--- a/prow/plugins/BUILD.bazel
+++ b/prow/plugins/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/repoowners:go_default_library",
         "//prow/slack:go_default_library",

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -106,3 +106,9 @@ deck:
       required_files:
         - ^podinfo\.json$
 ```
+
+### Accessing custom storage buckets
+
+By default, spyglass has access to all storage buckets defined globally
+(`plank.default_decoration_configs[...].gcs_configuration`) or on individual jobs (`<path-to-job>.gcs_configuration.bucket`).
+In order to access additional/custom storage buckets, those buckets must be listed in `deck.additional_storage_buckets`.

--- a/prow/spyglass/artifacts_test.go
+++ b/prow/spyglass/artifacts_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/io"
 )
 
@@ -84,7 +85,9 @@ func TestSpyglass_ListArtifacts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fakeGCSClient := fakeGCSServer.Client()
-			sg := New(context.Background(), fakeJa, nil, io.NewGCSOpener(fakeGCSClient), false)
+			ca := &config.Agent{}
+			ca.Set(&config.Config{})
+			sg := New(context.Background(), fakeJa, ca.Config, io.NewGCSOpener(fakeGCSClient), false)
 			got, err := sg.ListArtifacts(context.Background(), tt.args.src)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ListArtifacts() error = %v, wantErr %v", err, tt.wantErr)

--- a/prow/spyglass/spyglass.go
+++ b/prow/spyglass/spyglass.go
@@ -85,7 +85,7 @@ func New(ctx context.Context, ja *jobs.JobAgent, cfg config.Getter, opener pkgio
 		JobAgent:               ja,
 		config:                 cfg,
 		PodLogArtifactFetcher:  NewPodLogArtifactFetcher(ja),
-		StorageArtifactFetcher: NewStorageArtifactFetcher(opener, useCookieAuth),
+		StorageArtifactFetcher: NewStorageArtifactFetcher(opener, cfg, useCookieAuth),
 		testgrid: &TestGrid{
 			conf:   cfg,
 			opener: opener,

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"k8s.io/test-infra/prow/config"
 	pkgio "k8s.io/test-infra/prow/io"
 	"k8s.io/test-infra/prow/spyglass/api"
 )
@@ -41,6 +42,7 @@ var (
 // StorageArtifactFetcher contains information used for fetching artifacts from GCS
 type StorageArtifactFetcher struct {
 	opener        pkgio.Opener
+	cfg           config.Getter
 	useCookieAuth bool
 }
 
@@ -57,11 +59,30 @@ type storageJobSource struct {
 }
 
 // NewStorageArtifactFetcher creates a new ArtifactFetcher with a real GCS Client
-func NewStorageArtifactFetcher(opener pkgio.Opener, useCookieAuth bool) *StorageArtifactFetcher {
+func NewStorageArtifactFetcher(opener pkgio.Opener, cfg config.Getter, useCookieAuth bool) *StorageArtifactFetcher {
 	return &StorageArtifactFetcher{
 		opener:        opener,
+		cfg:           cfg,
 		useCookieAuth: useCookieAuth,
 	}
+}
+
+// parseStorageURL parses and validates the storage path.
+// If no scheme is given we assume Google Cloud Storage ("gs"). For example:
+// * test-bucket/logs/sig-flexing/example-ci-run/403 or
+// * gs://test-bucket/logs/sig-flexing/example-ci-run/403
+func (af *StorageArtifactFetcher) parseStorageURL(storagePath string) (*url.URL, error) {
+	if !strings.Contains(storagePath, "://") {
+		storagePath = "gs://" + storagePath
+	}
+	storageURL, err := url.Parse(storagePath)
+	if err != nil {
+		return nil, ErrCannotParseSource
+	}
+	if err := af.cfg().ValidateStorageBucket(storageURL.Host); err != nil {
+		return nil, err
+	}
+	return storageURL, nil
 }
 
 func fieldsForJob(src *storageJobSource) logrus.Fields {
@@ -70,16 +91,14 @@ func fieldsForJob(src *storageJobSource) logrus.Fields {
 	}
 }
 
-// newStorageJobSource creates a new storageJobSource from a given storage provider bucket and jobPrefix. If no scheme is given we assume GS, e.g.:
+// newStorageJobSource creates a new storageJobSource from a given storage URL.
+// If no scheme is given we assume Google Cloud Storage ("gs"). For example:
 // * test-bucket/logs/sig-flexing/example-ci-run/403 or
 // * gs://test-bucket/logs/sig-flexing/example-ci-run/403
-func newStorageJobSource(src string) (*storageJobSource, error) {
-	if !strings.Contains(src, "://") {
-		src = "gs://" + src
-	}
-	storageURL, err := url.Parse(src)
+func (af *StorageArtifactFetcher) newStorageJobSource(storagePath string) (*storageJobSource, error) {
+	storageURL, err := af.parseStorageURL(storagePath)
 	if err != nil {
-		return &storageJobSource{}, ErrCannotParseSource
+		return &storageJobSource{}, err
 	}
 	var object string
 	if storageURL.Path == "" {
@@ -95,7 +114,7 @@ func newStorageJobSource(src string) (*storageJobSource, error) {
 	buildID := tokens[len(tokens)-1]
 	name := tokens[len(tokens)-2]
 	return &storageJobSource{
-		source:     src,
+		source:     storageURL.String(),
 		linkPrefix: storageURL.Scheme + "://",
 		bucket:     storageURL.Host,
 		jobPrefix:  path.Clean(object) + "/",
@@ -109,10 +128,7 @@ func newStorageJobSource(src string) (*storageJobSource, error) {
 // * test-bucket/logs/sig-flexing/example-ci-run/403 or
 // * gs://test-bucket/logs/sig-flexing/example-ci-run/403
 func (af *StorageArtifactFetcher) artifacts(ctx context.Context, key string) ([]string, error) {
-	if !strings.Contains(key, "://") {
-		key = "gs://" + key
-	}
-	src, err := newStorageJobSource(key)
+	src, err := af.newStorageJobSource(key)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get GCS job source from %s: %v", key, err)
 	}
@@ -121,7 +137,7 @@ func (af *StorageArtifactFetcher) artifacts(ctx context.Context, key string) ([]
 	_, prefix := extractBucketPrefixPair(src.jobPath())
 	artifacts := []string{}
 
-	it, err := af.opener.Iterator(ctx, key, "")
+	it, err := af.opener.Iterator(ctx, src.source, "")
 	if err != nil {
 		return artifacts, err
 	}
@@ -178,10 +194,7 @@ func (h *storageArtifactHandle) Attrs(ctx context.Context) (pkgio.Attributes, er
 // * test-bucket/logs/sig-flexing/example-ci-run/403 or
 // * gs://test-bucket/logs/sig-flexing/example-ci-run/403
 func (af *StorageArtifactFetcher) Artifact(ctx context.Context, key string, artifactName string, sizeLimit int64) (api.Artifact, error) {
-	if !strings.Contains(key, "://") {
-		key = "gs://" + key
-	}
-	src, err := newStorageJobSource(key)
+	src, err := af.newStorageJobSource(key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get GCS job source from %s: %v", key, err)
 	}


### PR DESCRIPTION
_Note_: This is a rebase/follow-up to [pr/17650](https://github.com/kubernetes/test-infra/pull/17650), which was originally started by clarketm.

Added _bucket_ and _folder_ validation features to Deck to restrict artifact requests to only specific storage locations. This feature can be enabled by setting `deck.restrict_storage_paths` in the Prow config.

By default, _buckets_ specified in the `plank.decoration_config[*].gcs_configuration.bucket` and 
     the `pr-logs` and `logs` _folders_ are allowed allowed. _Additional buckets_ can be allowed by adding them to 
     `deck.additional_allowed_buckets`. _Additional folders_ can be allowed by adding them to `deck.additional_allowed_folders`.