### PR TITLE
Run CentOS only on nodes in SELinux storage job

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -21,6 +21,7 @@ periodics:
       - --extract=ci/latest
       - --ginkgo-parallel
       - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-args=--master-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200609
       - --kops-overrides=spec.docker.selinuxEnabled=true
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-ssh-user=centos


### PR DESCRIPTION
The job is currently failing because SELinux is denying access to files required by master nodes.
Ideally we'd fix the SELinux policies on masters (kops), but since we are currently only interested in testing SELinux on nodes, use Ubuntu on masters for now.

This was caught by @hakman.