### PR TITLE
Use go 1.13 for pull-publishing-bot-validate

### DIFF
--- a/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
+++ b/config/jobs/kubernetes/publishing-bot/publishing-bot-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       path_alias: k8s.io/publishing-bot
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
+      - image: golang:1.13
         command:
         - go
         args:


### PR DESCRIPTION
The test is red on master - https://testgrid.k8s.io/sig-release-publishing-bot#validate

We are probably hitting something like https://github.com/golang/go/issues/38748. I'll investigate why this happens later, but this should unblock k/k master (and PRs like https://github.com/kubernetes/kubernetes/pull/91014)

kubekins-e2e uses go 1.14:

https://github.com/kubernetes/test-infra/blob/d4e560452755717f2c4fca4f5121d464f05c04a5/images/kubekins-e2e/variants.yaml#L11

With go 1.14.4:

```
$ go run k8s.io/publishing-bot/cmd/validate-rules ./staging/publishing/rules.yaml
package k8s.io/publishing-bot/cmd/validate-rules: cannot find package "." in:
	/home/nikhita/go/src/k8s.io/kubernetes/vendor/k8s.io/publishing-bot/cmd/validate-rules
```

With go 1.13.12:

```
$ go run k8s.io/publishing-bot/cmd/validate-rules ./staging/publishing/rules.yaml
go: finding k8s.io/publishing-bot latest
I0708 03:03:16.384590   14888 rules.go:89] loading rules file : ./staging/publishing/rules.yaml
I0708 03:03:16.395696   14888 rules.go:125] validating repository order
I0708 03:03:16.395848   14888 main.go:37] validation successful
```

/assign @cheftako @dims 