### PR TITLE
Use gcr.io/rules-k8s/gcloud-bazel:v20200619-v0.4-44-g992f469 for rules_k8s

### DIFF
--- a/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
+++ b/config/jobs/bazelbuild/rules_k8s/rules_k8s_config.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/rules-k8s/gcloud-bazel:v20200113-v0.3.1-16-g7767a41
+      - image: gcr.io/rules-k8s/gcloud-bazel:v20200619-v0.4-44-g992f469
         args:
         - bash
         - -c


### PR DESCRIPTION
/assign @spiffxp 

This has multiple versions of bazel (2.2.0 and 3.0.0)