### PR TITLE
releng: Update variants (kubekins, krte) to use go1.14.4

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,14 +1,14 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.13.9
+    GO_VERSION: 1.14.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.13.9
+    GO_VERSION: 1.14.4
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
k/k has been [updated to 1.14.4](https://github.com/kubernetes/kubernetes/pull/88638), so let's bump the go version in kubekins and krte to match!

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @spiffxp 
cc: @kubernetes/release-engineering 

ref: https://github.com/kubernetes/release/issues/1216