### PR TITLE
Migrate TestGrid config from Prow -> config yaml

### DIFF
--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -147,7 +147,10 @@ periodics:
         result=0
         ( cd hack/tools && GO111MODULE=on go install gotest.tools/gotestsum ) || result=$?
         make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" KUBE_TIMEOUT="--timeout=300s" || result=$?
-        grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+        cd ../test-infra/gopherage
+        GO111MODULE=on go build .
+        ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+        ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
         exit $result
       securityContext:
         privileged: true

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -127,8 +127,6 @@ periodics:
     description: build instrumented kubernetes, run (non-slow/serial/disruptive/flaky/feature) e2e tests, generate line coverage using gopherage
 - interval: 1h
   name: ci-kubernetes-coverage-unit
-  annotations:
-    testgrid-dashboards: sig-testing-canaries
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -145,10 +145,7 @@ periodics:
         result=0
         ( cd hack/tools && GO111MODULE=on go install gotest.tools/gotestsum ) || result=$?
         make test KUBE_COVER=y KUBE_COVER_REPORT_DIR="${ARTIFACTS}" KUBE_TIMEOUT="--timeout=300s" || result=$?
-        cd ../test-infra/gopherage
-        GO111MODULE=on go build .
-        ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
-        ./gopherage junit --threshold 0 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
+        grep -v -E 'zz_generated|generated\.pb\.go' "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
         exit $result
       securityContext:
         privileged: true

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -27,7 +27,7 @@ dashboards:
   dashboard_tab:
   - name: ci-kubernetes-coverage-unit
     test_group_name: ci-kubernetes-coverage-unit
-    base_options: "sort-by-name="
+    base_options: "exclude-filter-by-regex=Overall$&group-by-directory=&expand-groups=&sort-by-name="
 - name: sig-testing-fejtabot
 - name: sig-testing-kind
 - name: sig-testing-maintenance

--- a/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
+++ b/config/testgrids/kubernetes/sig-testing/sig-testing.yaml
@@ -1,3 +1,10 @@
+# Test Groups
+
+test_groups:
+- name: ci-kubernetes-coverage-unit
+  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-coverage-unit
+  short_text_metric: coverage
+
 # Dashboard Group
 
 dashboard_groups:
@@ -17,6 +24,10 @@ dashboard_groups:
 dashboards:
 - name: sig-testing-misc
 - name: sig-testing-canaries
+  dashboard_tab:
+  - name: ci-kubernetes-coverage-unit
+    test_group_name: ci-kubernetes-coverage-unit
+    base_options: "sort-by-name="
 - name: sig-testing-fejtabot
 - name: sig-testing-kind
 - name: sig-testing-maintenance


### PR DESCRIPTION
To enable the more advanced `testgroup` config options that will allow coverage metrics to show in TestGrid Cells, I needed to move the tab/dashboard config from the prow annotations and add them into the direct TestGrid Config with a `test_group` for the one tab that displays coverage metrics. 