### PR TITLE
Kops - Build both AMD64 and ARM64 for Kubernetes presubmit - 2

### DIFF
--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -18,6 +18,7 @@ presubmits:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-e2e-platform-aws: "true"
+      preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master


### PR DESCRIPTION
Enable Docker builds. Followup of #18222 .