### PR TITLE
Exclude code coverage results from Triage

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -42,7 +42,8 @@ bq --headless --format=json query --max_rows 1000000 \
   from
     [k8s-gubernator:build.all]
   where
-    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))" \
+    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
+    and job != 'ci-kubernetes-coverage-unit'" \
   > triage_builds.json
 
 bq query --allow_large_results --headless --max_rows 0 --replace --destination_table k8s-gubernator:temp.triage \
@@ -55,7 +56,8 @@ bq query --allow_large_results --headless --max_rows 0 --replace --destination_t
     [k8s-gubernator:build.all]
   where
     test.failed
-    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))"
+    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
+    and job != 'ci-kubernetes-coverage-unit'"
 gsutil rm gs://k8s-gubernator/triage_tests/shard_*.json.gz || true
 bq extract --compression GZIP --destination_format NEWLINE_DELIMITED_JSON 'k8s-gubernator:temp.triage' gs://k8s-gubernator/triage_tests/shard_*.json.gz
 mkdir -p triage_tests


### PR DESCRIPTION
This addresses #18322 by removing `ci-kubernetes-coverage-unit` jobs from Triage.