### PR TITLE
cloud-provider-vsphere: remove inactive members from OWNERS

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -6,7 +6,6 @@ reviwers:
 - divyenpatel
 - imkin
 - kerneltime
-- luomiao
 - frapposelli
 - dougm
 - figo
@@ -18,7 +17,6 @@ approvers:
 - divyenpatel
 - imkin
 - kerneltime
-- luomiao
 - frapposelli
 - dougm
 - figo


### PR DESCRIPTION
As a part of kubernetes/org#2013, we are cleaning up inactive members from OWNERS who haven't been active
since the release of v1.11. This commit removes luomiao from `config/jobs/kubernetes/cloud-provider-vsphere/OWNERS`.

/assign @figo 
cc @mrbobbytables @luomiao 