### PR TITLE
Run some kops presubmits on release branches as well

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -1,8 +1,6 @@
 presubmits:
   kubernetes/kops:
   - name: pull-kops-bazel-build
-    branches:
-    - master
     always_run: true
     skip_report: false
     labels:
@@ -28,8 +26,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: bazel-build
   - name: pull-kops-bazel-test
-    branches:
-    - master
     always_run: true
     skip_report: false
     labels:
@@ -248,8 +244,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-1-18
   - name: pull-kops-verify-bazel
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -269,8 +263,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-bazel
   - name: pull-kops-verify-generated
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -290,8 +282,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-generated
   - name: pull-kops-verify-gomod
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -311,8 +301,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-gomod
   - name: pull-kops-verify-boilerplate
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -332,8 +320,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-boilerplate
   - name: pull-kops-verify-gofmt
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -358,8 +344,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-gofmt
   - name: pull-kops-verify-govet
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -379,8 +363,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-govet
   - name: pull-kops-verify-packages
-    branches:
-    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -421,8 +403,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-staticcheck
   - name: pull-kops-verify-hashes
-    branches:
-    - master
     skip_report: false
     run_if_changed: '^nodeup\/pkg\/'
     labels:
@@ -443,8 +423,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-hashes
   - name: pull-kops-verify-terraform
-    branches:
-    - master
     skip_report: false
     run_if_changed: '^tests\/integration\/update_cluster\/'
     labels:
@@ -469,8 +447,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-terraform
   - name: pull-kops-verify
-    branches:
-    - master
     optional: true
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
Left out pull-kops-verify-staticcheck because that isn't important on release branches.

/cc @rifelpet 