### PR TITLE
Allow /approval variant for Prow approve plugin.

### DIFF
--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -1043,6 +1043,26 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 </details>
 <!-- META={"approvers":[]} -->`,
 		},
+		{
+			name:     "approval command variant",
+			prBody:   "This is a great PR that will fix\nlots of things!",
+			hasLabel: false,
+			files:    []string{"a/a.go", "a/aa.go"},
+			comments: []github.IssueComment{
+				newTestComment("k8s-ci-robot", "[APPROVALNOTIFIER] This PR is **NOT APPROVED**\n\nblah"),
+				newTestCommentTime(time.Now(), "alice", "stuff\n/approval\nblah"),
+			},
+			reviews:             []github.Review{},
+			selfApprove:         false,
+			needsIssue:          false,
+			lgtmActsAsApprove:   true,
+			reviewActsAsApprove: false,
+			githubLinkURL:       &url.URL{Scheme: "https", Host: "github.com"},
+
+			expectDelete:  true,
+			expectToggle:  true,
+			expectComment: true,
+		},
 	}
 
 	fr := fakeRepo{


### PR DESCRIPTION
It's common within internal Google code review to see "LGTM, Approval"
as a response to approved code reviews, so I've been somewhat conditioned to use
`/approval` with Prow, only to discover later that it didn't work.

This adds the ability for Prow to accept both `/approve` and `/approval`
as valid commands.

This also makes it easy to add other variants (e.g. `/approved`?) later
if we need to.