### PR TITLE
Prevent autobump from failing if no ProwJobs use gcr.io/k8s-prow/* images.

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -71,7 +71,7 @@ main() {
   bumpfiles=($(add_suffix "$(split_on_commas "$COMPONENT_FILE_DIR")"))
   bumpfiles+=("${CONFIG_PATH}")
   if [[ -n "${JOB_CONFIG_PATH}" ]]; then
-    bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"))
+    bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"; true))
   fi
 
   echo "Attempting to bump the following files:" >&2


### PR DESCRIPTION
Since we use `set -o errexit` and a `grep` command to find job config files containing `gcr.io/k8s-prow/*` images, the script unintentionally fails early if there are no jobs that use such images.
I've confirmed this resolves the issue.

I also included a commit to add the `Included changes: https://github.com/kubernetes/test-infra/compare/${comparison}` body text to the commit for Gerrit like we do for GitHub.
/assign @fejta @michelle192837 
/kind bug