### PR TITLE
Update descheduler prow jobs to go 1.14.4

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.14.4
         command:
         - make
         args:
@@ -24,7 +24,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.14.4
         command:
         - make
         args:
@@ -38,7 +38,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.14.4
         command:
         - make
         args:


### PR DESCRIPTION
With k8s updating to 1.14 (https://github.com/kubernetes/kubernetes/pull/88638) we want to update our repo as well but need the tests to be on the same version (https://github.com/kubernetes-sigs/descheduler/pull/328)