### PR TITLE
Controller-Runtime: Bump CPU requests

### DIFF
--- a/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/controller-runtime/controller-runtime-presubmits-master.yaml
@@ -14,7 +14,7 @@ presubmits:
         - ./hack/ci-check-everything.sh
         resources:
           requests:
-            cpu: 4000m
+            cpu: 8000m
     annotations:
       testgrid-dashboards: sig-api-machinery-kubebuilder
       testgrid-tab-name: controller-runtime-master


### PR DESCRIPTION
In  https://github.com/kubernetes-sigs/controller-runtime/pull/967 the tests failed repeatedly, every single time for a different reason, indicating CPU starvation. Unfortunately we can not get usage graphs to test this theory, so we must trial and error.

/assign @vincepri 