### PR TITLE
Remove exporting KUBECONFIG as no longer needed on kind v0.6.0 or later

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -98,7 +98,6 @@ presubmits:
         - >-
           apt-get update && apt-get install bats && apt-get install gettext-base -y &&
           make e2e-bootstrap &&
-          export KUBECONFIG=$(kind get kubeconfig-path) &&
           make e2e-vault
         securityContext:
           privileged: true
@@ -134,7 +133,6 @@ presubmits:
         - >-
           apt-get update && apt-get install bats && apt-get install gettext-base -y &&
           make e2e-bootstrap &&
-          export KUBECONFIG=$(kind get kubeconfig-path) &&
           make e2e-azure
         securityContext:
           privileged: true
@@ -254,7 +252,6 @@ postsubmits:
         - >-
           apt-get update && apt-get install bats && apt-get install gettext-base -y &&
           make e2e-bootstrap &&
-          export KUBECONFIG=$(kind get kubeconfig-path) &&
           make e2e-vault
         securityContext:
           privileged: true
@@ -290,7 +287,6 @@ postsubmits:
         - >-
           apt-get update && apt-get install bats && apt-get install gettext-base -y &&
           make e2e-bootstrap &&
-          export KUBECONFIG=$(kind get kubeconfig-path) &&
           make e2e-azure
         securityContext:
           privileged: true


### PR DESCRIPTION
In PR https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/234, we are going to update kind.
Since kind is no longer supported `kind get kubeconfig-path`, kubectl context is automatically loaded and kubeconfig will be saved at `$HOME/.kube/config`.