### PR TITLE
Onboard bazelbuild/rules_k8s to make sure the hmac manangement tool works

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -76,6 +76,10 @@ log_level: debug
 managed_webhooks:
   # This has to be true if any of the managed repo/org is using the legacy global token that is manually created.
   respect_legacy_global_token: true
+  # Config for orgs and repos that have been onboarded to this Prow instance.
+  org_repo_config:
+    bazelbuild/rules_k8s:
+      token_created_after: 2020-06-23T00:00:00Z
 
 slack_reporter_configs:
   '*':


### PR DESCRIPTION
As the first step for onboarding repos/orgs to the hmac management tool, configure for `bazelbuild/rules_k8s` as it's a relatively inactive repo.

/cc @fejta @cjwagner @michelle192837 