### PR TITLE
Fix missing $ in ${id} in "file bug" (on triage dashboard) causing wrong link in issue

### DIFF
--- a/triage/render.js
+++ b/triage/render.js
@@ -249,7 +249,7 @@ function renderSpans(text, spans) {
 
 function makeGitHubIssue(id, text, owner, latestBuilds) {
   let title = `Failure cluster [${id.slice(0, 8)}...]`;
-  let body = `### Failure cluster [${id}](https://go.k8s.io/triage#{id})
+  let body = `### Failure cluster [${id}](https://go.k8s.io/triage#${id})
 
 ##### Error text:
 \`\`\`
@@ -262,7 +262,13 @@ ${text.slice(0, Math.min(text.length, 1500))}
     const started = tsToString(build.started);
     body += `[${started} ${job}](${url})\n`
   }
-  body += `\n\n/label sig/${owner}`
+  body += `\n\n/kind failing-test`;
+  body += '\n<!-- If this is a flake, please add: /kind flake -->';
+  if (owner) {
+    body += `\n\n/sig ${owner}`;
+  } else {
+    body += '\n\n<!-- Please assign a SIG using: /sig SIG-NAME -->';
+  }
   return [title, body];
 }
 


### PR DESCRIPTION
Mainly this PR is to fix the the "file bug" link where it does not build the triage dashboard link with the id correctly.

But I also made some tweaks to the generated issue body:
- Handle missing owner in issue body
- Add /kind failing-test in issue body
- Add comments about assigning a sig and optionally specifying /kind flake if it is a flaking test
