### PR TITLE
Make descheduler e2e required

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -60,7 +60,6 @@ presubmits:
     decoration_config:
       timeout: 20m
     always_run: true
-    optional: true
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"


### PR DESCRIPTION
This test was added in https://github.com/kubernetes/test-infra/pull/18292 as optional while we tested it. It seems to work now, so we can make it required. This will enable the changes in https://github.com/kubernetes-sigs/descheduler/pull/342#issuecomment-657943337