### PR TITLE
Teach Plank V1 To Create Pods In Multiple Namespaces

### DIFF
--- a/config/prow/cluster/plank_rbac.yaml
+++ b/config/prow/cluster/plank_rbac.yaml
@@ -22,10 +22,9 @@ rules:
       - update
       - patch
 ---
-kind: Role
+kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
   name: "plank"
 rules:
   - apiGroups:
@@ -50,10 +49,9 @@ subjects:
 - kind: ServiceAccount
   name: "plank"
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  namespace: test-pods
   name: "plank"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1771,8 +1771,7 @@ func validateAgent(v JobBase, podNamespace string) error {
 		return fmt.Errorf("error_on_eviction only applies to agent: %s (found %q)", k, agent)
 	case v.Namespace == nil || *v.Namespace == "":
 		return fmt.Errorf("failed to default namespace")
-	case *v.Namespace != podNamespace && agent != p:
-		// TODO(fejta): update plank to allow this (depends on client change)
+	case *v.Namespace != podNamespace && (agent != p || agent != k):
 		return fmt.Errorf("namespace customization requires agent: %s (found %q)", p, agent)
 	}
 	return nil

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -193,7 +193,7 @@ func (c *Controller) Sync() error {
 	pm := map[string]corev1.Pod{}
 	for alias, client := range c.buildClients {
 		listOpts := &ctrlruntimeclient.ListOptions{
-			Namespace: c.config().PodNamespace,
+			Namespace: "",
 			Raw:       &metav1.ListOptions{LabelSelector: selector},
 		}
 		pods := &corev1.PodList{}
@@ -529,7 +529,13 @@ func (c *Controller) startPod(pj *prowapi.ProwJob) error {
 	if err != nil {
 		return err
 	}
-	pod.Namespace = c.config().PodNamespace
+
+	// If the prowJob has a namespace specified use that value, else use the config prowJob namespace.
+	if pj.Spec.Namespace != "" {
+		pod.Namespace = pj.Spec.Namespace
+	} else {
+		pod.Namespace = c.config().PodNamespace
+	}
 
 	client, ok := c.buildClients[pj.ClusterAlias()]
 	if !ok {


### PR DESCRIPTION
fixes: #17922 

This PR allows plank v1 to create pods in any namespace for the kubernetes agent, if a prowJob has overridden the config value `PodNamespace`. Plank v2 was giving me much more trouble, so I hope to be able to do that change in a followup PR.