### PR TITLE
Update to containerd 1.3.5 - Take #2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -187,7 +187,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.3
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -442,7 +442,7 @@ periodics:
           - --check-leaked-resources
           - --extract=ci/latest
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.3
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
Previous attempt https://github.com/kubernetes/test-infra/pull/18086 was reverted in https://github.com/kubernetes/test-infra/pull/18089. A canary job was added in https://github.com/kubernetes/test-infra/pull/18091

which is now green  ✅  : 
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/92540/pull-kubernetes-e2e-gce-ubuntu-containerd-canary/1277916511897391104/

Signed-off-by: Davanum Srinivas <davanum@gmail.com>