### PR TITLE
enable iptables-nft on kind canary jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -81,6 +81,9 @@ presubmits:
           value: "true"
         - name: BUILD_TYPE
           value: bazel
+        # tell kind CI script to use iptables-nft
+        - name: "DOCKER_IN_DOCKER_NFT_ENABLED"
+          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -133,6 +136,9 @@ presubmits:
         # tell kind CI script to use ipv6
         - name: "IP_FAMILY"
           value: "ipv6"
+        # tell kind CI script to use iptables-nft
+        - name: "DOCKER_IN_DOCKER_NFT_ENABLED"
+          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
following up on previous PR,
we've added an environment variable to the krte image that allows us to choose the iptables flavor.

Use nft iptables for the canary jobs

