### PR TITLE
Add area/web-development label for kubernetes/website

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -383,6 +383,7 @@ larger set of contributors to apply/remove them.
 | ---- | ----------- | -------- | --- |
 | <a id="area/blog" href="#area/blog">`area/blog`</a> | Issues or PRs related to the Kubernetes Blog subproject| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="area/contributor-comms" href="#area/contributor-comms">`area/contributor-comms`</a> | Issues or PRs related to the upstream marketing team| humans | |
+| <a id="area/web-development" href="#area/web-development">`area/web-development`</a> | Issues or PRs related to the kubernetes.io's infrastructure, design, or build processes| humans | |
 | <a id="language/de" href="#language/de">`language/de`</a> | Issues or PRs related to German language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/en" href="#language/en">`language/en`</a> | Issues or PRs related to English language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
 | <a id="language/es" href="#language/es">`language/es`</a> | Issues or PRs related to Spanish language| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1319,6 +1319,11 @@ repos:
         name: area/contributor-comms
         target: both
         addedBy: humans
+      - color: 0052cc
+        description: Issues or PRs related to the kubernetes.io's infrastructure, design, or build processes
+        name: area/web-development
+        target: both
+        addedBy: humans
       - color: e9b3f9
         description: Issues or PRs related to German language
         name: language/de


### PR DESCRIPTION
`kubernetes/website` issue https://github.com/kubernetes/website/issues/20428

Add a label, `area/web-development`, to `kubernetes/website`. This label categorizes all issues and PRs related to the website's infrastructure, design, or build processes.