### PR TITLE
Adding area/robots label in label_sync

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -374,6 +374,7 @@ larger set of contributors to apply/remove them.
 | <a id="area/prow/tide" href="#area/prow/tide">`area/prow/tide`</a> | Issues or PRs related to prow's tide component| label | |
 | <a id="area/prow/tot" href="#area/prow/tot">`area/prow/tot`</a> | Issues or PRs related to prow's tot component| label | |
 | <a id="area/release-eng" href="#area/release-eng">`area/release-eng`</a> | Issues or PRs related to the Release Engineering subproject <br><br> This was previously `area/release-infra`, | label | |
+| <a id="area/robots" href="#area/robots">`area/robots`</a> | Issues or PRs related to code in /robots| label | |
 | <a id="kind/oncall-hotlist" href="#kind/oncall-hotlist">`kind/oncall-hotlist`</a> | Categorizes issue or PR as tracked by test-infra oncall.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 
 ## Labels that apply to kubernetes/website, for both issues and PRs

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1054,6 +1054,11 @@ repos:
   kubernetes/test-infra:
     labels:
       - color: 0052cc
+        description: Issues or PRs related to code in /robots
+        name: area/robots
+        target: both
+        addedBy: label
+      - color: 0052cc
         description: Issues or PRs related to code in /boskos
         name: area/boskos
         target: both


### PR DESCRIPTION
This PR will resolve #18249 

In this PR, We added area/robots in label_sync/labels.yaml and generated docs file.