### PR TITLE
Bump up CSI driver version in tests

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-gcp-compute-persistent-disk-csi-driver-release-0-5-k8s-master-integration
+- name: ci-gcp-compute-persistent-disk-csi-driver-release-0-7-k8s-master-integration
   interval: 4h
   labels:
     preset-service-account: "true"
@@ -8,7 +8,7 @@ periodics:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
       args:
-      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.5.0"
+      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.7"
       - "--root=/go/src"
       - "--upload=gs://kubernetes-jenkins/logs"
       - "--clean"
@@ -32,45 +32,8 @@ periodics:
         cpu: 2000m
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
-    testgrid-tab-name: Kubernetes Master Driver Release 0.5
-    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.5
-- name: ci-gcp-compute-persistent-disk-csi-driver-release-0-4-k8s-1-13-5-integration
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-    preset-dind-enabled: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
-      args:
-      - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.4.0"
-      - "--root=/go/src"
-      - "--upload=gs://kubernetes-jenkins/logs"
-      - "--clean"
-      - "--timeout=90" # Minutes
-      - "--scenario=execute"
-      - "--" # end bootstrap args, scenario args below
-      - "test/run-k8s-integration.sh"
-      env:
-      - name: GCE_PD_OVERLAY_NAME
-        value: "stable"
-      - name: GCE_PD_DO_DRIVER_BUILD
-        value: "false"
-      - name: GCE_PD_KUBE_VERSION
-        value: "1.13.5"
-      # docker-in-docker needs privileged mode
-      securityContext:
-        privileged: true
-      requests:
-        # these are both a bit below peak usage during build
-        # this is mostly for building kubernetes
-        memory: "9000Mi"
-        # during the tests more like 3-20m is used
-        cpu: 2000m
-  annotations:
-    testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
-    testgrid-tab-name: Kubernetes v1.13.5 Driver Release 0.4
-    description: Kubernetes Integration tests for Kubernetes 1.13.5 and Driver Release 0.4
+    testgrid-tab-name: Kubernetes Master Driver Release 0.7
+    description: Kubernetes Integration tests for Kubernetes Master branch and Driver Release 0.7
 - name: ci-gcp-compute-persistent-disk-csi-driver-latest-k8s-master-integration
   interval: 4h
   labels:


### PR DESCRIPTION
Changes:
1. Update test job to use latest release PD CSI driver 0.7
2. Remove test job testing against kubernetes 1.13x