### PR TITLE
Add support for GCP zone in GCE deployer

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -94,8 +94,14 @@ func (d *deployer) buildEnv() []string {
 	// can be removed if env is inherited from the os
 	env = append(env, fmt.Sprintf("USER=%s", os.Getenv("USER")))
 
-	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter for all gcloud commands
+	// kube-up.sh, kube-down.sh etc. use PROJECT as a parameter
+	// for gcloud commands
 	env = append(env, fmt.Sprintf("PROJECT=%s", d.GCPProject))
+
+	// KUBE_GCE_ZONE is used by up and down scripts. It is used mainly
+	// to set the ZONE var, which can't be set directly here because it
+	// will be overridden when the scripts check KUBE_GCE_ZONE.
+	env = append(env, fmt.Sprintf("KUBE_GCE_ZONE=%s", d.GCPZone))
 
 	// kubeconfig is set to tell kube-up.sh where to generate the kubeconfig
 	// we don't want this to be the default because this kubeconfig "belongs" to

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -57,6 +57,7 @@ type deployer struct {
 	BoskosAcquireTimeoutSeconds int    `desc:"How long (in seconds) to hang on a request to Boskos to acquire a resource before erroring."`
 	RepoRoot                    string `desc:"The path to the root of the local kubernetes/cloud-provider-gcp repo. Necessary to call certain scripts. Defaults to the current directory. If operating in legacy mode, this should be set to the local kubernetes/kubernetes repo."`
 	GCPProject                  string `desc:"GCP Project to create VMs in. If unset, the deployer will attempt to get a project from boskos."`
+	GCPZone                     string `desc:"GCP Zone to create VMs in. If unset, kube-up.sh and kube-down.sh defaults apply."`
 	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 }


### PR DESCRIPTION
Should be self-explanatory, details in comments.

Tested locally, inspected script output and GCE VM web UI to verify manually set zone was correct.