### PR TITLE
Get rid of OOMs tracking in jobs using experimental config

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -126,7 +126,6 @@ periodics:
           - --gcp-project-type=scalability-project
           - --gcp-zone=us-east1-b
           - --provider=gce
-          - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
           - --test=false
           - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
           - --test-cmd-args=cluster-loader2
@@ -179,7 +178,6 @@ periodics:
           - --gcp-project-type=scalability-project
           - --gcp-zone=us-east1-b
           - --provider=gce
-          - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
           - --test=false
           - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
           - --test-cmd-args=cluster-loader2


### PR DESCRIPTION
`testing/load/experimental-config.yaml` doesn't contain OOMs tracking measurement, hence env var enabling it doesn't make any sense for jobs using that config.

/sig scalability
/cc jkaniuk
/cc wojtek-t