### PR TITLE
kubekins-e2e: Add justaugustus to approvers

### DIFF
--- a/images/kubekins-e2e/OWNERS
+++ b/images/kubekins-e2e/OWNERS
@@ -2,9 +2,15 @@
 
 reviewers:
 - amwat
+- justaugustus
 - spiffxp
 - BenTheElder
 approvers:
 - amwat
+- justaugustus
 - spiffxp
 - BenTheElder
+
+labels:
+- sig/release
+- area/release-eng


### PR DESCRIPTION
I've been looking over/responsible for kubekins-e2e image changes for
multiple cycles as a subproject owner for Release Engineering.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @spiffxp 
cc: @kubernetes/release-engineering 