### PR TITLE
Crier: Retry when PJ update after report failed

### DIFF
--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//prow/kube:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",

--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -293,8 +293,7 @@ func (c *Controller) processNextItem() bool {
 			return c.updateReportState(pj, log, reportedState)
 		}); err != nil {
 			log.WithError(err).Error("Failed to update report state on prowjob")
-			c.queue.Forget(key)
-			return true
+			return c.retry(key, log, err)
 		}
 
 		log.Info("Successfully updated prowjob")

--- a/prow/crier/controller_test.go
+++ b/prow/crier/controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -100,7 +101,9 @@ func (fakeInformer) GetController() cache.Controller                            
 func (fakeInformer) LastSyncResourceVersion() string                                           { return "" }
 func (fakeInformer) AddIndexers(indexers cache.Indexers) error                                 { return nil }
 func (fakeInformer) GetIndexer() cache.Indexer                                                 { return nil }
-func (fakeInformer) List(selector labels.Selector) (ret []*prowv1.ProwJob, err error)          { return nil, nil }
+func (fakeInformer) List(selector labels.Selector) (ret []*prowv1.ProwJob, err error) {
+	return nil, nil
+}
 
 func TestController_Run(t *testing.T) {
 	tests := []struct {
@@ -238,7 +241,12 @@ func TestController_Run(t *testing.T) {
 					return test.shouldReport
 				},
 			}
-			cs := fake.NewSimpleClientset()
+
+			var prowjobs []runtime.Object
+			for _, job := range test.knownJobs {
+				prowjobs = append(prowjobs, job)
+			}
+			cs := fake.NewSimpleClientset(prowjobs...)
 			nmwrk := 2
 			c := NewController(cs, q, inf, &rp, nmwrk)
 


### PR DESCRIPTION
Currently we never retry a prowjob if we reported successfully but
failed to update the prowjob status. This was presumably done with the
thought that we don't want to report a second time.

However, the net result is that we will still report a second time when
either the prowjob gets modified or crier is restarted but its a lot
harder to correlate the report to the previous error.

/cc @michelle192837 