### PR TITLE
Add different issue lifecycle for SIG Network issues

### DIFF
--- a/config/jobs/kubernetes/sig-network/issue-lifecycle.yaml
+++ b/config/jobs/kubernetes/sig-network/issue-lifecycle.yaml
@@ -98,6 +98,7 @@ periodics:
       secret:
         secretName: fejta-bot-token
 
+# And following more 7 days we close the issue
 - name: periodic-sig-network-close
   interval: 1h
   decorate: true
@@ -131,6 +132,45 @@ periodics:
         /cc @rikatz
         /close
       - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+# Mark sig/network issues that weren't already triaged
+- name: periodic-sig-network-triage-unresolved
+  interval: 1h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-network-fejtabot
+    description: Mark SIG Network unresolved issues
+    testgrid-tab-name: close
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200630-1dca612287
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:kubernetes
+        -label:lifecycle/rotten
+        -label:lifecycle/frozen
+        -label:lifecycle/active
+        -label:triage/unresolved
+        label:sig/network
+        is:issue
+        is:open
+        NOT "/remove-triage unresolved" in:comments
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=/triage unresolved
+        Comment /remove-triage unresolved when the issue is assessed and confirmed.
+        --template
       - --ceiling=10
       - --confirm
       volumeMounts:

--- a/config/jobs/kubernetes/sig-network/issue-lifecycle.yaml
+++ b/config/jobs/kubernetes/sig-network/issue-lifecycle.yaml
@@ -1,0 +1,142 @@
+# SIG Network follows a different lifecycle for issues, warning users about stale issues after
+# 1 cycle of SIG Meeting (14 days) and then closes after 1 more cycle (14 more days)
+# It will only check for issues with the label sig/network and triage/needs-information
+
+periodics:
+# In the first 14 days we mark this as stale (first warning)
+- name: periodic-sig-network-stale
+  interval: 1h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-network-fejtabot
+    description: Adds lifecycle/stale to SIG Network issues after 14d of inactivity
+    testgrid-tab-name: stale
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200630-1dca612287
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:kubernetes
+        -label:lifecycle/frozen
+        -label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:lifecycle/active
+        label:triage/needs-information
+        label:sig/network
+        is:issue
+        is:open
+      - --updated=336h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=SIG Network Issues needing furhter informations
+        go stale after 14d of inactivity. Mark the issue as fresh
+        with `/remove-lifecycle stale`. Stale issues rot after an
+        additional 14d of inactivity and eventually close.
+
+        If this issue is safe to close now please do so with `/close`.
+
+        Send feedback to sig-network or @rikatz.
+        /cc @rikatz
+        /lifecycle stale
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+# Following 7 days, we mark this as rotten (2nd warning)
+- name: periodic-sig-network-rotten
+  interval: 1h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-network-fejtabot
+    description: Adds lifecycle/rotten to SIG Network stale issues after 7d of inactivity
+    testgrid-tab-name: rotten
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200630-1dca612287
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:kubernetes
+        label:lifecycle/stale
+        -label:lifecycle/rotten
+        -label:lifecycle/frozen
+        -label:lifecycle/active
+        label:triage/needs-information
+        label:sig/network
+        is:issue
+        is:open
+      - --updated=168h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=SIG Network stale issues rot after 7d of inactivity.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+        Rotten SIG Network issues close after an additional 7d of inactivity.
+
+        If this issue is safe to close now please do so with `/close`.
+
+        Send feedback to sig-network or @rikatz.
+        /cc @rikatz
+        /lifecycle rotten
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token
+
+- name: periodic-sig-network-close
+  interval: 1h
+  decorate: true
+  annotations:
+    testgrid-dashboards: sig-network-fejtabot
+    description: Closes rotten SIG Network issues after 7d of inactivity
+    testgrid-tab-name: close
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/commenter:v20200630-1dca612287
+      command:
+      - /app/robots/commenter/app.binary
+      args:
+      - |-
+        --query=org:kubernetes
+        label:lifecycle/rotten
+        -label:lifecycle/frozen
+        -label:lifecycle/active
+        label:triage/needs-information
+        label:sig/network
+        is:issue
+        is:open
+      - --updated=168h
+      - --token=/etc/token/bot-github-token
+      - |-
+        --comment=SIG Network Rotten issues close after 7d of inactivity.
+        Reopen the issue with `/reopen`.
+        Mark the issue as fresh with `/remove-lifecycle rotten`.
+
+        Send feedback to sig-network or @rikatz.
+        /cc @rikatz
+        /close
+      - --template
+      - --ceiling=10
+      - --confirm
+      volumeMounts:
+      - name: token
+        mountPath: /etc/token
+    volumes:
+    - name: token
+      secret:
+        secretName: fejta-bot-token


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

As it has been discussed in SIG Network meetings and [mailing list](https://groups.google.com/forum/#!msg/kubernetes-sig-network/20Es3oAoRaE), SIG Network follows  a guideline of closing issues that stay more than 28 days waiting for user information.

This job uses the same logic of fejta-bot (and if possible the same Token) to make a first warning to the user after 14 days, than another warning after 7 days and then closes the issue after more 7 days.

The bot only deals with issues marked as "sig/network" AND "needs/information" and should not be harmful to issues BUT I'm marking myself in each bot iteraction so I can gather some information and check if this is working as desired and not closing issues that it shouldn't.

Also there's a case where the issue is from multiple SIGs, and GH filters does not allow to filter this cases so is up to the assignee to put a lifecycle/active or lifecycle/frozen in the issue and then bot ignores it.

This still needs some approval from SIG Network chairs, I'm opening this PR to see if this is what we really want. Otherwise, as the volume of stale issues is not as big as it seems we can ignore this new job and close the PR :)

/hold
/cc @thockin @dcbw @caseydavenport 