### PR TITLE
Remove travis check from Kubernetes Dashboard

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -165,9 +165,6 @@ branch-protection:
             teams:
             - stage-bots
         dashboard:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci/pr
           required_pull_request_reviews:
             required_approving_review_count: 1
         dns:


### PR DESCRIPTION
Since we are migrating to Github Workflows travis check is no longer needed.

https://github.com/kubernetes/dashboard/pull/5281