### PR TITLE
Skip tests marked as [Deprecated] when running skew tests

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -103,7 +103,7 @@ periodics:
       - --ginkgo-parallel
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -130,7 +130,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -160,7 +160,7 @@ periodics:
       - --ginkgo-parallel=25
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -194,7 +194,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -222,7 +222,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=25
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -249,7 +249,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\]  --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -277,7 +277,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -303,7 +303,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -331,7 +331,7 @@ periodics:
       - --ginkgo-parallel
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -358,7 +358,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --skew
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -385,7 +385,7 @@ periodics:
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 
@@ -411,7 +411,7 @@ periodics:
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
+      - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
 


### PR DESCRIPTION
What do you guys think about this one? It just adds the ability to skip tests marked with [Deprecated] when running skew tests that use a newer version of kubectl.

I'll do another PR to annotate the tests in the k/k release-1.17 branch which in combination with this should then allow these periodic e2e tests to pass.

---

**The Problem**
[Some of the periodic kubectl e2e skew tests are failing 100%](https://storage.googleapis.com/k8s-gubernator/triage/index.html?#acb0ebd30035e7aaee80)

**The Cause:**
The tests are running an older version of the test suite using a newer version of kubectl, which has had some deprecated features removed (ie. kubectl run no longer supports generators).  

The older tests are attempting to do something that the newer kubectl no longer supports.

**The Fix:**
This PR adds `--ginkgo-skip=[Deprecated]` for skew tests that override the kubectl path to use a newer version of kubectl. This will allow tests that use deprecated features to be marked as such and skipped when running skew tests that would otherwise fail.

Fixes https://github.com/kubernetes/kubernetes/issues/92734

---

This is a second attempt at fixing the problem. For reference, a previously closed PR (https://github.com/kubernetes/test-infra/pull/18192) was the first attempt.

(I probably should have just kept that one open, but oh well. I couldn't re-open it after force-pushing to my branch).

---

CC'ing the people from the other PR...

/cc @liggitt @spiffxp @soltysh @seans3 @dims 
