### PR TITLE
kubetest2-gke: support acquiring project from boskos

### DIFF
--- a/kubetest2/BUILD.bazel
+++ b/kubetest2/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
         "//kubetest2/kubetest2-gke:all-srcs",
         "//kubetest2/kubetest2-kind:all-srcs",
         "//kubetest2/pkg/app:all-srcs",
+        "//kubetest2/pkg/boskos:all-srcs",
         "//kubetest2/pkg/build:all-srcs",
         "//kubetest2/pkg/exec:all-srcs",
         "//kubetest2/pkg/metadata:all-srcs",

--- a/kubetest2/kubetest2-gce/deployer/BUILD.bazel
+++ b/kubetest2/kubetest2-gce/deployer/BUILD.bazel
@@ -3,7 +3,6 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
-        "boskos.go",
         "build.go",
         "common.go",
         "deployer.go",
@@ -14,13 +13,13 @@ go_library(
     importpath = "k8s.io/test-infra/kubetest2/kubetest2-gce/deployer",
     visibility = ["//visibility:public"],
     deps = [
+        "//kubetest2/pkg/boskos:go_default_library",
         "//kubetest2/pkg/exec:go_default_library",
         "//kubetest2/pkg/types:go_default_library",
         "@com_github_octago_sflags//gen/gpflag:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_sigs_boskos//client:go_default_library",
-        "@io_k8s_sigs_boskos//common:go_default_library",
     ],
 )
 

--- a/kubetest2/kubetest2-gce/deployer/common.go
+++ b/kubetest2/kubetest2-gce/deployer/common.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/boskos"
 )
 
 func (d *deployer) init() error {
@@ -46,13 +47,13 @@ func (d *deployer) initialize() error {
 		if d.GCPProject == "" {
 			klog.V(1).Info("No GCP project provided, acquiring from Boskos")
 
-			boskos, err := makeBoskosClient(d.BoskosLocation)
+			boskosClient, err := boskos.MakeBoskosClient(d.BoskosLocation)
 			if err != nil {
 				return fmt.Errorf("failed to make boskos client: %s", err)
 			}
-			d.boskos = boskos
+			d.boskos = boskosClient
 
-			projectName, err := getProjectFromBoskos(
+			projectName, err := boskos.GetProjectFromBoskos(
 				d.boskos,
 				time.Duration(d.BoskosAcquireTimeoutSeconds)*time.Second,
 				d.boskosHeartbeatClose,

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -46,7 +46,7 @@ func (d *deployer) Down() error {
 
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")
-		err := boskos.ReleaseBoskosProject(
+		err := boskos.Release(
 			d.boskos,
 			d.GCPProject,
 			d.boskosHeartbeatClose,

--- a/kubetest2/kubetest2-gce/deployer/down.go
+++ b/kubetest2/kubetest2-gce/deployer/down.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 
 	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/boskos"
 	"k8s.io/test-infra/kubetest2/pkg/exec"
 )
 
@@ -45,7 +46,7 @@ func (d *deployer) Down() error {
 
 	if d.boskos != nil {
 		klog.V(2).Info("releasing boskos project")
-		err := releaseBoskosProject(
+		err := boskos.ReleaseBoskosProject(
 			d.boskos,
 			d.GCPProject,
 			d.boskosHeartbeatClose,

--- a/kubetest2/kubetest2-gke/deployer/common.go
+++ b/kubetest2/kubetest2-gke/deployer/common.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog"
+	"k8s.io/test-infra/kubetest2/pkg/boskos"
+)
+
+const (
+	gkeProjectResourceType = "gke-project"
+)
+
+func (d *deployer) init() error {
+	var err error
+	d.doInit.Do(func() { err = d.initialize() })
+	return err
+}
+
+// initialize should only be called by init(), behind a sync.Once
+func (d *deployer) initialize() error {
+	if d.commonOptions.ShouldUp() {
+		if err := d.verifyUpFlags(); err != nil {
+			return fmt.Errorf("init failed to verify flags for up: %s", err)
+		}
+
+		if d.project == "" {
+			klog.V(1).Info("No GCP project provided, acquiring from Boskos")
+
+			boskosClient, err := boskos.NewClient(d.boskosLocation)
+			if err != nil {
+				return fmt.Errorf("failed to make boskos client: %s", err)
+			}
+			d.boskos = boskosClient
+
+			resource, err := boskos.Acquire(
+				d.boskos,
+				gkeProjectResourceType,
+				time.Duration(d.boskosAcquireTimeoutSeconds)*time.Second,
+				d.boskosHeartbeatClose,
+			)
+
+			if err != nil {
+				return fmt.Errorf("init failed to get project from boskos: %s", err)
+			}
+			d.project = resource.Name
+			klog.V(1).Infof("Got project %s from boskos", d.project)
+		}
+
+	}
+
+	if d.commonOptions.ShouldDown() {
+		if err := d.verifyDownFlags(); err != nil {
+			return fmt.Errorf("init failed to verify flags for down: %s", err)
+		}
+	}
+
+	return nil
+}

--- a/kubetest2/pkg/boskos/BUILD.bazel
+++ b/kubetest2/pkg/boskos/BUILD.bazel
@@ -2,22 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "commandutils.go",
-        "common.go",
-        "deployer.go",
-    ],
-    importpath = "k8s.io/test-infra/kubetest2/kubetest2-gke/deployer",
+    srcs = ["boskos.go"],
+    importpath = "k8s.io/test-infra/kubetest2/pkg/boskos",
     visibility = ["//visibility:public"],
     deps = [
-        "//kubetest2/pkg/boskos:go_default_library",
-        "//kubetest2/pkg/build:go_default_library",
-        "//kubetest2/pkg/exec:go_default_library",
-        "//kubetest2/pkg/metadata:go_default_library",
-        "//kubetest2/pkg/types:go_default_library",
-        "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_sigs_boskos//client:go_default_library",
+        "@io_k8s_sigs_boskos//common:go_default_library",
     ],
 )
 

--- a/kubetest2/pkg/boskos/boskos.go
+++ b/kubetest2/pkg/boskos/boskos.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deployer
+package boskos
 
 import (
 	"context"
@@ -30,7 +30,8 @@ import (
 // const (for the run) owner string for consistency between up and down
 var boskosOwner = os.Getenv("JOB_NAME") + "-kubetest2"
 
-func makeBoskosClient(boskosLocation string) (*client.Client, error) {
+// MakeBoskosClient creates a boskos client for kubetest2 deployers.
+func MakeBoskosClient(boskosLocation string) (*client.Client, error) {
 	boskos, err := client.NewClient(
 		boskosOwner,
 		boskosLocation,
@@ -44,9 +45,9 @@ func makeBoskosClient(boskosLocation string) (*client.Client, error) {
 	return boskos, nil
 }
 
-// getProjectFromBoskos creates a boskos client, acquires a gcp project
+// GetProjectFromBoskos creates a boskos client, acquires a gcp project
 // and starts a heartbeat goroutine to keep the project reserved
-func getProjectFromBoskos(boskosClient *client.Client, timeout time.Duration, heartbeatClose chan struct{}) (string, error) {
+func GetProjectFromBoskos(boskosClient *client.Client, timeout time.Duration, heartbeatClose chan struct{}) (string, error) {
 	resourceType := "gce-project"
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
@@ -91,12 +92,11 @@ func startBoskosHeartbeat(boskosClient *client.Client, resource *boskosCommon.Re
 	}(boskosClient, resource)
 }
 
-func releaseBoskosProject(client *client.Client, projectName string, heartbeatClose chan struct{}) error {
+// ReleaseBoskosProject releases a project.
+func ReleaseBoskosProject(client *client.Client, projectName string, heartbeatClose chan struct{}) error {
 	if err := client.Release(projectName, "free"); err != nil {
 		return fmt.Errorf("failed to release %s: %s", projectName, err)
 	}
-
 	close(heartbeatClose)
-
 	return nil
 }


### PR DESCRIPTION
I am planning to use `kubetest2` in the prow environment.  Boskos support is required.

It includes:

- move boskos to a separate pkg
- support boskos in kubetest2-gke
- register klog flags in kubetest2-gke