### PR TITLE
Remove incorrect requirement of JOB_CONFIG_PATH for bump.sh.

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -112,9 +112,6 @@ check-args() {
   if [[ -z "${CONFIG_PATH}" ]]; then
     echo "ERROR: CONFIG_PATH must be specified as an env var." >&2
   fi
-  if [[ -z "${JOB_CONFIG_PATH}" ]]; then
-    echo "ERROR: JOB_CONFIG_PATH must be specified as an env var." >&2
-  fi
 }
 
 check-requirements() {


### PR DESCRIPTION
I added this validation to check-args incorrectly. This comment is respected (referring to `JOB_CONFIG_PATH`): https://github.com/kubernetes/test-infra/blob/d2cf7b0d1b296739c21b86a764cf36e32dbdf546/prow/cmd/autobump/bump.sh#L38

/assign @chaodaiG 