### PR TITLE
Kops - Use different names for ARM64 test clusters

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -87,7 +87,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-arm64.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-arm64-latest.test-cncf-aws.k8s.io
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu
@@ -123,7 +123,7 @@ periodics:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
       args:
-      - --cluster=e2e-kops-aws-arm64.test-cncf-aws.k8s.io
+      - --cluster=e2e-kops-aws-arm64-ci.test-cncf-aws.k8s.io
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu


### PR DESCRIPTION
There are some strange failures in tests after the last change.

/cc @rifelpet 