### PR TITLE
[1.19] releng: Update milestoneappliers for 1.19

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -314,10 +314,10 @@ milestone_applier:
     master: v1.19
   kubernetes/kubernetes:
     master: v1.19
+    release-1.19: v1.19
     release-1.18: v1.18
     release-1.17: v1.17
     release-1.16: v1.16
-    release-1.15: v1.15
   kubernetes/release:
     master: v1.19
   kubernetes/sig-release:


### PR DESCRIPTION
Release cut issue: https://github.com/kubernetes/sig-release/issues/1136

Pending branch cut:
/hold

/sig release
/area release-eng

/assign @tpepper @justaugustus @cblecker 
cc: @kubernetes/release-engineering @kubernetes/sig-release-admins