### PR TITLE
releng: Use latest-{{.Version}}-cross version markers for build jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -45,7 +45,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-master
+      - --extra-publish-file=latest-cross,k8s-master
       - --registry=gcr.io/kubernetes-ci-images
       # docker-in-docker needs privileged mode
       securityContext:
@@ -59,8 +59,7 @@ periodics:
       - 2241179 # release-managers
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extra-publish-file=k8s-master -> --extra-publish-file=k8s-beta"
-    fork-per-release-generic-suffix: "true"
+    fork-per-release-replacements: "latest-cross -> latest-{{.Version}}-cross, k8s-master -> k8s-beta"
     testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: build-master
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.15.yaml
@@ -147,7 +147,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable3
+      - --extra-publish-file=latest-1.15-cross,k8s-stable3
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -147,7 +147,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable2
+      - --extra-publish-file=latest-1.16-cross,k8s-stable2
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -184,7 +184,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable1
+      - --extra-publish-file=latest-1.17-cross,k8s-stable1
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -188,7 +188,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-beta
+      - --extra-publish-file=latest-1.18-cross,k8s-beta
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""


### PR DESCRIPTION
As of https://github.com/kubernetes/release/pull/1385, we can now support multiple additional version markers in `ci-kubernetes-build**` jobs.

This PR:
- Use `latest-{{.Version}}-cross` version markers for build jobs
- Add cross-build version markers to release branches

Note that we do not remove the current markers:
- `k8s-master`
- `k8s-beta`
- `k8s-stable1`
- `k8s-stable2`
- `k8s-stable3`

to allow us to search/replace usage of them across the codebase (in a follow-up PR).

As a proof-of-concept for branch generation, I have another branch open which generates the 1.19 release jobs: https://github.com/justaugustus/test-infra/blob/119-branches-test

Specifically, we can see that the `ci-kubernetes-build-1-19` appears to have the desired configuration:

https://github.com/justaugustus/test-infra/blob/2f65ba631ab0ad64772bd181afe25a87292de58f/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml#L168-L199

/assign @hasheddan @saschagrunert @cpanato @tpepper @alejandrox1 
cc: @kubernetes/release-engineering @kubernetes/ci-signal @BenTheElder @spiffxp 
ref: https://github.com/kubernetes/sig-release/issues/850, https://github.com/kubernetes/sig-release/issues/759