### PR TITLE
Revert "Update to containerd 1.3.5"

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -187,7 +187,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.3
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -386,7 +386,7 @@ periodics:
           - --check-leaked-resources
           - --extract=ci/latest
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.3
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
Reverts kubernetes/test-infra#18086

CI is failing, can't download.
this is also blocking PRs

we should test changes like this on a canary job first or make this one non-blocking @dims