### PR TITLE
Autobumper: fixing path splitting

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -68,7 +68,15 @@ main() {
   fi
   echo -e "Bumping: 'gcr.io/k8s-prow/' images to $(color-version "${new_version}") ..." >&2
 
-  bumpfiles=($(add_suffix "$(split_on_commas "$COMPONENT_FILE_DIR")"))
+  local IFS=,
+  local component_file_dir_array
+  read -ra component_file_dir_array <<< "${COMPONENT_FILE_DIR}"
+  bumpfiles=()
+  for c in "${component_file_dir_array[@]}"; do
+    # This expands wildcards into files if they exist
+    bumpfiles+=(${c}/*.yaml)
+  done
+
   bumpfiles+=("${CONFIG_PATH}")
   if [[ -n "${JOB_CONFIG_PATH}" ]]; then
     bumpfiles+=($(grep -rl -e "gcr.io/k8s-prow/" "${JOB_CONFIG_PATH}"; true))
@@ -196,18 +204,6 @@ list() {
       exit 1
     fi
   fi
-}
-
-split_on_commas() {
-  local IFS=,
-  local array=("$1")
-  echo "${array[@]}"
-}
-
-add_suffix() {
-  local array=("$1")
-  local suffix="${2:-/*.yaml}"
-  echo "${array[@]/%/$suffix}"
 }
 
 # See https://misc.flogisoft.com/bash/tip_colors_and_formatting


### PR DESCRIPTION
This is the second attempt of fixing path splitting in autobump tool. The original attempt #18060 failed at line 86:
```
${SED} -i "${replacer}" "${file}"
```
As `file` contains extra pair of single quotes after processing, and thus wildcards were not able to be expanded. 

Not able to figure out why the original approach didn't work, used a better readable way seemed work. This was tested using istio/test-infra repo and it worked


/cc @cjwagner 