### PR TITLE
Replace hack/e2e.sh with kubetest

### DIFF
--- a/gubernator/filters.py
+++ b/gubernator/filters.py
@@ -116,7 +116,7 @@ def do_testcmd(name):
         name_escaped = re.escape(name).replace('\\ ', '\\s')
 
         test_args = ('--ginkgo.focus=%s$' % name_escaped)
-        return "go run hack/e2e.go -v --test --test_args='%s'" % test_args
+        return "kubetest -v --test --test_args='%s'" % test_args
 
 
 def do_parse_pod_name(text):

--- a/gubernator/filters_test.py
+++ b/gubernator/filters_test.py
@@ -85,7 +85,7 @@ class HelperTest(unittest.TestCase):
             ('k8s.io/kubernetes/pkg/api/errors TestErrorNew',
              'go test -v k8s.io/kubernetes/pkg/api/errors -run TestErrorNew$'),
             ('[k8s.io] Proxy [k8s.io] works',
-            "go run hack/e2e.go -v --test --test_args='--ginkgo.focus="
+            "kubetest -v --test --test_args='--ginkgo.focus="
             "Proxy\\s\\[k8s\\.io\\]\\sworks$'"),
             ('//pkg/foo/bar:go_default_test',
             'bazel test //pkg/foo/bar:go_default_test'),


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/commit/83c56a03733991abc7712e52a01f825c8a294cec in k/k repo, hack/e2e.sh
has been removed. We should use kubetest instead.
This makes do_testcmd() of gubernator outputs kubetest instead.