### PR TITLE
create new Prow job to run promoter vulnerability presubmit check

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -21,6 +21,27 @@ presubmits:
         # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
         # suffice, but it's nice to be explicit.
         - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+  # Check that images to be promoted are free of vulnerabilities
+  - name: pull-k8sio-cip-vuln
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio
+    decorate: true
+    skip_report: false
+    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
+    max_concurrency: 10
+    branches:
+    - ^vuln-check-test$
+    spec:
+      serviceAccountName: k8s-infra-gcr-vuln-scanning
+      containers:
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200723-v2.3.1-242-g7c328ba
+        command:
+        - cip
+        args:
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - -vuln-severity-threshold=3
+        - -use-service-account
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     annotations:

--- a/config/prow/cluster/build_serviceaccounts.yaml
+++ b/config/prow/cluster/build_serviceaccounts.yaml
@@ -23,8 +23,8 @@ kind: ServiceAccount
 metadata:
   annotations:
     # Used by container image promoter vulnerability scanning presubmit check (pull-k8sio-cip-vuln)
-    iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter-vuln-scanning@k8s-artifacts-prod.iam.gserviceaccount.com
-  name: k8s-infra-gcr-promoter-vuln-scanning
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-scanning@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-infra-gcr-vuln-scanning
   namespace: test-pods
 ---
 apiVersion: v1


### PR DESCRIPTION
Creating the template for a new Prow job that will later be used to run the promoter's vulnerability presubmit check (https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/235) on pull requests that edit the promoter manifests. The template job won't be running over anything right now (only runs for the directory 'foo/bar'), but once the vulnerability check is finished the job can be used on a test directory for testing before running the presubmit on all the promoter manifests.