### PR TITLE
add post image build job for sig-static-local-static-provisioner

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -17,19 +17,20 @@ set -o errexit
 
 readonly OUTPUT="$(dirname $0)/k8s-staging-sig-storage.yaml"
 readonly REPOS=(
-    csi-driver-host-path
-    csi-driver-iscsi
-    csi-driver-nfs
-    csi-driver-smb
-    csi-proxy
-    csi-test
-    external-attacher
-    external-health-monitor
-    external-provisioner
-    external-resizer
-    external-snapshotter
-    livenessprobe
-    node-driver-registrar
+    kubernetes-csi/csi-driver-host-path
+    kubernetes-csi/csi-driver-iscsi
+    kubernetes-csi/csi-driver-nfs
+    kubernetes-csi/csi-driver-smb
+    kubernetes-csi/csi-proxy
+    kubernetes-csi/csi-test
+    kubernetes-csi/external-attacher
+    kubernetes-csi/external-health-monitor
+    kubernetes-csi/external-provisioner
+    kubernetes-csi/external-resizer
+    kubernetes-csi/external-snapshotter
+    kubernetes-csi/livenessprobe
+    kubernetes-csi/node-driver-registrar
+    kubernetes-sigs/sig-storage-local-static-provisioner
 )
 
 cat >"${OUTPUT}" <<EOF
@@ -39,8 +40,9 @@ postsubmits:
 EOF
 
 for repo in "${REPOS[@]}"; do
+    IFS=/ read -r org repo <<<"${repo}"
     cat >>"${OUTPUT}" <<EOF
-  kubernetes-csi/${repo}:
+  ${org}/${repo}:
     - name: post-${repo}-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -58,7 +60,7 @@ for repo in "${REPOS[@]}"; do
       spec:
         serviceAccountName: gcb-builder
         containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200603-f2d2bf0
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
             command:
               - /run.sh
             args:

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -378,3 +378,32 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/sig-storage-local-static-provisioner:
+    - name: post-sig-storage-local-static-provisioner-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
this depends on https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/pull/206
and will fix https://github.com/kubernetes-sigs/sig-storage-local-static-provisioner/issues/153
/cc @pohly 
/assign @msau42 