### PR TITLE
Cluster API AWS Presubmits: Correct typo

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -74,7 +74,7 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    decorate_config:
+    decoration_config:
       timeout: 3h
     max_concurrency: 1
     extra_refs:


### PR DESCRIPTION
The timeout was not being applied to the conformance presubmit.