### PR TITLE
Fix infinite loop in GetRootForClone

### DIFF
--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -201,7 +201,7 @@ func getRootForClone(c Client, bug *Bug) (*Bug, error) {
 		}
 		switch l := len(parent); {
 		case l <= 0:
-			break
+			return curr, utilerrors.NewAggregate(errs)
 		case l == 1:
 			curr = parent[0]
 		case l > 1:

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -1031,10 +1031,22 @@ func TestGetRootForClone(t *testing.T) {
 	bug1Create := &BugCreate{
 		Summary: "Dummy bug to test getAllClones",
 	}
+	bugDiffCreate := &BugCreate{
+		Summary: "Different bug",
+	}
+	diffBugID, err := fake.CreateBug(bugDiffCreate)
+	errorChecker(err, t)
 	bug1ID, err := fake.CreateBug(bug1Create)
 	if err != nil {
 		t.Fatalf("Error while creating bug in Fake!\n")
 	}
+	idUpdate := &IDUpdate{
+		Add: []int{diffBugID},
+	}
+	update := BugUpdate{
+		DependsOn: idUpdate,
+	}
+	fake.UpdateBug(bug1ID, update)
 	bug1, err := fake.GetBug(bug1ID)
 	errorChecker(err, t)
 	bug2ID, err := fake.CloneBug(bug1)


### PR DESCRIPTION
When bug has dependents but no clones in GetRootForClone we would
stay in an infinite loop since break would not change the iterator.
Added test case to handle this case as well.