### PR TITLE
trigger: /retest should force failed jobs to rerun

### DIFF
--- a/prow/config/jobs.go
+++ b/prow/config/jobs.go
@@ -354,12 +354,8 @@ func (ps Presubmit) ShouldRun(baseRef string, changes ChangedFilesProvider, forc
 	if forced {
 		return true, nil
 	}
-	if determined, shouldRun, err := ps.RegexpChangeMatcher.ShouldRun(changes); err != nil {
-		return false, err
-	} else if determined {
-		return shouldRun, nil
-	}
-	return defaults, nil
+	determined, shouldRun, err := ps.RegexpChangeMatcher.ShouldRun(changes)
+	return (determined && shouldRun) || defaults, err
 }
 
 // TriggersConditionally determines if the presubmit triggers conditionally (if it may or may not trigger).

--- a/prow/config/jobs_test.go
+++ b/prow/config/jobs_test.go
@@ -677,6 +677,9 @@ func TestPresubmitShouldRun(t *testing.T) {
 		fileError   error
 		job         Presubmit
 		ref         string
+		forced      bool
+		defaults    bool
+
 		expectedRun bool
 		expectedErr bool
 	}{
@@ -769,6 +772,19 @@ func TestPresubmitShouldRun(t *testing.T) {
 			ref:         "master",
 			fileChanges: []string{"something"},
 			expectedRun: false,
+		}, {
+			name: "job with run_if_changed not matching should run when default=true",
+			job: Presubmit{
+				Trigger:      `(?m)^/test (?:.*? )?foo(?: .*?)?$`,
+				RerunCommand: "/test foo",
+				RegexpChangeMatcher: RegexpChangeMatcher{
+					RunIfChanged: "^file$",
+				},
+			},
+			ref:         "master",
+			fileChanges: []string{"something"},
+			defaults:    true,
+			expectedRun: true,
 		},
 		{
 			name: "job with run_if_changed matching should run",
@@ -793,7 +809,7 @@ func TestPresubmitShouldRun(t *testing.T) {
 			}
 			jobShouldRun, err := jobs[0].ShouldRun(testCase.ref, func() ([]string, error) {
 				return testCase.fileChanges, testCase.fileError
-			}, false, false)
+			}, testCase.forced, testCase.defaults)
 			if err == nil && testCase.expectedErr {
 				t.Errorf("%s: expected an error and got none", testCase.name)
 			}

--- a/prow/pjutil/filter.go
+++ b/prow/pjutil/filter.go
@@ -97,7 +97,8 @@ func FilterPresubmits(filter Filter, changes config.ChangedFilesProvider, branch
 // RetestFilter builds a filter for `/retest`
 func RetestFilter(failedContexts, allContexts sets.String) Filter {
 	return func(p config.Presubmit) (bool, bool, bool) {
-		return failedContexts.Has(p.Context) || (!p.NeedsExplicitTrigger() && !allContexts.Has(p.Context)), false, true
+		failed := failedContexts.Has(p.Context)
+		return failed || (!p.NeedsExplicitTrigger() && !allContexts.Has(p.Context)), false, failed
 	}
 }
 

--- a/prow/pjutil/filter_test.go
+++ b/prow/pjutil/filter_test.go
@@ -577,7 +577,7 @@ func TestPresubmitFilter(t *testing.T) {
 					AlwaysRun: true,
 				},
 			},
-			expected: [][]bool{{false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, true}},
+			expected: [][]bool{{false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, false}},
 		},
 		{
 			name: "explicit test command filters for jobs that match",
@@ -742,7 +742,7 @@ func TestPresubmitFilter(t *testing.T) {
 					},
 				},
 			},
-			expected: [][]bool{{true, false, false}, {true, false, false}, {true, true, true}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, true}},
+			expected: [][]bool{{true, false, false}, {true, false, false}, {true, true, true}, {false, false, false}, {false, false, false}, {true, false, true}, {true, false, true}, {true, false, false}},
 		},
 	}
 

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -545,31 +545,6 @@ func TestHandleGenericComment(t *testing.T) {
 			},
 		},
 		{
-			name: "/retest of RunIfChanged job that doesn't need to run and hasn't run",
-
-			Author: "trusted-member",
-			Body:   "/retest",
-			State:  "open",
-			IsPR:   true,
-			Presubmits: map[string][]config.Presubmit{
-				"org/repo": {
-					{
-						JobBase: config.JobBase{
-							Name: "jeb",
-						},
-						RegexpChangeMatcher: config.RegexpChangeMatcher{
-							RunIfChanged: "CHANGED2",
-						},
-						Reporter: config.Reporter{
-							Context: "pull-jeb",
-						},
-						Trigger:      `(?m)^/test (?:.*? )?jeb(?: .*?)?$`,
-						RerunCommand: `/test jeb`,
-					},
-				},
-			},
-		},
-		{
 			name: "explicit /test for RunIfChanged job that doesn't need to run",
 
 			Author: "trusted-member",

--- a/prow/plugins/trigger/generic-comment_test.go
+++ b/prow/plugins/trigger/generic-comment_test.go
@@ -419,7 +419,7 @@ func TestHandleGenericComment(t *testing.T) {
 					},
 				},
 			},
-			ShouldBuild: false,
+			ShouldBuild: true,
 		},
 		{
 			name:   "Run if changed job triggered by /ok-to-test",
@@ -1070,7 +1070,7 @@ func TestRetestFilter(t *testing.T) {
 					},
 				},
 			},
-			expected: [][]bool{{true, false, true}, {false, false, true}},
+			expected: [][]bool{{true, false, true}, {false, false, false}},
 		},
 		{
 			name:           "retest filter matches jobs that would run automatically and haven't yet ",
@@ -1095,7 +1095,7 @@ func TestRetestFilter(t *testing.T) {
 					},
 				},
 			},
-			expected: [][]bool{{false, false, true}, {true, false, true}},
+			expected: [][]bool{{false, false, false}, {true, false, false}},
 		},
 	}
 


### PR DESCRIPTION
The interaction between `/retest` and conditionally executed jobs is
currently confusing. At least some users expect `/retest` to trigger all
failed jobs, even those that only run conditionally (`always_run: false`),
which was not true: the trigger criteria still applied.

I think that the expectation is valid though: once the job was for any
reason triggered and contributed a status to a PR, I find the
expectation that `/retest` will retest it reasonable.

This also makes the interaction with retest bot more intuitive. That bot
searches for jobs with failing tests and posts `/retest` on them. We had
saw a PR with a single contitionally executed job (manual trigger only)
failed, and the bot just continued to attempt to `/retest` without any
effect:

https://github.com/openshift/origin/pull/25195