### PR TITLE
Manually bump gubernator to working image

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -25,13 +25,13 @@ presubmits:
   - name: pull-test-infra-gubernator
     branches:
     - master
-    run_if_changed: 'gubernator|config/prow/config.yaml'
+    run_if_changed: 'gubernator|config/prow/config.yaml' # TODO(fejta): |config/jobs/.+\.yaml
     decorate: true
     labels:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/gubernator:v20200520-098b536
+      - image: gcr.io/k8s-testimages/gubernator:v20200706-8ff7838
         command:
         - ./gubernator/test-gubernator.sh
         env:


### PR DESCRIPTION
/assign @cjwagner @michelle192837 @hasheddan 

Use new image now that we have created it

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-test-gubernator/1280234621845377024

```
 Successfully built image: gcr.io/k8s-prow/gubernator:v20200706-8ff7838  
```

ref https://github.com/kubernetes/test-infra/issues/18178