### PR TITLE
kubeflow/pipelines: use merge_commit_template for stable commit message

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -515,6 +515,9 @@ tide:
     kubernetes-sigs/minibroker: squash
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
+  merge_commit_template:
+    kubeflow/pipelines:
+      title: "{{ .Title }} ({{ .Number }})"
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
Part of https://github.com/kubeflow/pipelines/issues/3920

Use merge_commit_template config from https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#general-configuration to configure a stable commit message for kubeflow/pipelines repo as a solution for https://github.com/kubernetes/test-infra/issues/17915.