### PR TITLE
kubekins-e2e: Use go1.14.5 and add 'go-canary' variant

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -6,6 +6,12 @@ variants:
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
+  go-canary:
+    CONFIG: go-canary
+    GO_VERSION: 1.15beta1
+    K8S_RELEASE: stable
+    BAZEL_VERSION: 2.2.0
+    OLD_BAZEL_VERSION: 0.23.2
   master:
     CONFIG: master
     GO_VERSION: 1.14.5

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,20 +1,20 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.14.4
+    GO_VERSION: 1.14.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   master:
     CONFIG: master
-    GO_VERSION: 1.14.4
+    GO_VERSION: 1.14.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.14.4
+    GO_VERSION: 1.14.5
     K8S_RELEASE: latest-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
- Update variants (kubekins, krte) to use go1.14.5 (part of Golang security updates in https://github.com/kubernetes/release/issues/1408)
- images/kubekins-e2e: Add 'go-canary' variant
  Eventually can be used in canary tests for Go prereleases.

/assign @BenTheElder @spiffxp 
cc: @kubernetes/release-engineering 