### PR TITLE
increase the time to run conformance

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind.yaml
@@ -35,6 +35,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true
+  decoration_config:
+    timeout: 150m
   extra_refs:
   - org: kubernetes
     repo: kubernetes
@@ -80,6 +82,8 @@ periodics:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
   decorate: true
+  decoration_config:
+    timeout: 150m
   extra_refs:
   - org: kubernetes
     repo: kubernetes


### PR DESCRIPTION
the kind conformance jobs are failing because they are timing out, seems they need more than 2 hours https://testgrid.k8s.io/sig-testing-kind#conformance,%20master%20(dev)&graph-metrics=test-duration-minutes&width=20