### PR TITLE
fejta-bot: update labels required for retesting

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -145,13 +145,18 @@ periodics:
         -label:do-not-merge
         -label:do-not-merge/blocked-paths
         -label:do-not-merge/cherry-pick-not-approved
+        -label:do-not-merge/contains-merge-commits
         -label:do-not-merge/hold
+        -label:do-not-merge/invalid-commit-message
         -label:do-not-merge/invalid-owners-file
         -label:do-not-merge/release-note-label-needed
         -label:do-not-merge/work-in-progress
         label:lgtm
         label:approved
+        label:"cncf-cla: yes"
         status:failure
+        -label:needs-sig
+        -label:needs-kind
         -label:needs-rebase
         -label:needs-ok-to-test
         -label:"cncf-cla: no"


### PR DESCRIPTION
This now matches the tide config in config.yaml:

https://github.com/kubernetes/test-infra/blob/2ccab26ebb83b741100d11c97c874dc7d663571c/config/prow/config.yaml#L485-L503

Without this change, @fejta-bot would automatically retest PRs if they had `lgtm` and `approved`, but missed labels like `kind/*` (example - https://github.com/kubernetes/kubernetes/pull/91742#issuecomment-656122053)

/assign @cblecker @spiffxp 