### PR TITLE
Implemented IsUp() in GCE deployer

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -48,6 +48,15 @@ func (d *deployer) Up() error {
 		return fmt.Errorf("error encountered during %s: %s", script, err)
 	}
 
+	isUp, err := d.IsUp()
+	if err != nil {
+		klog.Warningf("failed to check if cluster is up: %s", err)
+	} else if isUp {
+		klog.Infof("cluster reported as up")
+	} else {
+		klog.Errorf("cluster reported as down")
+	}
+
 	return nil
 }
 
@@ -78,6 +87,8 @@ func (d *deployer) verifyFlags() error {
 	if err := d.setRepoPathIfNotSet(); err != nil {
 		return err
 	}
+
+	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
 
 	if d.GCPProject == "" {
 		return fmt.Errorf("gcp project must be set")


### PR DESCRIPTION
Uses the same simple concept from other deployers: kubectl reporting nodes means the cluster is up.

Because kubetest2 core does not specify a flag for checking "is up" this method is called at the end of Up() for initial usage until kubetest2 core implements.

Tested with a regular run of up on a fresh GCP project. 