### PR TITLE
kubernetes-sigs/release-notes: switch to node 12

### DIFF
--- a/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/release-notes/release-notes-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c
@@ -37,7 +37,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c
@@ -53,7 +53,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c
@@ -85,7 +85,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c
@@ -101,7 +101,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: node:11
+      - image: node:12
         command:
         - /bin/bash
         - -c


### PR DESCRIPTION
This is required to update to the latest Angular version 10.

Required by https://github.com/kubernetes-sigs/release-notes/pull/165