### PR TITLE
Add kubernetes-sigs/seccomp-operator jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -1,0 +1,21 @@
+postsubmits:
+  kubernetes-sigs/seccomp-operator:
+    - name: post-seccomp-operator-push-image
+      cluster: k8s-infra-prow-build-trusted
+      decorate: true
+      always_run: true
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200708-4b69e15
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-infra-staging-seccomp-operator
+              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator-gcb
+              - .
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"

--- a/config/jobs/kubernetes-sigs/seccomp-operator/OWNERS
+++ b/config/jobs/kubernetes-sigs/seccomp-operator/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - hasheddan
+  - pjbgf
+  - saschagrunert
+approvers:
+  - hasheddan
+  - pjbgf
+  - saschagrunert

--- a/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
@@ -1,0 +1,78 @@
+presubmits:
+  kubernetes-sigs/seccomp-operator:
+  - name: pull-seccomp-operator-build
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    spec:
+      containers:
+      - image: golang:1.14
+        command:
+        - hack/pull-seccomp-operator-build
+
+  - name: pull-seccomp-operator-verify
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    spec:
+      containers:
+      - image: golang:1.14
+        command:
+        - hack/pull-seccomp-operator-verify
+
+  - name: pull-seccomp-operator-test-unit
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    spec:
+      containers:
+      - image: golang:1.14
+        command:
+        - hack/pull-seccomp-operator-test-unit
+
+  - name: pull-seccomp-operator-build-image
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+        securityContext:
+          privileged: true  # for dind
+        resources:
+          requests:
+            memory: 9000Mi
+            cpu: 7500m
+        command:
+        - hack/pull-seccomp-operator-build-image
+
+  - name: pull-seccomp-operator-test-e2e
+    always_run: true
+    decorate: true
+    annotations:
+      testgrid-num-columns-recent: '30'
+      testgrid-create-test-group: 'true'
+    labels:
+      preset-dind-enabled: "true"
+    spec:
+      hostNetwork: true
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+        securityContext:
+          privileged: true  # for dind
+        resources:
+          requests:
+            memory: 9000Mi
+            cpu: 7500m
+        command:
+        - hack/pull-seccomp-operator-test-e2e

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -898,6 +898,9 @@ plugins:
   kubernetes-sigs/contributor-playground:
   - require-matching-label
 
+  kubernetes-sigs/seccomp-operator:
+  - release-note
+
   containerd/cri:
   - assign
   - cla

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -10,6 +10,7 @@ dashboard_groups:
     - sig-node-arm64
     - sig-node-docker
     - sig-node-node-problem-detector
+    - sig-node-seccomp-operator
 
 dashboards:
 - name: sig-node-cadvisor
@@ -112,6 +113,27 @@ dashboards:
       description: k8s1.14.x node conformance test results for ee-19.03 on ubuntu16.04
 
 - name: sig-node-node-problem-detector
+
+- name: sig-node-seccomp-operator
+  dashboard_tab:
+  - name: build
+    test_group_name: pull-seccomp-operator-build
+    base_options: width=10
+  - name: build-image
+    test_group_name: pull-seccomp-operator-build-image
+    base_options: width=10
+  - name: verify
+    test_group_name: pull-seccomp-operator-verify
+    base_options: width=10
+  - name: test-unit
+    test_group_name: pull-seccomp-operator-test-unit
+    base_options: width=10
+  - name: test-e2e
+    test_group_name: pull-seccomp-operator-test-e2e
+    base_options: width=10
+  - name: push-image
+    test_group_name: post-seccomp-operator-push-image
+    base_options: width=10
 
 test_groups:
 - name: ci-kubernetes-node-kubelet-alpha


### PR DESCRIPTION
The seccomp-operator has moved into kubernetes-sigs and can be now used
to run prow jobs. This is the first set of basic jobs based on the
standard golang image. The scripts reside inside the repository to be
able to modify them directly there.

/cc @hasheddan @pjbgf 