### PR TITLE
Revert "enable iptables-nft on kind canary jobs"

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -81,9 +81,6 @@ presubmits:
           value: "true"
         - name: BUILD_TYPE
           value: bazel
-        # tell kind CI script to use iptables-nft
-        - name: "DOCKER_IN_DOCKER_NFT_ENABLED"
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -136,9 +133,6 @@ presubmits:
         # tell kind CI script to use ipv6
         - name: "IP_FAMILY"
           value: "ipv6"
-        # tell kind CI script to use iptables-nft
-        - name: "DOCKER_IN_DOCKER_NFT_ENABLED"
-          value: "true"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
This reverts commit abe73b758a9b4c63a3dd9e3688c0e29828e25971.

It turns out the results where not as expected, iptables is segfaulting and is possible causing instability

```
2020-06-20T12:45:24.851747193Z stderr F E0620 12:45:24.847378       1 proxier.go:1570] Failed to execute iptables-restore: signal: segmentation fault (core dumped) ()
2020-06-20T12:45:24.851785852Z stderr F I0620 12:45:24.847430       1 proxier.go:850] Sync failed; retrying in 30s
2020-06-20T12:45:29.96091679Z stderr F E0620 12:45:29.960179       1 proxier.go:1570] Failed to execute iptables-restore: signal: segmentation fault (core dumped) ()
2020-06-20T12:45:29.960957207Z stderr F I0620 12:45:29.960249       1 proxier.go:850] Sync failed; retrying in 30s
2020-06-20T12:45:58.355
```