### PR TITLE
Set KIND_E2E env var for e2e test script

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -75,6 +75,8 @@ presubmits:
         env:
         - name: KUBERNETES_VERSION
           value: "v1.18.2"
+        - name: KIND_E2E
+          value: "true"
         args:
         - make
         - test-e2e


### PR DESCRIPTION
Following https://github.com/kubernetes/test-infra/pull/18292, and working with the changes in https://github.com/kubernetes-sigs/descheduler/pull/340, this sets an env var to specify that the Prow tests should be run with kind.