### PR TITLE
GCE deployer supports the simplest build in k/k

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/build.go
+++ b/kubetest2/kubetest2-gce/deployer/build.go
@@ -31,13 +31,26 @@ func (d *deployer) Build() error {
 		return fmt.Errorf("build failed to init: %s", err)
 	}
 
-	// this code path supports the kubernetes/cloud-provider-gcp build
-	// TODO: update in future patch to support legacy (k/k) build
-	cmd := exec.Command("bazel", "build", "//release:release-tars")
-	cmd.SetDir(d.RepoRoot)
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("error during make step of build: %s", err)
+	if d.LegacyMode {
+		// this supports the kubernetes/kubernetes build
+		klog.V(2).Info("starting the legacy build")
+
+		cmd := exec.Command("make", "bazel-release")
+		cmd.SetDir(d.RepoRoot)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("error during make step of build: %s", err)
+		}
+	} else {
+		// this code path supports the kubernetes/cloud-provider-gcp build
+		klog.V(2).Info("starting the build")
+
+		cmd := exec.Command("bazel", "build", "//release:release-tars")
+		cmd.SetDir(d.RepoRoot)
+		err := cmd.Run()
+		if err != nil {
+			return fmt.Errorf("error during make step of build: %s", err)
+		}
 	}
 
 	// no untarring, uploading, etc is necessary because

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -59,6 +59,7 @@ type deployer struct {
 	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
 	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
+	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
 }
 
 // New implements deployer.New for gce


### PR DESCRIPTION
Original kubetest has more options for different build options like all, quick-release, etc. but this is a MVP. Support for more options can be evaluated during test migration. Tested locally.

As a result of this change, the GCE deployer supports k/k fully (can be run with k/k as the repo root for build, up, and down), though not with the amount of configurability that kubetest has. Support requires this PR: https://github.com/kubernetes/kubernetes/pull/92668