### PR TITLE
use user instead of org in git push method

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -400,8 +400,8 @@ func (r *Repo) Push(branch string) error {
 	if r.user == "" || r.pass == "" {
 		return errors.New("cannot push without credentials - configure your git client")
 	}
-	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.org, r.repo, branch)
-	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.org, r.repo)
+	r.logger.Infof("Pushing to '%s/%s (branch: %s)'.", r.user, r.repo, branch)
+	remote := fmt.Sprintf("https://%s:%s@%s/%s/%s", r.user, r.pass, r.host, r.user, r.repo)
 	co := r.gitCommand("push", remote, branch)
 	out, err := co.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
This PR reverts #18069  and #18051 

It seems that the changes in the above PRs, broke cherrypicker plugin.

/cc @stevekuznetsov @alvaroaleman 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>