### PR TITLE
Trigger krte image push on kubekins-e2e variants change

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -462,7 +462,7 @@ postsubmits:
         - images/kubekins-e2e/
   - name: post-test-infra-push-krte
     cluster: test-infra-trusted
-    run_if_changed: '^images/krte/'
+    run_if_changed: '^images/(krte/|kubekins-e2e/variants.yaml)'
     annotations:
       testgrid-dashboards: "sig-testing-images"
       testgrid-tab-name: "krte"

--- a/images/krte/wrapper.sh
+++ b/images/krte/wrapper.sh
@@ -39,10 +39,10 @@ printf '%0.s=' {1..80} >&2; echo >&2
 
 cleanup(){
   if [[ "${DOCKER_IN_DOCKER_ENABLED:-false}" == "true" ]]; then
-    >&2 echo "wrapper.sh] [CLEANUP] Cleaning up after docker in docker ..."
+    >&2 echo "wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ..."
     docker ps -aq | xargs -r docker rm -f || true
     service docker stop || true
-    >&2 echo "wrapper.sh] [CLEANUP] Done cleaning up after docker in docker."
+    >&2 echo "wrapper.sh] [CLEANUP] Done cleaning up after Docker in Docker."
   fi
 }
 


### PR DESCRIPTION
Updates post-test-infra-push-krte to be triggered every time
kubekins-e2e variants change because they are symlinked from the krte
image dir.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/assign @BenTheElder 
/cc @justaugustus  @kubernetes/ci-signal 