### PR TITLE
Teach sinker To Reap Pods In All Namespaces

### DIFF
--- a/config/prow/cluster/sinker_rbac.yaml
+++ b/config/prow/cluster/sinker_rbac.yaml
@@ -36,10 +36,9 @@ rules:
     verbs:
       - create
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
   name: "sinker"
 rules:
   - apiGroups:
@@ -63,14 +62,13 @@ subjects:
 - kind: ServiceAccount
   name: "sinker"
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
   name: "sinker"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: "sinker"
 subjects:
 - kind: ServiceAccount

--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -135,7 +135,7 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating manager")
 	}
 
-	buildClusterClients, err := o.kubernetes.BuildClusterClients(cfg().PodNamespace, o.dryRun.Value)
+	buildClusterClients, err := o.kubernetes.BuildClusterClients("", o.dryRun.Value)
 	if err != nil {
 		logrus.WithError(err).Fatal("Error creating build cluster clients.")
 	}


### PR DESCRIPTION
This PR updates sinker to select pods in all namespaces, instead of just the specified `podNamespace`... it also updates the rbac for sinker to allow this change.

This will pave the way to update plank to allow for test pods in different namespaces, via prowJob.Namespace override.