### PR TITLE
Removed three references to sig-pm

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -75,11 +75,6 @@ aliases:
   sig-node-leads:
     - dchen1107
     - derekwaynecarr
-  sig-pm-leads:
-    - calebamiles
-    - jdumars
-    - justaugustus
-    - lachie83
   sig-release-leads:
     - alejandrox1
     - justaugustus

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -210,7 +210,7 @@ slack:
   - repos:
     - kubernetes/enhancements
     channels:
-    - sig-pm
+    - enhancements
     whitelist:
     - k8s-ci-robot
   - repos:

--- a/jobs/validOwners.json
+++ b/jobs/validOwners.json
@@ -17,7 +17,6 @@
    "sig-node",
    "sig-onprem",
    "sig-openstack",
-   "sig-pm",
    "kubernetes-release",
    "sig-scalability",
    "sig-scheduling",


### PR DESCRIPTION
sig-pm does not exist as of April 2020. In `config/prow/plugins.yaml` I replaced the referred-to Slack channel (was sig-pm) with enhancements.