### PR TITLE
add the fetch from remote method to interactor's interface

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -488,22 +488,3 @@ func (i *Repo) ShowRef(commitlike string) (string, error) {
 	}
 	return strings.TrimSpace(string(out)), nil
 }
-
-// FetchFromRemote runs a git fetch command for the specified remote.
-// Pass the destination as org/repo format since the actual URI will be constructed
-// using the existing credentials and will always use the https protocol.
-func (r *Repo) FetchFromRemote(orgRepo, branch string) error {
-	r.logger.Infof("Fetching from '%s (branch: %s)'.", orgRepo, branch)
-
-	remoteURI := fmt.Sprintf("https://%s/%s", r.host, orgRepo)
-	if r.user != "" && r.pass != "" {
-		remoteURI = fmt.Sprintf("https://%s:%s@%s/%s", r.user, r.pass, r.host, orgRepo)
-	}
-
-	co := r.gitCommand("fetch", remoteURI, branch)
-	out, err := co.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("Fetching failed, output: %q, error: %v", string(out), err)
-	}
-	return nil
-}

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -86,6 +86,10 @@ func (a *repoClientAdapter) Fetch() error {
 	return errors.New("no Fetch implementation exists in the v1 repo client")
 }
 
+func (a *repoClientAdapter) FetchFromRemote(resolver RemoteResolver, branch string) error {
+	return errors.New("no FetchFromRemote implementation exists in the v1 repo client")
+}
+
 func (a *repoClientAdapter) RemoteUpdate() error {
 	return errors.New("no RemoteUpdate implementation exists in the v1 repo client")
 }

--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -54,6 +54,8 @@ type Interactor interface {
 	Fetch() error
 	// FetchRef fetches the refspec
 	FetchRef(refspec string) error
+	// FetchFromRemote fetches the branch of the given remote
+	FetchFromRemote(remote RemoteResolver, branch string) error
 	// CheckoutPullRequest fetches and checks out the synthetic refspec from GitHub for a pull request HEAD
 	CheckoutPullRequest(number int) error
 	// Config runs `git config`


### PR DESCRIPTION
Add the fetch from remote method to interactor's interface.
It also removes it from the v1 git client.


/cc @alvaroaleman @stevekuznetsov 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>