### PR TITLE
Add a canary job for pull-kubernetes-e2e-gce-ubuntu-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -212,6 +212,62 @@ presubmits:
             requests:
               memory: "6Gi"
 
+  - name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+    always_run: false
+    skip_report: false
+    skip_branches:
+      - release-\d+\.\d+ # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+      testgrid-dashboards: google-gce
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+    spec:
+      containers:
+        - args:
+            - --root=/go/src
+            - --repo=k8s.io/kubernetes=$(PULL_REFS)
+            - --repo=k8s.io/release
+            - --upload=gs://kubernetes-jenkins/pr-logs
+            - --timeout=105
+            - --scenario=kubernetes_e2e
+            - --
+            - --build=bazel
+            - --cluster=
+            - --env=KUBE_CONTAINER_RUNTIME=containerd
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
+            - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+            - --env=ENABLE_POD_SECURITY_POLICY=true
+            - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+            - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+            - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+            - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+            - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+            - --extract=local
+            - --gcp-master-image=ubuntu
+            - --gcp-node-image=ubuntu
+            - --gcp-zone=us-west1-b
+            - --ginkgo-parallel=30
+            - --provider=gce
+            - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+            - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
+            - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
+          resources:
+            requests:
+              memory: "6Gi"
+
   - name: pull-kubernetes-e2e-gce-rbe
     always_run: false
     skip_report: true


### PR DESCRIPTION
This will help us test newer containerd and runc versions

Signed-off-by: Davanum Srinivas <davanum@gmail.com>