### PR TITLE
Implemented Down() in GCE deployer for cloud-provider-gcp

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "build.go",
         "deployer.go",
+        "down.go",
         "up.go",
     ],
     importpath = "k8s.io/test-infra/kubetest2/kubetest2-gce/deployer",

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -80,5 +80,3 @@ func (d *deployer) Kubeconfig() (string, error) {
 	}
 	return "", fmt.Errorf("unknown error when checking for kubeconfig at %s: %s", d.kubeconfigPath, err)
 }
-
-func (d *deployer) Down() error { return nil }

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/exec"
+)
+
+func (d *deployer) Down() error {
+	klog.Info("GCE deployer starting Down()")
+
+	if err := d.verifyFlags(); err != nil {
+		return fmt.Errorf("down could not verify flags: %s", err)
+	}
+
+	env := d.buildEnv()
+	script := filepath.Join(d.RepoRoot, "cluster", "kube-down.sh")
+	klog.Infof("About to run script at: %s", script)
+
+	cmd := exec.Command(script)
+	cmd.SetEnv(env...)
+	exec.InheritOutput(cmd)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("error encountered during %s: %s", script, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is based on the MVP/POC (targeted at cloud-provider-gcp) implementation of Up() (#17964). Uses the same flags, environment, and process as Up(), but doesn't have to handle enable compute APIs because Up() should have already done that.

Tested with `--build --up --down` and verified that resources were deleted manually.