### PR TITLE
Update owners to remove former sig-cloud-provider co-lead

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/jobs/kubernetes/sig-cloud-provider/OWNERS
@@ -3,12 +3,10 @@
 reviewers:
 - andrewsykim
 - cheftako
-- hogepodge
 - justaugustus
 approvers:
 - andrewsykim
 - cheftako
-- hogepodge
 - justaugustus
 
 labels:

--- a/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
+++ b/config/testgrids/kubernetes/sig-cloud-provider/OWNERS
@@ -3,12 +3,10 @@
 reviewers:
 - andrewsykim
 - cheftako
-- hogepodge
 - justaugustus
 approvers:
 - andrewsykim
 - cheftako
-- hogepodge
 - justaugustus
 
 labels:


### PR DESCRIPTION
Update owners for sig-cloud-provider

@andrewsykim @cheftako this might be a good time to add or remove names from the OWNERS files