### PR TITLE
[git v2 publisher] add the ability to push to central remote

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -85,7 +85,7 @@ type Server struct {
 
 	gc git.ClientFactory
 	// Used for unit testing
-	push func(newBranch string) error
+	push func(newBranch string, force bool) error
 	ghc  githubClient
 	log  *logrus.Entry
 
@@ -443,12 +443,12 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 		return err
 	}
 
-	push := r.ForcePush
+	push := r.PushToFork
 	if s.push != nil {
 		push = s.push
 	}
 	// Push the new branch in the bot's fork.
-	if err := push(newBranch); err != nil {
+	if err := push(newBranch, true); err != nil {
 		resp := fmt.Sprintf("failed to push cherry-picked changes in GitHub: %v", err)
 		logger.Info(resp)
 		return s.createComment(org, repo, num, comment, resp)

--- a/prow/external-plugins/cherrypicker/server_test.go
+++ b/prow/external-plugins/cherrypicker/server_test.go
@@ -292,7 +292,7 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(newBranch string) error { return nil },
+		push:           func(newBranch string, force bool) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -437,7 +437,7 @@ func testCherryPickPR(clients localgit.Clients, t *testing.T) {
 	s := &Server{
 		botName:        botName,
 		gc:             c,
-		push:           func(newBranch string) error { return nil },
+		push:           func(newBranch string, force bool) error { return nil },
 		ghc:            ghc,
 		tokenGenerator: getSecret,
 		log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
@@ -586,7 +586,7 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 		s := &Server{
 			botName:        botName,
 			gc:             c,
-			push:           func(newBranch string) error { return nil },
+			push:           func(newBranch string, force bool) error { return nil },
 			ghc:            ghc,
 			tokenGenerator: getSecret,
 			log:            logrus.StandardLogger().WithField("client", "cherrypicker"),

--- a/prow/git/v2/adapter.go
+++ b/prow/git/v2/adapter.go
@@ -74,8 +74,12 @@ func (a *repoClientAdapter) Commit(title, body string) error {
 	return errors.New("no Commit implementation exists in the v1 repo client")
 }
 
-func (a *repoClientAdapter) ForcePush(branch string) error {
+func (a *repoClientAdapter) PushToFork(branch string, force bool) error {
 	return a.Repo.Push(branch)
+}
+
+func (a *repoClientAdapter) PushToCentral(branch string, force bool) error {
+	return errors.New("no PushToCentral implementation exists in the v1 repo client")
 }
 
 func (a *repoClientAdapter) MirrorClone() error {

--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -201,7 +201,10 @@ func (c *clientFactory) bootstrapClients(org, repo, dir string) (cacher, cloner,
 	}
 	client := &repoClient{
 		publisher: publisher{
-			remote:   c.remotes.PublishRemote(org, repo),
+			remotes: remotes{
+				publishRemote: c.remotes.PublishRemote(org, repo),
+				centralRemote: c.remotes.CentralRemote(org, repo),
+			},
 			executor: executor,
 			info:     c.gitUser,
 		},

--- a/prow/git/v2/publisher.go
+++ b/prow/git/v2/publisher.go
@@ -26,16 +26,23 @@ import (
 type Publisher interface {
 	// Commit stages all changes and commits them with the message
 	Commit(title, body string) error
-	// ForcePush runs `git push -f` to the publish remote
-	ForcePush(branch string) error
+	// PushToFork pushes the local state to the fork remote
+	PushToFork(branch string, force bool) error
+	// PushToCentral pushes the local state to the central remote
+	PushToCentral(branch string, force bool) error
 }
 
 // GitUserGetter fetches a name and email for us in git commits on-demand
 type GitUserGetter func() (name, email string, err error)
 
+type remotes struct {
+	publishRemote RemoteResolver
+	centralRemote RemoteResolver
+}
+
 type publisher struct {
 	executor executor
-	remote   RemoteResolver
+	remotes  remotes
 	info     GitUserGetter
 	logger   *logrus.Entry
 }
@@ -59,14 +66,41 @@ func (p *publisher) Commit(title, body string) error {
 	return nil
 }
 
-// ForcePush pushes the local state to the remote
-func (p *publisher) ForcePush(branch string) error {
-	p.logger.Infof("Pushing branch %q", branch)
-	remote, err := p.remote()
+// PublishPush pushes the local state to the publish remote
+func (p *publisher) PushToFork(branch string, force bool) error {
+	remote, err := p.remotes.publishRemote()
 	if err != nil {
 		return err
 	}
-	if out, err := p.executor.Run("push", "--force", remote, branch); err != nil {
+
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, []string{remote, branch}...)
+
+	p.logger.Infof("Pushing branch %q to %q", branch, remote)
+	if out, err := p.executor.Run(args...); err != nil {
+		return fmt.Errorf("error pushing %q: %v %v", branch, err, string(out))
+	}
+	return nil
+}
+
+// CentralPush pushes the local state to the central remote
+func (p *publisher) PushToCentral(branch string, force bool) error {
+	remote, err := p.remotes.centralRemote()
+	if err != nil {
+		return err
+	}
+
+	args := []string{"push"}
+	if force {
+		args = append(args, "--force")
+	}
+	args = append(args, []string{remote, branch}...)
+
+	p.logger.Infof("Pushing branch %q to %q", branch, remote)
+	if out, err := p.executor.Run(args...); err != nil {
 		return fmt.Errorf("error pushing %q: %v %v", branch, err, string(out))
 	}
 	return nil


### PR DESCRIPTION
Since there is no way to use the git v2 client to push the changes in the configured/cloned repo this PR gives the ability to publisher to push/forcepush to either publish or central remote as well.


/cc @stevekuznetsov @alvaroaleman 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>