### PR TITLE
Make a bazel 2.1.0->2.2.0 image for testgrid

### DIFF
--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -11,3 +11,7 @@ variants:
     CONFIG: test-infra # Used by test-infra repo
     NEW_VERSION: 3.1.0
     OLD_VERSION: 3.0.0
+  testgrid:
+    CONFIG: testgrid # Used by testgrid repo
+    NEW_VERSION: 2.2.0
+    OLD_VERSION: 2.1.0


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/tree/master/images#updating-test-infra-images but for testgrid

To support https://github.com/GoogleCloudPlatform/testgrid/pull/141 if we decide we only want to upgrade to bazel 2.2.0