### PR TITLE
Autobumper - include Kops' build-pipeline.py script

### DIFF
--- a/experiment/autobumper/main.go
+++ b/experiment/autobumper/main.go
@@ -40,9 +40,10 @@ const (
 )
 
 var extraFiles = map[string]bool{
-	"config/jobs/kubernetes/kops/build-grid.py": true,
-	"releng/generate_tests.py":                  true,
-	"images/kubekins-e2e/Dockerfile":            true,
+	"config/jobs/kubernetes/kops/build-grid.py":     true,
+	"config/jobs/kubernetes/kops/build-pipeline.py": true,
+	"releng/generate_tests.py":                      true,
+	"images/kubekins-e2e/Dockerfile":                true,
 }
 
 func cdToRootDir() error {


### PR DESCRIPTION
This updates the autobumper to also bump images in the new build-pipeline.py (ref: https://github.com/kubernetes/test-infra/pull/18164) 
