### PR TITLE
benchmark-config: use recommended Ubuntu images

### DIFF
--- a/jobs/e2e_node/benchmark-config.yaml
+++ b/jobs/e2e_node/benchmark-config.yaml
@@ -159,25 +159,8 @@ images:
     tests:
       - 'resource tracking for 90 pods per node \[Benchmark\]'
 
-  ubuntustable2-resource1:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 0 pods per node \[Benchmark\]'
-  ubuntustable2-resource2:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 35 pods per node \[Benchmark\]'
-  ubuntustable2-resource3:
-    image: ubuntu-gke-1804-1-16-v20200330
-    project: ubuntu-os-gke-cloud
-    machine: n1-standard-1
-    tests:
-      - 'resource tracking for 90 pods per node \[Benchmark\]'
-
+  # NOTE: recommended versions of the ubuntu-gke images for GKE 1.14, 1.15 and 1.16 clusters
+  # were taken from https://cloud.google.com/kubernetes-engine/docs/release-notes
   ubuntustable1-resource1:
     image: ubuntu-gke-1804-1-16-v20200330
     project: ubuntu-os-gke-cloud
@@ -192,6 +175,44 @@ images:
       - 'resource tracking for 35 pods per node \[Benchmark\]'
   ubuntustable1-resource3:
     image: ubuntu-gke-1804-1-16-v20200330
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
+
+  ubuntustable2-resource1:
+    image: ubuntu-gke-1804-1-15-v20200330
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  ubuntustable2-resource2:
+    image: ubuntu-gke-1804-1-15-v20200330
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  ubuntustable2-resource3:
+    image: ubuntu-gke-1804-1-15-v20200330
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 90 pods per node \[Benchmark\]'
+
+  ubuntustable3-resource1:
+    image: ubuntu-gke-1804-1-14-v20200219
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 0 pods per node \[Benchmark\]'
+  ubuntustable3-resource2:
+    image: ubuntu-gke-1804-1-14-v20200219
+    project: ubuntu-os-gke-cloud
+    machine: n1-standard-1
+    tests:
+      - 'resource tracking for 35 pods per node \[Benchmark\]'
+  ubuntustable3-resource3:
+    image: ubuntu-gke-1804-1-14-v20200219
     project: ubuntu-os-gke-cloud
     machine: n1-standard-1
     tests:


### PR DESCRIPTION
Used ubuntu-gke images recommended by the GKE Release Notes
https://cloud.google.com/kubernetes-engine/docs/release-notes:

 - for GKE 1.16 clusters: ubuntu-gke-1804-1-16-v20200330
 - for GKE 1.15.11-gke.17 clusters and up: ubuntu-gke-1804-1-15-v20200330
 - for GKE 1.14.10-gke.40 clusters: ubuntu-gke-1804-1-14-v20200219