### PR TITLE
Kubetest2 GCE deployer supports basic boskos

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "boskos.go",
         "build.go",
         "common.go",
         "deployer.go",

--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "build.go",
+        "common.go",
         "deployer.go",
         "down.go",
         "dumplogs.go",
@@ -17,6 +18,8 @@ go_library(
         "@com_github_octago_sflags//gen/gpflag:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
+        "@io_k8s_sigs_boskos//client:go_default_library",
+        "@io_k8s_sigs_boskos//common:go_default_library",
     ],
 )
 

--- a/kubetest2/kubetest2-gce/deployer/boskos.go
+++ b/kubetest2/kubetest2-gce/deployer/boskos.go
@@ -74,13 +74,15 @@ func getProjectFromBoskos(boskosClient *client.Client, timeout time.Duration, he
 // reaper from taking the resource from the deployer while it is still in use.
 func startBoskosHeartbeat(boskosClient *client.Client, resource *boskosCommon.Resource, interval time.Duration, close chan struct{}) {
 	go func(c *client.Client, resource *boskosCommon.Resource) {
+		klog.V(2).Info("boskos hearbeat starting")
+
 		for {
 			select {
 			case <-close:
-				klog.Info("Boskos heartbeat func received signal to close")
+				klog.V(2).Info("Boskos heartbeat func received signal to close")
 				return
 			case <-time.Tick(interval):
-				klog.Info("Sending heartbeat to Boskos")
+				klog.V(2).Info("Sending heartbeat to Boskos")
 				if err := c.UpdateOne(resource.Name, "busy", nil); err != nil {
 					klog.Warningf("[Boskos] Update of %s failed with %v", resource.Name, err)
 				}

--- a/kubetest2/kubetest2-gce/deployer/boskos.go
+++ b/kubetest2/kubetest2-gce/deployer/boskos.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/boskos/client"
+	boskosCommon "sigs.k8s.io/boskos/common"
+)
+
+// const (for the run) owner string for consistency between up and down
+var boskosOwner = os.Getenv("JOB_NAME") + "-kubetest2"
+
+func makeBoskosClient(boskosLocation string) (*client.Client, error) {
+	boskos, err := client.NewClient(
+		boskosOwner,
+		boskosLocation,
+		"",
+		"",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create boskos client: %s", err)
+	}
+
+	return boskos, nil
+}
+
+// getProjectFromBoskos creates a boskos client, acquires a gcp project
+// and starts a heartbeat goroutine to keep the project reserved
+func getProjectFromBoskos(boskosClient *client.Client, timeout time.Duration, heartbeatClose chan struct{}) (string, error) {
+	resourceType := "gce-project"
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	boskosProject, err := boskosClient.AcquireWait(ctx, resourceType, "free", "busy")
+	if err != nil {
+		return "", fmt.Errorf("failed to get a %q from boskos: %s", resourceType, err)
+	}
+	if boskosProject == nil {
+		return "", fmt.Errorf("boskos had no %s available", resourceType)
+	}
+
+	startBoskosHeartbeat(
+		boskosClient,
+		boskosProject,
+		5*time.Minute,
+		heartbeatClose,
+	)
+
+	return boskosProject.Name, nil
+}
+
+// startBoskosHeartbeat starts a goroutine that sends periodic updates to boskos
+// about the provided resource until the channel is closed. This prevents
+// reaper from taking the resource from the deployer while it is still in use.
+func startBoskosHeartbeat(boskosClient *client.Client, resource *boskosCommon.Resource, interval time.Duration, close chan struct{}) {
+	go func(c *client.Client, resource *boskosCommon.Resource) {
+		for {
+			select {
+			case <-close:
+				klog.Info("Boskos heartbeat func received signal to close")
+				return
+			case <-time.Tick(interval):
+				klog.Info("Sending heartbeat to Boskos")
+				if err := c.UpdateOne(resource.Name, "busy", nil); err != nil {
+					klog.Warningf("[Boskos] Update of %s failed with %v", resource.Name, err)
+				}
+			}
+		}
+	}(boskosClient, resource)
+}
+
+func releaseBoskosProject(client *client.Client, projectName string, heartbeatClose chan struct{}) error {
+	if err := client.Release(projectName, "free"); err != nil {
+		return fmt.Errorf("failed to release %s: %s", projectName, err)
+	}
+
+	close(heartbeatClose)
+
+	return nil
+}

--- a/kubetest2/kubetest2-gce/deployer/build.go
+++ b/kubetest2/kubetest2-gce/deployer/build.go
@@ -27,8 +27,8 @@ import (
 func (d *deployer) Build() error {
 	klog.Info("GCE deployer starting Build()")
 
-	if err := d.verifyBuildFlags(); err != nil {
-		return fmt.Errorf("Build() failed to verify build-specific flags: %s", err)
+	if err := d.init(); err != nil {
+		return fmt.Errorf("build failed to init: %s", err)
 	}
 
 	// this code path supports the kubernetes/cloud-provider-gcp build

--- a/kubetest2/kubetest2-gce/deployer/build.go
+++ b/kubetest2/kubetest2-gce/deployer/build.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (d *deployer) Build() error {
-	klog.Info("GCE deployer starting Build()")
+	klog.V(1).Info("GCE deployer starting Build()")
 
 	if err := d.init(); err != nil {
 		return fmt.Errorf("build failed to init: %s", err)
@@ -57,7 +57,7 @@ func (d *deployer) setRepoPathIfNotSet() error {
 	if err != nil {
 		return fmt.Errorf("Failed to get current working directory for setting Kubernetes root path: %s", err)
 	}
-	klog.Infof("defaulting repo root to the current directory: %s", path)
+	klog.V(1).Infof("defaulting repo root to the current directory: %s", path)
 	d.RepoRoot = path
 
 	return nil

--- a/kubetest2/kubetest2-gce/deployer/build_test.go
+++ b/kubetest2/kubetest2-gce/deployer/build_test.go
@@ -46,12 +46,12 @@ func TestSetRepoPathIfNotSet(t *testing.T) {
 		t.Errorf("failed to chdir for test: %s", err)
 	}
 
-	for _, c := range cases {
-		c := c
+	for i := range cases {
+		c := &cases[i]
 		t.Run(c.name, func(t *testing.T) {
 			t.Parallel()
 
-			d := c.initialDeployer
+			d := &c.initialDeployer
 			err := d.setRepoPathIfNotSet()
 			if err != nil {
 				t.Errorf("failed to set repo path: %s", err)

--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"k8s.io/klog"
+	"sigs.k8s.io/boskos/client"
+	boskosCommon "sigs.k8s.io/boskos/common"
+)
+
+func (d *deployer) init() error {
+	if d.commonOptions.ShouldBuild() {
+		if err := d.verifyBuildFlags(); err != nil {
+			return fmt.Errorf("init failed to check build flags: %s", err)
+		}
+	}
+
+	if d.commonOptions.ShouldUp() {
+		if d.GCPProject == "" {
+			klog.Info("No GCP project provided, acquiring from Boskos")
+
+			if err := d.getProjectFromBoskos(); err != nil {
+				return fmt.Errorf("init failed to get project from boskos: %s", err)
+			}
+			klog.Infof("Got project %s from boskos", d.GCPProject)
+		}
+
+		if err := d.verifyFlags(); err != nil {
+			return fmt.Errorf("init failed to verify flags for up: %s", err)
+		}
+	}
+
+	if d.commonOptions.ShouldDown() {
+		if err := d.verifyFlags(); err != nil {
+			return fmt.Errorf("init failed to verify flags for up: %s", err)
+		}
+	}
+
+	return nil
+}
+
+// getProjectFromBoskos creates a boskos client, acquires a gcp project
+// and starts a heartbeat goroutine to keep the project reserved
+func (d *deployer) getProjectFromBoskos() error {
+	// TODO
+	// boskosLocation := "http://boskos.test-pods.svc.cluster.local."
+	boskosLocation := "http://localhost:8080"
+	boskos, err := client.NewClient(
+		os.Getenv("JOB_NAME")+"-kubetest2",
+		boskosLocation,
+		"",
+		"",
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create boskos client: %s", err)
+	}
+
+	resourceType := "gce-project"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*5)
+	defer cancel()
+
+	boskosProject, err := boskos.AcquireWait(ctx, resourceType, "free", "busy")
+	if err != nil {
+		return fmt.Errorf("failed to get a %s from boskos: %s", resourceType, err)
+	}
+	if boskosProject == nil {
+		return fmt.Errorf("boksos had no %s available", resourceType)
+	}
+
+	go func(c *client.Client, resource *boskosCommon.Resource) {
+		for range time.Tick(time.Minute * 5) {
+			if err := c.UpdateOne(resource.Name, "busy", nil); err != nil {
+				klog.Warningf("[Boskos] Update of %s failed with %v", resource.Name, err)
+			}
+		}
+	}(boskos, boskosProject)
+
+	d.boskos = boskos
+	d.boskosProject = boskosProject
+	d.GCPProject = boskosProject.Name
+
+	return nil
+}
+
+func (d *deployer) verifyFlags() error {
+	if err := d.setRepoPathIfNotSet(); err != nil {
+		return err
+	}
+
+	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
+
+	if d.GCPProject == "" {
+		return fmt.Errorf("gcp project must be set")
+	}
+
+	return nil
+}
+
+func (d *deployer) buildEnv() []string {
+	// The base env currently does not inherit the current os env (except for PATH)
+	// because (for now) it doesn't have to. In future, this may have to change when
+	// support is added for k/k's kube-up.sh and kube-down.sh which support a wide
+	// variety of environment variables. Before doing so, it is worth investigating
+	// inheriting the os env vs. adding flags to this deployer on a case-by-case
+	// basis to support individual environment configurations.
+	var env []string
+
+	// path is necessary for scripts to find gsutil, gcloud, etc
+	// can be removed if env is inherited from the os
+	env = append(env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
+
+	// used by config-test.sh to set $NETWORK in the default case
+	// if unset, bash's set -u gets angry and kills the log dump script
+	// can be removed if env is inherited from the os
+	env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
+
+	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter for all gcloud commands
+	env = append(env, fmt.Sprintf("PROJECT=%s", d.GCPProject))
+
+	// kubeconfig is set to tell kube-up.sh where to generate the kubeconfig
+	// we don't want this to be the default because this kubeconfig "belongs" to
+	// the run of kubetest2 and so should be placed in the artifacts directory
+	env = append(env, fmt.Sprintf("KUBECONFIG=%s", d.kubeconfigPath))
+
+	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
+	// does not. opted to set it manually here for maximum consistency
+	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
+	return env
+}

--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -24,6 +24,13 @@ import (
 )
 
 func (d *deployer) init() error {
+	var err error
+	d.doInit.Do(func() { err = d.initialize() })
+	return err
+}
+
+// initialize should only be called by init(), behind a sync.Once
+func (d *deployer) initialize() error {
 	if d.commonOptions.ShouldBuild() {
 		if err := d.verifyBuildFlags(); err != nil {
 			return fmt.Errorf("init failed to check build flags: %s", err)

--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -44,7 +44,7 @@ func (d *deployer) initialize() error {
 		}
 
 		if d.GCPProject == "" {
-			klog.Info("No GCP project provided, acquiring from Boskos")
+			klog.V(1).Info("No GCP project provided, acquiring from Boskos")
 
 			boskos, err := makeBoskosClient(d.BoskosLocation)
 			if err != nil {
@@ -62,7 +62,7 @@ func (d *deployer) initialize() error {
 				return fmt.Errorf("init failed to get project from boskos: %s", err)
 			}
 			d.GCPProject = projectName
-			klog.Infof("Got project %s from boskos", d.GCPProject)
+			klog.V(1).Infof("Got project %s from boskos", d.GCPProject)
 		}
 
 	}

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -49,8 +49,9 @@ type deployer struct {
 	boskosProject *boskosCommon.Resource
 
 	RepoRoot         string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
-	GCPProject       string `desc:"GCP Project to create VMs in. Must be set."`
+	GCPProject       string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
 	OverwriteLogsDir bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
+	BoskosLocation   string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 }
 
 // New implements deployer.New for gce
@@ -59,6 +60,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		commonOptions:  opts,
 		kubeconfigPath: filepath.Join(opts.ArtifactsDir(), "kubetest2-kubeconfig"),
 		logsDir:        filepath.Join(opts.ArtifactsDir(), "cluster-logs"),
+		BoskosLocation: "http://boskos.test-pods.svc.cluster.local.",
 	}
 
 	flagSet, err := gpflag.Parse(d)

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -18,6 +18,7 @@ limitations under the License.
 package deployer
 
 import (
+	goflag "flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -76,6 +77,11 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		klog.Fatalf("couldn't parse flagset for deployer struct: %s", err)
 	}
 
+	// initing the klog flags adds them to goflag.CommandLine
+	// they can then be added to the built pflag set
+	klog.InitFlags(nil)
+	flagSet.AddGoFlagSet(goflag.CommandLine)
+
 	// register flags and return
 	return d, flagSet
 }
@@ -91,7 +97,7 @@ func (d *deployer) Provider() string {
 }
 
 func (d *deployer) IsUp() (up bool, err error) {
-	klog.Info("GCE deployer starting IsUp()")
+	klog.V(1).Info("GCE deployer starting IsUp()")
 
 	if d.GCPProject == "" {
 		return false, fmt.Errorf("isup requires a GCP project")

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -51,19 +51,26 @@ type deployer struct {
 	boskos        *client.Client
 	boskosProject *boskosCommon.Resource
 
-	RepoRoot         string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
-	GCPProject       string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
-	OverwriteLogsDir bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
-	BoskosLocation   string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
+	// this channel serves as a signal channel for the hearbeat goroutine
+	// so that it can be explicitly closed
+	boskosHeartbeatClose chan struct{}
+
+	BoskosAcquireTimeoutSeconds int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
+	RepoRoot                    string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
+	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
+	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
+	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 }
 
 // New implements deployer.New for gce
 func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 	d := &deployer{
-		commonOptions:  opts,
-		kubeconfigPath: filepath.Join(opts.ArtifactsDir(), "kubetest2-kubeconfig"),
-		logsDir:        filepath.Join(opts.ArtifactsDir(), "cluster-logs"),
-		BoskosLocation: "http://boskos.test-pods.svc.cluster.local.",
+		commonOptions:               opts,
+		kubeconfigPath:              filepath.Join(opts.ArtifactsDir(), "kubetest2-kubeconfig"),
+		logsDir:                     filepath.Join(opts.ArtifactsDir(), "cluster-logs"),
+		boskosHeartbeatClose:        make(chan struct{}),
+		BoskosAcquireTimeoutSeconds: 5 * 60,
+		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
 	}
 
 	flagSet, err := gpflag.Parse(d)

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"k8s.io/klog"
 	"k8s.io/test-infra/kubetest2/pkg/exec"
@@ -39,8 +40,10 @@ type deployer struct {
 	// generic parts
 	commonOptions types.Options
 
+	doInit sync.Once
+
 	kubeconfigPath string
-	kubectl        string
+	kubectlPath    string
 	logsDir        string
 
 	// boskos struct fields will be non-nil when the deployer is
@@ -93,7 +96,7 @@ func (d *deployer) IsUp() (up bool, err error) {
 	// naive assumption: nodes reported = cluster up
 	// similar to other deployers' implementations
 	args := []string{
-		d.kubectl,
+		d.kubectlPath,
 		"get",
 		"nodes",
 		"-o=name",

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/test-infra/kubetest2/pkg/exec"
 	"k8s.io/test-infra/kubetest2/pkg/types"
 	"sigs.k8s.io/boskos/client"
-	boskosCommon "sigs.k8s.io/boskos/common"
 
 	"github.com/octago/sflags/gen/gpflag"
 	"github.com/spf13/pflag"
@@ -46,10 +45,9 @@ type deployer struct {
 	kubectlPath    string
 	logsDir        string
 
-	// boskos struct fields will be non-nil when the deployer is
+	// boskos struct field will be non-nil when the deployer is
 	// using boskos to acquire a GCP project
-	boskos        *client.Client
-	boskosProject *boskosCommon.Resource
+	boskos *client.Client
 
 	// this channel serves as a signal channel for the hearbeat goroutine
 	// so that it can be explicitly closed

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -27,8 +27,8 @@ import (
 func (d *deployer) Down() error {
 	klog.Info("GCE deployer starting Down()")
 
-	if err := d.verifyFlags(); err != nil {
-		return fmt.Errorf("down could not verify flags: %s", err)
+	if err := d.init(); err != nil {
+		return fmt.Errorf("down failed to init: %s", err)
 	}
 
 	env := d.buildEnv()
@@ -43,5 +43,18 @@ func (d *deployer) Down() error {
 		return fmt.Errorf("error encountered during %s: %s", script, err)
 	}
 
+	if d.boskos != nil {
+		if err := d.releaseBoskosProject(); err != nil {
+			return fmt.Errorf("down failed to release boskos project: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func (d *deployer) releaseBoskosProject() error {
+	if err := d.boskos.Release(d.boskosProject.Name, "free"); err != nil {
+		return fmt.Errorf("failed to release %s: %s", d.boskosProject.Name, err)
+	}
 	return nil
 }

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -64,7 +64,7 @@ func (d *deployer) verifyDownFlags() error {
 		return err
 	}
 
-	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
+	d.kubectlPath = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
 
 	if d.GCPProject == "" {
 		return fmt.Errorf("gcp project must be set")

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -56,6 +56,9 @@ func (d *deployer) releaseBoskosProject() error {
 	if err := d.boskos.Release(d.boskosProject.Name, "free"); err != nil {
 		return fmt.Errorf("failed to release %s: %s", d.boskosProject.Name, err)
 	}
+
+	close(d.boskosHeartbeatClose)
+
 	return nil
 }
 

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -44,20 +44,15 @@ func (d *deployer) Down() error {
 	}
 
 	if d.boskos != nil {
-		if err := d.releaseBoskosProject(); err != nil {
+		err := releaseBoskosProject(
+			d.boskos,
+			d.GCPProject,
+			d.boskosHeartbeatClose,
+		)
+		if err != nil {
 			return fmt.Errorf("down failed to release boskos project: %s", err)
 		}
 	}
-
-	return nil
-}
-
-func (d *deployer) releaseBoskosProject() error {
-	if err := d.boskos.Release(d.boskosProject.Name, "free"); err != nil {
-		return fmt.Errorf("failed to release %s: %s", d.boskosProject.Name, err)
-	}
-
-	close(d.boskosHeartbeatClose)
 
 	return nil
 }

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (d *deployer) Down() error {
-	klog.Info("GCE deployer starting Down()")
+	klog.V(1).Info("GCE deployer starting Down()")
 
 	if err := d.init(); err != nil {
 		return fmt.Errorf("down failed to init: %s", err)
@@ -33,7 +33,7 @@ func (d *deployer) Down() error {
 
 	env := d.buildEnv()
 	script := filepath.Join(d.RepoRoot, "cluster", "kube-down.sh")
-	klog.Infof("About to run script at: %s", script)
+	klog.V(2).Infof("About to run script at: %s", script)
 
 	cmd := exec.Command(script)
 	cmd.SetEnv(env...)
@@ -44,6 +44,7 @@ func (d *deployer) Down() error {
 	}
 
 	if d.boskos != nil {
+		klog.V(2).Info("releasing boskos project")
 		err := releaseBoskosProject(
 			d.boskos,
 			d.GCPProject,

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -58,3 +58,17 @@ func (d *deployer) releaseBoskosProject() error {
 	}
 	return nil
 }
+
+func (d *deployer) verifyDownFlags() error {
+	if err := d.setRepoPathIfNotSet(); err != nil {
+		return err
+	}
+
+	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
+
+	if d.GCPProject == "" {
+		return fmt.Errorf("gcp project must be set")
+	}
+
+	return nil
+}

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -28,8 +28,8 @@ import (
 func (d *deployer) DumpClusterLogs() error {
 	klog.Info("GCE deployer starting DumpClusterLogs()")
 
-	if err := d.verifyFlags(); err != nil {
-		return fmt.Errorf("dump cluster logs could not verify flags: %s", err)
+	if err := d.init(); err != nil {
+		return fmt.Errorf("dump cluster logs failed to init: %s", err)
 	}
 
 	if err := d.makeLogsDir(); err != nil {

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -110,7 +110,7 @@ func (d *deployer) kubectlDump() error {
 	defer outfile.Close()
 
 	args := []string{
-		d.kubectl,
+		d.kubectlPath,
 		"cluster-info",
 		"dump",
 	}

--- a/kubetest2/kubetest2-gce/deployer/dumplogs.go
+++ b/kubetest2/kubetest2-gce/deployer/dumplogs.go
@@ -26,12 +26,13 @@ import (
 )
 
 func (d *deployer) DumpClusterLogs() error {
-	klog.Info("GCE deployer starting DumpClusterLogs()")
+	klog.V(1).Info("GCE deployer starting DumpClusterLogs()")
 
 	if err := d.init(); err != nil {
 		return fmt.Errorf("dump cluster logs failed to init: %s", err)
 	}
 
+	klog.V(2).Info("making logs directory")
 	if err := d.makeLogsDir(); err != nil {
 		return fmt.Errorf("couldn't make logs dir: %s", err)
 	}
@@ -68,6 +69,8 @@ func (d *deployer) makeLogsDir() error {
 	// file definitely exists, overwrite if requested
 
 	if d.OverwriteLogsDir {
+		klog.V(2).Infof("logs directory %s already exists, removing and recreating", d.logsDir)
+
 		if err := os.RemoveAll(d.logsDir); err != nil {
 			return fmt.Errorf("failed to delete existing logs directory: %s", err)
 		}
@@ -89,7 +92,7 @@ func (d *deployer) sshDump() error {
 		filepath.Join(d.RepoRoot, "cluster", "log-dump", "log-dump.sh"),
 		d.logsDir,
 	}
-	klog.Infof("About to run: %s", args)
+	klog.V(2).Infof("About to run: %s", args)
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(env...)
@@ -114,7 +117,7 @@ func (d *deployer) kubectlDump() error {
 		"cluster-info",
 		"dump",
 	}
-	klog.Infof("About to run: %s", args)
+	klog.V(2).Infof("About to run: %s", args)
 
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.SetEnv(env...)

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -26,12 +26,13 @@ import (
 )
 
 func (d *deployer) Up() error {
-	klog.Info("GCE deployer starting Up()")
+	klog.V(1).Info("GCE deployer starting Up()")
 
 	if err := d.init(); err != nil {
 		return fmt.Errorf("up failed to init: %s", err)
 	}
 
+	klog.V(2).Info("enabling compute API for project")
 	if err := enableComputeAPI(d.GCPProject); err != nil {
 		return fmt.Errorf("up couldn't enable compute API: %s", err)
 	}
@@ -44,7 +45,7 @@ func (d *deployer) Up() error {
 
 	env := d.buildEnv()
 	script := filepath.Join(d.RepoRoot, "cluster", "kube-up.sh")
-	klog.Infof("About to run script at: %s", script)
+	klog.V(2).Infof("About to run script at: %s", script)
 
 	cmd := exec.Command(script)
 	cmd.SetEnv(env...)
@@ -58,7 +59,7 @@ func (d *deployer) Up() error {
 	if err != nil {
 		klog.Warningf("failed to check if cluster is up: %s", err)
 	} else if isUp {
-		klog.Infof("cluster reported as up")
+		klog.V(1).Infof("cluster reported as up")
 	} else {
 		klog.Errorf("cluster reported as down")
 	}

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -113,7 +113,7 @@ func (d *deployer) getProjectFromBoskos() error {
 
 	boskosProject, err := boskos.AcquireWait(ctx, resourceType, "free", "busy")
 	if err != nil {
-		return fmt.Errorf("failed to get a %s from boskos: %s", resourceType, err)
+		return fmt.Errorf("failed to get a %q from boskos: %s", resourceType, err)
 	}
 	if boskosProject == nil {
 		return fmt.Errorf("boskos had no %s available", resourceType)
@@ -139,7 +139,7 @@ func (d *deployer) verifyUpFlags() error {
 		return err
 	}
 
-	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
+	d.kubectlPath = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
 
 	// verifyUpFlags does not check for a gcp project because it is
 	// assumed that one will be acquired from boskos if it is not set

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -28,8 +28,8 @@ import (
 func (d *deployer) Up() error {
 	klog.Info("GCE deployer starting Up()")
 
-	if err := d.verifyFlags(); err != nil {
-		return fmt.Errorf("up failed to verify flags: %s", err)
+	if err := d.init(); err != nil {
+		return fmt.Errorf("up failed to init: %s", err)
 	}
 
 	if err := enableComputeAPI(d.GCPProject); err != nil {
@@ -65,53 +65,6 @@ func (d *deployer) Up() error {
 
 	return nil
 }
-
-func (d *deployer) buildEnv() []string {
-	// The base env currently does not inherit the current os env (except for PATH)
-	// because (for now) it doesn't have to. In future, this may have to change when
-	// support is added for k/k's kube-up.sh and kube-down.sh which support a wide
-	// variety of environment variables. Before doing so, it is worth investigating
-	// inheriting the os env vs. adding flags to this deployer on a case-by-case
-	// basis to support individual environment configurations.
-	var env []string
-
-	// path is necessary for scripts to find gsutil, gcloud, etc
-	// can be removed if env is inherited from the os
-	env = append(env, fmt.Sprintf("PATH=%s", os.Getenv("PATH")))
-
-	// used by config-test.sh to set $NETWORK in the default case
-	// if unset, bash's set -u gets angry and kills the log dump script
-	// can be removed if env is inherited from the os
-	env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
-
-	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter for all gcloud commands
-	env = append(env, fmt.Sprintf("PROJECT=%s", d.GCPProject))
-
-	// kubeconfig is set to tell kube-up.sh where to generate the kubeconfig
-	// we don't want this to be the default because this kubeconfig "belongs" to
-	// the run of kubetest2 and so should be placed in the artifacts directory
-	env = append(env, fmt.Sprintf("KUBECONFIG=%s", d.kubeconfigPath))
-
-	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
-	// does not. opted to set it manually here for maximum consistency
-	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
-	return env
-}
-
-func (d *deployer) verifyFlags() error {
-	if err := d.setRepoPathIfNotSet(); err != nil {
-		return err
-	}
-
-	d.kubectl = filepath.Join(d.RepoRoot, "cluster", "kubectl.sh")
-
-	if d.GCPProject == "" {
-		return fmt.Errorf("gcp project must be set")
-	}
-
-	return nil
-}
-
 func enableComputeAPI(project string) error {
 	// In freshly created GCP projects, the compute API is
 	// not enabled. We need it. Enabling it after it has


### PR DESCRIPTION
This is the simplest implementation for the GCE deployer to support automatically acquiring projects from Boskos. It does not support a decoupled up/down step yet, that is coming in a future PR. The commit messages contain most information about change specifics. `$JOB_NAME` is based on kubetest: https://github.com/michaelmdresser/test-infra/blob/7f316346539d06be7cf45f382cd7d1c70a09b5f2/kubetest/main.go#L55

Tested against a locally running boskos.