### PR TITLE
Kubetest2 GCE Deployer can be configured with an arbitrary number of nodes

### DIFF
--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -40,6 +40,9 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["build_test.go"],
+    srcs = [
+        "build_test.go",
+        "up_test.go",
+    ],
     embed = [":go_default_library"],
 )

--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -111,5 +111,28 @@ func (d *deployer) buildEnv() []string {
 	// kube-up and kube-down get this as a default ("kubernetes") but log-dump
 	// does not. opted to set it manually here for maximum consistency
 	env = append(env, "KUBE_GCE_INSTANCE_PREFIX=kubetest2")
+
+	// Pass through number of nodes and associated IP range. In the future,
+	// IP range will be configurable.
+	env = append(env, fmt.Sprintf("NUM_NODES=%d", d.NumNodes))
+	env = append(env, fmt.Sprintf("CLUSTER_IP_RANGE=%s", getClusterIPRange(d.NumNodes)))
+
 	return env
+}
+
+// Taken from the kubetest bash (gce) deployer
+// Calculates the cluster IP range based on the no. of nodes in the cluster.
+// Note: This mimics the function get-cluster-ip-range used by kube-up script.
+func getClusterIPRange(numNodes int) string {
+	suggestedRange := "10.64.0.0/14"
+	if numNodes > 1000 {
+		suggestedRange = "10.64.0.0/13"
+	}
+	if numNodes > 2000 {
+		suggestedRange = "10.64.0.0/12"
+	}
+	if numNodes > 4000 {
+		suggestedRange = "10.64.0.0/11"
+	}
+	return suggestedRange
 }

--- a/kubetest2/kubetest2-gce/deployer/deployer.go
+++ b/kubetest2/kubetest2-gce/deployer/deployer.go
@@ -61,6 +61,7 @@ type deployer struct {
 	OverwriteLogsDir            bool   `desc:"If set, will overwrite an existing logs directory if one is encountered during dumping of logs. Useful when runnning tests locally."`
 	BoskosLocation              string `desc:"If set, manually specifies the location of the boskos server. If unset and boskos is needed, defaults to http://boskos.test-pods.svc.cluster.local."`
 	LegacyMode                  bool   `desc:"Set if the provided repo root is the kubernetes/kubernetes repo and not kubernetes/cloud-provider-gcp."`
+	NumNodes                    int    `desc:"The number of nodes in the cluster."`
 }
 
 // New implements deployer.New for gce
@@ -72,6 +73,7 @@ func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
 		boskosHeartbeatClose:        make(chan struct{}),
 		BoskosAcquireTimeoutSeconds: 5 * 60,
 		BoskosLocation:              "http://boskos.test-pods.svc.cluster.local.",
+		NumNodes:                    3,
 	}
 
 	flagSet, err := gpflag.Parse(d)

--- a/kubetest2/kubetest2-gce/deployer/up.go
+++ b/kubetest2/kubetest2-gce/deployer/up.go
@@ -92,6 +92,10 @@ func enableComputeAPI(project string) error {
 }
 
 func (d *deployer) verifyUpFlags() error {
+	if d.NumNodes < 1 {
+		return fmt.Errorf("number of nodes must be at least 1")
+	}
+
 	if err := d.setRepoPathIfNotSet(); err != nil {
 		return err
 	}

--- a/kubetest2/kubetest2-gce/deployer/up_test.go
+++ b/kubetest2/kubetest2-gce/deployer/up_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"testing"
+)
+
+func TestVerifyUpFlags(t *testing.T) {
+	cases := []struct {
+		name string
+
+		deployer  deployer
+		shouldErr bool
+	}{
+		{
+			name: "0 num nodes",
+			deployer: deployer{
+				NumNodes: 0,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "-3 num nodes",
+			deployer: deployer{
+				NumNodes: -3,
+			},
+			shouldErr: true,
+		},
+		{
+			name: "3 num nodes",
+			deployer: deployer{
+				NumNodes: 3,
+			},
+			shouldErr: false,
+		},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := &c.deployer
+			err := d.verifyUpFlags()
+			if err != nil && !c.shouldErr {
+				t.Errorf("got err when none was expected: %s", err)
+			} else if err == nil && c.shouldErr {
+				t.Error("got no error when one was expected")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Includes the cluster IP range function from original kubetest. Tested with 6 nodes, verified script output and GCP web console. Also added unit tests for verify up flags because it can be tested now.