### PR TITLE
Remove Validate from Deserialize

### DIFF
--- a/testgrid/cmd/configurator/BUILD.bazel
+++ b/testgrid/cmd/configurator/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "@com_github_googlecloudplatform_testgrid//util/gcs:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_storage//:go_default_library",
+        "@io_k8s_sigs_yaml//:go_default_library",
     ],
 )
 

--- a/testgrid/cmd/configurator/main.go
+++ b/testgrid/cmd/configurator/main.go
@@ -35,6 +35,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
 )
 
 type multiString []string
@@ -216,7 +217,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 	// Print proto if requested
 	if opt.printText {
 		if opt.writeYAML {
-			b, err := yamlcfg.MarshalYAML(&c)
+			b, err := yaml.Marshal(c)
 			if err != nil {
 				return fmt.Errorf("could not print yaml config: %v", err)
 			}
@@ -231,7 +232,7 @@ func doOneshot(ctx context.Context, client *storage.Client, opt options, prowCon
 		var b []byte
 		var err error
 		if opt.writeYAML {
-			b, err = yamlcfg.MarshalYAML(&c)
+			b, err = yaml.Marshal(c)
 		} else {
 			b, err = tgCfgUtil.MarshalBytes(&c)
 		}


### PR DESCRIPTION
Cause Configurator to, when serializing to YAML only, not validate for completeness.

This is necessary since something that's an "obviously wrong, common error" (`days_of_results = 0`) in a proto is perfectly valid in YAML (days of results is not set; it should be the default value of the repository).

Needs testing as a Prow Job with the broken config (xref https://github.com/GoogleCloudPlatform/oss-test-infra/issues/437) to see if it resolves the issue.