### PR TITLE
fix(config): fix merge_commit_template format and apply to kubeflow org

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -521,7 +521,7 @@ tide:
     kubernetes/cloud-provider-openstack: squash
     kubernetes/dashboard: squash
   merge_commit_template:
-    kubeflow/pipelines:
+    kubeflow:
       title: "{{ .Title }} (#{{ .Number }})"
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -522,7 +522,7 @@ tide:
     kubernetes/dashboard: squash
   merge_commit_template:
     kubeflow/pipelines:
-      title: "{{ .Title }} ({{ .Number }})"
+      title: "{{ .Title }} (#{{ .Number }})"
   pr_status_base_urls:
     '*': https://prow.k8s.io/pr
   blocker_label: tide/merge-blocker


### PR DESCRIPTION
Follow up on https://github.com/kubernetes/test-infra/pull/18043.

Example commit with current config: https://github.com/kubeflow/pipelines/commit/c52a73e52c64a2d1414d0294e8617da42445dfd8.
Config documentation: https://github.com/kubernetes/test-infra/blob/master/prow/cmd/tide/config.md#general-configuration

Just realized the `{{ .Number }}` is just the PR number, so I added a `#` before it.

/assign @jlewi @spiffxp

Can I get your approvals? Thanks!