### PR TITLE
Setup periodic jobs for  kubeflow1.1 branches

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -1,3 +1,8 @@
+#******************************************************************************
+# kubeflow/kfctl
+#******************************************************************************
+# These tests are named kubeflow even though they are for the kfctl repo
+# because that used to be the repo that had our main E2E tests for kubeflow
 periodics:
 - name: kubeflow-periodic-1-1
   cluster: kubeflow
@@ -58,6 +63,9 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 0-7 release
+#******************************************************************************
+# kubeflow/kubeflow
+#******************************************************************************
 - name: kubeflow-periodic-master
   cluster: kubeflow
   interval: 4h
@@ -80,10 +88,34 @@ periodics:
     # TODO: use a public email group
     testgrid-alert-email: kubeflow-engineering@google.com
     testgrid-num-failures-to-alert: "3"
+
+- name: kubeflow-kubeflow-periodic-1-1
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: kfctl
+      - name: BRANCH_NAME
+        value: v1.1-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow on the 1-1 branch
+
+#******************************************************************************
+# kubeflow/gcp-blueprints
+#******************************************************************************
 # Periodic tests currently aren't deploying infrastructure; they are
 # just running against the auto deployed clusters so we can run them
 # fairly frequently.
-- name: kubeflow-gcp-blueprints-master-periodic
+- name: kubeflow-gcp-blueprints-periodic-master
   cluster: kubeflow
   interval: 20m
   labels:
@@ -105,6 +137,50 @@ periodics:
     # TODO: use a public email group
     testgrid-alert-email: kubeflow-engineering@google.com
     testgrid-num-failures-to-alert: "3"
+- name: kubeflow-gcp-blueprints-periodic-1-1
+  cluster: kubeflow
+  interval: 20m
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: gcp-blueprints
+      - name: BRANCH_NAME
+        value: v1.1-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow gcp blueprints on the 1.1 branch.
+    # TODO: use a public email group
+    testgrid-alert-email: kubeflow-engineering@google.com
+    testgrid-num-failures-to-alert: "3"
+#******************************************************************************
+# kubeflow/manifests
+#******************************************************************************
+- name: kubeflow-manifests-periodic-1-1
+  cluster: kubeflow
+  interval: 8h
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/kubeflow-ci/test-worker:latest
+      imagePullPolicy: Always
+      env:
+      - name: REPO_OWNER
+        value: kubeflow
+      - name: REPO_NAME
+        value: manifests
+      - name: BRANCH_NAME
+        value: v1.1-branch
+  annotations:
+    testgrid-dashboards: sig-big-data
+    description: Periodic testing of Kubeflow/manifests on the master branch.
 - name: kubeflow-manifests-periodic-master
   cluster: kubeflow
   interval: 8h
@@ -124,7 +200,10 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow/manifests on the master branch.
-- name: kubeflow-periodic-examples
+#******************************************************************************
+# kubeflow/examples
+#******************************************************************************
+- name: kubeflow-examples-periodic
   cluster: kubeflow
   interval: 1h
   labels:
@@ -143,7 +222,10 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow examples
-- name: kubeflow-periodic-kfctl
+#******************************************************************************
+# kubeflow/kfctl
+#******************************************************************************
+- name: kubeflow-kfctl-periodic
   cluster: kubeflow
   interval: 8h
   labels:


### PR DESCRIPTION
* Related to kubeflow/gcp-blueprints#1.1

* Standardize some of the names in the format
  <org>-<repo>-<periodic|postusbmit|presubmit>-<version>