### PR TITLE
Use kubekins-e2e 1.18 images for Cluster API provider Azure

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-entrypoint.sh"
@@ -57,7 +57,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -37,7 +37,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -75,7 +75,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -103,7 +103,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -124,7 +124,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         command:
         - "runner.sh"
         - "make"
@@ -142,7 +142,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         imagePullPolicy: Always
         command:
         - "./hack/verify-bazel.sh"
@@ -159,7 +159,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-test.sh"
@@ -176,7 +176,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-build.sh"
@@ -193,7 +193,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
         imagePullPolicy: Always
         command:
         - "./hack/verify_boilerplate.py"
@@ -219,7 +219,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-entrypoint.sh"
@@ -259,7 +259,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-entrypoint.sh"
@@ -297,7 +297,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200710-6b3b6fe-1.18
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pr-apidiff


### PR DESCRIPTION
applying similar change made here: #18265

From change made by @cpanato in https://github.com/kubernetes/test-infra/pull/18268 (rebased and opened a new PR sp we can get this in sooner and fix some flaky tests).

/assign @nader-ziada @devigned 