### PR TITLE
Enable alerting for Golang CI test job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -38,7 +38,9 @@ periodics:
     preset-e2e-kubemark-common: "true"
     preset-e2e-kubemark-gce-scale: "true"
   annotations:
+    testgrid-alert-email: go-kubernetes-scalability-tickets@googlegroups.com
     testgrid-dashboards: sig-scalability-golang
+    testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: golang-tip-k8s-1-18
   spec:
     containers:


### PR DESCRIPTION
Route email alerts to Golang team when there are 2 `ci-golang-tip-k8s-1-18` test job failures in a row.

/sig scalability
/assign mm4tt