### PR TITLE
milestone_applier: change default milestone for CAPIDO to v0.4

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -345,7 +345,7 @@ milestone_applier:
     release-0.4: v0.4
     release-0.3: v0.3
   kubernetes-sigs/cluster-api-provider-digitalocean:
-    master: v0.3
+    master: v0.4
     release-0.4: v0.4
     release-0.3: v0.3
 


### PR DESCRIPTION
Change default milestone for Cluster-API provider DigitalOcean to v0.4, as v0.3 has been released some time ago.