### PR TITLE
fix push method in git client

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -401,7 +401,7 @@ func (r *Repo) Push(branch string) error {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
 	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, r.repo, branch)
-	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.user, r.repo)
+	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.org, r.repo)
 	co := r.gitCommand("push", remote, branch)
 	out, err := co.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
Make the push method to construct a remote using the
org/repo from the already configured git client
instead of using the Github user as the organization

/cc @stevekuznetsov @alvaroaleman 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>