### PR TITLE
prow: hook: fix defaulting of commandHelpLink property of approve plugin

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -850,6 +850,11 @@ func (c *Configuration) setDefaults() {
 			c.ExternalPlugins[repo][i].Endpoint = fmt.Sprintf("http://%s", p.Name)
 		}
 	}
+	for i, approve := range c.Approve {
+		if approve.CommandHelpLink == "" {
+			c.Approve[i].CommandHelpLink = "https://go.k8s.io/bot-commands"
+		}
+	}
 	if c.Blunderbuss.ReviewerCount == nil {
 		c.Blunderbuss.ReviewerCount = new(int)
 		*c.Blunderbuss.ReviewerCount = defaultBlunderbussReviewerCount
@@ -1101,14 +1106,6 @@ func compileRegexpsAndDurations(pc *Configuration) error {
 		rs[i].GracePeriodDuration = dur
 	}
 	return nil
-}
-
-func (c *Configuration) ApplyDefaults() {
-	for _, a := range c.Approve {
-		if a.CommandHelpLink == "" {
-			a.CommandHelpLink = "https://go.k8s.io/bot-commands"
-		}
-	}
 }
 
 func (c *Configuration) Validate() error {

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -210,6 +210,44 @@ func TestTriggerFor(t *testing.T) {
 	}
 }
 
+func TestSetApproveDefaults(t *testing.T) {
+	tests := []struct {
+		name string
+
+		commandHelpLink         string
+		expectedCommandHelpLink string
+	}{
+		{
+			name:                    "set commandHelpLink default",
+			commandHelpLink:         "",
+			expectedCommandHelpLink: "https://go.k8s.io/bot-commands",
+		},
+		{
+			name:                    "keep commandHelpLink value",
+			commandHelpLink:         "https://prow.k8s.io/command-help",
+			expectedCommandHelpLink: "https://prow.k8s.io/command-help",
+		},
+	}
+
+	for _, test := range tests {
+		c := &Configuration{
+			Approve: []Approve{{
+				Repos: []string{
+					"kubernetes/kubernetes",
+					"kubernetes-client",
+				},
+				CommandHelpLink: test.commandHelpLink,
+			}},
+		}
+
+		c.setDefaults()
+
+		if c.Approve[0].CommandHelpLink != test.expectedCommandHelpLink {
+			t.Errorf("unexpected commandHelpLink: %s, expected: %s", c.Approve[0].CommandHelpLink, test.expectedCommandHelpLink)
+		}
+	}
+}
+
 func TestSetTriggerDefaults(t *testing.T) {
 	tests := []struct {
 		name string

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -239,8 +239,6 @@ func (pa *ConfigAgent) Load(path string, checkUnknownPlugins bool) error {
 		return err
 	}
 
-	np.ApplyDefaults()
-
 	if err := np.Validate(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes the bug introduced by: https://github.com/kubernetes/test-infra/pull/17784

See also: https://github.com/kubernetes/test-infra/pull/17784#issuecomment-650772422