### PR TITLE
Port triage/berghelroach.py to Go

### DIFF
--- a/triage/BUILD.bazel
+++ b/triage/BUILD.bazel
@@ -42,7 +42,11 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//triage/berghelroach:all-srcs",
+        "//triage/utils:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/triage/berghelroach/BUILD.bazel
+++ b/triage/berghelroach/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "berghelroach.go",
+        "doc.go",
+    ],
+    importpath = "k8s.io/test-infra/triage/berghelroach",
+    visibility = ["//visibility:public"],
+    deps = ["//triage/utils:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["berghelroach_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//triage/utils:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/triage/berghelroach/berghelroach.go
+++ b/triage/berghelroach/berghelroach.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Ported from Java com.google.gwt.dev.util.editdistance, which is:
+Copyright 2010 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/
+
+package berghelroach
+
+import (
+	"k8s.io/test-infra/triage/utils"
+)
+
+// Dist takes two strings and returns the edit distance between them.
+// It is the only name exported from this package. If limit is 0, the
+// limit is len(a)+len(b).
+func Dist(a string, b string, limit int) int {
+	br := berghelRoach{pattern: a}
+
+	if limit != 0 {
+		return br.getDistance(b, limit)
+	}
+	return br.getDistance(b, len(a)+len(b))
+}
+
+// berghelRoach maintains state as the strings are compared.
+type berghelRoach struct {
+	// The "pattern" string against which others are compared.
+	pattern string
+
+	/*
+		The current and two preceding sets of Ukkonen f(k,p) values for diagonals
+		around the main, computed by the main loop of {@code getDistance}.  These
+		arrays are retained between calls to save allocation costs.  (They are all
+		initialized to a real array so that we can indiscriminately use length
+		when ensuring/resizing.)
+	*/
+	currentLeft  []int
+	currentRight []int
+	lastLeft     []int
+	lastRight    []int
+
+	priorLeft  []int
+	priorRight []int
+}
+
+// getDistance calculates the distance internally. This should not be called directly.
+// Dist should be used instead.
+func (br *berghelRoach) getDistance(target string, limit int) int {
+	// Compute the main diagonal number.
+	// The final result lies on this diagonal.
+	main := len(br.pattern) - len(target)
+	// Compute our initial distance candidate.
+	// The result cannot be less than the difference in
+	// string lengths, so we start there.
+	distance := utils.Abs(main)
+	if distance > limit {
+		// More than we wanted.  Give up right away
+		return distance
+	}
+
+	/*
+	   In the main loop below, the current{Right,Left} arrays record results
+	   from the current outer loop pass.  The last{Right,Left} and
+	   prior{Right,Left} arrays hold the results from the preceding two passes.
+	   At the end of the outer loop, we shift them around (reusing the prior
+	   array as the current for the next round, to avoid reallocating).
+	   The Right reflects higher-numbered diagonals, Left lower-numbered.
+	   Fill in "prior" values for the first two passes through
+	   the distance loop.  Note that we will execute only one side of
+	   the main diagonal in these passes, so we only need
+	   initialize one side of prior values.
+	*/
+
+	if main <= 0 {
+		br.ensureCapacityRight(distance, false)
+		for j := 0; j < distance; j++ {
+			br.lastRight[j] = distance - j - 1 // Make diagonal -k start in row k
+			br.priorRight[j] = -1
+		}
+	} else {
+		br.ensureCapacityLeft(distance, false)
+		for j := 0; j < distance; j++ {
+			br.lastLeft[j] = -1 // Make diagonal +k start in row 0
+			br.priorLeft[j] = -1
+		}
+	}
+
+	// Keep track of even rounds.  Only those rounds consider new diagonals,
+	// and thus only they require artificial "last" values below.
+	even := true
+
+	// MAIN LOOP: try each successive possible distance until one succeeds.
+	for {
+		// Before calling computeRow(main, distance), we need to fill in
+		// missing cache elements.  See the high-level description above.
+		// Higher-numbered diagonals
+		var offDiagonal int = (distance - main) / 2
+		br.ensureCapacityRight(offDiagonal, true)
+
+		if even {
+			// Higher diagonals start at row 0
+			br.lastRight[offDiagonal] = -1
+		}
+
+		immediateRight := -1
+		for offDiagonal > 0 {
+			immediateRight = computeRow(
+				(main + offDiagonal),
+				(distance - offDiagonal),
+				br.pattern,
+				target,
+				br.priorRight[offDiagonal-1],
+				br.lastRight[offDiagonal],
+				immediateRight)
+			br.currentRight[offDiagonal] = immediateRight
+			offDiagonal--
+		}
+		// Lower-numbered diagonals
+		offDiagonal = (distance + main) / 2
+		br.ensureCapacityLeft(offDiagonal, true)
+
+		if even {
+			// Lower diagonals, fictitious values for f(-x-1,x) = x
+			br.lastLeft[offDiagonal] = (distance-main)/2 - 1
+		}
+
+		var immediateLeft int
+		if even {
+			immediateLeft = -1
+		} else {
+			immediateLeft = (distance - main) / 2
+		}
+
+		for offDiagonal > 0 {
+			immediateLeft = computeRow(
+				(main - offDiagonal),
+				(distance - offDiagonal),
+				br.pattern, target,
+				immediateLeft,
+				br.lastLeft[offDiagonal],
+				br.priorLeft[offDiagonal-1])
+			br.currentLeft[offDiagonal] = immediateLeft
+			offDiagonal--
+		}
+
+		// We are done if the main diagonal has distance in the last row.
+		mainRow := computeRow(main, distance, br.pattern, target,
+			immediateLeft, br.lastLeft[0], immediateRight)
+
+		if mainRow == len(target) {
+			break
+		}
+		distance++
+		if distance > limit || distance < 0 {
+			break
+		}
+
+		// The [0] element goes to both sides.
+		br.currentRight[0] = mainRow
+		br.currentLeft[0] = mainRow
+
+		// Rotate rows around for next round: current=>last=>prior (=>current)
+		tmp := br.priorLeft
+		br.priorLeft = br.lastLeft
+		br.lastLeft = br.currentLeft
+		br.currentLeft = tmp
+
+		tmp = br.priorRight
+		br.priorRight = br.lastRight
+		br.lastRight = br.currentRight
+		br.currentRight = tmp
+
+		// Update evenness, too
+		even = !even
+	}
+
+	return distance
+}
+
+// ensureCapacityLeft ensures that the Left arrays can be indexed through
+// a certain index (inclusively), resizing (and copying) as necessary.
+func (br *berghelRoach) ensureCapacityLeft(index int, cp bool) {
+	if len(br.currentLeft) <= index {
+		index++
+		br.priorLeft = resize(br.priorLeft, index, cp)
+		br.lastLeft = resize(br.lastLeft, index, cp)
+		br.currentLeft = resize(br.currentLeft, index, false)
+	}
+}
+
+// ensureCapacityLeft ensures that the Left arrays can be indexed through
+// a certain index (inclusively), resizing (and copying) as necessary.
+func (br *berghelRoach) ensureCapacityRight(index int, cp bool) {
+	if len(br.currentRight) <= index {
+		index++
+		br.priorRight = resize(br.priorRight, index, cp)
+		br.lastRight = resize(br.lastRight, index, cp)
+		br.currentRight = resize(br.currentRight, index, false)
+	}
+}
+
+// resize resizes an array, copying old contents if requested.
+func resize(array []int, size int, cp bool) []int {
+	if cp {
+		return append(array, make([]int, size-len(array))...)
+	}
+	return make([]int, size)
+}
+
+/*
+computeRow computes the highest row in which the distance p appears
+in diagonal k of the edit distance computation for
+strings a and b.  The diagonal number is
+represented by the difference in the indices for the two strings;
+it can range from
+
+	-b.length()
+
+through
+
+	a.length()
+
+More precisely, this computes the highest value x such that
+
+	p = edit-distance(a[0:(x+k)), b[0:x)).
+
+This is the "f" function described by Ukkonen.
+
+The caller must assure that the absolute value of k <= p,
+the only values for which this is well-defined.
+
+The implementation depends on the cached results of prior
+computeRow calls for diagonals k-1, k, and k+1 for distance p-1.
+These must be supplied in knownLeft, knownAbove,
+and knownRight, respectively.
+
+k: diagonal number
+
+p: edit distance
+
+a: one string to be compared
+
+b: other string to be compared
+
+knownLeft: value of `computeRow(k-1, p-1, ...)`
+
+knownAbove: value of `computeRow(k, p-1, ...)`
+
+knownRight: value of `computeRow(k+1, p-1, ...)`
+*/
+func computeRow(k int, p int, a string, b string,
+	knownLeft int, knownAbove int, knownRight int) int {
+	if !(utils.Abs(k) <= p) {
+		panic("Abs(k) is not less than or equal to p")
+	}
+	if !(p >= 0) {
+		panic("p is not greater than or equal to 0")
+	}
+	/*
+	   Compute our starting point using the recurrence.
+	   That is, find the first row where the desired edit distance
+	   appears in our diagonal.  This is at least one past
+	   the highest row for
+	*/
+	var t int
+	if p == 0 {
+		t = 0
+	} else {
+		/*
+		   We look at the adjacent diagonals for the next lower edit distance.
+		   We can start in the next row after the prior result from
+		   our own diagonal (the "substitute" case), or the next diagonal
+		   ("delete"), but only the same row as the prior result from
+		   the prior diagonal ("insert").
+		*/
+		t = utils.Max(utils.Max(knownAbove, knownRight)+1, knownLeft)
+	}
+	// Look down our diagonal for matches to find the maximum
+	// row with edit-distance p.
+	tmax := utils.Min(len(b), len(a)-k)
+	for t < tmax && b[t] == a[t+k] {
+		t++
+	}
+
+	return t
+}

--- a/triage/berghelroach/berghelroach_test.go
+++ b/triage/berghelroach/berghelroach_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Ported from Java com.google.gwt.dev.util.editdistance, which is:
+Copyright 2010 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/
+
+package berghelroach
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+
+	"k8s.io/test-infra/triage/utils"
+)
+
+/*
+Since Berghel-Roach is superior for longer strings with moderately
+low edit distances, we try a few of those specifically.
+This Modified form uses less space, and can handle yet larger ones.
+*/
+
+func TestHugeEdit(t *testing.T) {
+	const size int = 10000
+	const seed int64 = 1
+
+	verifySomeEdits(t, generateRandomString(size, seed), (size / 50), (size / 50))
+}
+
+func TestHugeString(t *testing.T) {
+	// An even larger size is feasible, but the test would no longer
+	// qualify as "small".
+	const size int = 20000
+	const seed int64 = 1
+
+	verifySomeEdits(t, generateRandomString(size, seed), 30, 25)
+}
+
+func TestLongString(t *testing.T) {
+	// A very large string for testing.
+	veryLargeString := "We have granted to God, and by this our present Charter have " +
+		"confirmed, for Us and our Heirs for ever, that the Church of " +
+		"England shall be free, and shall have all her whole Rights and " +
+		"Liberties inviolable.  We have granted also, and given to all " +
+		"the Freemen of our Realm, for Us and our Heirs for ever, these " +
+		"Liberties under-written, to have and to hold to them and their " +
+		"Heirs, of Us and our Heirs for ever."
+
+	t.Run("Small number of edits", func(t *testing.T) {
+		verifySomeEdits(t, veryLargeString, 8, 10)
+	})
+
+	t.Run("Larger number of edits", func(t *testing.T) {
+		verifySomeEdits(t, veryLargeString, 40, 30)
+	})
+
+}
+
+/*
+Abstract Levenshtein engine test cases
+*/
+
+// TestLevenshteinOnWords tests a Levenshtein engine against the dynamic programming-based computation
+// for a bunch of string pairs.
+func TestLevenshteinOnWords(t *testing.T) {
+	// First, some setup
+
+	// A small set of words for testing, including at least some of
+	// each of these: empty, very short, more than 32/64 character,
+	// punctuation, non-ASCII characters
+	words := []string{
+		"", "a", "b", "c", "ab", "ace",
+		"fortressing", "inadequately", "prank", "authored",
+		"fortresing", "inadeqautely", "prang", "awthered",
+		"cruller's", "fanatic", "Laplace", "recollections",
+		"Kevlar", "underpays", "jalape\u00f1o", "ch\u00e2telaine",
+		"kevlar", "overpaid", "jalapeno", "chatelaine",
+		"A survey of algorithms for running text search by Navarro appeared",
+		"in ACM Computing Surveys 33#1: http://portal.acm.org/citation.cfm?...",
+		"Another algorithm (Four Russians) that Navarro",
+		"long patterns and high limits was not evaluated for inclusion here.",
+		"long patterns and low limits were evaluated for inclusion here.",
+		"Filtering algorithms also improve running search",
+		"for pure edit distance.",
+	}
+
+	// To be used as a key for the wordDistances map
+	type wordPair struct {
+		wordA string
+		wordb string
+	}
+	// The cartesian product of words with itself.
+	wordDistances := make(map[wordPair]int, len(words)*len(words))
+
+	// Prepare the map of word distances
+	for _, wordA := range words {
+		for _, wordB := range words {
+			wordDistances[wordPair{wordA, wordB}] = dynamicProgrammingLevenshtein(wordA, wordB)
+		}
+	}
+
+	// Now for the actual test
+	for _, wordA := range words {
+		for _, wordB := range words {
+			ed := getInstance(wordA)
+			specificAlgorithmVerify(t, ed, wordA, wordB, wordDistances[wordPair{wordA, wordB}])
+		}
+	}
+}
+
+// TestLongerPattern tests Levenshtein edit distance on a longer pattern
+func TestLongerPattern(t *testing.T) {
+	genericLevenshteinVerify(t, "abcdefghijklmnopqrstuvwxyz",
+		"abcefghijklMnopqrStuvwxyz..",
+		5) // dMS..
+}
+
+// TestShortPattern tests Levenshtein edit distance on a very short pattern
+func TestShortPattern(t *testing.T) {
+	genericLevenshteinVerify(t, "short", "shirt", 1)
+}
+
+// TestZeroLengthPattern verifies zero-length behavior
+func TestZeroLengthPattern(t *testing.T) {
+	nonEmpty := "target"
+	genericLevenshteinVerify(t, "", nonEmpty, len(nonEmpty))
+	genericLevenshteinVerify(t, nonEmpty, "", len(nonEmpty))
+}
+
+// Utility functions
+
+// dynamicProgrammingLevenshtein computes Levenshtein edit distance
+// using the far-from-optimal dynamic programming technique.  This is
+// here purely to verify the results of better algorithms.
+func dynamicProgrammingLevenshtein(s1 string, s2 string) int {
+	lastRowSize := len(s1) + 1
+	lastRow := make([]int, lastRowSize)
+	for i := 0; i < lastRowSize; i++ {
+		lastRow[i] = i
+	}
+
+	for j := 0; j < len(s2); j++ {
+		thisRow := make([]int, len(lastRow))
+		thisRow[0] = j + 1
+		for i := 1; i < len(thisRow); i++ {
+			thisRow[i] = utils.Min(lastRow[i]+1,
+				thisRow[i-1]+1,
+				lastRow[i-1]+utils.BtoI(s2[j] != s1[i-1]))
+		}
+		lastRow = thisRow
+	}
+	return lastRow[len(lastRow)-1]
+}
+
+/*
+performEdits performs some edits on a string.
+
+original: string to be modified
+
+alphabet: some characters guaranteed not to be in the original
+
+replacements: how many single-character replacements to try
+
+insertions: how many characters to insert
+*/
+func performEdits(original string, alphabet string, replacements int, insertions int) (int, string) {
+	rand.Seed(768614336404564651)
+	edits := 0
+
+	// Convert the original string to a slice for easier manipulation.
+	originalSlice := []byte(original)
+
+	for i := 0; i < insertions; i++ {
+		utils.ByteSliceInsert(&originalSlice, alphabet[rand.Intn(len(alphabet))], rand.Intn(len(originalSlice)))
+		edits++
+	}
+
+	for i := 0; i < replacements; i++ {
+		where := rand.Intn(len(originalSlice))
+		letterInAlphabet := false
+		for i := 0; i < len(alphabet); i++ {
+			if originalSlice[where] == alphabet[i] {
+				letterInAlphabet = true
+				break
+			}
+		}
+
+		if !letterInAlphabet {
+			originalSlice[where] = alphabet[rand.Intn(len(alphabet))]
+			edits++
+		}
+	}
+
+	return edits, string(originalSlice)
+}
+
+/*
+generateRandomString Generates a long random alphabetic string,
+suitable for use with verifySomeEdits (using digits for the alphabet).
+
+size: desired string length
+
+seed: random number generator seed
+*/
+func generateRandomString(size int, seed int64) string {
+	alphabet := "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	// Create a (repeatable) random string from the alphabet
+	rand.Seed(seed)
+	var builder strings.Builder
+
+	for i := 0; i < size; i++ {
+		builder.WriteByte(alphabet[rand.Intn(len(alphabet))])
+	}
+
+	return builder.String()
+}
+
+func getInstance(s string) berghelRoach {
+	return berghelRoach{pattern: s}
+}
+
+/*
+verifyResult verifies a single edit distance result.
+If the expected distance is within limit, result must b
+be correct; otherwise, result must be over limit.
+
+s1: one string compared
+
+s2: other string compared
+
+expectedResult: correct distance from s1 to s2
+
+k: limit applied to computation
+
+d: distance computed
+*/
+func verifyResult(t *testing.T, s1 string, s2 string, expectedResult int, k int, d int) {
+	// Check if the strings are long. If so, truncate them.
+	maxLength := 50
+	if len(s1) > maxLength {
+		s1 = s1[:maxLength] + "[truncated]"
+	}
+	if len(s2) > maxLength {
+		s2 = s2[:maxLength] + "[truncated]"
+	}
+
+	// Use %#v to add quotation marks around the text
+	if k >= expectedResult {
+		if expectedResult != d {
+			t.Errorf("Distance from %#v to %#v should be %d (within limit=%d) but was %d", s1, s2, expectedResult, k, d)
+		}
+	} else {
+		if !(d > k) {
+			t.Errorf("Distance from %#v to %#v should be %d (exceeding limit=%d) but was %d", s1, s2, expectedResult, k, d)
+		}
+	}
+}
+
+// genericVerification exercises an edit distance engine across a wide range of limit values
+func genericVerification(t *testing.T, ed berghelRoach, s1 string, s2 string, expectedResult int) {
+	if len(s1) < 500 {
+		// For small strings, try every limit
+		maxDiff := utils.Max(len(s1), len(s2)) + 2
+		for k := 0; k < maxDiff; k++ {
+			verifyResult(t, s1, s2, expectedResult, k, ed.getDistance(s2, k))
+		}
+	} else {
+		// For big strings, try a sampling of limits:
+		//   0 to 3,
+		//   another 4 on either side of the expected result
+		//   s2 length
+		for k := 0; k < 4; k++ {
+			verifyResult(t, s1, s2, expectedResult, k, ed.getDistance(s2, k))
+		}
+		for k := utils.Max(4, expectedResult-4); k < expectedResult+4; k++ {
+			verifyResult(t, s1, s2, expectedResult, k, ed.getDistance(s2, k))
+		}
+		verifyResult(t, s1, s2, expectedResult, len(s2),
+			ed.getDistance(s2, len(s2)))
+	}
+
+	// Always try near MAX_VALUE
+	if ed.getDistance(s2, int(^uint(0)>>1)-1) != expectedResult { // int(^uint(0) >> 1) is the largest possible int
+		t.Errorf("getDistance failed with maximum uint value minus 1, got %d", expectedResult)
+	}
+	if ed.getDistance(s2, int(^uint(0)>>1)) != expectedResult { // int(^uint(0) >> 1) is the largest possible int
+		t.Errorf("getDistance failed with maximum uint value, got %d", expectedResult)
+	}
+}
+
+// specificAlgorithmVerify tests a specific engine on a pair of strings
+func specificAlgorithmVerify(t *testing.T, ed berghelRoach, s1 string, s2 string, expectedResult int) {
+	genericVerification(t, ed, s1, s2, expectedResult)
+
+	// Try again with the same instance
+	genericVerification(t, ed, s1, s2, expectedResult)
+}
+
+// genericLevenshteinVerify tests the default Levenshtein engine on a pair of strings
+func genericLevenshteinVerify(t *testing.T, s1 string, s2 string, expectedResult int) {
+	specificAlgorithmVerify(t, getInstance(s1), s1, s2, expectedResult)
+}
+
+// verifySomeEdits verifies the distance between an original string and some
+// number of simple edits on it.  The distance is assumed to
+// be unit-cost Levenshtein distance.
+func verifySomeEdits(t *testing.T, original string, replacements int, insertions int) {
+	edits, modified := performEdits(original, "0123456789", replacements, insertions)
+
+	specificAlgorithmVerify(t, getInstance(original), original, modified, edits)
+
+	specificAlgorithmVerify(t, getInstance(modified), modified, original, edits)
+}

--- a/triage/berghelroach/doc.go
+++ b/triage/berghelroach/doc.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Ported from Java com.google.gwt.dev.util.editdistance, which is:
+Copyright 2010 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License. You may obtain a copy of
+the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+License for the specific language governing permissions and limitations under
+the License.
+*/
+
+/*
+Package berghelraoch is a modification of the original Berghel-Roach edit
+distance (based on prior work by Ukkonen) described in
+  ACM Transactions on Information Systems, Vol. 14, No. 1,
+  January 1996, pages 94-106.
+
+I observed that only O(d) prior computations are required
+to compute edit distance.  Rather than keeping all prior
+f(k,p) results in a matrix, we keep only the two "outer edges"
+in the triangular computation pattern that will be used in
+subsequent rounds.  We cannot reconstruct the edit path,
+but many applications do not require that; for them, this
+modification uses less space (and empirically, slightly
+less time).
+
+First, some history behind the algorithm necessary to understand
+Berghel-Roach and our modification...
+
+The traditional algorithm for edit distance uses dynamic programming,
+building a matrix of distances for substrings:
+D[i,j] holds the distance for string1[0..i]=>string2[0..j].
+The matrix is initially populated with the trivial values
+D[0,j]=j and D[i,0]=i; and then expanded with the rule:
+
+   D[i,j] = min( D[i-1,j]+1,       // insertion
+                 D[i,j-1]+1,       // deletion
+                 (D[i-1,j-1]
+                  + (string1[i]==string2[j])
+                     ? 0           // match
+                     : 1           // substitution ) )
+
+Ukkonen observed that each diagonal of the matrix must increase
+by either 0 or 1 from row to row.  If D[i,j] = p, then the
+matching rule requires that D[i+x,j+x] = p for all x
+where string1[i..i+x) matches string2[j..j+j+x). Ukkonen
+defined a function f(k,p) as the highest row number in which p
+appears on the k-th diagonal (those D[i,j] where k=(i-j), noting
+that k may be negative).  The final result of the edit
+distance is the D[n,m] cell, on the (n-m) diagonal; it is
+the value of p for which f(n-m, p) = m.  The function f can
+also be computed dynamically, according to a simple recursion:
+
+   f(k,p) {
+     contains_p = max(f(k-1,p-1), f(k,p-1)+1, f(k+1,p-1)+1)
+     while (string1[contains_p] == string2[contains_p + k])
+       contains_p++;
+     return contains_p;
+   }
+
+The max() expression finds a row where the k-th diagonal must
+contain p by virtue of an edit from the prior, same, or following
+diagonal (corresponding to an insert, substitute, or delete);
+we need not consider more distant diagonals because row-to-row
+and column-to-column changes are at most +/- 1.
+
+The original Ukkonen algorithm computed f(k,p) roughly as
+follows:
+
+   for (p = 0; ; p++) {
+     compute f(k,p) for all valid k
+     if (f(n-m, p) == m) return p;
+   }
+
+
+Berghel and Roach observed that many values of f(k,p) are
+computed unnecessarily, and reorganized the computation into
+a just-in-time sequence.  In each iteration, we are primarily
+interested in the terminating value f(main,p), where main=(n-m)
+is the main diagonal.  To compute that we need f(x,p-1) for
+three values of x: main-1, main, and main+1.  Those depend on
+values for p-2, and so forth.  We will already have computed
+f(main,p-1) in the prior round, and thus f(main-1,p-2) and
+f(main+1,p-2), and so forth.  The only new values we need to compute
+are on the edges: f(main-i,p-i) and f(main+i,p-i).  Noting that
+f(k,p) is only meaningful when abs(k) is no greater than p,
+one of the Berghel-Roach reviewers noted that we can compute
+the bounds for i:
+
+   (main+i &le p-i) implies (i &le; (p-main)/2)
+
+(where main+i is limited on the positive side) and similarly
+
+   (-(main-i) &le p-i) implies (i &le; (p+main)/2).
+
+(where main-i is limited on the negative side).
+
+This reduces the computation sequence to
+
+  for (i = (p-main)/2; i > 0; i--) compute f(main+i,p-i);
+  for (i = (p+main)/2; i > 0; i--) compute f(main-i,p-i);
+  if (f(main, p) == m) return p;
+
+
+The original Berghel-Roach algorithm recorded prior values
+of f(k,p) in a matrix, using O(distance^2) space, enabling
+reconstruction of the edit path, but if all we want is the
+edit *distance*, we only need to keep O(distance) prior computations.
+
+The requisite prior k-1, k, and k+1 values are conveniently
+computed in the current round and the two preceding it.
+For example, on the higher-diagonal side, we compute:
+
+   current[i] = f(main+i, p-i)
+
+We keep the two prior rounds of results, where p was one and two
+smaller.  So, from the preceidng round
+
+   last[i] = f(main+i, (p-1)-i)
+
+ and from the prior round, but one position back:
+
+   prior[i-1] = f(main+(i-1), (p-2)-(i-1))
+
+In the current round, one iteration earlier:
+
+   current[i+1] = f(main+(i+1), p-(i+1))
+
+Note that the distance in all of these evaluates to p-i-1,
+and the diagonals are (main+i) and its neighbors... just
+what we need.  The lower-diagonal side behaves similarly.
+
+We need to materialize values that are not computed in prior
+rounds, for either of two reasons:
+
+- Initially, we have no prior rounds, so we need to fill
+all of the "last" and "prior" values for use in the
+first round.  The first round uses only on one side
+of the main diagonal or the other.
+
+- In every other round, we compute one more diagonal than before.
+
+In all of these cases, the missing f(k,p) values are for abs(k) > p,
+where a real value of f(k,p) is undefined.  [The original Berghel-Roach
+algorithm prefills its F matrix with these values, but we fill
+them as we go, as needed.]  We define
+
+   f(-p-1,p) = p, so that we start diagonal -p with row p,
+   f(p+1,p) = -1, so that we start diagonal p with row 0.
+
+(We also allow f(p+2,p)=f(-p-2,p)=-1, causing those values to
+have no effect in the starting row computation.]
+
+We only expand the set of diagonals visited every other round,
+when (p-main) or (p+main) is even.  We keep track of even/oddness
+to save some arithmetic.  The first round is always even, as p=abs(main).
+Note that we rename the "f" function to "computeRow" to be Googley.
+*/
+package berghelroach

--- a/triage/utils/BUILD.bazel
+++ b/triage/utils/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["utils.go"],
+    importpath = "k8s.io/test-infra/triage/utils",
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["utils_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/triage/utils/utils.go
+++ b/triage/utils/utils.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package utils is a small collection of utility functions helpful to Triage.
+*/
+package utils
+
+// Min takes any number of integers and returns the smallest.
+func Min(nums ...int) int {
+	smallest := nums[0]
+
+	for _, num := range nums[1:] {
+		if num < smallest {
+			smallest = num
+		}
+	}
+
+	return smallest
+}
+
+// Max takes any number of integers and returns the largest.
+func Max(nums ...int) int {
+	largest := nums[0]
+
+	for _, num := range nums[1:] {
+		if num > largest {
+			largest = num
+		}
+	}
+
+	return largest
+}
+
+// Abs returns the absolute value of an integer.
+func Abs(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// BtoI converts true to 1 and false to 0.
+func BtoI(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+// ByteSliceInsert inserts an element into a slice at a given index.
+func ByteSliceInsert(slc *[]byte, element byte, index int) {
+	// Add a dummy element that will get overwritten to ensure capacity
+	// for the new element
+	*slc = append(*slc, 'a')
+
+	// Effectively shift the elements to the right starting from the
+	// desired index
+	copy((*slc)[index+1:], (*slc)[index:])
+
+	// Add in the new element
+	(*slc)[index] = element
+}

--- a/triage/utils/utils_test.go
+++ b/triage/utils/utils_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestMin(t *testing.T) {
+	testCases := []struct {
+		name      string
+		arguments []int
+		want      int
+	}{
+		{"One value", []int{1}, 1},
+		{"Two values", []int{1, 2}, 1},
+		{"Three values", []int{1, 2, 3}, 1},
+		{"Three values reordered", []int{2, 1, 3}, 1},
+		{"Negative values", []int{-1, -2}, -2},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Min(tc.arguments...)
+
+			if got != tc.want {
+				// Format the function arguments nicely
+				formattedArgs := fmt.Sprintf("%d", tc.arguments[0])
+				for _, arg := range tc.arguments[1:] {
+					formattedArgs = fmt.Sprintf("%s, %d", formattedArgs, arg)
+				}
+
+				t.Errorf("Min(%s) = %d, wanted %d", formattedArgs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMax(t *testing.T) {
+	testCases := []struct {
+		name      string
+		arguments []int
+		want      int
+	}{
+		{"One value", []int{1}, 1},
+		{"Two values", []int{1, 2}, 2},
+		{"Three values", []int{1, 2, 3}, 3},
+		{"Three values reordered", []int{3, 1, 2}, 3},
+		{"Negative values", []int{-1, -2}, -1},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Max(tc.arguments...)
+
+			if got != tc.want {
+				// Format the function arguments nicely
+				formattedArgs := fmt.Sprintf("%d", tc.arguments[0])
+				for _, arg := range tc.arguments[1:] {
+					formattedArgs = fmt.Sprintf("%s, %d", formattedArgs, arg)
+				}
+
+				t.Errorf("Max(%s) = %d, wanted %d", formattedArgs, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBtoI(t *testing.T) {
+	testCases := []struct {
+		name     string
+		argument bool
+		want     int
+	}{
+		{"True", true, 1},
+		{"False", false, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BtoI(tc.argument)
+
+			if got != tc.want {
+				t.Errorf("BtoI(%t) = %d, wanted %d", tc.argument, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestByteSliceInsert(t *testing.T) {
+	t.Run("Normal slice", func(t *testing.T) {
+		s := []byte{'1', '3', '4'}
+		ByteSliceInsert(&s, '2', 1)
+
+		for i, element := range s {
+			// We want a slice of ['1' '2' '3' '4']
+			if element != byte(48+i+1) { // U+0030 (48 decimal) is '0', add 1 to make it equal the current element
+				t.Errorf("s[%d] = %q; wanted %d", i, element, i+1)
+			}
+		}
+	})
+
+	t.Run("Empty slice", func(t *testing.T) {
+		s := make([]byte, 0)
+		ByteSliceInsert(&s, '1', 0)
+
+		if s[0] != '1' {
+			t.Errorf("s[0] = %q; wanted %q", s[0], '1')
+		}
+	})
+}
+
+func TestAbs(t *testing.T) {
+	testCases := []struct {
+		name     string
+		argument int
+		want     int
+	}{
+		{"Negative", -1, 1},
+		{"Positive", 1, 1},
+		{"Zero", 0, 0},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Abs(tc.argument)
+
+			if got != tc.want {
+				t.Errorf("Abs(%d) = %d; wanted %d", tc.argument, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is the first PR in a series to port over Triage's Python scripts to Go, [as laid out here](https://docs.google.com/document/d/1Co9_0Oc5iCtSFiNNVvOe4QpysINPyW6hFHLB4t2xRyU/edit?usp=sharing) (accessible by kubernetes-sig-testing@).

`berghelroach.go` is more or less a line-for-line translation, with Python constructs replaced with appropriate Go ones where necessary. `berghelroach_test.go` contains the same testing logic as `berghelroach_test.py`, but was rearranged to work better with `go test`'s style. There is also a `utils` package that contains a few utility functions that I did not find implemented elsewhere and which did not seem to warrant being added to test-infra's `utils` package.

Comments were rewritten to follow GoDoc style, and the large exposition at the beginning of `berghelroach.py` was moved to its own `doc.go` file.

/cc bentheelder spiffxp