### PR TITLE
Sidecar Support for Multiple Containers in Parallel

### DIFF
--- a/prow/entrypoint/run.go
+++ b/prow/entrypoint/run.go
@@ -79,7 +79,7 @@ func (o Options) Run() int {
 	if err != nil {
 		logrus.WithError(err).Error("Error executing test process")
 	}
-	if err := o.mark(code); err != nil {
+	if err := o.Mark(code); err != nil {
 		logrus.WithError(err).Error("Error writing exit code to marker file")
 		return InternalErrorCode // we need to mark the real error code to safely return AlwaysZero
 	}
@@ -122,7 +122,8 @@ func (o Options) ExecuteProcess() (int, error) {
 			case <-ctx.Done():
 			}
 		}()
-		code, err := wrapper.WaitForMarker(ctx, o.PreviousMarker)
+		prevMarkerResult := wrapper.WaitForMarkers(ctx, o.PreviousMarker)[o.PreviousMarker]
+		code, err := prevMarkerResult.ReturnCode, prevMarkerResult.Err
 		cancel() // end previous go-routine when not interrupted
 		if err != nil {
 			return InternalErrorCode, fmt.Errorf("wait for previous marker %s: %v", o.PreviousMarker, err)
@@ -196,12 +197,12 @@ func (o Options) ExecuteProcess() (int, error) {
 	return returnCode, commandErr
 }
 
-func (o *Options) mark(exitCode int) error {
+func (o *Options) Mark(exitCode int) error {
 	content := []byte(strconv.Itoa(exitCode))
 
-	// create temp file in the same directory as the desired marker file
+	// create temp file outside the directory of the desired marker file
 	dir := filepath.Dir(o.MarkerFile)
-	tempFile, err := ioutil.TempFile(dir, "temp-marker")
+	tempFile, err := ioutil.TempFile("", "temp-marker")
 	if err != nil {
 		return fmt.Errorf("could not create temp marker file in %s: %v", dir, err)
 	}

--- a/prow/entrypoint/run.go
+++ b/prow/entrypoint/run.go
@@ -25,7 +25,6 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"syscall"
 	"time"
@@ -201,10 +200,9 @@ func (o *Options) Mark(exitCode int) error {
 	content := []byte(strconv.Itoa(exitCode))
 
 	// create temp file outside the directory of the desired marker file
-	dir := filepath.Dir(o.MarkerFile)
 	tempFile, err := ioutil.TempFile("", "temp-marker")
 	if err != nil {
-		return fmt.Errorf("could not create temp marker file in %s: %v", dir, err)
+		return fmt.Errorf("could not create temp marker file: %v", err)
 	}
 	// write the exit code to the tempfile, sync to disk and close
 	if _, err = tempFile.Write(content); err != nil {

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -479,10 +479,11 @@ func entrypointLocation(tools coreapi.VolumeMount) string {
 // InjectEntrypoint will make the entrypoint binary in the tools volume the container's entrypoint, which will output to the log volume.
 func InjectEntrypoint(c *coreapi.Container, timeout, gracePeriod time.Duration, prefix, previousMarker string, exitZero bool, log, tools coreapi.VolumeMount) (*wrapper.Options, error) {
 	wrapperOptions := &wrapper.Options{
-		Args:         append(c.Command, c.Args...),
-		ProcessLog:   processLog(log, prefix),
-		MarkerFile:   markerFile(log, prefix),
-		MetadataFile: metadataFile(log, prefix),
+		Args:          append(c.Command, c.Args...),
+		ContainerName: c.Name,
+		ProcessLog:    processLog(log, prefix),
+		MarkerFile:    markerFile(log, prefix),
+		MetadataFile:  metadataFile(log, prefix),
 	}
 	// TODO(fejta): use flags
 	entrypointConfigEnv, err := entrypoint.Encode(entrypoint.Options{

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -677,7 +677,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -701,7 +701,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","mediaTypes":{"log":"text/plain"},"gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -916,7 +916,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -940,7 +940,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1165,7 +1165,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageReadFile,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1189,7 +1189,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1429,7 +1429,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1453,7 +1453,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1633,7 +1633,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "JOB_SPEC", Value: `{"type":"periodic","job":"job-name","buildid":"blabla","prowjobid":"pod"}`},
 								{Name: "JOB_TYPE", Value: "periodic"},
 								{Name: "PROW_JOB_ID", Value: "pod"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1653,7 +1653,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"periodic","job":"job-name","buildid":"blabla","prowjobid":"pod"}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1832,7 +1832,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -1852,7 +1852,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test","process_log":"/logs/process-log.txt","marker_file":"/logs/marker-file.txt","metadata_file":"/logs/artifacts/metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2081,7 +2081,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/thing","some","args"],"container_name":"test-0","process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2123,7 +2123,7 @@ func TestProwJobToPod(t *testing.T) {
 								{Name: "PULL_REFS", Value: "base-ref:base-sha,1:pull-sha"},
 								{Name: "REPO_NAME", Value: "repo-name"},
 								{Name: "REPO_OWNER", Value: "org-name"},
-								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
+								{Name: "ENTRYPOINT_OPTIONS", Value: `{"timeout":7200000000000,"grace_period":10000000000,"artifact_dir":"/logs/artifacts","args":["/bin/otherthing","other","args"],"container_name":"test-1","process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{
@@ -2147,7 +2147,7 @@ func TestProwJobToPod(t *testing.T) {
 							Command: []string{"/sidecar"},
 							Env: []coreapi.EnvVar{
 								{Name: "JOB_SPEC", Value: `{"type":"presubmit","job":"job-name","buildid":"blabla","prowjobid":"pod","refs":{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},"extra_refs":[{"org":"extra-org","repo":"extra-repo"}]}`},
-								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
+								{Name: "SIDECAR_OPTIONS", Value: `{"gcs_options":{"items":["/logs/artifacts"],"bucket":"my-bucket","path_strategy":"legacy","default_org":"kubernetes","default_repo":"kubernetes","gcs_credentials_file":"/secrets/gcs/service-account.json","dry_run":false},"entries":[{"args":["/bin/thing","some","args"],"container_name":"test-0","process_log":"/logs/test-0-log.txt","marker_file":"/logs/test-0-marker.txt","metadata_file":"/logs/artifacts/test-0-metadata.json"},{"args":["/bin/otherthing","other","args"],"container_name":"test-1","process_log":"/logs/test-1-log.txt","marker_file":"/logs/test-1-marker.txt","metadata_file":"/logs/artifacts/test-1-metadata.json"}]}`},
 							},
 							TerminationMessagePolicy: coreapi.TerminationMessageFallbackToLogsOnError,
 							VolumeMounts: []coreapi.VolumeMount{

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -122,11 +121,11 @@ const errorKey = "sidecar-errors"
 func logReaders(entries []wrapper.Options) map[string]io.Reader {
 	readers := make(map[string]io.Reader)
 	for _, opt := range entries {
-		log, err := os.Open(opt.ProcessLog)
 		buildLog := "build-log.txt"
 		if len(entries) > 1 {
-			buildLog = fmt.Sprintf("%s-build-log.txt", strings.TrimSuffix(filepath.Base(opt.ProcessLog), "-log.txt"))
+			buildLog = fmt.Sprintf("%s-build-log.txt", opt.ContainerName)
 		}
+		log, err := os.Open(opt.ProcessLog)
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to open %s", opt.ProcessLog)
 			readers[buildLog] = strings.NewReader(fmt.Sprintf("Failed to open %s: %v\n", opt.ProcessLog, err))

--- a/prow/sidecar/run.go
+++ b/prow/sidecar/run.go
@@ -123,11 +123,15 @@ func logReaders(entries []wrapper.Options) map[string]io.Reader {
 	readers := make(map[string]io.Reader)
 	for _, opt := range entries {
 		log, err := os.Open(opt.ProcessLog)
+		buildLog := "build-log.txt"
+		if len(entries) > 1 {
+			buildLog = fmt.Sprintf("%s-build-log.txt", strings.TrimSuffix(filepath.Base(opt.ProcessLog), "-log.txt"))
+		}
 		if err != nil {
 			logrus.WithError(err).Errorf("Failed to open %s", opt.ProcessLog)
-			readers[filepath.Base(opt.ProcessLog)] = strings.NewReader(fmt.Sprintf("Failed to open %s: %v\n", opt.ProcessLog, err))
+			readers[buildLog] = strings.NewReader(fmt.Sprintf("Failed to open %s: %v\n", opt.ProcessLog, err))
 		} else {
-			readers[filepath.Base(opt.ProcessLog)] = log
+			readers[buildLog] = log
 		}
 	}
 	return readers

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -152,6 +152,7 @@ func TestWait(t *testing.T) {
 
 func TestWaitParallelContainers(t *testing.T) {
 	aborted := strconv.Itoa(entrypoint.AbortedErrorCode)
+	skip := strconv.Itoa(entrypoint.PreviousErrorCode)
 	const (
 		pass                 = "0"
 		fail                 = "1"
@@ -203,6 +204,12 @@ func TestWaitParallelContainers(t *testing.T) {
 			markers:  []string{pass},
 			missing:  true,
 			failures: 1,
+		},
+		{
+			name:     "count all failures",
+			markers:  []string{pass, fail, aborted, skip, fail, pass},
+			abort:    true,
+			failures: 3,
 		},
 	}
 

--- a/prow/sidecar/run_test.go
+++ b/prow/sidecar/run_test.go
@@ -405,39 +405,39 @@ func TestLogReader(t *testing.T) {
 		{
 			name: "basically works",
 			processLogs: map[string]string{
-				"log.txt": "hello world",
+				"process-log.txt": "hello world",
 			},
 			expected: map[string]string{
-				"log.txt": "hello world",
+				"build-log.txt": "hello world",
 			},
 		},
 		{
 			name: "multiple logs works",
 			processLogs: map[string]string{
-				"log-1.txt": "hello",
-				"log-2.txt": "world",
+				"test1-log.txt": "hello",
+				"test2-log.txt": "world",
 			},
 			expected: map[string]string{
-				"log-1.txt": "hello",
-				"log-2.txt": "world",
+				"test1-build-log.txt": "hello",
+				"test2-build-log.txt": "world",
 			},
 		},
 		{
 			name: "note when a part has a problem",
 			processLogs: map[string]string{
-				"log-1.txt": "hello",
-				"log-2.txt": "missing",
-				"log-3.txt": "world",
+				"test1-log.txt": "hello",
+				"test2-log.txt": "missing",
+				"test3-log.txt": "world",
 			},
 			expected: map[string]string{
-				"log-1.txt": "hello",
-				"log-2.txt": "Failed to open log-2.txt: whatever\n",
-				"log-3.txt": "world",
+				"test1-build-log.txt": "hello",
+				"test2-build-log.txt": "Failed to open test2-log.txt: whatever\n",
+				"test3-build-log.txt": "world",
 			},
 		},
 	}
 
-	re := regexp.MustCompile(`(?m)(Failed to open) .*log-\d.txt: .*$`)
+	re := regexp.MustCompile(`(?m)(Failed to open) .*log\.txt: .*$`)
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			tmpDir, err := ioutil.TempDir("", tc.name)


### PR DESCRIPTION
Update sidecar to support multiple containers running in parallel
- `WaitForMarker()` is now `WaitForMarkers()` and watches for multiple marker file paths.
- Sidecar's `wait()` function calls `WaitForMarkers()` to retrieve exit codes for each test container.
- Entrypoint's `Mark()` function creates a temp file outside the directory of the desired marker file.  This is necessary to prevent concurrency bugs with fsnotify's `addWatch()`.
- New test cases added to test new sidecar functionality.