### PR TITLE
Update testgrid bazel image to support 2.1.0->3.0.0

### DIFF
--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -13,5 +13,5 @@ variants:
     OLD_VERSION: 3.0.0
   testgrid:
     CONFIG: testgrid # Used by testgrid repo
-    NEW_VERSION: 2.2.0
+    NEW_VERSION: 3.0.0
     OLD_VERSION: 2.1.0


### PR DESCRIPTION
I was able to move from 2.1.0 to 3.0.0 locally