### PR TITLE
Fix hmac tool issue and add docs

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,8 @@
 ## New features
 
 New features added to each component:
+ - *June 23rd, 2020* An [hmac](/prow/cmd/hmac) tool was added to automatically reconcile webhooks and hmac
+    tokens for the orgs and repos integrated with your prow instance.
  - *June 8th, 2020* A new informer-based Plank implementation was added. It can be used by deploying
     the new [prow-controller-manager](/config/prow/experimental/controller_manager.yaml) binary.
     We plan to gradually move all our controllers into that binary, see https://github.com/kubernetes/test-infra/issues/17024

--- a/prow/cmd/hmac/README.md
+++ b/prow/cmd/hmac/README.md
@@ -32,10 +32,10 @@ bazel run //prow/cmd/hmac -- \
   --dryrun=true  # Remove it to actually update hmac tokens and webhooks
 ```
 
-1. Run it as a postsubmit job:
+2. Run it as a Prow job:
 
-TODO(chizhg): add the link of the postsubmit job once we have the image and
-configured for k8s Prow.
+The recommended way to run this tool would be running it as a postsubmit job.
+One example Prow job configured for k8s Prow can be found [here](https://github.com/kubernetes/test-infra/blob/b11722064aea0913f4b02cb6aabda1f91f0abc7f/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L113-L156).
 
 ## How it works
 

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -180,13 +180,15 @@ to start receiving GitHub events!
 
 ## Add the webhook to GitHub
 
-You have two options to do this.
+### Add your first webhook
 
-You can do this with the `update-hook` utility:
+You have two options to do this:
+
+1. You can do this with the `update-hook` utility:
 
 ```sh
 # Note /path/to/hook/secret and /path/to/oauth/secret from earlier secrets step
-# Note the an.ip.addr.ess from previous ingres step
+# Note the an.ip.addr.ess from previous ingress step
 
 # Ideally use https://bazel.build, alternatively try:
 #   go get -u k8s.io/test-infra/experiment/update-hook && update-hook
@@ -199,18 +201,24 @@ $ bazel run //experiment/update-hook -- \
   --confirm=false  # Remove =false to actually add hook
 ```
 
-If you don't want to use the `add-hook` utility, go to your org or repo and click `Settings -> Webhooks`.
-
 Look for the `http://an.ip.addr.ess/hook` you added above.
 A green check mark (for a ping event, if you click edit and view the details of the event) suggests everything is working!
 
-You can click `Add webhook` on the Webhooks page to add the hook manually,
-if you do not want to use the `update-hook` utility:
-- Go to your org or repo and click `Settings -> Webhooks`, and click `Add webhook`
+2. If you do not want to use the `update-hook` utility, you can go the GitHub web page and add the hook manually:
+
+- Go to your org or repo and click `Settings -> Webhooks`, and click `Add webhook`.
 - Change the `Payload URL` to `http://an.ip.addr.ess/hook` you are planning to add.
 - Change the `Content type` to `application/json`, and change your `Secret` to the `hmac-path` secret you created above.
-- Change the trigger to `Send me **everything**.`
-- Click `Add webhook` 
+- Change the trigger to `Send me **everything**`.
+- Click `Add webhook`.
+
+### Use `hmac` tool to manage webhooks and hmac tokens (recommended)
+
+If you need to configure webhooks for multiple orgs or repos, the manual process does not work that well as it
+can be error-prone, and it'll be painful when you want to replace the hmac token if it is accidentally leaked.
+
+In such case, it's recommended to use the [hmac](/prow/cmd/hmac/README.md) tool to automatically manage the webhooks
+and hmac tokens for you via declarative configuration.  
 
 ## Next Steps
 


### PR DESCRIPTION
1. Fix one issue for the hmac tool - revert the hmacs for a repo if its webhook fails to be created/updated. This can prevent the valid hmac token to be deleted when the tool is run for the second time. (I didn't add the unit tests here as there is not a clean way to emulate the error with the `fakehook` utility..)

2. Update some docs for the `hmac` management tool.

/assign @cjwagner 