### PR TITLE
Fix git v2 panic in repoclient's publisher and include the missing login details.

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -204,6 +204,7 @@ func (c *clientFactory) bootstrapClients(org, repo, dir string) (cacher, cloner,
 			remote:   c.remotes.PublishRemote(org, repo),
 			executor: executor,
 			info:     c.gitUser,
+			logger:   logger,
 		},
 		interactor: interactor{
 			dir:      dir,

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -90,6 +90,9 @@ func (cfo *ClientFactoryOpts) Apply(target *ClientFactoryOpts) {
 	if cfo.Censor != nil {
 		target.Censor = cfo.Censor
 	}
+	if cfo.Username != nil {
+		target.Username = cfo.Username
+	}
 }
 
 // ClientFactoryOpts allows to manipulate the options for a ClientFactory


### PR DESCRIPTION
This fixes a panic when a publisher's method is being used
because of the nil logger.

The second commit adds the missing LoginGetter function ton the clientfactory's options.

/cc @alvaroaleman @stevekuznetsov 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>