### PR TITLE
add ksa for Container Image Promoter image vulnerability check

### DIFF
--- a/config/prow/cluster/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build_serviceaccounts.yaml
@@ -22,6 +22,15 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:
+    # Used by container image promoter vulnerability scanning presubmit check (pull-k8sio-cip-vuln)
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter-vuln-scanning@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-infra-gcr-promoter-vuln-scanning
+  namespace: test-pods
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
     # Used by Kops testing jobs
     iam.gke.io/gcp-service-account: pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com
   name: k8s-kops-test


### PR DESCRIPTION
In order to implement a new vulnerability presubmit check for the promoter (https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/235), a new KSA needs to be created that will eventually be used to authenticate the Prow job that runs the check. The KSA will be used in order to authenticate a new Prow job via Workload Identity. The Prow job (which will be called pull-k8sio-cip-vuln)will be created in a future pull request. 