### PR TITLE
Implemented DumpClusterLogs() in GCE deployer for cloud-provider-gcp

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "build.go",
         "deployer.go",
         "down.go",
+        "dumplogs.go",
         "up.go",
     ],
     importpath = "k8s.io/test-infra/kubetest2/kubetest2-gce/deployer",

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -101,10 +101,12 @@ func (d *deployer) IsUp() (up bool, err error) {
 
 func (d *deployer) Kubeconfig() (string, error) {
 	_, err := os.Stat(d.kubeconfigPath)
-	if err == nil {
-		return d.kubeconfigPath, nil
-	} else if os.IsNotExist(err) {
+	if os.IsNotExist(err) {
 		return "", fmt.Errorf("kubeconfig does not exist at: %s", d.kubeconfigPath)
 	}
-	return "", fmt.Errorf("unknown error when checking for kubeconfig at %s: %s", d.kubeconfigPath, err)
+	if err != nil {
+		return "", fmt.Errorf("unknown error when checking for kubeconfig at %s: %s", d.kubeconfigPath, err)
+	}
+
+	return d.kubeconfigPath, nil
 }

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -39,6 +39,7 @@ type deployer struct {
 
 	kubeconfigPath string
 	kubectl        string
+	logsDir        string
 	RepoRoot       string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
 	GCPProject     string `desc:"GCP Project to create VMs in. Must be set."`
 }
@@ -48,6 +49,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	d := &deployer{
 		commonOptions:  opts,
 		kubeconfigPath: filepath.Join(opts.ArtifactsDir(), "kubetest2-kubeconfig"),
+		logsDir:        filepath.Join(opts.ArtifactsDir(), "cluster-logs"),
 	}
 
 	flagSet, err := gpflag.Parse(d)
@@ -95,8 +97,6 @@ func (d *deployer) IsUp() (up bool, err error) {
 
 	return len(lines) > 0, nil
 }
-
-func (d *deployer) DumpClusterLogs() error { return nil }
 
 func (d *deployer) Kubeconfig() (string, error) {
 	_, err := os.Stat(d.kubeconfigPath)

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -37,11 +37,12 @@ type deployer struct {
 	// generic parts
 	commonOptions types.Options
 
-	kubeconfigPath string
-	kubectl        string
-	logsDir        string
-	RepoRoot       string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
-	GCPProject     string `desc:"GCP Project to create VMs in. Must be set."`
+	kubeconfigPath   string
+	kubectl          string
+	logsDir          string
+	RepoRoot         string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
+	GCPProject       string `desc:"GCP Project to create VMs in. Must be set."`
+	OverwriteLogsDir bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 }
 
 // New implements deployer.New for gce

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -55,6 +55,17 @@ func (d *deployer) makeLogsDir() error {
 	_, err := os.Stat(d.logsDir)
 
 	if err == nil {
+		if d.OverwriteLogsDir {
+			if err := os.RemoveAll(d.logsDir); err != nil {
+				return fmt.Errorf("failed to delete existing logs directory: %s", err)
+			}
+
+			err := os.Mkdir(d.logsDir, os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("failed to create %s: %s", d.logsDir, err)
+			}
+			return nil
+		}
 		return fmt.Errorf("cluster logs directory %s already exists, please clean up manually before continuing", d.logsDir)
 	}
 	if os.IsNotExist(err) {

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/exec"
+)
+
+func (d *deployer) DumpClusterLogs() error {
+	klog.Info("GCE deployer starting DumpClusterLogs()")
+
+	if err := d.verifyFlags(); err != nil {
+		return fmt.Errorf("dump cluster logs could not verify flags: %s", err)
+	}
+
+	if err := d.makeLogsDir(); err != nil {
+		return fmt.Errorf("couldn't make logs dir: %s", err)
+	}
+
+	env := d.buildEnv()
+	outfile, err := os.Create(filepath.Join(d.logsDir, "cluster-info.log"))
+	if err != nil {
+		return fmt.Errorf("failed to create cluster-info log file: %s", err)
+	}
+	defer outfile.Close()
+
+	command := []string{
+		d.kubectl,
+		"cluster-info",
+		"dump",
+	}
+	klog.Infof("About to run: %s", command)
+
+	cmd := exec.Command(command[0], command[1:]...)
+	cmd.SetEnv(env...)
+	exec.InheritOutput(cmd)
+	cmd.SetStderr(os.Stderr)
+	cmd.SetStdout(outfile)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("couldn't use kubectl to dump cluster info: %s", err)
+	}
+
+	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubernetes")
+
+	command = []string{
+		filepath.Join(d.RepoRoot, "cluster", "log-dump", "log-dump.sh"),
+		d.logsDir,
+	}
+	klog.Infof("About to run: %s", command)
+
+	cmd = exec.Command(command[0], command[1:]...)
+	cmd.SetEnv(env...)
+	exec.InheritOutput(cmd)
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to use log-dump.sh for cluster logs: %s", err)
+	}
+
+	return nil
+}
+
+func (d *deployer) makeLogsDir() error {
+	_, err := os.Stat(d.logsDir)
+
+	if err == nil {
+		// TODO: removeall instead?
+		return fmt.Errorf("cluster logs directory %s already exists, please clean up manually before continuing", d.logsDir)
+	} else if os.IsNotExist(err) {
+		err := os.Mkdir(d.logsDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create %s: %s", d.logsDir, err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("unexpected exception when making cluster logs directory: %s", err)
+}

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -56,7 +56,8 @@ func (d *deployer) makeLogsDir() error {
 
 	if err == nil {
 		return fmt.Errorf("cluster logs directory %s already exists, please clean up manually before continuing", d.logsDir)
-	} else if os.IsNotExist(err) {
+	}
+	if os.IsNotExist(err) {
 		err := os.Mkdir(d.logsDir, os.ModePerm)
 		if err != nil {
 			return fmt.Errorf("failed to create %s: %s", d.logsDir, err)
@@ -69,7 +70,6 @@ func (d *deployer) makeLogsDir() error {
 
 func (d *deployer) sshDump() error {
 	env := d.buildEnv()
-	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubernetes")
 
 	args := []string{
 		filepath.Join(d.RepoRoot, "cluster", "log-dump", "log-dump.sh"),

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -54,20 +54,6 @@ func (d *deployer) DumpClusterLogs() error {
 func (d *deployer) makeLogsDir() error {
 	_, err := os.Stat(d.logsDir)
 
-	if err == nil {
-		if d.OverwriteLogsDir {
-			if err := os.RemoveAll(d.logsDir); err != nil {
-				return fmt.Errorf("failed to delete existing logs directory: %s", err)
-			}
-
-			err := os.Mkdir(d.logsDir, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to create %s: %s", d.logsDir, err)
-			}
-			return nil
-		}
-		return fmt.Errorf("cluster logs directory %s already exists, please clean up manually before continuing", d.logsDir)
-	}
 	if os.IsNotExist(err) {
 		err := os.Mkdir(d.logsDir, os.ModePerm)
 		if err != nil {
@@ -75,8 +61,25 @@ func (d *deployer) makeLogsDir() error {
 		}
 		return nil
 	}
+	if err != nil {
+		return fmt.Errorf("unexpected exception when making cluster logs directory: %s", err)
+	}
 
-	return fmt.Errorf("unexpected exception when making cluster logs directory: %s", err)
+	// file definitely exists, overwrite if requested
+
+	if d.OverwriteLogsDir {
+		if err := os.RemoveAll(d.logsDir); err != nil {
+			return fmt.Errorf("failed to delete existing logs directory: %s", err)
+		}
+
+		err := os.Mkdir(d.logsDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create %s: %s", d.logsDir, err)
+		}
+		return nil
+	}
+
+	return fmt.Errorf("cluster logs directory %s already exists, please clean up manually or use the overwrite flag before continuing", d.logsDir)
 }
 
 func (d *deployer) sshDump() error {

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -92,6 +92,9 @@ func (d *deployer) buildEnv() []string {
 	// the run of kubetest2 and so should be placed in the artifacts directory
 	env = append(env, fmt.Sprintf("KUBECONFIG=%s", d.kubeconfigPath))
 
+	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
+	// does not. opted to set it manually here for maximum consistency
+	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
 	return env
 }
 


### PR DESCRIPTION
Like the initial Up() and Down() commits, this only supports the k/cloud-provider-gcp repo. Handles checking and creation of logs directory and using kubectl and log-dump.sh to get logs. Opted to use the repo/cluster/kubectl.sh script instead of just calling the local kubectl for consistency. Had to add one environment var `$USER` for the reasons explained in the code comment.

Because Kubetest2 core does not currently support a flag to enable/disable cluster log dumps, it will currently run at the end of every up.

Tested against fresh GCP projects by calling up regularly and then manually inspecting the created logs directory.

I would like to specifically call attention to `makeLogsDir()`. Should it automatically remove the logs dir if at already exists? I think for most normal use it does not matter, as CI should be running in a fresh filesystem, but it could impact manual users.