### PR TITLE
Update iSCSI test images

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -227,8 +227,9 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-lts-1
-        - --image-project=ubuntu-os-gke-cloud
+        - --image-family=ubuntu-2004-lts
+        - --image-project=ubuntu-oscloud
+        - --env=KUBE_CONTAINER_RUNTIME=docker
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --ginkgo-parallel=30
@@ -268,8 +269,9 @@ presubmits:
         - --cluster=
         - --extract=local
         - --gcp-node-image=ubuntu
-        - --image-family=ubuntu-gke-1804-lts-1
-        - --image-project=ubuntu-os-gke-cloud
+        - --image-family=ubuntu-2004-lts
+        - --image-project=ubuntu-oscloud
+        - --env=KUBE_CONTAINER_RUNTIME=docker
         - --gcp-zone=us-west1-b
         - --provider=gce
         - --runtime-config=batch/v2alpha1=true
@@ -335,8 +337,9 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-lts-1
-      - --image-project=ubuntu-os-gke-cloud
+      - --image-family=ubuntu-2004-lts
+      - --image-project=ubuntu-oscloud
+      - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --ginkgo-parallel=30
@@ -360,8 +363,9 @@ periodics:
       - --check-leaked-resources
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
-      - --image-family=ubuntu-gke-1804-lts-1
-      - --image-project=ubuntu-os-gke-cloud
+      - --image-family=ubuntu-2004-lts
+      - --image-project=ubuntu-oscloud
+      - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8


### PR DESCRIPTION
Another attempt to fix failing sig-storage iSCSI tests: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-iscsi-serial/1277500363099869185

```
Jun 29 07:17:29.018596 bootstrap-e2e-minion-group-0984 configure.sh[1856]: Downloading Kubelet config file, if it exists
Jun 29 07:17:29.035355 bootstrap-e2e-minion-group-0984 configure.sh[1856]: ERROR ctr not found. Aborting.
```

This time, explicitly setting `KUBE_CONTAINER_RUNTIME=docker` (so `ctr` is not required) and using the latest ubuntu LTS image.