### PR TITLE
Checkconfig: Fail on duplicate refs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -93,5 +93,6 @@ presubmits:
         - --warnings=missing-trigger
         - --warnings=validate-urls
         - --warnings=unknown-fields
+        - --warnings=duplicate-job-refs
     annotations:
       testgrid-dashboards: presubmits-test-infra


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/18272

Passes on current HEAD:
```
$ go run ./prow/cmd/checkconfig/ --config-path=config/prow/config.yaml --job-config-path=config/jobs --plugin-config=config/prow/plugins.yaml --strict --warnings=duplicate-job-refs
{"component":"unset","file":"/home/alvaro/git/work/test-infra/prow/plugins/config.go:830","func":"k8s.io/test-infra/prow/plugins.(*ConfigUpdater).SetDefaults","level":"warning","msg":"'namespace' and 'additional_namespaces' are deprecated for config-updater plugin, use 'clusters' instead","severity":"warning","time":"2020-07-10T17:10:08-04:00"}
{"component":"unset","file":"/home/alvaro/git/work/test-infra/prow/plugins/config.go:830","func":"k8s.io/test-infra/prow/plugins.(*ConfigUpdater).SetDefaults","level":"warning","msg":"'namespace' and 'additional_namespaces' are deprecated for config-updater plugin, use 'clusters' instead","severity":"warning","time":"2020-07-10T17:10:08-04:00"}
{"component":"unset","file":"/home/alvaro/git/work/test-infra/prow/cmd/checkconfig/main.go:211","func":"main.main","level":"info","msg":"checkconfig passes without any error!","severity":"info","time":"2020-07-10T17:10:08-04:00"}
```

/assign @BenTheElder 