### PR TITLE
Basic presubmit for Kubetest2 GCE deployer

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
@@ -7,6 +7,8 @@ presubmits:
     # run_if_changed: "kubetest2/kubetest2-gce/.*"
     labels:
       preset-service-account: "true"
+    annotations:
+      testgrid-dashboards: sig-testing-canaries
     extra_refs:
     - base_ref: master
       org: kubernetes

--- a/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
@@ -1,10 +1,10 @@
 presubmits:
-  kubernetes/test-infra:
-  - name: kubetest2-gce-build-up-down
+  kubernetes-sigs/kubetest2:
+  - name: gce-build-up-down
     always_run: false
     decorate: true
     # TODO: uncomment when job has been tested successfully
-    # run_if_changed: "kubetest2/kubetest2-gce/.*"
+    # run_if_changed: "kubetest2-gce/.*"
     labels:
       preset-service-account: "true"
     annotations:

--- a/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  kubernetes/test-infra:
+  - name: kubetest2-gce-build-up-down
+    always_run: false
+    decorate: true
+    # TODO: uncomment when job has been tested successfully
+    # run_if_changed: "kubetest2/kubetest2-gce/.*"
+    labels:
+      preset-service-account: "true"
+    extra_refs:
+    - base_ref: master
+      org: kubernetes
+      repo: cloud-provider-gcp
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
+        command:
+        - "runner.sh"
+        args:
+        - "./kubetest2/kubetest2-gce/ci-tests/buildupdown.sh"


### PR DESCRIPTION
Will be run manually while the test script is tuned, then will be turned on as a presubmit for all changes that affect the GCE deployer. The cloud-provider-gcp repo is needed as an extra dependency because we need a repo to build that also contains the cluster/gce scripts like kube-up.sh. k/k could also be used, but cloud-provider-gcp is the expected and encouraged future default.