### PR TITLE
remove triming when passing the commit message option

### DIFF
--- a/prow/git/v2/interactor.go
+++ b/prow/git/v2/interactor.go
@@ -88,15 +88,6 @@ type MergeOpt struct {
 	CommitMessage string
 }
 
-// trimMessage surrounds the message with double quotes if is a multi word message
-func trimMessage(message string) string {
-	// In case of a message with multiple words, put it into quotes
-	if len(strings.Split(message, " ")) > 1 {
-		return fmt.Sprintf("\"%s\"", message)
-	}
-	return message
-}
-
 type interactor struct {
 	executor executor
 	remote   RemoteResolver
@@ -200,7 +191,7 @@ func (i *interactor) mergeMerge(commitlike string, opts ...MergeOpt) (bool, erro
 		args = append(args, []string{"-m", "merge"}...)
 	} else {
 		for _, opt := range opts {
-			args = append(args, []string{"-m", trimMessage(opt.CommitMessage)}...)
+			args = append(args, []string{"-m", opt.CommitMessage}...)
 		}
 	}
 

--- a/prow/git/v2/interactor_test.go
+++ b/prow/git/v2/interactor_test.go
@@ -561,12 +561,12 @@ func TestInteractor_MergeWithStrategy(t *testing.T) {
 			strategy:   "merge",
 			opts:       []MergeOpt{{CommitMessage: "my happy merge message"}},
 			responses: map[string]execResponse{
-				"merge --no-ff --no-stat -m \"my happy merge message\" shasum": {
+				"merge --no-ff --no-stat -m my happy merge message shasum": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"merge", "--no-ff", "--no-stat", "-m", "\"my happy merge message\"", "shasum"},
+				{"merge", "--no-ff", "--no-stat", "-m", "my happy merge message", "shasum"},
 			},
 			expectedMerge: true,
 			expectedErr:   false,
@@ -581,12 +581,12 @@ func TestInteractor_MergeWithStrategy(t *testing.T) {
 				{CommitMessage: "message"},
 			},
 			responses: map[string]execResponse{
-				"merge --no-ff --no-stat -m my -m \"happy merge\" -m message shasum": {
+				"merge --no-ff --no-stat -m my -m happy merge -m message shasum": {
 					out: []byte(`ok`),
 				},
 			},
 			expectedCalls: [][]string{
-				{"merge", "--no-ff", "--no-stat", "-m", "my", "-m", "\"happy merge\"", "-m", "message", "shasum"},
+				{"merge", "--no-ff", "--no-stat", "-m", "my", "-m", "happy merge", "-m", "message", "shasum"},
 			},
 			expectedMerge: true,
 			expectedErr:   false,


### PR DESCRIPTION
Since the potential multi-word commit message is one of the values of a slice of strings, `os/exec` is smart enough to surround it with quotes in git's command arguments. The current code was causing to commit the merge message with the extra quotes included. This PR fix this.

/cc @alvaroaleman 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>