### PR TITLE
podspec decoration changed to support multiple containers

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1264,7 +1264,7 @@ func validateJobBase(v JobBase, jobType prowapi.ProwJobType, podNamespace string
 	if err := validateAgent(v, podNamespace); err != nil {
 		return err
 	}
-	if err := validatePodSpec(jobType, v.Spec, v.Annotations["ProwMultipleContainerSupport"] == "Yes, I know what I'm doing.", v.Decorate != nil && *v.Decorate); err != nil {
+	if err := validatePodSpec(jobType, v.Spec, v.Annotations["ProwMultipleContainerSupport"] == "Yes, I know what I'm doing.", v.DecorationConfig != nil); err != nil {
 		return err
 	}
 	if err := ValidatePipelineRunSpec(jobType, v.ExtraRefs, v.PipelineRunSpec); err != nil {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -818,7 +818,7 @@ func TestValidatePodSpec(t *testing.T) {
 			name: "reject reserved mount name",
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
-					Name:      decorate.VolumeMounts()[0],
+					Name:      decorate.VolumeMounts().List()[0],
 					MountPath: "/whatever",
 				})
 			},
@@ -828,7 +828,7 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "fun",
-					MountPath: decorate.VolumeMountPaths()[0],
+					MountPath: decorate.VolumeMountPaths().List()[0],
 				})
 			},
 		},
@@ -837,7 +837,7 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",
-					MountPath: filepath.Dir(decorate.VolumeMountPaths()[0]),
+					MountPath: filepath.Dir(decorate.VolumeMountPaths().List()[0]),
 				})
 			},
 		},
@@ -846,14 +846,14 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",
-					MountPath: filepath.Join(decorate.VolumeMountPaths()[0], "extra"),
+					MountPath: filepath.Join(decorate.VolumeMountPaths().List()[0], "extra"),
 				})
 			},
 		},
 		{
 			name: "reject reserved volume",
 			spec: func(s *v1.PodSpec) {
-				s.Volumes = append(s.Volumes, v1.Volume{Name: decorate.VolumeMounts()[0]})
+				s.Volumes = append(s.Volumes, v1.Volume{Name: decorate.VolumeMounts().List()[0]})
 			},
 		},
 		{
@@ -896,7 +896,7 @@ func TestValidatePodSpec(t *testing.T) {
 			} else if tc.spec != nil {
 				tc.spec(current)
 			}
-			switch err := validatePodSpec(jt, current, false); {
+			switch err := validatePodSpec(jt, current, false, true); {
 			case err == nil && !tc.pass:
 				t.Error("validation failed to raise an error")
 			case err != nil && tc.pass:
@@ -1150,13 +1150,30 @@ func TestValidateLabels(t *testing.T) {
 
 func TestValidateMultipleContainers(t *testing.T) {
 	ka := string(prowjobv1.KubernetesAgent)
+	yes := true
+	defCfg := prowapi.DecorationConfig{
+		UtilityImages: &prowjobv1.UtilityImages{
+			CloneRefs:  "clone-me",
+			InitUpload: "upload-me",
+			Entrypoint: "enter-me",
+			Sidecar:    "official-drink-of-the-org",
+		},
+		GCSCredentialsSecret: "upload-secret",
+		GCSConfiguration: &prowjobv1.GCSConfiguration{
+			PathStrategy: prowjobv1.PathStrategyExplicit,
+			DefaultOrg:   "so-org",
+			DefaultRepo:  "very-repo",
+		},
+	}
 	goodSpec := v1.PodSpec{
 		Containers: []v1.Container{
 			{
-				Name: "test1",
+				Name:    "test1",
+				Command: []string{"hello", "world"},
 			},
 			{
 				Name: "test2",
+				Args: []string{"hello", "world"},
 			},
 		},
 	}
@@ -1169,6 +1186,75 @@ func TestValidateMultipleContainers(t *testing.T) {
 		{
 			name: "valid kubernetes job with multiple containers",
 			base: JobBase{
+				Name:          "name",
+				Agent:         ka,
+				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
+				Spec:          &goodSpec,
+				Namespace:     &ns,
+				Annotations: map[string]string{
+					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
+				},
+			},
+			pass: true,
+		},
+		{
+			name: "invalid: containers with no cmd or args",
+			base: JobBase{
+				Name:          "name",
+				Agent:         ka,
+				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name: "test1",
+						},
+						{
+							Name: "test2",
+						},
+					},
+				},
+				Namespace: &ns,
+				Annotations: map[string]string{
+					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
+				},
+			},
+		},
+		{
+			name: "invalid: containers with no names",
+			base: JobBase{
+				Name:          "name",
+				Agent:         ka,
+				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
+				Spec: &v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Command: []string{"hello", "world"},
+						},
+						{
+							Args: []string{"hello", "world"},
+						},
+					},
+				},
+				Namespace: &ns,
+				Annotations: map[string]string{
+					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
+				},
+			},
+		},
+		{
+			name: "invalid: no ProwMultipleContainerSupport annotation",
+			base: JobBase{
+				Name:          "name",
+				Agent:         ka,
+				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
+				Spec:          &goodSpec,
+				Namespace:     &ns,
+				Annotations:   map[string]string{},
+			},
+		},
+		{
+			name: "invalid: no decoration enabled",
+			base: JobBase{
 				Name:      "name",
 				Agent:     ka,
 				Spec:      &goodSpec,
@@ -1177,49 +1263,28 @@ func TestValidateMultipleContainers(t *testing.T) {
 					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
 				},
 			},
-			pass: true,
-		},
-		{
-			name: "invalid: no ProwMultipleContainerSupport annotation",
-			base: JobBase{
-				Name:        "name",
-				Agent:       ka,
-				Spec:        &goodSpec,
-				Namespace:   &ns,
-				Annotations: map[string]string{},
-			},
-		},
-		{
-			name: "invalid: no container names",
-			base: JobBase{
-				Name:  "name",
-				Agent: ka,
-				Spec: &v1.PodSpec{
-					Containers: []v1.Container{
-						{}, {},
-					},
-				},
-				Namespace:   &ns,
-				Annotations: map[string]string{},
-			},
 		},
 		{
 			name: "invalid: container names reserved for decoration",
 			base: JobBase{
-				Name:  "name",
-				Agent: ka,
+				Name:          "name",
+				Agent:         ka,
+				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
 				Spec: &v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "place-entrypoint",
+							Name:    "place-entrypoint",
+							Command: []string{"hello", "world"},
 						},
 						{
-							Name: "test",
+							Name: "sidecar",
+							Args: []string{"hello", "world"},
 						},
 					},
+				}, Namespace: &ns,
+				Annotations: map[string]string{
+					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
 				},
-				Namespace:   &ns,
-				Annotations: map[string]string{},
 			},
 		},
 	}

--- a/prow/pod-utils/decorate/BUILD.bazel
+++ b/prow/pod-utils/decorate/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation:go_default_library",
     ],
 )

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -450,14 +450,14 @@ func processLog(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "process-log.txt")
 	}
-	return filepath.Join(log.MountPath, fmt.Sprintf("%s-build-log.txt", prefix))
+	return filepath.Join(log.MountPath, fmt.Sprintf("%s-log.txt", prefix))
 }
 
 func markerFile(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "marker-file.txt")
 	}
-	return filepath.Join(log.MountPath, fmt.Sprintf("%s-marker-file.txt", prefix))
+	return filepath.Join(log.MountPath, fmt.Sprintf("%s-marker.txt", prefix))
 }
 
 func metadataFile(log coreapi.VolumeMount, prefix string) string {

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -66,19 +67,19 @@ func Labels() []string {
 	return []string{kube.ProwJobTypeLabel, kube.CreatedByProw, kube.ProwJobIDLabel}
 }
 
-// VolumeMounts returns a string slice with *MountName consts in it.
-func VolumeMounts() []string {
-	return []string{logMountName, codeMountName, toolsMountName, gcsCredentialsMountName, s3CredentialsMountName}
+// VolumeMounts returns a string set with *MountName consts in it.
+func VolumeMounts() sets.String {
+	return sets.NewString(logMountName, codeMountName, toolsMountName, gcsCredentialsMountName, s3CredentialsMountName)
 }
 
-// VolumeMountPaths returns a string slice with *MountPath consts in it.
-func VolumeMountPaths() []string {
-	return []string{logMountPath, codeMountPath, toolsMountPath, gcsCredentialsMountPath, s3CredentialsMountPath}
+// VolumeMountPaths returns a string set with *MountPath consts in it.
+func VolumeMountPaths() sets.String {
+	return sets.NewString(logMountPath, codeMountPath, toolsMountPath, gcsCredentialsMountPath, s3CredentialsMountPath)
 }
 
-// PodUtilsContainerNames returns a string slice with pod utility container name consts in it.
-func PodUtilsContainerNames() []string {
-	return []string{cloneRefsName, initUploadName, entrypointName, sidecarName}
+// PodUtilsContainerNames returns a string set with pod utility container name consts in it.
+func PodUtilsContainerNames() sets.String {
+	return sets.NewString(cloneRefsName, initUploadName, entrypointName, sidecarName)
 }
 
 // LabelsAndAnnotationsForSpec returns a minimal set of labels to add to prowjobs or its owned resources.
@@ -178,10 +179,6 @@ func ProwJobToPodLocal(pj prowapi.ProwJob, buildID string, outputDir string) (*c
 	spec.RestartPolicy = "Never"
 	if len(spec.Containers) == 1 {
 		spec.Containers[0].Name = kube.TestContainerName
-	} else {
-		for i := range spec.Containers {
-			spec.Containers[i].Name = fmt.Sprintf("%s-%d", kube.TestContainerName, i)
-		}
 	}
 
 	// if the user has not provided a serviceaccount to use or explicitly
@@ -453,14 +450,14 @@ func processLog(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "process-log.txt")
 	}
-	return filepath.Join(log.MountPath, fmt.Sprintf("%s-log.txt", prefix))
+	return filepath.Join(log.MountPath, fmt.Sprintf("%s-build-log.txt", prefix))
 }
 
 func markerFile(log coreapi.VolumeMount, prefix string) string {
 	if prefix == "" {
 		return filepath.Join(log.MountPath, "marker-file.txt")
 	}
-	return filepath.Join(log.MountPath, fmt.Sprintf("%s-marker.txt", prefix))
+	return filepath.Join(log.MountPath, fmt.Sprintf("%s-marker-file.txt", prefix))
 }
 
 func metadataFile(log coreapi.VolumeMount, prefix string) string {

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -76,6 +76,11 @@ func VolumeMountPaths() []string {
 	return []string{logMountPath, codeMountPath, toolsMountPath, gcsCredentialsMountPath, s3CredentialsMountPath}
 }
 
+// PodUtilsContainerNames returns a string slice with pod utility container name consts in it.
+func PodUtilsContainerNames() []string {
+	return []string{cloneRefsName, initUploadName, entrypointName, sidecarName}
+}
+
 // LabelsAndAnnotationsForSpec returns a minimal set of labels to add to prowjobs or its owned resources.
 //
 // User-provided extraLabels and extraAnnotations values will take precedence over auto-provided values.
@@ -171,7 +176,13 @@ func ProwJobToPodLocal(pj prowapi.ProwJob, buildID string, outputDir string) (*c
 
 	spec := pj.Spec.PodSpec.DeepCopy()
 	spec.RestartPolicy = "Never"
-	spec.Containers[0].Name = kube.TestContainerName
+	if len(spec.Containers) == 1 {
+		spec.Containers[0].Name = kube.TestContainerName
+	} else {
+		for i := range spec.Containers {
+			spec.Containers[i].Name = fmt.Sprintf("%s-%d", kube.TestContainerName, i)
+		}
+	}
 
 	// if the user has not provided a serviceaccount to use or explicitly
 	// requested mounting the default token, we treat the unset value as
@@ -183,7 +194,9 @@ func ProwJobToPodLocal(pj prowapi.ProwJob, buildID string, outputDir string) (*c
 	}
 
 	if pj.Spec.DecorationConfig == nil {
-		spec.Containers[0].Env = append(spec.Containers[0].Env, KubeEnv(rawEnv)...)
+		for i, container := range spec.Containers {
+			spec.Containers[i].Env = append(container.Env, KubeEnv(rawEnv)...)
+		}
 	} else {
 		if err := decorate(spec, &pj, rawEnv, outputDir); err != nil {
 			return nil, fmt.Errorf("error decorating podspec: %v", err)
@@ -225,6 +238,9 @@ func CloneLogPath(logMount coreapi.VolumeMount) string {
 
 // Exposed for testing
 const (
+	entrypointName   = "place-entrypoint"
+	initUploadName   = "initupload"
+	sidecarName      = "sidecar"
 	cloneRefsName    = "clonerefs"
 	cloneRefsCommand = "/clonerefs"
 )
@@ -494,7 +510,7 @@ func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, 
 // PlaceEntrypoint will copy entrypoint from the entrypoint image to the tools volume
 func PlaceEntrypoint(config *prowapi.DecorationConfig, toolsMount coreapi.VolumeMount) coreapi.Container {
 	container := coreapi.Container{
-		Name:         "place-entrypoint",
+		Name:         entrypointName,
 		Image:        config.UtilityImages.Entrypoint,
 		Command:      []string{"/bin/cp"},
 		Args:         []string{"/entrypoint", entrypointLocation(toolsMount)},
@@ -574,7 +590,7 @@ func InitUpload(config *prowapi.DecorationConfig, gcsOptions gcsupload.Options, 
 		return nil, fmt.Errorf("could not encode initupload configuration as JSON: %v", err)
 	}
 	container := &coreapi.Container{
-		Name:    "initupload",
+		Name:    initUploadName,
 		Image:   config.UtilityImages.InitUpload,
 		Command: []string{"/initupload"}, // TODO(fejta): remove this, use image's entrypoint and delete /initupload symlink
 		Env: KubeEnv(map[string]string{
@@ -669,24 +685,32 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 		*initUpload,
 		PlaceEntrypoint(pj.Spec.DecorationConfig, toolsMount),
 	)
-	spec.Containers[0].Env = append(spec.Containers[0].Env, KubeEnv(rawEnv)...)
+	for i, container := range spec.Containers {
+		spec.Containers[i].Env = append(container.Env, KubeEnv(rawEnv)...)
+	}
 
-	const ( // these values may change when/if we support multiple containers
-		prefix   = "" // unique per container
+	const (
 		previous = ""
 		exitZero = false
 	)
-	wrapperOptions, err := InjectEntrypoint(&spec.Containers[0], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), prefix, previous, exitZero, logMount, toolsMount)
-	if err != nil {
-		return fmt.Errorf("wrap container: %v", err)
+	var wrappers []wrapper.Options
+
+	for i, container := range spec.Containers {
+		prefix := container.Name
+		if len(spec.Containers) == 1 {
+			prefix = ""
+		}
+		wrapperOptions, err := InjectEntrypoint(&spec.Containers[i], pj.Spec.DecorationConfig.Timeout.Get(), pj.Spec.DecorationConfig.GracePeriod.Get(), prefix, previous, exitZero, logMount, toolsMount)
+		if err != nil {
+			return fmt.Errorf("wrap container: %v", err)
+		}
+		wrappers = append(wrappers, *wrapperOptions)
 	}
 
-	sidecar, err := Sidecar(pj.Spec.DecorationConfig, blobStorageOptions, blobStorageMounts, logMount, outputMount, encodedJobSpec, !RequirePassingEntries, *wrapperOptions)
+	sidecar, err := Sidecar(pj.Spec.DecorationConfig, blobStorageOptions, blobStorageMounts, logMount, outputMount, encodedJobSpec, !RequirePassingEntries, wrappers...)
 	if err != nil {
 		return fmt.Errorf("create sidecar: %v", err)
 	}
-
-	spec.Containers = append(spec.Containers, *sidecar)
 
 	spec.Volumes = append(spec.Volumes, logVolume, toolsVolume)
 	spec.Volumes = append(spec.Volumes, blobStorageVolumes...)
@@ -695,10 +719,14 @@ func decorate(spec *coreapi.PodSpec, pj *prowapi.ProwJob, rawEnv map[string]stri
 	}
 
 	if len(refs) > 0 {
-		spec.Containers[0].WorkingDir = DetermineWorkDir(codeMount.MountPath, refs)
-		spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, codeMount)
+		for i, container := range spec.Containers {
+			spec.Containers[i].WorkingDir = DetermineWorkDir(codeMount.MountPath, refs)
+			spec.Containers[i].VolumeMounts = append(container.VolumeMounts, codeMount)
+		}
 		spec.Volumes = append(spec.Volumes, append(cloneVolumes, codeVolume)...)
 	}
+
+	spec.Containers = append(spec.Containers, *sidecar)
 
 	if spec.TerminationGracePeriodSeconds == nil && pj.Spec.DecorationConfig.GracePeriod != nil {
 		gracePeriodSeconds := int64(pj.Spec.DecorationConfig.GracePeriod.Seconds())
@@ -740,7 +768,7 @@ func Sidecar(config *prowapi.DecorationConfig, gcsOptions gcsupload.Options, blo
 	}
 
 	container := &coreapi.Container{
-		Name:    "sidecar",
+		Name:    sidecarName,
 		Image:   config.UtilityImages.Sidecar,
 		Command: []string{"/sidecar"}, // TODO(fejta): remove, use image's entrypoint
 		Env: KubeEnv(map[string]string{

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -2081,7 +2081,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-build-log.txt","marker_file":"/logs/test-0-marker-file.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2123,7 +2123,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-build-log.txt","marker_file":"/logs/test-1-marker-file.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2147,7 +2147,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-build-log.txt","marker_file":"/logs/test-0-marker-file.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-build-log.txt","marker_file":"/logs/test-1-marker-file.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -1941,6 +1941,7 @@ func TestProwJobToPod(t *testing.T) {
 				PodSpec: &coreapi.PodSpec{
 					Containers: []coreapi.Container{
 						{
+							Name:    "test-0",
 							Image:   "tester",
 							Command: []string{"/bin/thing"},
 							Args:    []string{"some", "args"},
@@ -1949,6 +1950,7 @@ func TestProwJobToPod(t *testing.T) {
 							},
 						},
 						{
+							Name:    "test-1",
 							Image:   "othertester",
 							Command: []string{"/bin/otherthing"},
 							Args:    []string{"other", "args"},
@@ -2079,7 +2081,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-build-log.txt","marker_file":"/logs/test-0-marker-file.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2121,7 +2123,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-build-log.txt","marker_file":"/logs/test-1-marker-file.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2145,7 +2147,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-build-log.txt","marker_file":"/logs/test-0-marker-file.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-build-log.txt","marker_file":"/logs/test-1-marker-file.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -1893,6 +1893,330 @@ func TestProwJobToPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			podName: "pod",
+			buildID: "blabla",
+			labels:  map[string]string{"needstobe": "inherited"},
+			pjSpec: prowapi.ProwJobSpec{
+				Type: prowapi.PresubmitJob,
+				Job:  "job-name",
+				DecorationConfig: &prowapi.DecorationConfig{
+					Timeout:     &prowapi.Duration{Duration: 120 * time.Minute},
+					GracePeriod: &prowapi.Duration{Duration: 10 * time.Second},
+					UtilityImages: &prowapi.UtilityImages{
+						CloneRefs:  "clonerefs:tag",
+						InitUpload: "initupload:tag",
+						Entrypoint: "entrypoint:tag",
+						Sidecar:    "sidecar:tag",
+					},
+					GCSConfiguration: &prowapi.GCSConfiguration{
+						Bucket:       "my-bucket",
+						PathStrategy: "legacy",
+						DefaultOrg:   "kubernetes",
+						DefaultRepo:  "kubernetes",
+					},
+					GCSCredentialsSecret: "secret-name",
+					SSHKeySecrets:        []string{"ssh-1", "ssh-2"},
+					CookiefileSecret:     "yummy",
+				},
+				Agent: prowapi.KubernetesAgent,
+				Refs: &prowapi.Refs{
+					Org:     "org-name",
+					Repo:    "repo-name",
+					BaseRef: "base-ref",
+					BaseSHA: "base-sha",
+					Pulls: []prowapi.Pull{{
+						Number: 1,
+						Author: "author-name",
+						SHA:    "pull-sha",
+					}},
+					PathAlias: "somewhere/else",
+				},
+				ExtraRefs: []prowapi.Refs{
+					{
+						Org:  "extra-org",
+						Repo: "extra-repo",
+					},
+				},
+				PodSpec: &coreapi.PodSpec{
+					Containers: []coreapi.Container{
+						{
+							Image:   "tester",
+							Command: []string{"/bin/thing"},
+							Args:    []string{"some", "args"},
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+							},
+						},
+						{
+							Image:   "othertester",
+							Command: []string{"/bin/otherthing"},
+							Args:    []string{"other", "args"},
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "stones"},
+							},
+						},
+					},
+				},
+			},
+
+			expected: &coreapi.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "pod",
+					Labels: map[string]string{
+						kube.CreatedByProw:     "true",
+						kube.ProwJobTypeLabel:  "presubmit",
+						kube.ProwJobIDLabel:    "pod",
+						"needstobe":            "inherited",
+						kube.OrgLabel:          "org-name",
+						kube.RepoLabel:         "repo-name",
+						kube.PullLabel:         "1",
+						kube.ProwJobAnnotation: "job-name",
+						kube.ProwBuildIDLabel:  "",
+					},
+					Annotations: map[string]string{
+						kube.ProwJobAnnotation: "job-name",
+					},
+				},
+				Spec: coreapi.PodSpec{
+					AutomountServiceAccountToken: &falseth,
+					RestartPolicy:                "Never",
+					InitContainers: []coreapi.Container{
+						{
+							Name:    "clonerefs",
+							Image:   "clonerefs:tag",
+							Command: []string{"/clonerefs"},
+							Args:    []string{"--cookiefile=" + cookiePathOnly("yummy")},
+							Env: []coreapi.EnvVar{
+								{Name: "CLONEREFS_OPTIONS", Value: `{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},{"org":"extra-org","repo":"extra-repo"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"cookie_path":"` + cookiePathOnly("yummy") + `"}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+								{
+									Name:      "ssh-keys-ssh-1",
+									MountPath: "/secrets/ssh/ssh-1",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "ssh-keys-ssh-2",
+									MountPath: "/secrets/ssh/ssh-2",
+									ReadOnly:  true,
+								},
+								{
+									Name:      "clonerefs-tmp",
+									MountPath: "/tmp",
+								},
+								cookieMountOnly("yummy"),
+							},
+						},
+						{
+							Name:    "initupload",
+							Image:   "initupload:tag",
+							Command: []string{"/initupload"},
+							Env: []coreapi.EnvVar{
+								{Name: "INITUPLOAD_OPTIONS", Value: `{"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false,"log":"/logs/clone.json"}`},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+						{
+							Name:    "place-entrypoint",
+							Image:   "entrypoint:tag",
+							Command: []string{"/bin/cp"},
+							Args: []string{
+								"/entrypoint",
+								"/tools/entrypoint",
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+							},
+						},
+					},
+					Containers: []coreapi.Container{
+						{
+							Name:       "test-0",
+							Image:      "tester",
+							Command:    []string{"/tools/entrypoint"},
+							Args:       []string{},
+							WorkingDir: "/home/prow/go/src/somewhere/else",
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "rocks"},
+								{Name: "ARTIFACTS", Value: "/logs/artifacts"},
+								{Name: "BUILD_ID", Value: "blabla"},
+								{Name: "BUILD_NUMBER", Value: "blabla"},
+								{Name: "CI", Value: "true"},
+								{Name: "GOPATH", Value: "/home/prow/go"},
+								{Name: "JOB_NAME", Value: "job-name"},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
+								{Name: "JOB_TYPE", Value: "presubmit"},
+								{Name: "PROW_JOB_ID", Value: "pod"},
+								{Name: "PULL_BASE_REF", Value: "base-ref"},
+								{Name: "PULL_BASE_SHA", Value: "base-sha"},
+								{Name: "PULL_NUMBER", Value: "1"},
+								{Name: "PULL_PULL_SHA", Value: "pull-sha"},
+								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
+								{Name: "REPO_NAME", Value: "repo-name"},
+								{Name: "REPO_OWNER", Value: "org-name"},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+							},
+						},
+						{
+							Name:       "test-1",
+							Image:      "othertester",
+							Command:    []string{"/tools/entrypoint"},
+							Args:       []string{},
+							WorkingDir: "/home/prow/go/src/somewhere/else",
+							Env: []coreapi.EnvVar{
+								{Name: "MY_ENV", Value: "stones"},
+								{Name: "ARTIFACTS", Value: "/logs/artifacts"},
+								{Name: "BUILD_ID", Value: "blabla"},
+								{Name: "BUILD_NUMBER", Value: "blabla"},
+								{Name: "CI", Value: "true"},
+								{Name: "GOPATH", Value: "/home/prow/go"},
+								{Name: "JOB_NAME", Value: "job-name"},
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
+								{Name: "JOB_TYPE", Value: "presubmit"},
+								{Name: "PROW_JOB_ID", Value: "pod"},
+								{Name: "PULL_BASE_REF", Value: "base-ref"},
+								{Name: "PULL_BASE_SHA", Value: "base-sha"},
+								{Name: "PULL_NUMBER", Value: "1"},
+								{Name: "PULL_PULL_SHA", Value: "pull-sha"},
+								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
+								{Name: "REPO_NAME", Value: "repo-name"},
+								{Name: "REPO_OWNER", Value: "org-name"},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "tools",
+									MountPath: "/tools",
+								},
+								{
+									Name:      "code",
+									MountPath: "/home/prow/go",
+								},
+							},
+						},
+						{
+							Name:    "sidecar",
+							Image:   "sidecar:tag",
+							Command: []string{"/sidecar"},
+							Env: []coreapi.EnvVar{
+								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
+							},
+							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
+							VolumeMounts: []coreapi.VolumeMount{
+								{
+									Name:      "logs",
+									MountPath: "/logs",
+								},
+								{
+									Name:      "gcs-credentials",
+									MountPath: "/secrets/gcs",
+								},
+							},
+						},
+					},
+					TerminationGracePeriodSeconds: utilpointer.Int64Ptr(10),
+					Volumes: []coreapi.Volume{
+						{
+							Name: "logs",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "tools",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						{
+							Name: "gcs-credentials",
+							VolumeSource: coreapi.VolumeSource{
+								Secret: &coreapi.SecretVolumeSource{
+									SecretName: "secret-name",
+								},
+							},
+						},
+						{
+							Name: "ssh-keys-ssh-1",
+							VolumeSource: coreapi.VolumeSource{
+								Secret: &coreapi.SecretVolumeSource{
+									SecretName:  "ssh-1",
+									DefaultMode: &sshKeyMode,
+								},
+							},
+						},
+						{
+							Name: "ssh-keys-ssh-2",
+							VolumeSource: coreapi.VolumeSource{
+								Secret: &coreapi.SecretVolumeSource{
+									SecretName:  "ssh-2",
+									DefaultMode: &sshKeyMode,
+								},
+							},
+						},
+						{
+							Name: "clonerefs-tmp",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+						cookieVolumeOnly("yummy"),
+						{
+							Name: "code",
+							VolumeSource: coreapi.VolumeSource{
+								EmptyDir: &coreapi.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	findContainer := func(name string, pod coreapi.Pod) *coreapi.Container {


### PR DESCRIPTION
Update decoration of pod specs to no longer assume that Pod has a single container.  
- If Pod has single container, test container name will be set automatically to `TestContainerName` (i.e. "Test").
- If Pod has multiple containers, test container names will be indexed (i.e. "Test-0", "Test-1"...)
- `InjectEntrypoint` called on all containers and generates `wrapperOptions` for each.
- `Sidecar` is given `wrapperOptions` for each container instead of for just one container.