### PR TITLE
Make unknown contexts required for Kubernetes Dashboard

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -566,7 +566,6 @@ tide:
       kubernetes:
         repos:
           dashboard:
-            skip-unknown-contexts: true
             from-branch-protection: true
       kubernetes-sigs:
         repos:


### PR DESCRIPTION
As we have changed our pipeline recently we want to require all checks again.