### PR TITLE
Kops - Add ARM64 periodic e2e for CI builds

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -73,7 +73,7 @@ periodics:
     testgrid-tab-name: kops-aws-ha-euwest1
 
 - interval: 3h
-  name: e2e-kops-aws-misc-arm64
+  name: e2e-kops-aws-misc-arm64-latest
   labels:
     preset-service-account: "true"
     preset-aws-ssh: "true"
@@ -106,7 +106,42 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
-    testgrid-tab-name: kops-aws-arm64
+    testgrid-tab-name: kops-aws-arm64-latest
+
+- interval: 3h
+  name: e2e-kops-aws-misc-arm64-ci
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 140m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-aws-arm64.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=ci/k8s-master
+      - --ginkgo-parallel
+      - --kops-args=--node-size=a1.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200609
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
+      - --timeout=120m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
+    testgrid-tab-name: kops-aws-arm64-ci
 
 - interval: 4h
   name: e2e-kops-aws-misc-containerd


### PR DESCRIPTION
This way there will be 2 jobs testing ARM64, one for `release/latest` and one for `ci/k8s-master`.

/cc @rifelpet 