### PR TITLE
Add coverage Properties to xml for ci-kubernetes-coverage-unit

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -147,7 +147,10 @@ periodics:
         result=0
         ( cd hack/tools && GO111MODULE=on go install gotest.tools/gotestsum ) || result=$?
         make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" KUBE_TIMEOUT="--timeout=300s" || result=$?
-        grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+        cd ../test-infra/gopherage
+        GO111MODULE=on go build .
+        ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+        ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
         exit $result
       securityContext:
         privileged: true


### PR DESCRIPTION
To display the coverage results as short text in Testgrid the xml needs <property> tags under the testcases. `gopherage junit` handles this so I added it as part of the run. Similar to earlier in the file with e2e tests (currently broken). 

This is a WIP: Still looking for best way to test this. Might be easiest to run a fake job locally that skips the testing and directly interfaces with a static results file. 