### PR TITLE
Add periodic kops conformance test for Arm64

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -108,6 +108,41 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-arm64
 
+- interval: 3h
+  name: e2e-kops-aws-misc-arm64-conformance
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-arm64-conformance.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=ci/k8s-master
+      - --ginkgo-parallel
+      - --kops-args=--node-size=a1.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200609
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
+      - --provider=aws
+      - --test_args=--ginkgo.focus=\[Conformance\]
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
+    testgrid-tab-name: kops-aws-arm64-conformance
+
 - interval: 4h
   name: e2e-kops-aws-misc-containerd
   labels:


### PR DESCRIPTION
  Before, we used kubeadm to verify the conformance test on AWS arm64 cluster:
  https://testgrid.k8s.io/conformance-arm#Periodic%20Arm64%20conformance%20test%20on%20AWS

  And now, Kops has supported Arm64.
  So, we can use kops to deploy an arm64 cluster on AWS, and check the conformance test jobs.

Signed-off-by: Bin Lu <bin.lu@arm.com>