### PR TITLE
Configure hmac management postsubmit job for k8s Prow

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -110,6 +110,50 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: deploys the configured version of prow by running prow/deploy.sh
+  - name: post-test-infra-reconcile-hmacs
+    cluster: test-infra-trusted
+    run_if_changed: 'config/prow/config.yaml'
+    decorate: true
+    branches:
+    - master
+    spec:
+      containers:
+      - image: gcr.io/k8s-prow/hmac:v20200622-168a90f1b0
+        command:
+        - /hmac
+        args:
+        - --config-path=config/prow/config.yaml
+        - --hook-url=https://prow.k8s.io/hook
+        - --hmac-token-secret-name=hmac-token
+        - --hmac-token-key=hmac
+        - --kubeconfig=/etc/kubeconfig/config
+        - --kubeconfig-context=prow-services
+        - --github-token-path=/etc/github/oauth
+        - --github-endpoint=http://ghproxy.default.svc.cluster.local
+        - --github-endpoint=https://api.github.com
+        - --dry-run=false
+        volumeMounts:
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
+          readOnly: true
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig-prow-services
+      - name: oauth
+        secret:
+          defaultMode: 420
+          secretName: oauth-token
+    annotations:
+      testgrid-dashboards: sig-testing-prow
+      testgrid-tab-name: reconcile-hmacs
+      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
+      testgrid-num-failures-to-alert: '1'
+      description: reconcile the hmac tokens and webhooks based on the managed_webhooks configuration in prow core config file
   - name: post-test-infra-push-resultstore
     cluster: test-infra-trusted
     run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|prow/prow.bzl|experiment/resultstore/)'

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -73,6 +73,10 @@ prowjob_namespace: default
 pod_namespace: test-pods
 log_level: debug
 
+managed_webhooks:
+  # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
+  respect_legacy_global_token: true
+
 slack_reporter_configs:
   '*':
     job_types_to_report:

--- a/prow/cmd/hmac/main.go
+++ b/prow/cmd/hmac/main.go
@@ -89,7 +89,7 @@ func gatherOptions(fs *flag.FlagSet, args ...string) options {
 	o.github.AddFlags(fs)
 	o.kubernetes.AddFlags(fs)
 
-	fs.StringVar(&o.kubeconfigCtx, "kubeconfig-context", "", "Context of the Prow component cluster in the kubeconfig.")
+	fs.StringVar(&o.kubeconfigCtx, "kubeconfig-context", "", "Context of the Prow component cluster and namespace in the kubeconfig.")
 	fs.StringVar(&o.configPath, "config-path", "", "Path to config.yaml.")
 	fs.BoolVar(&o.dryRun, "dry-run", true, "Dry run for testing. Uses API tokens but does not mutate.")
 

--- a/prow/flagutil/kubernetes_cluster_clients.go
+++ b/prow/flagutil/kubernetes_cluster_clients.go
@@ -163,15 +163,7 @@ func (o *KubernetesOptions) InfrastructureClusterConfig(dryRun bool) (*rest.Conf
 
 // InfrastructureClusterClient returns a Kubernetes client for the infrastructure cluster.
 func (o *KubernetesOptions) InfrastructureClusterClient(dryRun bool) (kubernetesClient kubernetes.Interface, err error) {
-	if err := o.resolve(dryRun); err != nil {
-		return nil, err
-	}
-
-	if o.dryRun {
-		return nil, errors.New("no dry-run kubernetes client is supported in dry-run mode")
-	}
-
-	return o.kubernetesClientsByContext[kube.InClusterContext], nil
+	return o.ClusterClientForContext(kube.InClusterContext, dryRun)
 }
 
 // ClusterClientForContext returns a Kubernetes client for the given context name.


### PR DESCRIPTION
Configure hmac management postsubmit job for k8s Prow, which can reconcile the hmac tokens and webhooks based on the `managed_webhooks` setting in the Prow core config file.
And by the way fix two code review issues left in https://github.com/kubernetes/test-infra/pull/17966.

There are two things need to be done before getting this merged:
1. Back up the global HMAC token we currently have for k8s Prow, in case any issue happens
2. Make sure the github oauth token we use here has `admin:repo_hook` and `admin:org_hook` scopes.

/cc @cjwagner @michelle192837 