### PR TITLE
Kops - Add KOPS_RUN_TOO_NEW_VERSION to pipeline jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -45,6 +45,7 @@ template = """
       - --deployment=kops
       - --provider=aws
       - --cluster={{name}}.test-cncf-aws.k8s.io
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user={{ssh_user}}
       - --kops-nodes=4
       - --extract={{extract}}
@@ -74,11 +75,11 @@ def build_tests(branch, k8s_version, ssh_user):
 
     if branch == 'master':
         extract = "release/latest"
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-master"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master"
     else:
         extract = expand("release/stable-{k8s_version}")
         # Hack to stop the autobumper getting confused
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200602-05eeaff-1.18"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18"
         e2e_image = e2e_image[:-4] + k8s_version
 
     tab = expand('kops-pipeline-updown-{branch}')

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -32,6 +32,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kopsmaster.test-cncf-aws.k8s.io
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/latest
@@ -80,6 +81,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops116.test-cncf-aws.k8s.io
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=admin
       - --kops-nodes=4
       - --extract=release/stable-1.16
@@ -128,6 +130,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops117.test-cncf-aws.k8s.io
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=admin
       - --kops-nodes=4
       - --extract=release/stable-1.17
@@ -176,6 +179,7 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops118.test-cncf-aws.k8s.io
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/stable-1.18


### PR DESCRIPTION
This is really only needed for the "master" job but I figure its easier to include in all jobs.
The master job has been failing because this env var isnt set

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-pipeline-updown-kopsmaster/1281429687200911360

Also updating the image tags in build-pipeline.py to match what autobumper has set them to in kops-pipeline.yaml (autobumper fix in https://github.com/kubernetes/test-infra/pull/18250 )