### PR TITLE
releng: Generate 1.19 branch jobs

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -10,7 +10,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -27,7 +27,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-gkespec
@@ -42,7 +42,7 @@ periodics:
     containers:
     - args:
       - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -59,7 +59,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-serial
@@ -74,7 +74,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.18
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -91,7 +91,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-gkespec
@@ -106,7 +106,7 @@ periodics:
     containers:
     - args:
       - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/kubernetes=release-1.18
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -123,7 +123,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-serial
@@ -138,7 +138,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.16
+      - --repo=k8s.io/kubernetes=release-1.17
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -155,7 +155,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-gkespec
@@ -170,7 +170,7 @@ periodics:
     containers:
     - args:
       - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.16
+      - --repo=k8s.io/kubernetes=release-1.17
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -187,7 +187,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-serial
@@ -202,7 +202,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.15
+      - --repo=k8s.io/kubernetes=release-1.16
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -219,7 +219,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-gkespec
@@ -234,7 +234,7 @@ periodics:
     containers:
     - args:
       - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.15
+      - --repo=k8s.io/kubernetes=release-1.16
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -251,7 +251,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-serial
@@ -266,7 +266,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -283,7 +283,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-gkespec
@@ -298,6 +298,70 @@ periodics:
     containers:
     - args:
       - --timeout=320
+      - --repo=k8s.io/kubernetes=release-1.19
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --node-tests=true
+      - --provider=gce
+      - --gcp-zone=us-west1-b
+      - --image-family=pipeline-2
+      - --image-project=ubuntu-os-gke-cloud-devel
+      - --timeout=300m
+      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeAlphaFeature:.+\]"
+      - --gcp-project=ubuntu-image-validation
+      - --node-test-args=--feature-gates=DynamicKubeletConfig=true
+      env:
+      - name: GOPATH
+        value: /go
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
+  annotations:
+    testgrid-dashboards: canonical-ubuntu2-k8sbeta
+    testgrid-tab-name: ubuntu2-k8sbeta-serial
+- tags:
+  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
+  interval: 2h
+  labels:
+    preset-service-account: 'true'
+    preset-k8s-ssh: 'true'
+  name: ci-kubernetes-e2enode-ubuntu2-k8sstable1-gkespec
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --repo=k8s.io/kubernetes=release-1.18
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --node-tests=true
+      - --provider=gce
+      - --gcp-zone=us-west1-b
+      - --image-family=pipeline-2
+      - --image-project=ubuntu-os-gke-cloud-devel
+      - --timeout=120m
+      - --test_args=--nodes=8 --skip="\[Flaky\]|\[Serial\]|\[NodeAlphaFeature:.+\]"
+      - --node-args=--system-spec-name=gke
+      - --gcp-project=ubuntu-image-validation
+      env:
+      - name: GOPATH
+        value: /go
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+  annotations:
+    testgrid-dashboards: canonical-ubuntu2-k8sstable1
+    testgrid-tab-name: ubuntu2-k8sstable1-gkespec
+- tags:
+  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
+  interval: 2h
+  labels:
+    preset-service-account: 'true'
+    preset-k8s-ssh: 'true'
+  name: ci-kubernetes-e2enode-ubuntu2-k8sstable1-serial
+  spec:
+    containers:
+    - args:
+      - --timeout=320
       - --repo=k8s.io/kubernetes=release-1.18
       - --root=/go/src
       - --scenario=kubernetes_e2e
@@ -317,70 +381,6 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
   annotations:
-    testgrid-dashboards: canonical-ubuntu2-k8sbeta
-    testgrid-tab-name: ubuntu2-k8sbeta-serial
-- tags:
-  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
-  interval: 2h
-  labels:
-    preset-service-account: 'true'
-    preset-k8s-ssh: 'true'
-  name: ci-kubernetes-e2enode-ubuntu2-k8sstable1-gkespec
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.17
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --node-tests=true
-      - --provider=gce
-      - --gcp-zone=us-west1-b
-      - --image-family=pipeline-2
-      - --image-project=ubuntu-os-gke-cloud-devel
-      - --timeout=120m
-      - --test_args=--nodes=8 --skip="\[Flaky\]|\[Serial\]|\[NodeAlphaFeature:.+\]"
-      - --node-args=--system-spec-name=gke
-      - --gcp-project=ubuntu-image-validation
-      env:
-      - name: GOPATH
-        value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
-  annotations:
-    testgrid-dashboards: canonical-ubuntu2-k8sstable1
-    testgrid-tab-name: ubuntu2-k8sstable1-gkespec
-- tags:
-  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
-  interval: 2h
-  labels:
-    preset-service-account: 'true'
-    preset-k8s-ssh: 'true'
-  name: ci-kubernetes-e2enode-ubuntu2-k8sstable1-serial
-  spec:
-    containers:
-    - args:
-      - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.17
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --node-tests=true
-      - --provider=gce
-      - --gcp-zone=us-west1-b
-      - --image-family=pipeline-2
-      - --image-project=ubuntu-os-gke-cloud-devel
-      - --timeout=300m
-      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeAlphaFeature:.+\]"
-      - --gcp-project=ubuntu-image-validation
-      - --node-test-args=--feature-gates=DynamicKubeletConfig=true
-      env:
-      - name: GOPATH
-        value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
-  annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-serial
 - tags:
@@ -394,7 +394,7 @@ periodics:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.16
+      - --repo=k8s.io/kubernetes=release-1.17
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -411,7 +411,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-gkespec
@@ -426,6 +426,70 @@ periodics:
     containers:
     - args:
       - --timeout=320
+      - --repo=k8s.io/kubernetes=release-1.17
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --node-tests=true
+      - --provider=gce
+      - --gcp-zone=us-west1-b
+      - --image-family=pipeline-2
+      - --image-project=ubuntu-os-gke-cloud-devel
+      - --timeout=300m
+      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeAlphaFeature:.+\]"
+      - --gcp-project=ubuntu-image-validation
+      - --node-test-args=--feature-gates=DynamicKubeletConfig=true
+      env:
+      - name: GOPATH
+        value: /go
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
+  annotations:
+    testgrid-dashboards: canonical-ubuntu2-k8sstable2
+    testgrid-tab-name: ubuntu2-k8sstable2-serial
+- tags:
+  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
+  interval: 2h
+  labels:
+    preset-service-account: 'true'
+    preset-k8s-ssh: 'true'
+  name: ci-kubernetes-e2enode-ubuntu2-k8sstable3-gkespec
+  spec:
+    containers:
+    - args:
+      - --timeout=140
+      - --repo=k8s.io/kubernetes=release-1.16
+      - --root=/go/src
+      - --scenario=kubernetes_e2e
+      - --
+      - --deployment=node
+      - --node-tests=true
+      - --provider=gce
+      - --gcp-zone=us-west1-b
+      - --image-family=pipeline-2
+      - --image-project=ubuntu-os-gke-cloud-devel
+      - --timeout=120m
+      - --test_args=--nodes=8 --skip="\[Flaky\]|\[Serial\]|\[NodeAlphaFeature:.+\]"
+      - --node-args=--system-spec-name=gke
+      - --gcp-project=ubuntu-image-validation
+      env:
+      - name: GOPATH
+        value: /go
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
+  annotations:
+    testgrid-dashboards: canonical-ubuntu2-k8sstable3
+    testgrid-tab-name: ubuntu2-k8sstable3-gkespec
+- tags:
+  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
+  interval: 2h
+  labels:
+    preset-service-account: 'true'
+    preset-k8s-ssh: 'true'
+  name: ci-kubernetes-e2enode-ubuntu2-k8sstable3-serial
+  spec:
+    containers:
+    - args:
+      - --timeout=320
       - --repo=k8s.io/kubernetes=release-1.16
       - --root=/go/src
       - --scenario=kubernetes_e2e
@@ -444,70 +508,6 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
-  annotations:
-    testgrid-dashboards: canonical-ubuntu2-k8sstable2
-    testgrid-tab-name: ubuntu2-k8sstable2-serial
-- tags:
-  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
-  interval: 2h
-  labels:
-    preset-service-account: 'true'
-    preset-k8s-ssh: 'true'
-  name: ci-kubernetes-e2enode-ubuntu2-k8sstable3-gkespec
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.15
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --node-tests=true
-      - --provider=gce
-      - --gcp-zone=us-west1-b
-      - --image-family=pipeline-2
-      - --image-project=ubuntu-os-gke-cloud-devel
-      - --timeout=120m
-      - --test_args=--nodes=8 --skip="\[Flaky\]|\[Serial\]|\[NodeAlphaFeature:.+\]"
-      - --node-args=--system-spec-name=gke
-      - --gcp-project=ubuntu-image-validation
-      env:
-      - name: GOPATH
-        value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
-  annotations:
-    testgrid-dashboards: canonical-ubuntu2-k8sstable3
-    testgrid-tab-name: ubuntu2-k8sstable3-gkespec
-- tags:
-  - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
-  interval: 2h
-  labels:
-    preset-service-account: 'true'
-    preset-k8s-ssh: 'true'
-  name: ci-kubernetes-e2enode-ubuntu2-k8sstable3-serial
-  spec:
-    containers:
-    - args:
-      - --timeout=320
-      - --repo=k8s.io/kubernetes=release-1.15
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --node-tests=true
-      - --provider=gce
-      - --gcp-zone=us-west1-b
-      - --image-family=pipeline-2
-      - --image-project=ubuntu-os-gke-cloud-devel
-      - --timeout=300m
-      - --test_args=--nodes=1 --focus="\[Serial\]" --skip="\[Flaky\]|\[Benchmark\]|\[NodeAlphaFeature:.+\]"
-      - --gcp-project=ubuntu-image-validation
-      - --node-test-args=--feature-gates=DynamicKubeletConfig=true
-      env:
-      - name: GOPATH
-        value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-serial
@@ -531,7 +531,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -564,7 +564,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -597,7 +597,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -630,7 +630,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -663,7 +663,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -696,7 +696,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -729,7 +729,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -762,7 +762,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -795,7 +795,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -828,7 +828,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -861,7 +861,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -894,7 +894,7 @@ periodics:
       - --image-family=pipeline-1
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -927,7 +927,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -960,7 +960,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -993,7 +993,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1026,7 +1026,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1059,7 +1059,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1092,7 +1092,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1125,7 +1125,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1158,7 +1158,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1191,7 +1191,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1224,7 +1224,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1257,7 +1257,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1290,7 +1290,7 @@ periodics:
       - --image-family=pipeline-2
       - --image-project=ubuntu-os-gke-cloud-devel
       - --gcp-node-image=custom
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1322,7 +1322,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
@@ -1331,7 +1331,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
-    testgrid-dashboards: sig-release-1.18-blocking
+    testgrid-dashboards: sig-release-1.19-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 1h
@@ -1351,7 +1351,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -1359,7 +1359,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
-    testgrid-dashboards: sig-release-1.18-blocking
+    testgrid-dashboards: sig-release-1.19-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 1h
@@ -1379,7 +1379,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1391,7 +1391,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
-    testgrid-dashboards: sig-release-1.18-blocking
+    testgrid-dashboards: sig-release-1.19-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 1h
@@ -1411,7 +1411,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1421,7 +1421,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
-    testgrid-dashboards: sig-release-1.18-informing
+    testgrid-dashboards: sig-release-1.19-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1442,7 +1442,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1452,7 +1452,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
-    testgrid-dashboards: sig-release-1.18-informing
+    testgrid-dashboards: sig-release-1.19-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1473,7 +1473,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
@@ -1487,7 +1487,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
-    testgrid-dashboards: sig-release-1.18-blocking
+    testgrid-dashboards: sig-release-1.19-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 2h
@@ -1507,7 +1507,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
@@ -1516,7 +1516,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
-    testgrid-dashboards: sig-release-1.17-blocking
+    testgrid-dashboards: sig-release-1.18-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 2h
@@ -1536,7 +1536,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -1544,7 +1544,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
-    testgrid-dashboards: sig-release-1.17-blocking
+    testgrid-dashboards: sig-release-1.18-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 2h
@@ -1564,7 +1564,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1575,7 +1575,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
-    testgrid-dashboards: sig-release-1.17-informing
+    testgrid-dashboards: sig-release-1.18-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1596,7 +1596,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1606,7 +1606,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
-    testgrid-dashboards: sig-release-1.17-informing
+    testgrid-dashboards: sig-release-1.18-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1627,7 +1627,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1637,7 +1637,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
-    testgrid-dashboards: sig-release-1.17-informing
+    testgrid-dashboards: sig-release-1.18-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1658,7 +1658,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.17
+      - --extract=ci/latest-1.18
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
@@ -1672,7 +1672,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
-    testgrid-dashboards: sig-release-1.17-blocking
+    testgrid-dashboards: sig-release-1.18-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 6h
@@ -1692,7 +1692,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
@@ -1701,7 +1701,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
-    testgrid-dashboards: sig-release-1.16-blocking
+    testgrid-dashboards: sig-release-1.17-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 6h
@@ -1721,7 +1721,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -1729,7 +1729,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
-    testgrid-dashboards: sig-release-1.16-blocking
+    testgrid-dashboards: sig-release-1.17-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 6h
@@ -1749,7 +1749,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1759,7 +1759,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
-    testgrid-dashboards: sig-release-1.16-informing
+    testgrid-dashboards: sig-release-1.17-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1780,7 +1780,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1790,7 +1790,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
-    testgrid-dashboards: sig-release-1.16-informing
+    testgrid-dashboards: sig-release-1.17-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1811,7 +1811,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1821,7 +1821,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
-    testgrid-dashboards: sig-release-1.16-informing
+    testgrid-dashboards: sig-release-1.17-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1842,7 +1842,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.16
+      - --extract=ci/latest-1.17
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --env=KUBE_PROXY_DAEMONSET=true
@@ -1856,7 +1856,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
-    testgrid-dashboards: sig-release-1.16-blocking
+    testgrid-dashboards: sig-release-1.17-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 24h
@@ -1876,7 +1876,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
@@ -1884,7 +1884,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
-    testgrid-dashboards: sig-release-1.15-blocking
+    testgrid-dashboards: sig-release-1.16-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 24h
@@ -1904,7 +1904,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
@@ -1913,7 +1913,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
-    testgrid-dashboards: sig-release-1.15-blocking
+    testgrid-dashboards: sig-release-1.16-blocking
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
   interval: 24h
@@ -1933,7 +1933,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=120m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1943,7 +1943,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
-    testgrid-dashboards: sig-release-1.15-informing
+    testgrid-dashboards: sig-release-1.16-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1964,7 +1964,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=660m
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -1974,7 +1974,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
-    testgrid-dashboards: sig-release-1.15-informing
+    testgrid-dashboards: sig-release-1.16-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -1995,7 +1995,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
@@ -2005,7 +2005,7 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
-    testgrid-dashboards: sig-release-1.15-informing
+    testgrid-dashboards: sig-release-1.16-informing
     testgrid-num-failures-to-alert: '6'
 - tags:
   - generated   # AUTO-GENERATED by releng/generate_tests.py - DO NOT EDIT!
@@ -2026,7 +2026,7 @@ periodics:
       - --provider=gce
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
-      - --extract=ci/latest-1.15
+      - --extract=ci/latest-1.16
       - --gcp-project-type=k8s-infra-gce-project
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:(ExternalTrafficLocalOnly|DynamicKubeletConfig)\] --minStartupPods=8
@@ -2040,4 +2040,4 @@ periodics:
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures
-    testgrid-dashboards: sig-release-1.15-blocking
+    testgrid-dashboards: sig-release-1.16-blocking

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -172,8 +172,6 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "24"
-    fork-per-release: "true"
-    fork-per-release-generic-suffix: "true"
 - interval: 1h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   labels:

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -137,7 +137,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     testgrid-dashboards: sig-node-kubelet, sig-release-master-informing
-    testgrid-tab-name: node-kubelet-features
+    testgrid-tab-name: node-kubelet-features-master
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -30,19 +30,19 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-cron: 0 8-23/24 * * *
+    fork-per-release-cron: ""
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.16-blocking, google-gce
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.16
-  cron: 0 8-23/12 * * *
+  cron: 0 8-23/24 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable2
+  name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable3
   spec:
     containers:
     - args:
@@ -62,12 +62,12 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 24h
+    fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.16
   cluster: k8s-infra-prow-build
-  interval: 6h
+  interval: 24h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -136,7 +136,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-stable2
+  name: ci-kubernetes-build-stable3
   spec:
     containers:
     - args:
@@ -147,7 +147,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=latest-1.16-cross,k8s-stable2
+      - --extra-publish-file=latest-1.16-cross,k8s-stable3
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""
@@ -158,7 +158,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 8-20/12 * * *
+    fork-per-release-cron: ""
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-scalability-gce, google-gce,
@@ -166,12 +166,12 @@ periodics:
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.16-scalability-100
   cluster: k8s-infra-prow-build
-  cron: 0 4-16/12 * * *
+  cron: 0 8-20/12 * * *
   labels:
     preset-e2e-scalability-common: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gci-gce-scalability-stable2
+  name: ci-kubernetes-e2e-gci-gce-scalability-stable3
   spec:
     containers:
     - args:
@@ -199,9 +199,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-      # TODO(oxddr): re-enable this once we understand impact on https://github.com/kubernetes/kubernetes/issues/89051
-      # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-      # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
       - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
       - --test-cmd-args=--testoverrides=./testing/overrides/enable_oom_tracking.yaml
       - --test-cmd-name=ClusterLoaderV2
@@ -215,18 +212,18 @@ periodics:
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
-    fork-per-release-cron: 0 21 * * *
+    fork-per-release-cron: ""
     fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: kubemark-1.16-500
-  cron: 0 15 * * *
+  cron: 0 21 * * *
   labels:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-kubemark-500-gce-stable2
+  name: ci-kubernetes-kubemark-500-gce-stable3
   spec:
     containers:
     - args:
@@ -344,7 +341,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 24h
+    fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: integration-1.16
@@ -355,11 +352,11 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 6h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-integration-stable2
+  name: ci-kubernetes-integration-stable3
   spec:
     containers:
     - args:
@@ -375,7 +372,7 @@ periodics:
         privileged: true
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 24h
+    fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
@@ -387,11 +384,11 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 6h
+  interval: 24h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-verify-stable2
+  name: ci-kubernetes-verify-stable3
   spec:
     containers:
     - args:
@@ -430,7 +427,7 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-windows-gce-stable2
+  name: ci-kubernetes-e2e-windows-gce-stable3
   spec:
     containers:
     - args:
@@ -459,15 +456,15 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 24h
     description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a
       latest kubernetes release-1.16 cluster created with sigs.k8s.io/kind
+    fork-per-release-periodic-interval: ""
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.16-parallel
   cluster: k8s-infra-prow-build
-  interval: 6h
+  interval: 24h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
@@ -499,15 +496,15 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-periodic-interval: 24h
     description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a
       latest kubernetes release-1.16 IPv6 cluster created with sigs.k8s.io/kind
+    fork-per-release-periodic-interval: ""
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.16-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-ipv6-1.16-parallel
   cluster: k8s-infra-prow-build
-  interval: 6h
+  interval: 24h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -12,7 +12,7 @@ periodics:
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-stable1
+  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-stable2
   spec:
     containers:
     - args:
@@ -22,7 +22,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --check-version-skew=false
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-stable2
       - --extract=ci/latest
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-node-image=gci
@@ -67,19 +67,19 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *
+    fork-per-release-cron: 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
     testgrid-dashboards: sig-release-1.17-blocking, google-gce
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.17
-  cron: 0 3-23/6 * * *
+  cron: 0 8-23/12 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
+  name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable2
   spec:
     containers:
     - args:
@@ -99,12 +99,12 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-node-kubelet
     testgrid-tab-name: node-kubelet-1.17
   cluster: k8s-infra-prow-build
-  interval: 2h
+  interval: 6h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
@@ -173,7 +173,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-stable1
+  name: ci-kubernetes-build-stable2
   spec:
     containers:
     - args:
@@ -184,7 +184,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=latest-1.17-cross,k8s-stable1
+      - --extra-publish-file=latest-1.17-cross,k8s-stable2
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""
@@ -195,7 +195,7 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-cron: 0 8-20/12 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-scalability-gce, google-gce,
@@ -203,12 +203,12 @@ periodics:
     testgrid-num-failures-to-alert: "2"
     testgrid-tab-name: gce-cos-1.17-scalability-100
   cluster: k8s-infra-prow-build
-  cron: 0 0/12 * * *
+  cron: 0 4-16/12 * * *
   labels:
     preset-e2e-scalability-common: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gci-gce-scalability-stable1
+  name: ci-kubernetes-e2e-gci-gce-scalability-stable2
   spec:
     containers:
     - args:
@@ -239,9 +239,6 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-      # TODO(oxddr): re-enable this once we understand impact on https://github.com/kubernetes/kubernetes/issues/89051
-      # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/override.yaml
-      # - --test-cmd-args=--testoverrides=./testing/chaosmonkey/ignore_node_killer_container_restarts_100.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
       - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
@@ -264,18 +261,18 @@ periodics:
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
-    fork-per-release-cron: 0 15 * * *, 0 21 * * *
+    fork-per-release-cron: 0 21 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "1"
     testgrid-tab-name: kubemark-1.17-500
-  cron: 0 9 * * *
+  cron: 0 15 * * *
   labels:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-kubemark-500-gce-stable1
+  name: ci-kubernetes-kubemark-500-gce-stable2
   spec:
     containers:
     - args:
@@ -400,7 +397,7 @@ periodics:
       resources: {}
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: integration-1.17
@@ -411,11 +408,11 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 2h
+  interval: 6h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-integration-stable1
+  name: ci-kubernetes-integration-stable2
   spec:
     containers:
     - args:
@@ -431,7 +428,7 @@ periodics:
         privileged: true
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
       release-managers@kubernetes.io
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
@@ -443,11 +440,11 @@ periodics:
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 2h
+  interval: 6h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-verify-stable1
+  name: ci-kubernetes-verify-stable2
   spec:
     containers:
     - args:
@@ -513,15 +510,15 @@ periodics:
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
     description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a
       latest kubernetes release-1.17 cluster created with sigs.k8s.io/kind
+    fork-per-release-periodic-interval: 24h
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-1.17-parallel
   cluster: k8s-infra-prow-build
-  interval: 2h
+  interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
@@ -553,15 +550,15 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
     description: Uses kubetest to run e2e tests (+Conformance, -Serial) against a
       latest kubernetes release-1.17 IPv6 cluster created with sigs.k8s.io/kind
+    fork-per-release-periodic-interval: 24h
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.17-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
     testgrid-tab-name: kind-ipv6-1.17-parallel
   cluster: k8s-infra-prow-build
-  interval: 2h
+  interval: 6h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
@@ -1193,9 +1190,9 @@ presubmits:
       path_alias: k8s.io/kubeadm
       repo: kubeadm
     labels:
-      preset-dind-enabled: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
     name: pull-kubernetes-e2e-kind
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1,53 +1,17 @@
 periodics:
 - annotations:
-    fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: kubernetes-release-team@googlegroups.com, kubernetes-sig-cli@googlegroups.com
-    testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.18-blocking, sig-cli-master
-    testgrid-num-columns-recent: "3"
-    testgrid-num-failures-to-alert: "2"
-    testgrid-tab-name: skew-cluster-latest-kubectl-beta-gce
-  cluster: k8s-infra-prow-build
-  interval: 1h
-  labels:
-    preset-k8s-ssh: "true"
-    preset-service-account: "true"
-  name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-stable1
-  spec:
-    containers:
-    - args:
-      - --timeout=140
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --check-version-skew=false
-      - --extract=ci/k8s-stable1
-      - --extract=ci/latest
-      - --gcp-project-type=k8s-infra-gce-project
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --ginkgo-parallel=25
-      - --provider=gce
-      - --skew
-      - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
-      - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
-      name: ""
-      resources: {}
-- annotations:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.18-blocking, conformance-all, conformance-gce
+    testgrid-dashboards: sig-release-1.19-blocking, conformance-all, conformance-gce
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: Conformance - GCE - 1.18
+    testgrid-tab-name: Conformance - GCE - 1.19
   cluster: k8s-infra-prow-build
   interval: 3h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-gce-conformance-latest-1-18
+  name: ci-kubernetes-gce-conformance-latest-1-19
   spec:
     containers:
     - args:
@@ -55,7 +19,7 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
@@ -63,23 +27,23 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *
+    fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: gke-kubernetes-accelerators-bugs@google.com
     testgrid-alert-stale-results-hours: "24"
-    testgrid-dashboards: sig-release-1.18-blocking, google-gce
-    testgrid-num-failures-to-alert: "12"
-    testgrid-tab-name: gce-device-plugin-gpu-1.18
-  cron: 0 3-23/6 * * *
+    testgrid-dashboards: sig-release-1.19-blocking, google-gce
+    testgrid-num-failures-to-alert: "6"
+    testgrid-tab-name: gce-device-plugin-gpu-1.19
+  cron: 0 0-23/2 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gce-device-plugin-gpu-stable1
+  name: ci-kubernetes-e2e-gce-device-plugin-gpu-beta
   spec:
     containers:
     - args:
@@ -96,24 +60,24 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-node+testgrid@googlegroups.com
-    testgrid-dashboards: sig-release-1.18-blocking, sig-node-kubelet
-    testgrid-tab-name: node-kubelet-1.18
+    testgrid-dashboards: sig-release-1.19-blocking, sig-node-kubelet
+    testgrid-tab-name: node-kubelet-1.19
   cluster: k8s-infra-prow-build
-  interval: 2h
+  interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-1-18
+  name: ci-kubernetes-node-kubelet-1-19
   spec:
     containers:
     - args:
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --timeout=90
       - --root=/go/src
       - --scenario=kubernetes_e2e
@@ -130,22 +94,22 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: sig-node-kubelet, sig-release-1.18-informing
-    testgrid-tab-name: node-kubelet-features-1-18
+    testgrid-dashboards: sig-node-kubelet, sig-release-1.19-informing
+    testgrid-tab-name: node-kubelet-features-1.19
   cluster: k8s-infra-prow-build
   interval: 1h
   labels:
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-node-kubelet-features-1-18
+  name: ci-kubernetes-node-kubelet-features-1-19
   spec:
     containers:
     - args:
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --timeout=90
       - --root=/go/src
       - --scenario=kubernetes_e2e
@@ -162,33 +126,32 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-generic-suffix: "true"
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.18-blocking
-    testgrid-tab-name: build-1.18
+    testgrid-dashboards: sig-release-1.19-blocking
+    testgrid-tab-name: build-1.19
   interval: 1h
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-build-stable1
+  name: ci-kubernetes-build-1-19
   rerun_auth_config:
     github_team_ids:
     - 2241179
   spec:
     containers:
     - args:
-      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
       - --repo=k8s.io/release
       - --root=/go/src
       - --timeout=180
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=latest-1.18-cross,k8s-stable1
+      - --extra-publish-file=latest-1.19-cross,k8s-beta
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200430-be2a8a9
       name: ""
@@ -199,29 +162,29 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-cron: 0 15 * * *, 0 21 * * *
+    fork-per-release-cron: 0 9 * * *, 0 15 * * *, 0 21 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-scalability-kubemark, sig-release-job-config-errors
     testgrid-num-failures-to-alert: "1"
-    testgrid-tab-name: kubemark-1.18-500
-  cron: 0 9 * * *
+    testgrid-tab-name: kubemark-1.19-500
+  cron: 0 3 * * *
   labels:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-kubemark-500-gce-stable1
+  name: ci-kubernetes-kubemark-500-gce-beta
   spec:
     containers:
     - args:
-      - --repo=k8s.io/kubernetes=release-1.18
-      - --repo=k8s.io/perf-tests=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
+      - --repo=k8s.io/perf-tests=release-1.19
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-500
-      - --extract=ci/latest-1.18
+      - --extract=ci/latest-1.19
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
       - --gcp-node-size=n1-standard-8
@@ -238,50 +201,47 @@ periodics:
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--nodes=500
       - --test-cmd-args=--provider=kubemark
+      - --env=CL2_ENABLE_PVS=false
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_500_nodes.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
       securityContext:
         privileged: true
   tags:
-  - 'perfDashPrefix: kubemark-500Nodes-1.18'
+  - 'perfDashPrefix: kubemark-500Nodes-1.19'
   - 'perfDashJobType: performance'
 - annotations:
-    fork-per-release-cron: 0 4-16/12 * * *, 0 8-20/12 * * *
+    fork-per-release-cron: 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
-    testgrid-dashboards: sig-release-1.18-blocking, sig-scalability-gce, google-gce,
+    testgrid-dashboards: sig-release-1.19-blocking, sig-scalability-gce, google-gce,
       google-gci
     testgrid-num-failures-to-alert: "2"
-    testgrid-tab-name: gce-cos-1.18-scalability-100
+    testgrid-tab-name: gce-cos-1.19-scalability-100
   cluster: k8s-infra-prow-build
-  cron: 0 0/12 * * *
+  cron: 0 */6 * * *
   labels:
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-containerd: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-gci-gce-scalability-stable1
+  name: ci-kubernetes-e2e-gci-gce-scalability-beta
   spec:
     containers:
     - args:
       - --timeout=140
-      - --repo=k8s.io/kubernetes=release-1.18
-      - --repo=k8s.io/perf-tests=release-1.18
+      - --repo=k8s.io/kubernetes=release-1.19
+      - --repo=k8s.io/perf-tests=release-1.19
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -294,6 +254,7 @@ periodics:
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce
+      - --env=CL2_ENABLE_DNS_PROGRAMMING=true
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
@@ -307,33 +268,27 @@ periodics:
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml
       - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-      - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/load_throughput.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
   tags:
-  - 'perfDashPrefix: gce-100Nodes-1.18'
+  - 'perfDashPrefix: gce-100Nodes-1.19'
   - 'perfDashJobType: performance'
   - 'perfDashBuildsCount: 500'
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
-    testgrid-tab-name: bazel-build-1.18
+    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-tab-name: bazel-build-1.19
   decorate: true
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     repo: kubernetes
   - base_ref: master
@@ -343,7 +298,7 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-build-1-18
+  name: periodic-kubernetes-bazel-build-1-19
   rerun_auth_config:
     github_team_ids:
     - 2241179
@@ -362,16 +317,16 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
-    testgrid-tab-name: bazel-test-1.18
+    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-tab-name: bazel-test-1.19
   decorate: true
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     repo: kubernetes
   - base_ref: master
@@ -381,7 +336,7 @@ periodics:
   labels:
     preset-bazel-scratch-dir: "true"
     preset-service-account: "true"
-  name: periodic-kubernetes-bazel-test-1-18
+  name: periodic-kubernetes-bazel-test-1-19
   spec:
     containers:
     - args:
@@ -396,19 +351,19 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: launcher.gcr.io/google/bazel:0.25.2
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
       resources: {}
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
-    testgrid-tab-name: integration-1.18
+    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-tab-name: integration-1.19
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
@@ -416,14 +371,14 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-integration-stable1
+  name: ci-kubernetes-integration-beta
   spec:
     containers:
     - args:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources:
         requests:
@@ -432,15 +387,15 @@ periodics:
         privileged: true
 - annotations:
     fork-per-release-generic-suffix: "true"
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
       release-managers@kubernetes.io
-    testgrid-dashboards: sig-release-1.18-blocking, google-unit
-    testgrid-tab-name: verify-1.18
+    testgrid-dashboards: sig-release-1.19-blocking, google-unit
+    testgrid-tab-name: verify-1.19
   cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
@@ -448,7 +403,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-verify-stable1
+  name: ci-kubernetes-verify-beta
   spec:
     containers:
     - args:
@@ -459,10 +414,10 @@ periodics:
       - name: EXCLUDE_READONLY_PACKAGE
         value: "y"
       - name: KUBE_VERIFY_GIT_BRANCH
-        value: release-1.18
+        value: release-1.19
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       imagePullPolicy: Always
       name: ""
       resources:
@@ -471,8 +426,8 @@ periodics:
       securityContext:
         privileged: true
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows
-    testgrid-tab-name: gce-windows-2019-1.18
+    testgrid-dashboards: google-windows, sig-windows, sig-release-1.19-informing
+    testgrid-tab-name: gce-windows-2019-1.19
   decorate: true
   extra_refs:
   - base_ref: master
@@ -485,13 +440,13 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-windows-gce-2019-1-18
+  name: ci-kubernetes-e2e-windows-gce-2019-1-19
   spec:
     containers:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -510,12 +465,12 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    testgrid-dashboards: google-windows, sig-windows, sig-release-1.18-informing
-    testgrid-tab-name: gce-windows-1909-1.18
+    testgrid-dashboards: google-windows, sig-windows, sig-release-1.19-informing
+    testgrid-tab-name: gce-windows-1909-1.19
   decorate: true
   extra_refs:
   - base_ref: master
@@ -528,13 +483,13 @@ periodics:
     preset-e2e-gce-windows: "true"
     preset-k8s-ssh: "true"
     preset-service-account: "true"
-  name: ci-kubernetes-e2e-windows-gce-1909-1-18
+  name: ci-kubernetes-e2e-windows-gce-1909-1-19
   spec:
     containers:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-stable1
+      - --extract=ci/k8s-beta
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -553,31 +508,31 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
       name: ""
       resources: {}
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.18-blocking, sig-testing-kind
+    testgrid-dashboards: sig-release-1.19-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
-    testgrid-tab-name: kind-1.18-parallel
+    testgrid-tab-name: kind-1.19-parallel
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 2h
+  interval: 1h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-kind-e2e-parallel-1-18
+  name: ci-kubernetes-kind-e2e-parallel-1-19
   spec:
     containers:
     - command:
@@ -595,36 +550,36 @@ periodics:
         value: "true"
       - name: BUILD_TYPE
         value: bazel
-      image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.18
+      image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.19
       name: ""
       resources:
         requests:
-          cpu: "2"
+          cpu: 7400m
           memory: 9000Mi
       securityContext:
         privileged: true
 - annotations:
-    fork-per-release-periodic-interval: 6h 24h
+    fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: bentheelder@google.com,antonio.ojea.garcia@gmail.com,kubernetes-release-team@googlegroups.com
-    testgrid-dashboards: sig-release-1.18-blocking, sig-testing-kind
+    testgrid-dashboards: sig-release-1.19-blocking, sig-testing-kind
     testgrid-num-columns-recent: "6"
-    testgrid-tab-name: kind-ipv6-1.18-parallel
+    testgrid-tab-name: kind-ipv6-1.19-parallel
   cluster: k8s-infra-prow-build
   decorate: true
   decoration_config:
     timeout: 1h0m0s
   extra_refs:
-  - base_ref: release-1.18
+  - base_ref: release-1.19
     org: kubernetes
     path_alias: k8s.io/kubernetes
     repo: kubernetes
-  interval: 2h
+  interval: 1h
   labels:
     preset-bazel-remote-cache-enabled: "true"
     preset-bazel-scratch-dir: "true"
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-  name: ci-kubernetes-kind-ipv6-e2e-parallel-1-18
+  name: ci-kubernetes-kind-ipv6-e2e-parallel-1-19
   spec:
     containers:
     - command:
@@ -646,7 +601,7 @@ periodics:
         value: "true"
       - name: BUILD_TYPE
         value: bazel
-      image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.18
+      image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.19
       name: ""
       resources:
         requests:
@@ -659,12 +614,12 @@ postsubmits:
   - annotations:
       testgrid-dashboards: google-unit, sig-release-job-config-errors
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: ci-kubernetes-bazel-build-1-18
+    name: ci-kubernetes-bazel-build-1-19
     rerun_auth_config:
       github_team_ids:
       - 2241179
@@ -682,16 +637,16 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - annotations:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-dashboards: sig-release-1.18-informing, google-unit
+      testgrid-dashboards: sig-release-1.19-informing, google-unit
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     extra_refs:
     - base_ref: master
@@ -700,7 +655,7 @@ postsubmits:
     labels:
       preset-bazel-scratch-dir: "true"
       preset-service-account: "true"
-    name: post-kubernetes-bazel-test-1-18
+    name: post-kubernetes-bazel-test-1-19
     spec:
       containers:
       - args:
@@ -715,19 +670,20 @@ postsubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
 presubmits:
   kubernetes/kubernetes:
   - always_run: false
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-aws-credential: "true"
       preset-aws-ssh: "true"
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
+      preset-dind-enabled: "true"
       preset-e2e-platform-aws: "true"
       preset-service-account: "true"
     max_concurrency: 12
@@ -749,6 +705,7 @@ presubmits:
         - --aws-cluster-domain=test-cncf-aws.k8s.io
         - --build=bazel
         - --cluster=
+        - --env=KOPS_ARCH=amd64
         - --env=KOPS_LATEST=latest-ci-green.txt
         - --env=KOPS_DEPLOY_LATEST_KUBE=n
         - --env=KUBE_GCS_UPDATE_LATEST=n
@@ -759,14 +716,14 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
@@ -798,14 +755,14 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: false
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-dind-enabled: "true"
       preset-k8s-ssh: "true"
@@ -837,7 +794,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
@@ -846,7 +803,7 @@ presubmits:
           privileged: true
   - always_run: false
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
@@ -868,10 +825,10 @@ presubmits:
         - --build=bazel
         - --cluster=
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
         - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --extract=local
         - --gcp-master-image=ubuntu
@@ -884,14 +841,14 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
-  - always_run: false
+  - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
@@ -913,16 +870,16 @@ presubmits:
         - --build=bazel
         - --cluster=
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.3
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=ENABLE_POD_SECURITY_POLICY=true
         - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
         - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
-        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
         - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
-        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-1804-bionic-v20200108
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
         - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
         - --extract=local
         - --gcp-master-image=ubuntu
@@ -930,19 +887,68 @@ presubmits:
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce
-        - --runtime-config=batch/v2alpha1=true
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: false
     branches:
-    - release-1.18
+    - release-1.19
+    labels:
+      preset-bazel-remote-cache-enabled: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-k8s-ssh: "true"
+      preset-pull-kubernetes-e2e: "true"
+      preset-pull-kubernetes-e2e-gce: "true"
+      preset-service-account: "true"
+    name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+    spec:
+      containers:
+      - args:
+        - --root=/go/src
+        - --repo=k8s.io/kubernetes=$(PULL_REFS)
+        - --repo=k8s.io/release
+        - --upload=gs://kubernetes-jenkins/pr-logs
+        - --timeout=105
+        - --scenario=kubernetes_e2e
+        - --
+        - --build=bazel
+        - --cluster=
+        - --env=KUBE_CONTAINER_RUNTIME=containerd
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.6
+        - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
+        - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
+        - --env=ENABLE_POD_SECURITY_POLICY=true
+        - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
+        - --env=KUBE_MASTER_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_MASTER_IMAGE=ubuntu-2004-focal-v20200423
+        - --env=KUBE_GCE_MASTER_PROJECT=ubuntu-os-cloud
+        - --env=KUBE_NODE_OS_DISTRIBUTION=ubuntu
+        - --env=KUBE_GCE_NODE_IMAGE=ubuntu-2004-focal-v20200423
+        - --env=KUBE_GCE_NODE_PROJECT=ubuntu-os-cloud
+        - --extract=local
+        - --gcp-master-image=ubuntu
+        - --gcp-node-image=ubuntu
+        - --gcp-zone=us-west1-b
+        - --ginkgo-parallel=30
+        - --provider=gce
+        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+          --minStartupPods=8
+        - --timeout=80m
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
+        name: ""
+        resources:
+          requests:
+            memory: 6Gi
+  - always_run: false
+    branches:
+    - release-1.19
     decorate: true
     extra_refs:
     - base_ref: master
@@ -980,12 +986,12 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources: {}
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
@@ -1020,14 +1026,14 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1053,14 +1059,14 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: false
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"
@@ -1094,17 +1100,18 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-scratch-dir: "true"
       preset-e2e-scalability-common: "true"
+      preset-e2e-scalability-containerd: "true"
       preset-e2e-scalability-presubmits: "true"
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1115,7 +1122,7 @@ presubmits:
       - args:
         - --root=/go/src
         - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=release-1.18
+        - --repo=k8s.io/perf-tests=master
         - --repo=k8s.io/release
         - --upload=gs://kubernetes-jenkins/pr-logs
         - --timeout=120
@@ -1131,7 +1138,6 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-100-performance
         - --tear-down-previous
         - --test=false
-        - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
         - --test-cmd-args=cluster-loader2
         - --test-cmd-args=--nodes=100
@@ -1143,24 +1149,18 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_pvs.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/gce/throughput_override.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/load_throughput.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
             memory: 6Gi
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     labels:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
@@ -1176,7 +1176,7 @@ presubmits:
         - --root=/go/src
         - --job=$(JOB_NAME)
         - --repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)
-        - --repo=k8s.io/perf-tests=release-1.18
+        - --repo=k8s.io/perf-tests=master
         - --repo=k8s.io/release
         - --service-account=/etc/service-account/service-account.json
         - --upload=gs://kubernetes-jenkins/pr-logs
@@ -1196,13 +1196,13 @@ presubmits:
         - --provider=gce
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-kubemark-e2e-gce-big
         - --tear-down-previous
-        - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
         - --test=false
         - --test_args=--ginkgo.focus=xxxx
         - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
         - --test-cmd-args=cluster-loader2
         - --test-cmd-args=--nodes=500
         - --test-cmd-args=--provider=kubemark
+        - --env=CL2_ENABLE_PVS=false
         - --test-cmd-args=--report-dir=/workspace/_artifacts
         - --test-cmd-args=--testconfig=testing/density/config.yaml
         - --test-cmd-args=--testconfig=testing/load/config.yaml
@@ -1210,16 +1210,11 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
         - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_configmaps.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_daemonsets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_jobs.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_secrets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/experimental/overrides/enable_statefulsets.yaml
-        - --test-cmd-args=--testoverrides=./testing/load/kubemark/500_nodes/override.yaml
+        - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_500_nodes.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
@@ -1228,7 +1223,7 @@ presubmits:
           privileged: true
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     extra_refs:
     - base_ref: master
@@ -1246,12 +1241,12 @@ presubmits:
           ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     extra_refs:
     - base_ref: master
@@ -1274,12 +1269,12 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -1296,14 +1291,32 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: main
         resources: {}
         securityContext:
           privileged: true
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
+    decorate: true
+    name: pull-kubernetes-files-remake
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - args:
+        - verify
+        command:
+        - make
+        env:
+        - name: WHAT
+          value: generated-files-remake
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
+        name: main
+        resources: {}
+  - always_run: true
+    branches:
+    - release-1.19
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -1316,7 +1329,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: ""
         resources:
           requests:
@@ -1325,9 +1338,10 @@ presubmits:
           privileged: true
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     decoration_config:
+      grace_period: 15m0s
       timeout: 1h0m0s
     labels:
       preset-bazel-remote-cache-enabled: "true"
@@ -1348,22 +1362,22 @@ presubmits:
         - name: FOCUS
           value: .
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Network.should.set.TCP.CLOSE_WAIT.timeout|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|should.provide.basic.identity|\[NodeFeature:PodReadinessGate\]
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing|Conntrack|udp|UDP|NFS|nfs|inline.execution.and.attach|should.be.rejected.when.no.endpoints.exist
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE
           value: bazel
-        image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.18
+        image: gcr.io/k8s-testimages/krte:v20200619-19b0ee3-1.19
         name: ""
         resources:
           requests:
-            cpu: "2"
+            cpu: 7500m
             memory: 9000Mi
         securityContext:
           privileged: true
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     name: pull-kubernetes-typecheck
     path_alias: k8s.io/kubernetes
@@ -1375,13 +1389,13 @@ presubmits:
         - make
         env:
         - name: WHAT
-          value: typecheck typecheck-providerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+          value: typecheck typecheck-providerless typecheck-dockerless
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         name: main
         resources: {}
   - always_run: true
     branches:
-    - release-1.18
+    - release-1.19
     decorate: true
     labels:
       preset-dind-enabled: "true"
@@ -1397,13 +1411,15 @@ presubmits:
         env:
         - name: EXCLUDE_TYPECHECK
           value: "y"
+        - name: EXCLUDE_FILES_REMAKE
+          value: "y"
         - name: EXCLUDE_GODEP
           value: "y"
         - name: KUBE_VERIFY_GIT_BRANCH
-          value: release-1.18
+          value: release-1.19
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/testgrids/kubernetes/sig-release/config.yaml
+++ b/config/testgrids/kubernetes/sig-release/config.yaml
@@ -5,14 +5,14 @@ dashboard_groups:
   dashboard_names:
   - sig-release-master-blocking
   - sig-release-master-informing
+  - sig-release-1.19-blocking
+  - sig-release-1.19-informing
   - sig-release-1.18-blocking
   - sig-release-1.18-informing
   - sig-release-1.17-blocking
   - sig-release-1.17-informing
   - sig-release-1.16-blocking
   - sig-release-1.16-informing
-  - sig-release-1.15-blocking
-  - sig-release-1.15-informing
   - sig-release-releng-blocking
   - sig-release-releng-informing
   - sig-release-releng-presubmits
@@ -32,14 +32,14 @@ dashboards:
   - name: Conformance - OpenStack
     test_group_name: ci-periodic-cloud-provider-openstack-acceptance-test-e2e-conformance
     description: "OWNER: sig-openstack; Runs conformance tests using kubetest against latest kubernetes master with cloud-provider-openstack"
+- name: sig-release-1.19-blocking
+- name: sig-release-1.19-informing
 - name: sig-release-1.18-blocking
 - name: sig-release-1.18-informing
 - name: sig-release-1.17-blocking
 - name: sig-release-1.17-informing
 - name: sig-release-1.16-blocking
 - name: sig-release-1.16-informing
-- name: sig-release-1.15-blocking
-- name: sig-release-1.15-informing
 - name: sig-release-releng-blocking
 - name: sig-release-releng-informing
 - name: sig-release-releng-presubmits

--- a/releng/prepare_release_branch.py
+++ b/releng/prepare_release_branch.py
@@ -49,8 +49,12 @@ def check_version(branch_path):
 
 
 def delete_dead_branch(branch_path, current_version):
+    print("Deleting dead branch...")
     filename = '%d.%d.yaml' % (current_version[0], current_version[1] - 3)
-    os.unlink(os.path.join(branch_path, filename))
+    if os.path.exists(filename):
+        os.unlink(os.path.join(branch_path, filename))
+    else:
+        print("the branch config (%s) does not exist" % filename)
 
 
 def rotate_files(rotator_bin, branch_path, current_version):
@@ -117,7 +121,6 @@ def main():
     d = os.environ.get('BUILD_WORKSPACE_DIRECTORY')
     version = check_version(os.path.join(d, BRANCH_JOB_DIR))
     print("Current version: %d.%d" % (version[0], version[1]))
-    print("Deleting dead branch...")
     delete_dead_branch(os.path.join(d, BRANCH_JOB_DIR), version)
     print("Rotating files...")
     rotate_files(rotator_bin, os.path.join(d, BRANCH_JOB_DIR), version)

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -523,20 +523,20 @@ k8sVersions:
     version: master
   beta:
     args:
+    - --extract=ci/latest-1.19
+    version: '1.19'
+  stable1:
+    args:
     - --extract=ci/latest-1.18
     version: '1.18'
-  stable1:
+  stable2:
     args:
     - --extract=ci/latest-1.17
     version: '1.17'
-  stable2:
+  stable3:
     args:
     - --extract=ci/latest-1.16
     version: '1.16'
-  stable3:
-    args:
-    - --extract=ci/latest-1.15
-    version: '1.15'
 
 testSuites:
   alphafeatures:
@@ -564,8 +564,7 @@ testSuites:
     args:
     - --gcp-project-type=ingress-project
     - --timeout=150m
-    - --test_args=--ginkgo.focus=\[Feature:Ingress\]
-      --minStartupPods=8
+    - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
   reboot:
     args:
     - --gcp-project-type=k8s-infra-gce-project
@@ -660,20 +659,20 @@ nodeK8sVersions:
     prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-master
   beta:
     args:
+    - --repo=k8s.io/kubernetes=release-1.19
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.19
+  stable1:
+    args:
     - --repo=k8s.io/kubernetes=release-1.18
     prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.18
-  stable1:
+  stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.17
     prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.17
-  stable2:
+  stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.16
     prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.16
-  stable3:
-    args:
-    - --repo=k8s.io/kubernetes=release-1.15
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200623-2424179-1.15
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/18232, now that the 1.19 branch has been cut and new kubekins-e2e images have been built: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1281390426061803520

- releng/prepare_release_branch: Ignore dead branch if already deleted
- releng: Add 1.19 testgrid configs, remove 1.15 configs
- sig-node: Rename node-kubelet-features tab name to allow proper forking
- sig-cli: Disable forking for kubectl-skew jobs
  
  kubectl skews jobs consistently cause config forking issues because of
  the way they use generic version markers and oddities in the job name.
  
  The kubectl skew jobs are also defined within a single file, instead of
  alongside the other release branch jobs, which means they don't take
  advantage of forking and are frequently stale.
  
  We disable forking for the main kubectl-skew job to unblock creation of
  the 1.19 branch release jobs.
- releng: Generate 1.19 branch jobs

/priority critical-urgent
cc: @kubernetes/release-engineering 
/hold because some of the jobs have are being generated with duplicate testgrid tab names

```console
$ time bazel test //config/... //hack:verify-all
Starting local Bazel server and connecting to it...
INFO: Analyzed 14 targets (1296 packages loaded, 20130 targets configured).
INFO: Found 14 test targets...
INFO: Deleting stale sandbox base /home/augustus/.cache/bazel/_bazel_augustus/e12d25d9a9ef0205fe09fd32cbe17129/sandbox
ERROR: /home/augustus/go/src/k8s.io/test-infra/config/tests/testgrids/BUILD.bazel:25:1: Executing genrule //config/tests/testgrids:testgrid_config failed (Exit 1) bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
2020/07/10 00:59:53 FAIL: could not write config: 2 errors occurred:
	* found duplicate name after normalizing: (DashboardTab) skewclusterlatestkubectlstable1gce
	* found duplicate name after normalizing: (DashboardTab) nodekubeletfeatures

INFO: Elapsed time: 17.244s, Critical Path: 2.71s
INFO: 1 process: 1 linux-sandbox.
FAILED: Build did NOT complete successfully
//config/prow/cluster:go_default_test                           (cached) PASSED in 2.3s
//config/tests/lint:go_default_test                             (cached) PASSED in 2.5s
//hack:verify-gopherage                                         (cached) PASSED in 0.2s
//hack:verify-pylint                                            (cached) PASSED in 18.3s
//hack:verify-spelling                                          (cached) PASSED in 7.5s
//hack:verify-tslint                                            (cached) PASSED in 3.6s
@io_k8s_repo_infra//hack:verify-bazel                           (cached) PASSED in 7.4s
@io_k8s_repo_infra//hack:verify-boilerplate                     (cached) PASSED in 0.7s
@io_k8s_repo_infra//hack:verify-gofmt                           (cached) PASSED in 2.7s
//config/tests/jobs:go_default_test                                   NO STATUS
//hack:verify-codegen                                                 NO STATUS
//hack:verify-labels                                                  NO STATUS
@io_k8s_repo_infra//hack:verify-deps                                  NO STATUS
//config/tests/testgrids:go_default_test                        FAILED TO BUILD

Executed 0 out of 14 tests: 9 tests pass, 1 fails to build and 4 were skipped.
FAILED: Build did NOT complete successfully
```