### PR TITLE
Allow use of vhds in aks-engine 

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -493,15 +493,6 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 		return fmt.Errorf("No template file specified %v", err)
 	}
 
-	// set default distro so we do not use prebuilt os image
-	if v.Properties.MasterProfile.Distro == "" {
-		v.Properties.MasterProfile.Distro = "ubuntu"
-	}
-	for _, agentPool := range v.Properties.AgentPoolProfiles {
-		if agentPool.Distro == "" {
-			agentPool.Distro = "ubuntu"
-		}
-	}
 	// replace APIModel template properties from flags
 	if c.location != "" {
 		v.Location = c.location


### PR DESCRIPTION
This helps solve issue https://github.com/kubernetes/kubernetes/issues/92771 and https://github.com/kubernetes-sigs/windows-testing/issues/177 where tests are flaking because of a node reboot.  Using a different VHD specified in the [sig-windows template](https://github.com/kubernetes-sigs/windows-testing/tree/master/job-templates) resolves this issue and speeds up the tests.

This requires a change to aks-engine to use kubectl and kubelet built from kubernetes job that @chewong is working on. 
/hold
/sig windows