### PR TITLE
Add the ability to pass commit messages in the git merge operations

### DIFF
--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -62,7 +62,7 @@ func (a *repoClientAdapter) MergeAndCheckout(baseSHA string, mergeStrategy strin
 	return a.Repo.MergeAndCheckout(baseSHA, github.PullRequestMergeType(mergeStrategy), headSHAs...)
 }
 
-func (a *repoClientAdapter) MergeWithStrategy(commitlike, mergeStrategy string) (bool, error) {
+func (a *repoClientAdapter) MergeWithStrategy(commitlike, mergeStrategy string, opts ...MergeOpt) (bool, error) {
 	return a.Repo.MergeWithStrategy(commitlike, github.PullRequestMergeType(mergeStrategy))
 }
 


### PR DESCRIPTION
Add the ability to pass commit messages in the `git merge` operations.

The change affects only the merge strategy.


/cc @alvaroaleman @stevekuznetsov 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>