### PR TITLE
Ability to dump logs in node e2e jobs

### DIFF
--- a/kubetest/node.go
+++ b/kubetest/node.go
@@ -39,8 +39,7 @@ func (n nodeDeploy) IsUp() error {
 }
 
 func (n nodeDeploy) DumpClusterLogs(localPath, gcsPath string) error {
-	log.Printf("Noop - Node DumpClusterLogs() - %s: %s", localPath, gcsPath)
-	return nil
+	return defaultDumpClusterLogs(localPath, gcsPath)
 }
 
 func (n nodeDeploy) TestSetup() error {


### PR DESCRIPTION
When pull-kubernetes-node-e2e-containerd fails, we don't capture logs at all:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/92333/pull-kubernetes-node-e2e-containerd/1274403672662478848/build-log.txt

```
W0620 19:15:54.443] 2020/06/20 19:15:54 node.go:42: Noop - Node DumpClusterLogs() - /workspace/_artifacts: 
```

Signed-off-by: Davanum Srinivas <davanum@gmail.com>