### PR TITLE
Address a auth race condition.

### DIFF
--- a/prow/crier/reporters/gerrit/reporter.go
+++ b/prow/crier/reporters/gerrit/reporter.go
@@ -92,7 +92,7 @@ func NewReporter(cookiefilePath string, projects map[string][]string, lister pjl
 	if err != nil {
 		return nil, err
 	}
-	gc.Start(cookiefilePath)
+	gc.Authenticate(cookiefilePath, "")
 	return &Client{
 		gc:     gc,
 		lister: lister,

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -919,7 +919,7 @@ func TestProcessChange(t *testing.T) {
 				tracker:       &fakeSync{val: fakeLastSync},
 			}
 
-			err := c.ProcessChange(testInstance, tc.change)
+			err := c.processChange(testInstance, tc.change)
 			if err != nil && !tc.shouldError {
 				t.Errorf("expect no error, but got %v", err)
 			} else if err == nil && tc.shouldError {


### PR DESCRIPTION
Also add --token-path for easier local development (no need to insert this token into a cookie).

When gerrit starts up it often sees transient unauthorized errors.
This is likely because we add authentication to the handlers in a go routine.
This change makes it set up all the handlers before forking a routine to keep
the auth up to date.

Also remove some pointless functions.