### PR TITLE
Use structured logging in gerrit packages.

### DIFF
--- a/prow/cmd/gerrit/main.go
+++ b/prow/cmd/gerrit/main.go
@@ -61,6 +61,9 @@ func (o *options) validate() error {
 		return errors.New("--gerrit-projects must be set")
 	}
 
+	if o.cookiefilePath != "" && o.tokenPathOverride != "" {
+		return fmt.Errorf("only one of --cookiefile=%q --token-path=%q allowed, not both", o.cookiefilePath, o.tokenPathOverride)
+	}
 	if o.cookiefilePath == "" && o.tokenPathOverride == "" {
 		logrus.Info("--cookiefile is not set, using anonymous authentication")
 	}

--- a/prow/gerrit/adapter/adapter_test.go
+++ b/prow/gerrit/adapter/adapter_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/andygrunwald/go-gerrit"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -919,7 +920,7 @@ func TestProcessChange(t *testing.T) {
 				tracker:       &fakeSync{val: fakeLastSync},
 			}
 
-			err := c.processChange(testInstance, tc.change)
+			err := c.processChange(logrus.WithField("name", tc.name), testInstance, tc.change)
 			if err != nil && !tc.shouldError {
 				t.Errorf("expect no error, but got %v", err)
 			} else if err == nil && tc.shouldError {

--- a/prow/gerrit/adapter/trigger.go
+++ b/prow/gerrit/adapter/trigger.go
@@ -28,7 +28,7 @@ import (
 )
 
 // presubmitContexts returns the set of failing and all job names contained in the reports.
-func presubmitContexts(failed sets.String, presubmits []config.Presubmit, logger *logrus.Entry) (sets.String, sets.String) {
+func presubmitContexts(failed sets.String, presubmits []config.Presubmit, logger logrus.FieldLogger) (sets.String, sets.String) {
 	allContexts := sets.String{}
 	for _, presubmit := range presubmits {
 		allContexts.Insert(presubmit.Name) // TODO(fejta): context, not name
@@ -56,7 +56,7 @@ func currentMessages(change gerrit.ChangeInfo, since time.Time) []string {
 // messageFilter returns filter that matches all /test all, /test foo, /retest comments since lastUpdate.
 //
 // The behavior of each message matches the behavior of pjutil.PresubmitFilter.
-func messageFilter(messages []string, failingContexts, allContexts sets.String, logger *logrus.Entry) pjutil.Filter {
+func messageFilter(messages []string, failingContexts, allContexts sets.String, logger logrus.FieldLogger) pjutil.Filter {
 	var filters []pjutil.Filter
 	contextGetter := func() (sets.String, sets.String, error) {
 		return failingContexts, allContexts, nil

--- a/prow/gerrit/client/BUILD.bazel
+++ b/prow/gerrit/client/BUILD.bazel
@@ -29,5 +29,8 @@ go_test(
     name = "go_default_test",
     srcs = ["client_test.go"],
     embed = [":go_default_library"],
-    deps = ["@com_github_andygrunwald_go_gerrit//:go_default_library"],
+    deps = [
+        "@com_github_andygrunwald_go_gerrit//:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )

--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -26,7 +26,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/andygrunwald/go-gerrit"
+	gerrit "github.com/andygrunwald/go-gerrit"
 	"github.com/sirupsen/logrus"
 )
 
@@ -103,6 +103,8 @@ type gerritInstanceHandler struct {
 	accountService gerritAccount
 	changeService  gerritChange
 	projectService gerritProjects
+
+	log logrus.FieldLogger
 }
 
 // Client holds a instance:handler map
@@ -157,6 +159,7 @@ func NewClient(instances map[string][]string) (*Client, error) {
 			accountService: gc.Accounts,
 			changeService:  gc.Changes,
 			projectService: gc.Projects,
+			log:            logrus.WithField("host", instance),
 		}
 	}
 
@@ -179,18 +182,19 @@ func (c *Client) authenticateOnce(previousToken string) string {
 
 	c.lock.Lock()
 	defer c.lock.Unlock()
-	logrus.Info("New gerrit token, updating handlers...")
+	logrus.Info("New gerrit token, updating handler authentication...")
 
 	// update auth token for each instance
 	for instance, handler := range c.handlers {
+		log := handler.log
 		handler.authService.SetCookieAuth("o", current)
 
 		self, _, err := handler.accountService.GetAccount("self")
 		if err != nil {
-			logrus.WithField("instance", instance).WithError(err).Error("Failed to auth with token")
+			log.WithError(err).Error("GetAccount() failed with new authentication")
 			continue
 		}
-		logrus.Infof("Authentication to %s successful, Username: %s", handler.instance, self.Name)
+		log.WithField("name", self.Name).Info("Authentication successful")
 		c.accounts[instance] = self
 	}
 	return current
@@ -198,10 +202,17 @@ func (c *Client) authenticateOnce(previousToken string) string {
 
 // Authenticate client calls using the specified file.
 // Periodically re-reads the file to check for an updated value.
+// cookiefilePath takes precedence over tokenPath if both are set.
 func (c *Client) Authenticate(cookiefilePath, tokenPath string) {
 	var was, auth func() (string, error)
 	switch {
 	case cookiefilePath != "":
+		if tokenPath != "" {
+			logrus.WithFields(logrus.Fields{
+				"cookiefile": cookiefilePath,
+				"token":      tokenPath,
+			}).Warn("Ignoring token path in favor of cookiefile")
+		}
 		auth = func() (string, error) {
 			// TODO(fejta): listen for changes
 			raw, err := ioutil.ReadFile(cookiefilePath)
@@ -246,11 +257,12 @@ func (c *Client) QueryChanges(lastState LastSyncState, rateLimit int) map[string
 	for _, h := range c.handlers {
 		lastStateForInstance := lastState[h.instance]
 		changes := h.queryAllChanges(lastStateForInstance, rateLimit)
-		if len(changes) > 0 {
-			result[h.instance] = []ChangeInfo{}
-			for _, change := range changes {
-				result[h.instance] = append(result[h.instance], change)
-			}
+		if len(changes) == 0 {
+			continue
+		}
+
+		for _, change := range changes {
+			result[h.instance] = append(result[h.instance], change)
 		}
 	}
 	return result
@@ -299,15 +311,19 @@ func (h *gerritInstanceHandler) queryAllChanges(lastState map[string]time.Time, 
 	result := []gerrit.ChangeInfo{}
 	timeNow := time.Now()
 	for _, project := range h.projects {
+		log := h.log.WithField("repo", project)
 		lastUpdate, ok := lastState[project]
 		if !ok {
-			logrus.WithField("project", project).Warnf("could not find lastTime for project %q, probably something went wrong with initTracker?", project)
 			lastUpdate = timeNow
+			log.WithField("now", timeNow).Warn("lastState not found, defaultint to now")
 		}
-		changes, err := h.queryChangesForProject(project, lastUpdate, rateLimit)
+		changes, err := h.queryChangesForProject(log, project, lastUpdate, rateLimit)
 		if err != nil {
 			// don't halt on error from one project, log & continue
-			logrus.WithError(err).Errorf("fail to query changes for project %s", project)
+			log.WithError(err).WithFields(logrus.Fields{
+				"lastUpdate": lastUpdate,
+				"rateLimit":  rateLimit,
+			}).Error("Failed to query changes")
 			continue
 		}
 		result = append(result, changes...)
@@ -348,8 +364,8 @@ func (h *gerritInstanceHandler) injectPatchsetMessages(change *gerrit.ChangeInfo
 	return nil
 }
 
-func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdate time.Time, rateLimit int) ([]gerrit.ChangeInfo, error) {
-	pending := []gerrit.ChangeInfo{}
+func (h *gerritInstanceHandler) queryChangesForProject(log logrus.FieldLogger, project string, lastUpdate time.Time, rateLimit int) ([]gerrit.ChangeInfo, error) {
+	var pending []gerrit.ChangeInfo
 
 	var opt gerrit.QueryChangeOptions
 	opt.Query = append(opt.Query, "project:"+project)
@@ -366,15 +382,15 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 		changes, _, err := h.changeService.QueryChanges(&opt)
 		if err != nil {
 			// should not happen? Let next sync loop catch up
-			return nil, fmt.Errorf("failed to query gerrit changes: %v", err)
+			return nil, err
 		}
 
 		if changes == nil || len(*changes) == 0 {
-			logrus.Infof("no more changes from query, returning...")
+			log.Info("No more changes")
 			return pending, nil
 		}
 
-		logrus.Infof("Find %d changes from query %v", len(*changes), opt.Query)
+		log.WithField("query", opt.Query).Infof("Found %d changes", len(*changes))
 
 		start += len(*changes)
 
@@ -382,56 +398,70 @@ func (h *gerritInstanceHandler) queryChangesForProject(project string, lastUpdat
 			// if we already processed this change, then we stop the current sync loop
 			updated := parseStamp(change.Updated)
 
-			logrus.Infof("Change %d, last updated %s, status %s", change.Number, change.Updated, change.Status)
+			log := log.WithFields(logrus.Fields{
+				"change":     change.Number,
+				"updated":    change.Updated,
+				"status":     change.Status,
+				"lastUpdate": lastUpdate,
+			})
 
-			// process if updated later than last updated
-			// stop if update was stale
-			if updated.After(lastUpdate) {
-				switch change.Status {
-				case Merged:
-					submitted := parseStamp(*change.Submitted)
-					if !submitted.After(lastUpdate) {
-						logrus.Infof("Change %d, submitted %s before lastUpdate %s, skipping this patchset", change.Number, submitted, lastUpdate)
-						continue
-					}
-					pending = append(pending, change)
-				case New:
-					// we need to make sure the change update is from a fresh commit change
-					rev, ok := change.Revisions[change.CurrentRevision]
-					if !ok {
-						logrus.WithError(err).Errorf("(should not happen?)cannot find current revision for change %v", change.ID)
-						continue
-					}
+			// stop when we find a change last updated before lastUpdate
+			if !updated.After(lastUpdate) {
+				log.Info("No more recently updated changes")
+				return pending, nil
+			}
 
-					created := parseStamp(rev.Created)
-					h.injectPatchsetMessages(&change)
-					changeMessages := change.Messages
-					var newMessages bool
+			// process recently updated change
+			switch change.Status {
+			case Merged:
+				submitted := parseStamp(*change.Submitted)
+				log := log.WithField("submitted", submitted)
+				if !submitted.After(lastUpdate) {
+					log.Info("Skipping previously merged change")
+					continue
+				}
+				log.Info("Found merged change")
+				pending = append(pending, change)
+			case New:
+				// we need to make sure the change update is from a fresh commit change
+				rev, ok := change.Revisions[change.CurrentRevision]
+				if !ok {
+					log.WithError(err).WithField("revision", change.CurrentRevision).Error("Revision not found")
+					continue
+				}
 
-					for _, message := range changeMessages {
-						if message.RevisionNumber == rev.Number {
-							messageTime := parseStamp(message.Date)
-							if messageTime.After(lastUpdate) {
-								logrus.Infof("Change %d: Found a new message %s at time %v after lastSync at %v", change.Number, message.Message, messageTime, lastUpdate)
-								newMessages = true
-								break
-							}
+				created := parseStamp(rev.Created)
+				log := log.WithField("created", created)
+				h.injectPatchsetMessages(&change)
+				changeMessages := change.Messages
+				var newMessages bool
+
+				for _, message := range changeMessages {
+					if message.RevisionNumber == rev.Number {
+						messageTime := parseStamp(message.Date)
+						if messageTime.After(lastUpdate) {
+							log.WithFields(logrus.Fields{
+								"message":     message.Message,
+								"messageDate": messageTime,
+							}).Info("New messages")
+							newMessages = true
+							break
 						}
 					}
-
-					if !newMessages && !created.After(lastUpdate) {
-						// stale commit
-						logrus.Infof("Change %d, latest revision updated %s before lastUpdate %s, skipping this patchset", change.Number, created, lastUpdate)
-						continue
-					}
-
-					pending = append(pending, change)
-				default:
-					// change has been abandoned, do nothing
 				}
-			} else {
-				logrus.Infof("Change %d, updated %s before lastUpdate %s, return", change.Number, change.Updated, lastUpdate)
-				return pending, nil
+
+				if !newMessages && !created.After(lastUpdate) {
+					// stale commit
+					log.Info("Skipping existing change")
+					continue
+				}
+				if !newMessages {
+					log.Info("Found updated change")
+				}
+				pending = append(pending, change)
+			default:
+				// change has been abandoned, do nothing
+				log.Info("Ignored change")
 			}
 		}
 	}

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	gerrit "github.com/andygrunwald/go-gerrit"
+	"github.com/sirupsen/logrus"
 )
 
 type fgc struct {
@@ -634,6 +635,7 @@ func TestQueryChange(t *testing.T) {
 						instance: "foo",
 						comments: tc.comments,
 					},
+					log: logrus.WithField("host", "foo"),
 				},
 				"baz": {
 					instance: "baz",
@@ -642,6 +644,7 @@ func TestQueryChange(t *testing.T) {
 						changes:  tc.changes,
 						instance: "baz",
 					},
+					log: logrus.WithField("host", "baz"),
 				},
 			},
 		}

--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -70,7 +70,7 @@ func AggregateFilter(filters []Filter) Filter {
 }
 
 // FilterPresubmits determines which presubmits should run by evaluating the user-provided filter.
-func FilterPresubmits(filter Filter, changes config.ChangedFilesProvider, branch string, presubmits []config.Presubmit, logger *logrus.Entry) ([]config.Presubmit, error) {
+func FilterPresubmits(filter Filter, changes config.ChangedFilesProvider, branch string, presubmits []config.Presubmit, logger logrus.FieldLogger) ([]config.Presubmit, error) {
 
 	var toTrigger []config.Presubmit
 	var namesToTrigger []string
@@ -104,7 +104,7 @@ func RetestFilter(failedContexts, allContexts sets.String) Filter {
 type contextGetter func() (sets.String, sets.String, error)
 
 // PresubmitFilter creates a filter for presubmits
-func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body string, logger *logrus.Entry) (Filter, error) {
+func PresubmitFilter(honorOkToTest bool, contextGetter contextGetter, body string, logger logrus.FieldLogger) (Filter, error) {
 	// the filters determine if we should check whether a job should run, whether
 	// it should run regardless of whether its triggering conditions match, and
 	// what the default behavior should be for that check. Multiple filters


### PR DESCRIPTION
This should make it easier to search for and debug logs.

Also reduce some indentation by continuing/returning early.