### PR TITLE
Revert "Fix ubuntu image name for iSCSI tests"

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -227,7 +227,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-1-16-v20200330
+        - --image-family=ubuntu-gke-1804-lts-1
         - --image-project=ubuntu-os-gke-cloud
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -268,7 +268,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-1-16-v20200330
+        - --image-family=ubuntu-gke-1804-lts-1
         - --image-project=ubuntu-os-gke-cloud
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -335,7 +335,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-1-16-v20200330
+      - --image-family=ubuntu-gke-1804-lts-1
       - --image-project=ubuntu-os-gke-cloud
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -360,7 +360,7 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-1-16-v20200330
+      - --image-family=ubuntu-gke-1804-lts-1
       - --image-project=ubuntu-os-gke-cloud
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
This reverts commit 8bbff1d61798ddb1b64c5e0332b8aa31cf3e5023.
E2e jobs can't find ubuntu-gke-1804-1-16-v20200330 image:

```
W0619 07:06:53.448] ERROR: (gcloud.compute.images.describe-from-family) Could not fetch resource:
W0619 07:06:53.450]  - The resource 'projects/ubuntu-os-gke-cloud/global/images/family/ubuntu-gke-1804-1-16-v20200330' was not found
```

I'll continue debugging with ubuntu-gke-1804-lts-1.