### PR TITLE
Fix Ubuntu image family name in storage tests

### DIFF
--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -228,7 +228,7 @@ presubmits:
         - --extract=local
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
-        - --image-project=ubuntu-oscloud
+        - --image-project=ubuntu-os-cloud
         - --env=KUBE_CONTAINER_RUNTIME=docker
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -270,7 +270,7 @@ presubmits:
         - --extract=local
         - --gcp-node-image=ubuntu
         - --image-family=ubuntu-2004-lts
-        - --image-project=ubuntu-oscloud
+        - --image-project=ubuntu-os-cloud
         - --env=KUBE_CONTAINER_RUNTIME=docker
         - --gcp-zone=us-west1-b
         - --provider=gce
@@ -338,7 +338,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
-      - --image-project=ubuntu-oscloud
+      - --image-project=ubuntu-os-cloud
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -364,7 +364,7 @@ periodics:
       - --extract=ci/latest
       - --gcp-node-image=ubuntu
       - --image-family=ubuntu-2004-lts
-      - --image-project=ubuntu-oscloud
+      - --image-project=ubuntu-os-cloud
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
Fixes a stupid typo in image name:

```
W0629 19:35:48.933] 2020/06/29 19:35:48 process.go:153: Running: gcloud compute images describe-from-family ubuntu-2004-lts --project ubuntu-oscloud
W0629 19:35:50.093] ERROR: (gcloud.compute.images.describe-from-family) Could not fetch resource:
W0629 19:35:50.093]  - Failed to find project ubuntu-oscloud
```

/assign @msau42 