### PR TITLE
kubernetes-sigs/descheduler: separate branch-based configs, go 1.13 for release-1.17 and release-1.18

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -1,0 +1,54 @@
+# sigs.k8s.io/descheduler presubmits
+presubmits:
+  kubernetes-sigs/descheduler:
+  - name: pull-descheduler-verify-master
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-verify-master
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.14.4
+        command:
+        - make
+        args:
+        - verify
+  - name: pull-descheduler-verify-build-master
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-verify-build-master
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.14.4
+        command:
+        - make
+        args:
+        - build
+  - name: pull-descheduler-unit-test-master-master
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-unit-test-master
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.14.4
+        command:
+        - make
+        args:
+        - test-unit

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
@@ -1,44 +1,53 @@
 # sigs.k8s.io/descheduler presubmits
 presubmits:
   kubernetes-sigs/descheduler:
-  - name: pull-descheduler-verify
+  - name: pull-descheduler-verify-release-1-17
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify
+      testgrid-tab-name: pull-descheduler-verify-release-1.17
     decorate: true
     path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.17$
     always_run: true
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.13
         command:
         - make
         args:
         - verify
-  - name: pull-descheduler-verify-build
+  - name: pull-descheduler-verify-build-release-1-17
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-verify-build
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.17
     decorate: true
     path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.17$
     always_run: true
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.13
         command:
         - make
         args:
         - build
-  - name: pull-descheduler-unit-test
+  - name: pull-descheduler-unit-test-release-1-17
     annotations:
       testgrid-dashboards: sig-scheduling
-      testgrid-tab-name: pull-descheduler-unit-test
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.17
     decorate: true
     path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.17$
     always_run: true
     spec:
       containers:
-      - image: golang:1.14.4
+      - image: golang:1.13
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
@@ -1,0 +1,54 @@
+# sigs.k8s.io/descheduler presubmits
+presubmits:
+  kubernetes-sigs/descheduler:
+  - name: pull-descheduler-verify-release-1-18
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-verify-release-1.18
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - verify
+  - name: pull-descheduler-verify-build-release-1-18
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-verify-build-release-1.18
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - build
+  - name: pull-descheduler-unit-test-release-1-18
+    annotations:
+      testgrid-dashboards: sig-scheduling
+      testgrid-tab-name: pull-descheduler-unit-test-release-1.18
+    decorate: true
+    path_alias: sigs.k8s.io/descheduler
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-1.18$
+    always_run: true
+    spec:
+      containers:
+      - image: golang:1.13
+        command:
+        - make
+        args:
+        - test-unit


### PR DESCRIPTION
Older versions of k8s are run with go1.13