### PR TITLE
Prow autobump script fixing splitting function

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -198,17 +198,18 @@ list() {
   fi
 }
 
-split_on_commas() {
-  local IFS=,
-  local array=("$1")
-  echo "${array[@]}"
-}
+ split_on_commas() {
+   local IFS=,
+   local array
+   read -ra array <<< "$1"
+   echo "${array[@]}"
+ }
 
-add_suffix() {
-  local array=("$1")
-  local suffix="${2:-/*.yaml}"
-  echo "${array[@]/%/$suffix}"
-}
+ add_suffix() {
+   local array=($1)
+   local suffix="${2:-/*.yaml}"
+   echo "${array[@]/%/$suffix}"
+ }
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 color-image() { # Bold magenta

--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -68,7 +68,10 @@ main() {
   fi
   echo -e "Bumping: 'gcr.io/k8s-prow/' images to $(color-version "${new_version}") ..." >&2
 
-  bumpfiles=($(add_suffix "$(split_on_commas "$COMPONENT_FILE_DIR")"))
+  local IFS=,
+  local component_file_dir_array
+  read -ra component_file_dir_array <<< "${COMPONENT_FILE_DIR}"
+  bumpfiles=("${component_file_dir_array[@]/%/*.yaml}")
   bumpfiles+=("${CONFIG_PATH}")
   if [[ -n "${JOB_CONFIG_PATH}" ]]; then
     bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"; true))
@@ -197,19 +200,6 @@ list() {
     fi
   fi
 }
-
- split_on_commas() {
-   local IFS=,
-   local array
-   read -ra array <<< "$1"
-   echo "${array[@]}"
- }
-
- add_suffix() {
-   local array=($1)
-   local suffix="${2:-/*.yaml}"
-   echo "${array[@]/%/$suffix}"
- }
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 color-image() { # Bold magenta


### PR DESCRIPTION
As title, also make job config as optional since it's already functionally supported. For some reason `split_on_commas` and `add_suffix` don't work on my machine, updated these two to make them work on my machine too