### PR TITLE
Enable OOM tracking in periodic 1.15 perf test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -197,6 +197,7 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/enable_oom_tracking.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
@@ -251,6 +252,7 @@ periodics:
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
       - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/enable_oom_tracking.yaml
       - --test-cmd-args=--testoverrides=./testing/prometheus/not-scrape-kube-proxy.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m


### PR DESCRIPTION
Roll out the mechanism implemented in kubernetes/perf-tests#1309 to periodic 1.15 performance tests.

Analogous PR from the past but for 1.16-1.18 releases: https://github.com/kubernetes/test-infra/pull/18016.

/sig scalability
/cc jkaniuk
/cc mm4tt
/cc wojtek-t