### PR TITLE
Organizes sig-windows tests in test grid

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
@@ -165,7 +165,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-16-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -219,7 +219,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.16-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-16-windows-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
@@ -164,7 +164,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.17-informing, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.17-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-17-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.17 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -217,7 +217,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-17-windows-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.17 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -166,7 +166,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, sig-release-1.18-informing, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, sig-release-1.18-informing, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-18-windows
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -219,7 +219,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-1-18-windows-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release serial tests on K8s 1.18 clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -62,7 +62,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
+      testgrid-dashboards: sig-windows-presubmit, provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
       testgrid-tab-name: pr-aks-engine-azure-windows
       description: Presubmit job for Windows tests on k8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
       testgrid-num-columns-recent: '30'
@@ -125,7 +125,7 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
+      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit, provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
       testgrid-tab-name: pr-k8s-azure-disk-e2e-master-windows
       description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
   - name: pull-kubernetes-e2e-azure-file-windows
@@ -187,7 +187,7 @@ presubmits:
         - name: TEST_WINDOWS
           value: "true"
     annotations:
-      testgrid-dashboards: provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
+      testgrid-dashboards: sig-windows-azure, sig-windows-presubmit, provider-azure-windows, provider-azure-upstream, provider-azure-presubmit
       testgrid-tab-name: pr-k8s-azure-file-e2e-master-windows
       description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
 periodics:
@@ -294,7 +294,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-releases, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master-staging
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Staging job for new Windows tests on a Kubernetes cluster provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -347,7 +347,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-containerd, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master-containerd
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -400,7 +400,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-containerd, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master-containerd-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -460,7 +460,7 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-periodic, provider-azure-windows
+    testgrid-dashboards: sig-windows-containerd,sig-windows-azure, provider-azure-periodic, provider-azure-windows
     testgrid-tab-name: aks-engine-azure-windows-containerd-azuredisk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: "Run Azure Disk CSI driver E2E tests on a Windows cluster using containerd"
@@ -513,7 +513,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-containerd, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master-containerd-hyperv
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -566,7 +566,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-containerd, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-master-containerd-hyperv-serial-slow
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs serial Windows tests on a Kubernetes cluster running containerd with HyperV isolation provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -628,7 +628,7 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-periodic, provider-azure-windows
+    testgrid-dashboards: sig-windows-azure, provider-azure-periodic, provider-azure-windows
     testgrid-tab-name: aks-engine-azure-windows-azure-disk
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
@@ -690,7 +690,7 @@ periodics:
       - name: TEST_WINDOWS
         value: "true"
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-periodic, provider-azure-windows
+    testgrid-dashboards: sig-windows-azure, provider-azure-periodic, provider-azure-windows
     testgrid-tab-name: aks-engine-azure-windows-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
@@ -744,7 +744,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-windows, provider-azure-periodic
+    testgrid-dashboards: sig-windows-sac, sig-windows-azure, provider-azure-windows, provider-azure-periodic
     testgrid-tab-name: aks-engine-azure-windows-1903-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -798,7 +798,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-periodic, provider-azure-windows
+    testgrid-dashboards: sig-windows-sac, sig-windows-azure, provider-azure-periodic, provider-azure-windows
     testgrid-tab-name: aks-engine-azure-windows-1909-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
@@ -852,7 +852,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-windows, provider-azure-periodic, provider-azure-windows
+    testgrid-dashboards: sig-windows-sac, sig-windows-azure, provider-azure-periodic, provider-azure-windows
     testgrid-tab-name: aks-engine-azure-windows-2004-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -26,7 +26,7 @@ periodics:
       - "runner.sh"
       - "./kubeadm/hack/ci-e2e.sh"
   annotations:
-    testgrid-dashboards: sig-windows
+    testgrid-dashboards: sig-windows-gce, sig-windows-releases
     testgrid-tab-name: kubeadm-windows-gcp-k8s-stable
     description: Periodic job that runs conformance tests on a Linux/Windows cluster created with kubeadm (stable k8s version)"
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -413,7 +413,7 @@ periodics:
 - annotations:
     description: Runs tests on a Kubernetes 1.16 cluster with Windows 2019 nodes on
       GCE
-    testgrid-dashboards: google-windows, sig-release-1.16-informing, sig-windows
+    testgrid-dashboards: google-windows, sig-release-1.16-informing, sig-windows-releases, sig-windows-gce
     testgrid-tab-name: gce-windows-1.16
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -467,7 +467,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.17-informing
+    testgrid-dashboards: google-windows, sig-windows-releases, sig-windows-gce, sig-release-1.17-informing
     testgrid-tab-name: gce-windows-1.17
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -471,7 +471,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows
+    testgrid-dashboards: google-windows, sig-windows-releases, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-1.18
   decorate: true
   extra_refs:
@@ -514,7 +514,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.18-informing
+    testgrid-dashboards: google-windows, sig-windows-releases, sig-windows-gce, sig-release-1.18-informing
     testgrid-tab-name: gce-windows-1909-1.18
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -426,7 +426,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.19-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-1.19-informing
     testgrid-tab-name: gce-windows-2019-1.19
   decorate: true
   extra_refs:
@@ -469,7 +469,7 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.19-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-windows-sac, sig-release-1.19-informing
     testgrid-tab-name: gce-windows-1909-1.19
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -91,7 +91,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
-    testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-master-informing
     testgrid-tab-name: gce-windows-2019-master
     description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
 
@@ -135,7 +135,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
-    testgrid-dashboards: google-windows, sig-windows, sig-release-master-informing
+    testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing
     testgrid-tab-name: gce-windows-1909-master
     description: Runs tests on a Kubernetes cluster with Windows 1909 nodes on GCE
 
@@ -179,7 +179,7 @@ periodics:
         value: "WindowsGMSA=true"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
-    testgrid-dashboards: google-windows, sig-windows
+    testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-master-alpha-features
     description: Runs tests on a Kubernetes cluster with Windows nodes on GCE and alpha features enabled
 
@@ -223,7 +223,7 @@ periodics:
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
-    testgrid-dashboards: google-windows
+    testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-serial
 
 - name: ci-kubernetes-e2e-windows-containerd-gce
@@ -267,7 +267,7 @@ periodics:
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-master
     description: Runs tests on a Kubernetes cluster with Windows containerd nodes on GCE
 
@@ -315,7 +315,7 @@ periodics:
       name: ""
       resources: {}
   annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-node-containerd
+    testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-1.18
 
 - name: ci-kubernetes-e2e-windows-node-throughput
@@ -326,7 +326,7 @@ periodics:
     preset-common-gce-windows: "true"
     preset-load-gce-windows: "true"
   annotations:
-    testgrid-dashboards: google-windows
+    testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-node-throughput
   decorate: true
   decoration_config:
@@ -380,7 +380,7 @@ periodics:
     preset-common-gce-windows: "true"
     preset-load-gce-windows: "true"
   annotations:
-    testgrid-dashboards: google-windows
+    testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-node-throughput-iis
   decorate: true
   decoration_config:
@@ -489,5 +489,5 @@ presubmits:
           requests:
             memory: "6Gi"
     annotations:
-      testgrid-dashboards: google-windows
+      testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-presubmit
       testgrid-tab-name: pull-windows-gce

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -110,20 +110,6 @@ test_groups:
 - name: test_pull_request_crio_e2e_rhel
   gcs_prefix: origin-federated-results/pr-logs/directory/test_pull_request_crio_e2e_rhel
 
-# Flannel CNI on Windows test groups
-- name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-l2bridge-master-windows
-- name: ci-kubernetes-e2e-flannel-overlay-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-overlay-master-windows
-- name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
-- name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
-
-# OVN-OVS CNI on Windows test groups
-- name: ci-kubernetes-e2e-ovn-ovs-master-windows
-  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-ovn-ovs-master-windows
-
 #
 # Start dashboards
 #
@@ -512,26 +498,7 @@ dashboards:
 - name: presubmits-kube-batch
 - name: presubmits-node-problem-detector
 - name: google-rules_k8s
-
-# sig-windows dashboard
-- name: sig-windows
-  dashboard_tab:
-  - name: flannel-l2bridge-windows-master
-    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in l2bridge network mode.
-    test_group_name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
-  - name: flannel-overlay-windows-master
-    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in overlay network mode.
-    test_group_name: ci-kubernetes-e2e-flannel-overlay-master-windows
-  - name: containerd-l2bridge-windows-master
-    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in l2bridge network mode.
-    test_group_name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
-  - name: containerd-overlay-windows-master
-    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in overlay network mode.
-    test_group_name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
-  - name: ovn-ovs-windows-master
-    description: Runs Windows e2e tests on K8s clusters on Openstack vms with OVN-OVS CNI.
-    test_group_name: ci-kubernetes-e2e-ovn-ovs-master-windows
-
+    
 - name: google-cel
   dashboard_tab:
   - name: cel-go

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -1,0 +1,43 @@
+dashboard_groups:
+- name: sig-windows
+  dashboard_names:
+    - sig-windows-releases
+    - sig-windows-sac
+    - sig-windows-containerd
+    - sig-windows-presubmit
+    - sig-windows-gce
+    - sig-windows-azure
+    - sig-windows-networking
+
+dashboards:
+- name: sig-windows-releases
+- name: sig-windows-sac
+- name: sig-windows-containerd
+- name: sig-windows-presubmit
+- name: sig-windows-gce
+- name: sig-windows-azure
+- name: sig-windows-networking
+  dashboard_tab:
+  - name: flannel-l2bridge-windows-master
+    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in l2bridge network mode.
+    test_group_name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
+  - name: flannel-overlay-windows-master
+    description: Runs Windows e2e tests on K8s clusters on Openstack vms with Flannel CNI in overlay network mode.
+    test_group_name: ci-kubernetes-e2e-flannel-overlay-master-windows
+  - name: containerd-l2bridge-windows-master
+    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in l2bridge network mode.
+    test_group_name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
+  - name: containerd-overlay-windows-master
+    description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in overlay network mode.
+    test_group_name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+
+test_groups:
+# Flannel CNI on Windows test groups
+- name: ci-kubernetes-e2e-flannel-l2bridge-master-windows
+  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-l2bridge-master-windows
+- name: ci-kubernetes-e2e-flannel-overlay-master-windows
+  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-flannel-overlay-master-windows
+- name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+- name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
+  gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-master-windows


### PR DESCRIPTION
The number of sig-windows tests has grown and this is a PR to organize the tests on the dashboard into dashboard groups.  Discussed at sig-windows [meeting today](https://docs.google.com/document/d/1Tjxzjjuy4SQsFSUVXZbvqVb64hjNAG5CQX8bK7Yda9w/edit#heading=h.kbz22d1yc431).  A test can be added to multiple dashboard groups.

Current sig-windows tests: https://testgrid.k8s.io/sig-windows
You can look at `blue` colored boxes on https://testgrid.k8s.io/ to see an example of what it will look like.

/sig windows