### PR TITLE
update pull-kubernetes-e2e-gce-ubuntu-containerd-canary to use containerd 1.3.6

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -243,7 +243,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.6
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
1.3.5 had a problem with seccomp. there's a 1.3.6 now https://github.com/containerd/containerd/releases/tag/v1.3.6