### PR TITLE
Kops - Build both AMD64 and ARM64 for Kubernetes presubmit

### DIFF
--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -28,12 +28,12 @@ presubmits:
         - "--repo=k8s.io/release"
         - "--service-account=/etc/service-account/service-account.json"
         - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - "--timeout=75"
+        - "--timeout=200"
         - --scenario=kubernetes_e2e
         - --
         - --aws
         - --aws-cluster-domain=test-cncf-aws.k8s.io
-        - --build=bazel
+        - --build=release
         - --cluster=
         - --env=KOPS_LATEST=latest-ci-green.txt
         - --env=KOPS_DEPLOY_LATEST_KUBE=n
@@ -44,7 +44,7 @@ presubmits:
         - --provider=aws
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
-        - --timeout=55m
+        - --timeout=150m
         resources:
           requests:
             memory: "6Gi"


### PR DESCRIPTION
Since ARM64 support, Kops needs Kubernetes ARM64 binaries.
Fixes: https://github.com/kubernetes/kops/issues/9526

/cc @rifelpet 