### PR TITLE
Revert "Kops - Add KOPS_RUN_TOO_NEW_VERSION to pipeline jobs"

### DIFF
--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -45,7 +45,6 @@ template = """
       - --deployment=kops
       - --provider=aws
       - --cluster={{name}}.test-cncf-aws.k8s.io
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user={{ssh_user}}
       - --kops-nodes=4
       - --extract={{extract}}

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -32,7 +32,6 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kopsmaster.test-cncf-aws.k8s.io
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/latest
@@ -81,7 +80,6 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops116.test-cncf-aws.k8s.io
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=admin
       - --kops-nodes=4
       - --extract=release/stable-1.16
@@ -130,7 +128,6 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops117.test-cncf-aws.k8s.io
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=admin
       - --kops-nodes=4
       - --extract=release/stable-1.17
@@ -179,7 +176,6 @@ periodics:
       - --deployment=kops
       - --provider=aws
       - --cluster=e2e-kops-pipeline-updown-kops118.test-cncf-aws.k8s.io
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --kops-ssh-user=ubuntu
       - --kops-nodes=4
       - --extract=release/stable-1.18


### PR DESCRIPTION
This reverts commit 2cbb5602

Kubetest doesn't support `--env` arg:
```
2020/07/10 06:30:01 main.go:279: Flag parse failed: unknown flag: --env
```

https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-pipeline-updown-kops118/1281475715966963715/build-log.txt

/cc @rifelpet 
