### PR TITLE
Add saschagrunert and alejandrox1 as SIG Release admins

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -81,8 +81,9 @@ aliases:
     - justaugustus
     - lachie83
   sig-release-leads:
-    - calebamiles
+    - alejandrox1
     - justaugustus
+    - saschagrunert
     - tpepper
   sig-scalability-leads:
     - mm4tt


### PR DESCRIPTION
To fulfill the role as new technical lead we need to be part of the SIG
release admin role.

Ref kubernetes/community#4867