### PR TITLE
rename feature-gate-machine-pool to exp-machine-pool for cluster-api-provider-azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -272,7 +272,7 @@ presubmits:
               value: "true"
             - name: USE_CI_ARTIFACTS
               value: "true"
-            - name: FEATURE_GATE_MACHINE_POOL
+            - name: EXP_MACHINE_POOL
               value: "true"
           securityContext:
             privileged: true

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -463,7 +463,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-disk # In-tree Azure disk storage class
@@ -573,7 +573,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-file # In-tree Azure file storage class

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -463,7 +463,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-disk # In-tree Azure disk storage class
@@ -573,7 +573,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-file # In-tree Azure file storage class

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -463,7 +463,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-disk # In-tree Azure disk storage class
@@ -573,7 +573,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       - name: AZURE_STORAGE_DRIVER
         value: kubernetes.io/azure-file # In-tree Azure file storage class

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -349,7 +349,7 @@ periodics:
         value: "true"
       - name: USE_CI_ARTIFACTS
         value: "true"
-      - name: FEATURE_GATE_MACHINE_POOL
+      - name: EXP_MACHINE_POOL
         value: "true"
       securityContext:
         privileged: true


### PR DESCRIPTION
to match between cluster-api and cluster-api-provider-azure

/cc @CecileRobertMichon 

related to: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/782  