### PR TITLE
Update Windows SAC version test timing

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -748,7 +748,7 @@ periodics:
     testgrid-tab-name: aks-engine-azure-windows-1903-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 72h
+- interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-master-windows-1909
   decorate: true
   decoration_config:
@@ -802,7 +802,7 @@ periodics:
     testgrid-tab-name: aks-engine-azure-windows-1909-master
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Runs SIG-Windows release tests on K8s clusters provided by aks-engine (https://github.com/Azure/aks-engine) on Azure cloud
-- interval: 72h
+- interval: 24h
   name: ci-kubernetes-e2e-aks-engine-azure-master-windows-2004
   decorate: true
   decoration_config:


### PR DESCRIPTION
This bumps the 1909 and 2004 tests to run every 24hrs.  Leaving 1903 where it is as windows will only support latest 2 SAC release as 2004 support comes online in 1.19.
