### PR TITLE
benchmark-config: decrease number of pods to 90

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -20,7 +20,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   cosstable2-density1:
     image: cos-77-12371-274-0
@@ -35,28 +35,28 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 100ms interval \[Benchmark\]'
+      - 'create 90 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
     image: cos-stable-81-12871-103-0
@@ -78,7 +78,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
   cosbeta-resource1:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
@@ -99,7 +99,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   cosbeta-density1:
     image: cos-beta-81-12871-44-0
@@ -114,28 +114,28 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosbeta-density2-qps60:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosbeta-density3:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosbeta-density4:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 100ms interval \[Benchmark\]'
+      - 'create 90 pods with 100ms interval \[Benchmark\]'
 
   cosdev-resource1:
     image: cos-dev-83-13020-12-0
@@ -157,7 +157,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data<test/e2e_node/jenkins/gci-init.yaml,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
     image: ubuntu-gke-1804-1-16-v20200330
@@ -176,7 +176,7 @@ images:
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
     image: ubuntu-gke-1804-1-16-v20200330
@@ -195,4 +195,4 @@ images:
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'

--- a/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
+++ b/jobs/e2e_node/containerd/cri-master/benchmark-config.yaml
@@ -20,7 +20,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   cosstable2-density1:
     image: cos-77-12371-274-0
@@ -35,28 +35,28 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosstable2-density2-qps60:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosstable2-density3:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosstable2-density4:
     image: cos-77-12371-274-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 100ms interval \[Benchmark\]'
+      - 'create 90 pods with 100ms interval \[Benchmark\]'
 
   cosstable1-resource1:
     image: cos-stable-81-12871-103-0
@@ -78,7 +78,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
   cosbeta-resource1:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
@@ -99,7 +99,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   cosbeta-density1:
     image: cos-beta-81-12871-44-0
@@ -114,28 +114,28 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosbeta-density2-qps60:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \(QPS 60\) \[Benchmark\]'
   cosbeta-density3:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-2
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 0s? interval \[Benchmark\]'
+      - 'create 90 pods with 0s? interval \[Benchmark\]'
   cosbeta-density4:
     image: cos-beta-81-12871-44-0
     project: cos-cloud
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'create 105 pods with 100ms interval \[Benchmark\]'
+      - 'create 90 pods with 100ms interval \[Benchmark\]'
 
   cosdev-resource1:
     image: cos-dev-83-13020-12-0
@@ -157,7 +157,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-extra-init-sh</go/src/github.com/containerd/cri/test/e2e_node/gci-init.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env,gci-update-strategy=update_disabled"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   ubuntustable2-resource1:
     image: ubuntu-gke-1804-1-16-v20200330
@@ -179,7 +179,7 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
 
   ubuntustable1-resource1:
     image: ubuntu-gke-1804-1-16-v20200330
@@ -201,4 +201,4 @@ images:
     machine: n1-standard-1
     metadata: "user-data</go/src/github.com/containerd/cri/test/e2e_node/init.yaml,containerd-configure-sh</go/src/github.com/containerd/cri/cluster/gce/configure.sh,containerd-env</workspace/test-infra/jobs/e2e_node/containerd/cri-master/env"
     tests:
-      - 'resource tracking for 105 pods per node \[Benchmark\]'
+      - 'resource tracking for 90 pods per node \[Benchmark\]'


### PR DESCRIPTION
This PR synchronises number of pods in the benchmark config and the correspondent e2e_node tests.
The number of pods was recently changed from 105 to 90 in the tests by [this PR](https://github.com/kubernetes/kubernetes/pull/91813), so image config should be updated as well.