### PR TITLE
Cleanup sig-cli periodic e2e test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -1,5 +1,6 @@
 periodics:
-- interval: 2h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   labels:
     preset-service-account: "true"
@@ -19,13 +20,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: gce-serial
-    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
     description: kubectl gce serial e2e tests for master branch
-- interval: 2h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gci-gce-sig-cli
   labels:
     preset-service-account: "true"
@@ -48,13 +49,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: gce
-    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
     description: kubectl gce e2e tests for master branch
-- interval: 2h
+
+- interval: 12h
   name: ci-kubernetes-e2e-kops-aws-sig-cli
   labels:
     preset-service-account: "true"
@@ -76,13 +77,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   # kubectl skew tests
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: aws
-    testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
-- interval: 2h
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -113,11 +114,12 @@ periodics:
         requests:
           cpu: 1
           memory: 6Gi
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.14-1.13-gci-kubectl-skew
-- interval: 2h
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-beta-stable1-gci-kubectl-skew
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -140,11 +142,12 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.14-1.13-gci-kubectl-skew-serial
-- interval: 1h
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-beta-stable1-gci-kubectl-skew-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
   cluster: k8s-infra-prow-build
   labels:
@@ -176,7 +179,6 @@ periodics:
         requests:
           cpu: 1
           memory: 6Gi
-
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce
@@ -185,7 +187,8 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "24"
-- interval: 1h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -208,12 +211,13 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
     description: stable1 serial tests run against a master gce cluster using a stable1 kubectl binary
-- interval: 1h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -236,12 +240,13 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
     description: stable1 e2e tests run against a stable1 gce cluster using a master kubectl binary
-- interval: 1h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -263,12 +268,13 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
     description: stable1 serial tests run against a stable1 gce cluster using a master kubectl binary
-- interval: 2h
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -291,11 +297,12 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.13-1.14-gci-kubectl-skew
-- interval: 2h
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable1-beta-gci-kubectl-skew
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
+- interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -317,10 +324,11 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.13-1.14-gci-kubectl-skew-serial
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable1-beta-gci-kubectl-skew-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew
   labels:
@@ -345,10 +353,11 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable1-stable2-gci-kubectl-skew
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-stable2-gci-kubectl-skew-serial
   labels:
@@ -372,10 +381,11 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.13-1.12-gci-kubectl-skew-serial
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable1-stable2-gci-kubectl-skew-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew
   labels:
@@ -399,10 +409,11 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable2-stable1-gci-kubectl-skew
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com
+
 - interval: 12h
   name: ci-kubernetes-e2e-gce-stable2-stable1-gci-kubectl-skew-serial
   labels:
@@ -425,7 +436,7 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
-
   annotations:
-    testgrid-dashboards: sig-release-job-config-errors
-    testgrid-tab-name: gce-1.12-1.13-gci-kubectl-skew-serial
+    testgrid-dashboards: sig-release-job-config-errors, sig-cli-master
+    testgrid-tab-name: gce-stable2-stable1-gci-kubectl-skew-serial
+    testgrid-alert-email: kubernetes-sig-cli@googlegroups.com


### PR DESCRIPTION
Per the outcome of our discussion on [today's SIG-CLI meeting](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?pli=1#heading=h.himo1st0tqyy).

- Set interval for all jobs to 12h
- Use kubernetes-sig-cli-oncall@gmail.com as the alert email
- Add sig-cli-master testgrid-dashboard if not already set
- Rename testgrid-tab-names to remove specific version numbers, using latest, beta, stable1, stable2 instead
- Fix whitespace to improve readability

/cc @soltysh 