### PR TITLE
gce-ipvs: use gci node image

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -30,7 +30,7 @@ presubmits:
         - --cluster=
         - --env=KUBE_PROXY_MODE=ipvs
         - --extract=local
-        - --gcp-node-image=ubuntu
+        - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=30
         - --provider=gce


### PR DESCRIPTION
Some of the flexvolume tests are failing and aside from the proxy mode, the node image is the only difference
compared to other jobs where the flexvolume tests pass. Seeing if changing the node image to gci would fix the
flex volume tests

More details about test failures here: https://github.com/kubernetes/kubernetes/issues/92708 

Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>