### PR TITLE
Make autobump only update gerrit PRs when there are changes.

### DIFF
--- a/prow/cmd/autobump/bump.sh
+++ b/prow/cmd/autobump/bump.sh
@@ -42,7 +42,7 @@ JOB_CONFIG_PATH="${JOB_CONFIG_PATH:-}"
 
 usage() {
   echo "Usage: $(basename "$0") [--list || --latest || --upstream || vYYYYMMDD-deadbeef]" >&2
-  exit 1
+  return 1
 }
 
 main() {
@@ -104,7 +104,7 @@ main() {
         echo "The image ${image} does not exist, please double check." >&2
         # Revert the changes for this file.
         git checkout -- "${file}"
-        exit 1
+        return 1
       fi
     done
   done
@@ -115,9 +115,11 @@ main() {
 check-args() {
   if [[ -z "${COMPONENT_FILE_DIR}" ]]; then
     echo "ERROR: COMPONENT_FILE_DIR must be specified as an env var." >&2
+    return 1
   fi
   if [[ -z "${CONFIG_PATH}" ]]; then
     echo "ERROR: CONFIG_PATH must be specified as an env var." >&2
+    return 1
   fi
 }
 
@@ -131,7 +133,7 @@ check-requirements() {
   if ! (${SED} --version 2>&1 | grep -q GNU); then
     # darwin is great (not)
     echo "!!! GNU sed is required.  If on OS X, use 'brew install gnu-sed'." >&2
-    exit 1
+    return 1
   fi
 
   TAC=tac
@@ -142,7 +144,7 @@ check-requirements() {
 
   if ! command -v "${TAC}" &>/dev/null; then
     echo "tac (reverse cat) required. If on OS X then 'brew install coreutils'." >&2
-    exit 1
+    return 1
   fi
 
   if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
@@ -173,7 +175,7 @@ list() {
   mapfile -t options < <(list-options 10)
   if [[ -z "${options[*]}" ]]; then
     echo "No versions found" >&2
-    exit 1
+    return 1
   fi
   local def_opt=$(upstream-version)
   new_version=
@@ -197,7 +199,7 @@ list() {
     done
     if [[ -z "${found}" ]]; then
       echo "Invalid version: ${new_version}" >&2
-      exit 1
+      return 1
     fi
   fi
 }


### PR DESCRIPTION
Unlike GitHub, pushing the same changes to Gerrit multiple times causes new patchsets to be created rather than behaving as a no-op. This means that the autobump job generates a new patchset on the PR every time it runs, even if there is no change since the previous run.
To avoid this I've added some logic to look up the remote ref with the matching `Change-Id` and compare against that to determine if we actually need to push changes and update the PR. Rather than using the Gerrit API to map the `Change-Id` to the correct refspec so that we can fetch the individual PR, I've opted for fetching all the PR refs. This takes about 10 seconds on our GoB repo, but I think it is worth avoiding the complexity of providing Gerrit credentials and interacting with the Gerrit API from bash. @chizhg is working on migrating autobump to Go as which point we can use the gerrit go client if we want to make this more performant.
I've tested the new behavior with pj-on-kind
/assign @fejta 