### PR TITLE
Revert autobump split changes

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -68,10 +68,7 @@ main() {
   fi
   echo -e "Bumping: 'gcr.io/k8s-prow/' images to $(color-version "${new_version}") ..." >&2
 
-  local IFS=,
-  local component_file_dir_array
-  read -ra component_file_dir_array <<< "${COMPONENT_FILE_DIR}"
-  bumpfiles=("${component_file_dir_array[@]/%/*.yaml}")
+  bumpfiles=($(add_suffix "$(split_on_commas "$COMPONENT_FILE_DIR")"))
   bumpfiles+=("${CONFIG_PATH}")
   if [[ -n "${JOB_CONFIG_PATH}" ]]; then
     bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"; true))
@@ -200,6 +197,19 @@ list() {
     fi
   fi
 }
+
+ split_on_commas() {
+   local IFS=,
+   local array
+   read -ra array <<< "$1"
+   echo "${array[@]}"
+ }
+
+ add_suffix() {
+   local array=($1)
+   local suffix="${2:-/*.yaml}"
+   echo "${array[@]/%/$suffix}"
+ }
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 color-image() { # Bold magenta

--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -198,18 +198,17 @@ list() {
   fi
 }
 
- split_on_commas() {
-   local IFS=,
-   local array
-   read -ra array <<< "$1"
-   echo "${array[@]}"
- }
+split_on_commas() {
+  local IFS=,
+  local array=("$1")
+  echo "${array[@]}"
+}
 
- add_suffix() {
-   local array=($1)
-   local suffix="${2:-/*.yaml}"
-   echo "${array[@]/%/$suffix}"
- }
+add_suffix() {
+  local array=("$1")
+  local suffix="${2:-/*.yaml}"
+  echo "${array[@]/%/$suffix}"
+}
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting
 color-image() { # Bold magenta


### PR DESCRIPTION
Revert of https://github.com/kubernetes/test-infra/pull/18060 because a `/` is missing and also `*` expansion is no longer working.

/assign @chaodaiG 