### PR TITLE
fix: skip logDumperWindows error

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1208,7 +1208,8 @@ func (c *aksEngineDeployer) DumpClusterLogs(localPath, gcsPath string) error {
 		errors = append(errors, err.Error())
 	}
 	if err := logDumperWindows(); err != nil {
-		errors = append(errors, err.Error())
+		// don't log error since logDumperWindows failed is expected on non-Windows cluster
+		//errors = append(errors, err.Error())
 	}
 	if len(errors) != 0 {
 		return fmt.Errorf(strings.Join(errors, "\n"))


### PR DESCRIPTION
/assign @chewong 

hit following error in e2e test:
```
2020/07/11 01:37:52 process.go:155: Step 'bash -c /root/tmp368228808/log-dump.sh' finished in 36.688542004s
2020/07/11 01:37:52 aksengine_helpers.go:409: downloading /root/tmp368228808/win-ci-logs-collector.sh from https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/scripts/win-ci-logs-collector.sh
2020/07/11 01:37:52 util.go:68: curl https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/scripts/win-ci-logs-collector.sh
2020/07/11 01:37:52 process.go:153: Running: chmod +x /root/tmp368228808/win-ci-logs-collector.sh
2020/07/11 01:37:52 process.go:155: Step 'chmod +x /root/tmp368228808/win-ci-logs-collector.sh' finished in 7.026388ms
2020/07/11 01:37:52 process.go:153: Running: bash -c /root/tmp368228808/win-ci-logs-collector.sh kubetest-de0f8cb7-c313-11ea-b76b-3e5b066e9719.eastus2.cloudapp.azure.com /root/tmp368228808 /root/.ssh/id_rsa
ssh key file /root/.ssh/id_rsa does not exist. Exiting.
2020/07/11 01:37:52 process.go:155: Step 'bash -c /root/tmp368228808/win-ci-logs-collector.sh kubetest-de0f8cb7-c313-11ea-b76b-3e5b066e9719.eastus2.cloudapp.azure.com /root/tmp368228808 /root/.ssh/id_rsa' finished in 24.90878ms
2020/07/11 01:37:52 aksengine.go:1155: Deleting resource group: kubetest-de0f8cb7-c313-11ea-b76b-3e5b066e9719.
2020/07/11 01:47:53 process.go:96: Saved XML output to /logs/artifacts/junit_runner.xml.
2020/07/11 01:47:53 process.go:153: Running: bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"
2020/07/11 01:47:57 process.go:155: Step 'bash -c . hack/lib/version.sh && KUBE_ROOT=. kube::version::get_version_vars && echo "${KUBE_GIT_VERSION-}"' finished in 4.396582005s
2020/07/11 01:47:57 main.go:312: Something went wrong: encountered 1 errors: [error running log collection script /root/tmp368228808/log-dump.sh: error during bash -c /root/tmp368228808/log-dump.sh: exit status 126]
+ EXIT_VALUE=1
+ set +o xtrace
Cleaning up after docker in docker.
```
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_blobfuse-csi-driver/178/pull-blobfuse-csi-driver-e2e-vmss/1281757748400230400/build-log.txt

