### PR TITLE
Add a presubmit job for kubernetes-client/haskell [Attempt 2]

### DIFF
--- a/config/jobs/kubernetes-client/haskell/OWNERS
+++ b/config/jobs/kubernetes-client/haskell/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- brendandburns
+- mbohlool
+reviewers:
+- brendandburns
+- mbohlool

--- a/config/jobs/kubernetes-client/haskell/client-haskell-presubmits.yaml
+++ b/config/jobs/kubernetes-client/haskell/client-haskell-presubmits.yaml
@@ -1,0 +1,21 @@
+presubmits:
+  kubernetes-client/haskell:
+  - name: kubernetes-clients-haskell-unit-tests
+    always_run: true
+    decorate: true
+    optional: true
+    spec:
+      containers:
+      - image: docker.io/haskell:8.6.5
+        env:
+        command:
+        - bash
+        args:
+        - -c
+        - |
+          set -euo pipefail
+
+          stack upgrade
+          stack test --system-ghc --no-install-ghc --allow-different-user
+    annotations:
+      testgrid-create-test-group: 'true'

--- a/config/testgrids/kubernetes/clients/OWNERS
+++ b/config/testgrids/kubernetes/clients/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- brendandburns
+- mbohlool
+reviewers:
+- brendandburns
+- mbohlool

--- a/config/testgrids/kubernetes/clients/config.yaml
+++ b/config/testgrids/kubernetes/clients/config.yaml
@@ -1,0 +1,12 @@
+dashboard_groups:
+- name: kubernetes-clients
+  dashboard_names:
+    - kubernetes-clients-haskell-presubmits
+
+dashboards:
+- name: kubernetes-clients-haskell-presubmits
+  dashboard_tab:
+    - name: kubernetes-clients-haskell-presubmits-unit-tests
+      test_group_name: kubernetes-clients-haskell-unit-tests
+      base_options: include-filter-by-regex=clients
+      description: presubmits for haskell client

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -60,6 +60,7 @@ var (
 		"sig",
 		"wg",
 		"provider",
+		"kubernetes-clients",
 	}
 	dashboardPrefixes = [][]string{orgs, companies}
 


### PR DESCRIPTION
First created here: https://github.com/kubernetes/test-infra/pull/15331, I didn't realize force pushing would make the PR impossible to be reopened, so here is attempt 2. 
Last time I underestimated how much time it might take. Hopefully this time I am able to dedicate enough time to figure out the process to get CI going for the haskell-client :crossed_fingers: