### PR TITLE
Also look for top-level comments in the /PATCHSET_LEVEL file.

### DIFF
--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -29,6 +29,25 @@ import (
 type fgc struct {
 	instance string
 	changes  map[string][]gerrit.ChangeInfo
+	comments map[string]map[string][]gerrit.CommentInfo
+}
+
+func (f *fgc) ListChangeComments(id string) (*map[string][]gerrit.CommentInfo, *gerrit.Response, error) {
+	comments := map[string][]gerrit.CommentInfo{}
+
+	val, ok := f.comments[id]
+	if !ok {
+		return &comments, nil, nil
+	}
+
+	for path, retComments := range val {
+		for _, comment := range retComments {
+			comments[path] = append(comments[path], comment)
+		}
+	}
+
+	return &comments, nil, nil
+
 }
 
 func (f *fgc) QueryChanges(opt *gerrit.QueryChangeOptions) (*[]gerrit.ChangeInfo, *gerrit.Response, error) {
@@ -79,7 +98,9 @@ func TestQueryChange(t *testing.T) {
 		name       string
 		lastUpdate map[string]time.Time
 		changes    map[string][]gerrit.ChangeInfo
+		comments   map[string]map[string][]gerrit.CommentInfo
 		revisions  map[string][]string
+		messages   map[string][]gerrit.ChangeMessageInfo
 	}{
 		{
 			name: "no changes",
@@ -110,6 +131,90 @@ func TestQueryChange(t *testing.T) {
 				},
 			},
 			revisions: map[string][]string{},
+		},
+		{
+			name: "find comments in special patchset file",
+			lastUpdate: map[string]time.Time{
+				"bar": now.Add(-time.Minute),
+			},
+			changes: map[string][]gerrit.ChangeInfo{
+				"foo": {
+					{
+						Project:         "bar",
+						ID:              "100",
+						ChangeID:        "random-string",
+						CurrentRevision: "1-1",
+						Updated:         makeStamp(now),
+						Revisions: map[string]gerrit.RevisionInfo{
+							"1-1": {
+								Created: makeStamp(now.Add(-time.Hour)),
+								Number:  1,
+							},
+						},
+						Status: "NEW",
+						Messages: []gerrit.ChangeMessageInfo{
+							{
+								Date:           makeStamp(now),
+								Message:        "first",
+								RevisionNumber: 1,
+							},
+							{
+								Date:           makeStamp(now.Add(2 * time.Second)),
+								Message:        "second",
+								RevisionNumber: 1,
+							},
+						},
+					},
+				},
+			},
+			comments: map[string]map[string][]gerrit.CommentInfo{
+				"random-string": {
+					"/PATCHSET_LEVEL": {
+						{
+							Message:  "before",
+							Updated:  newStamp(now.Add(-time.Second)),
+							PatchSet: 1,
+						},
+						{
+							Message:  "after",
+							Updated:  newStamp(now.Add(time.Second)),
+							PatchSet: 1,
+						},
+					},
+					"random.yaml": {
+						{
+							Message:  "ignore this file",
+							Updated:  newStamp(now.Add(-time.Second)),
+							PatchSet: 1,
+						},
+					},
+				},
+			},
+			revisions: map[string][]string{"foo": {"1-1"}},
+			messages: map[string][]gerrit.ChangeMessageInfo{
+				"random-string": {
+					{
+						Date:           makeStamp(now.Add(-time.Second)),
+						Message:        "before",
+						RevisionNumber: 1,
+					},
+					{
+						Date:           makeStamp(now),
+						Message:        "first",
+						RevisionNumber: 1,
+					},
+					{
+						Date:           makeStamp(now.Add(time.Second)),
+						Message:        "after",
+						RevisionNumber: 1,
+					},
+					{
+						Date:           makeStamp(now.Add(2 * time.Second)),
+						Message:        "second",
+						RevisionNumber: 1,
+					},
+				},
+			},
 		},
 		{
 			name: "one outdated change, but there's a new message",
@@ -527,6 +632,7 @@ func TestQueryChange(t *testing.T) {
 					changeService: &fgc{
 						changes:  tc.changes,
 						instance: "foo",
+						comments: tc.comments,
 					},
 				},
 				"baz": {
@@ -544,16 +650,24 @@ func TestQueryChange(t *testing.T) {
 		changes := client.QueryChanges(testLastSync, 5)
 
 		revisions := map[string][]string{}
+		messages := map[string][]gerrit.ChangeMessageInfo{}
 		for instance, changes := range changes {
 			revisions[instance] = []string{}
 			for _, change := range changes {
 				revisions[instance] = append(revisions[instance], change.CurrentRevision)
+				for _, m := range change.Messages {
+					messages[change.ChangeID] = append(messages[change.ChangeID], m)
+				}
 			}
 			sort.Strings(revisions[instance])
 		}
 
 		if !reflect.DeepEqual(revisions, tc.revisions) {
 			t.Errorf("tc %s - wrong revisions: got %#v, expect %#v", tc.name, revisions, tc.revisions)
+		}
+
+		if tc.messages != nil && !reflect.DeepEqual(messages, tc.messages) {
+			t.Errorf("tc %s - wrong messages:\nhave %#v,\nwant %#v", tc.name, messages, tc.messages)
 		}
 	}
 }


### PR DESCRIPTION
Gerrit is changing where the top-level comment is stored -- moving it out of the change message and into a comment on a special file.
Patch the code to look in both locations