### PR TITLE
Add ingress-nginx jobs to build e2e images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
+++ b/config/jobs/image-pushing/k8s-staging-ingress-nginx.yaml
@@ -49,3 +49,103 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
               - --env-passthrough=PULL_BASE_REF
               - images/nginx
+
+    - name: post-ingress-nginx-build-e2e-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx
+      decorate: true
+      run_if_changed: 'images/e2e/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - images/e2e
+
+    - name: post-ingress-nginx-build-cfssl-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx
+      decorate: true
+      run_if_changed: 'images/cfssl/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - images/cfssl
+
+    - name: post-ingress-nginx-build-echo-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx
+      decorate: true
+      run_if_changed: 'images/echo/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - images/echo
+
+    - name: post-ingress-nginx-build-fastcgi-helloserver-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx
+      decorate: true
+      run_if_changed: 'images/fastcgi-helloserver/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - images/fastcgi-helloserver
+
+    - name: post-ingress-nginx-build-httpbin-image
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-network-ingress-nginx
+      decorate: true
+      run_if_changed: 'images/httpbin/.*'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-ingress-nginx
+              - --scratch-bucket=gs://k8s-staging-ingress-nginx-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - images/httpbin


### PR DESCRIPTION
~~These images are used only for e2e and never will be promoted from staging~~. The goal here is to avoid building the images every time we run e2e tests.

note: the images must be promoted. As @spiffxp suggested, I will change the name adding a prefix `e2e-test-xxx`