### PR TITLE
Create testgrid bazelbuild variant

### DIFF
--- a/images/bazelbuild/variants.yaml
+++ b/images/bazelbuild/variants.yaml
@@ -7,3 +7,7 @@ variants:
     CONFIG: test-infra
     BAZEL_VERSION: 3.1.0
     OLD_BAZEL_VERSION: 3.0.0
+  testgrid:
+    CONFIG: testgrid
+    BAZEL_VERSION: 3.3.0
+    OLD_BAZEL_VERSION: 3.0.0


### PR DESCRIPTION
/assign @spiffxp @michelle192837 

Testgrid pushes are failing because the image doesn't have bazel 3.0.0