### PR TITLE
Don't attempt to edit archived repos

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1036,6 +1036,12 @@ func configureRepos(opt options, client repoClient, orgName string, orgConfig or
 		}
 
 		if existing != nil {
+			if existing.Archived {
+				if wantRepo.Archived != nil && *wantRepo.Archived {
+					repoLogger.Infof("repo %q is archived, skipping changes", wantName)
+					continue
+				}
+			}
 			repoLogger.Info("repo exists, considering an update")
 			delta := newRepoUpdateRequest(*existing, wantName, wantRepo)
 			if deltaErrors := sanitizeRepoDelta(opt, &delta); len(deltaErrors) > 0 {


### PR DESCRIPTION
It turns out archived repos are read-only, so there's not much point in trying to sync more than the archived state (assuming that desired archived state and actual archived state agree).

Updated test behavior to match observed github behavior.