### PR TITLE
[capz] Add periodic job for CAPI E2E

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -41,3 +41,33 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: periodic-conformance-v1alpha3
+- name: periodic-cluster-api-provider-azure-capi-e2e
+  decorate: true
+  decoration_config:
+    timeout: 4h
+  interval: 12h
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+    preset-azure-cred: "true"
+  extra_refs:
+    - org: kubernetes-sigs
+      repo: cluster-api-provider-azure
+      base_ref: master
+      path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-experimental
+      command:
+      - "runner.sh"
+      - "./scripts/ci-e2e.sh"
+      env:
+        - name: GINKGO_FOCUS
+          value: "Cluster API E2E tests"
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+    testgrid-tab-name: periodic-capi-e2e
+    testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
This adds a periodic job for running the Cluster API test suite in CAPZ, now that https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/701 has merged.

This job is equivalent to https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml#L92 but periodic.