### PR TITLE
Cache bugs for getRecursiveClones

### DIFF
--- a/prow/bugzilla/BUILD.bazel
+++ b/prow/bugzilla/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
 

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -1042,25 +1042,25 @@ func TestGetAllClones(t *testing.T) {
 		{
 			"Clones including multiple children",
 			bug1,
-			sets.NewInt(bug2ID, bug3ID, bug4ID),
+			sets.NewInt(bug1ID, bug2ID, bug3ID, bug4ID),
 			bug1,
 		},
 		{
 			"Clones should include parent as well as child",
 			bug2,
-			sets.NewInt(bug1ID, bug3ID, bug4ID),
+			sets.NewInt(bug1ID, bug2ID, bug3ID, bug4ID),
 			bug1,
 		},
 		{
 			"Clones includes parent and grandparent",
 			bug3,
-			sets.NewInt(bug1ID, bug2ID, bug4ID),
+			sets.NewInt(bug1ID, bug2ID, bug3ID, bug4ID),
 			bug1,
 		},
 		{
 			"Clones when not directly related",
 			bug4,
-			sets.NewInt(bug1ID, bug2ID, bug3ID),
+			sets.NewInt(bug1ID, bug2ID, bug3ID, bug4ID),
 			bug1,
 		},
 	}


### PR DESCRIPTION
Improve performance of the GetAllClones function by reusing the
bug details fetched by getRoot in getRecursiveClones.