### PR TITLE
Update each job to each jobs' reported state

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -279,8 +279,8 @@ func (c *Controller) processNextItem() bool {
 	}
 
 	log.Info("Reported job, now will update pj")
-	reportedState := pj.Status.State
 	for _, pjob := range pjs {
+		reportedState := pjob.Status.State
 		// We have to retry here, if we return we lose the information that we already reported this job.
 		if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 			// Get it first, this is very cheap


### PR DESCRIPTION
/assign @alvaroaleman @michelle192837 

We currently have a bug where we update all the reported prowjobs to a single state, which only works if all the reported jobs have the same state.

This sounds wrong even for github, but I suspect it hasn't been causing problems because github has a unique context per job. Thus the only jobs returned by report are all for a single context, which has a single state.

By contrast, gerrit has a single review label, so we report all of the jobs associated with the CR (github PR) at once. This means that a normal and expected state of affairs is for Report to return a collection of jobs in a variety of states (passing, failing, etc)

We will update all of these to a single value, which will be wrong for some of them. Patching the job causes it to go back on the queue:

https://github.com/kubernetes/test-infra/blob/e27ebc8ad689d018ecc5b5059130ff38b8a197ec/prow/crier/controller.go#L95-L102

And since this value is wrong we never remove this value from the queue unless they all pass:

https://github.com/kubernetes/test-infra/blob/e27ebc8ad689d018ecc5b5059130ff38b8a197ec/prow/crier/controller.go#L266-L271

Since some of the jobs continue to have the wrong state, we wind up continually reporting all of the jobs, sending hundreds of emails:

https://github.com/kubernetes/test-infra/blob/e27ebc8ad689d018ecc5b5059130ff38b8a197ec/prow/crier/controller.go#L275

I have another more complicated PR to try and add unit test coverage for this, but this should do for now.


