### PR TITLE
bugzilla: restrict automation for bug in groups

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -446,6 +446,18 @@ func handle(e event, gc githubClient, bc bugzilla.Client, options plugins.Bugzil
 		}
 		if !isBugAllowed(bug, options.AllowedGroups) {
 			// ignore bugs that are in non-allowed groups for this repo
+			if refreshCommandMatch.MatchString(e.body) {
+				response := fmt.Sprintf(bugLink+" is in a bug group that is not in the allowed groups for this repo.", e.bugId, bc.Endpoint(), e.bugId)
+				if len(options.AllowedGroups) > 0 {
+					response += "\nAllowed groups for this repo are:"
+					for _, group := range options.AllowedGroups {
+						response += "\n- " + group
+					}
+				} else {
+					response += " There are no allowed bug groups configured for this repo."
+				}
+				return comment(response)
+			}
 			return nil
 		}
 	}

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1415,6 +1415,41 @@ Instructions for interacting with me using PR comments are available [here](http
 			prs:  []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}},
 			// there should be no comment returned in this test case
 		}, {
+			name: "Bug with non-allowed group on repo with no allowed groups results in comment on /bugzilla refresh",
+			bugs: []bugzilla.Bug{{ID: 123, Groups: []string{"security"}}},
+			prs:  []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}},
+			body: "/bugzilla refresh",
+			expectedComment: `org/repo#1:@user: [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) is in a bug group that is not in the allowed groups for this repo. There are no allowed bug groups configured for this repo.
+
+<details>
+
+In response to [this](http.com):
+
+>/bugzilla refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
+			name:    "Bug with non-allowed group on repo with different allowed groups results in comment on /bugzilla refresh",
+			bugs:    []bugzilla.Bug{{ID: 123, Groups: []string{"security"}}},
+			prs:     []github.PullRequest{{Number: base.number, Body: base.body, Title: base.body}},
+			body:    "/bugzilla refresh",
+			options: plugins.BugzillaBranchOptions{AllowedGroups: []string{"internal"}},
+			expectedComment: `org/repo#1:@user: [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) is in a bug group that is not in the allowed groups for this repo.
+Allowed groups for this repo are:
+- internal
+
+<details>
+
+In response to [this](http.com):
+
+>/bugzilla refresh
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		}, {
 			name:           "Bug with allowed group is properly handled",
 			bugs:           []bugzilla.Bug{{ID: 123, Severity: "medium", Groups: []string{"security"}}},
 			options:        plugins.BugzillaBranchOptions{StateAfterValidation: &updated, AllowedGroups: []string{"security"}},

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1327,6 +1327,11 @@ type BugzillaBranchOptions struct {
 	// StateAfterMerge is the state to which the bug will be moved after all pull requests
 	// in the external bug tracker have been merged.
 	StateAfterMerge *BugzillaBugState `json:"state_after_merge,omitempty"`
+
+	// AllowedGroups is a list of bugzilla bug group names that the bugzilla plugin can
+	// link to in PRs. If a bug is part of a group that is not in this list, the bugzilla
+	// plugin will not link the bug to the PR.
+	AllowedGroups []string `json:"allowed_groups,omitempty"`
 }
 
 type BugzillaBugStateSet map[BugzillaBugState]interface{}
@@ -1484,6 +1489,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 		if parent.StateAfterMerge != nil {
 			output.StateAfterMerge = parent.StateAfterMerge
 		}
+		if parent.AllowedGroups != nil {
+			output.AllowedGroups = sets.NewString(output.AllowedGroups...).Insert(parent.AllowedGroups...).UnsortedList()
+		}
 	}
 
 	// override with the child
@@ -1550,6 +1558,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	}
 	if child.StateAfterMerge != nil {
 		output.StateAfterMerge = child.StateAfterMerge
+	}
+	if child.AllowedGroups != nil {
+		output.AllowedGroups = sets.NewString(output.AllowedGroups...).Insert(child.AllowedGroups...).UnsortedList()
 	}
 
 	// Status fields should not be used anywhere now when they were mirrored to states

--- a/prow/plugins/config_test.go
+++ b/prow/plugins/config_test.go
@@ -693,6 +693,7 @@ func TestOptionsForBranch(t *testing.T) {
 	verifiedState, modifiedState := BugzillaBugState{Status: "VERIFIED"}, BugzillaBugState{Status: "MODIFIED"}
 	postState, preState, releaseState, notabugState := BugzillaBugState{Status: post}, BugzillaBugState{Status: pre}, BugzillaBugState{Status: release}, BugzillaBugState{Status: notabug}
 	closedErrata := BugzillaBugState{Status: "CLOSED", Resolution: "ERRATA"}
+	orgAllowedGroups, repoAllowedGroups := []string{"test"}, []string{"test", "security"}
 
 	rawConfig := `default:
   "*":
@@ -708,6 +709,8 @@ orgs:
         target_release: my-org-default
         state_after_validation:
           status: "PRE"
+        allowed_groups:
+        - test
       "my-org-branch":
         target_release: my-org-branch-default
         state_after_validation:
@@ -732,6 +735,8 @@ orgs:
             validate_by_default: true
             state_after_merge:
               status: NOTABUG
+            allowed_groups:
+            - security
           "my-legacy-branch":
             target_release: my-legacy-branch
             statuses:
@@ -770,28 +775,28 @@ orgs:
 			org:      "my-org",
 			repo:     "some-repo",
 			branch:   "some-branch",
-			expected: BugzillaBranchOptions{IsOpen: &open, TargetRelease: &orgDefault, StateAfterValidation: &preState},
+			expected: BugzillaBranchOptions{IsOpen: &open, TargetRelease: &orgDefault, StateAfterValidation: &preState, AllowedGroups: orgAllowedGroups},
 		},
 		{
 			name:     "branch on configured org but not repo gets org branch default",
 			org:      "my-org",
 			repo:     "some-repo",
 			branch:   "my-org-branch",
-			expected: BugzillaBranchOptions{IsOpen: &open, TargetRelease: &orgBranchDefault, StateAfterValidation: &postState},
+			expected: BugzillaBranchOptions{IsOpen: &open, TargetRelease: &orgBranchDefault, StateAfterValidation: &postState, AllowedGroups: orgAllowedGroups},
 		},
 		{
 			name:     "branch on configured org and repo gets repo default",
 			org:      "my-org",
 			repo:     "my-repo",
 			branch:   "some-branch",
-			expected: BugzillaBranchOptions{ValidateByDefault: &no, IsOpen: &closed, TargetRelease: &repoDefault, ValidStates: &[]BugzillaBugState{verifiedState}, StateAfterValidation: &preState, StateAfterMerge: &releaseState},
+			expected: BugzillaBranchOptions{ValidateByDefault: &no, IsOpen: &closed, TargetRelease: &repoDefault, ValidStates: &[]BugzillaBugState{verifiedState}, StateAfterValidation: &preState, StateAfterMerge: &releaseState, AllowedGroups: orgAllowedGroups},
 		},
 		{
 			name:     "branch on configured org and repo gets branch config",
 			org:      "my-org",
 			repo:     "my-repo",
 			branch:   "my-repo-branch",
-			expected: BugzillaBranchOptions{ValidateByDefault: &yes, IsOpen: &closed, TargetRelease: &repoBranch, ValidStates: &[]BugzillaBugState{modifiedState, closedErrata}, StateAfterValidation: &preState, StateAfterMerge: &notabugState},
+			expected: BugzillaBranchOptions{ValidateByDefault: &yes, IsOpen: &closed, TargetRelease: &repoBranch, ValidStates: &[]BugzillaBugState{modifiedState, closedErrata}, StateAfterValidation: &preState, StateAfterMerge: &notabugState, AllowedGroups: repoAllowedGroups},
 		},
 	}
 	for _, testCase := range testCases {
@@ -821,8 +826,8 @@ orgs:
 			org:  "my-org",
 			repo: "some-repo",
 			expected: map[string]BugzillaBranchOptions{
-				"*":             {IsOpen: &open, TargetRelease: &orgDefault, StateAfterValidation: &preState},
-				"my-org-branch": {IsOpen: &open, TargetRelease: &orgBranchDefault, StateAfterValidation: &postState},
+				"*":             {IsOpen: &open, TargetRelease: &orgDefault, StateAfterValidation: &preState, AllowedGroups: orgAllowedGroups},
+				"my-org-branch": {IsOpen: &open, TargetRelease: &orgBranchDefault, StateAfterValidation: &postState, AllowedGroups: orgAllowedGroups},
 			},
 		},
 		{
@@ -837,6 +842,7 @@ orgs:
 					ValidStates:          &[]BugzillaBugState{verifiedState},
 					StateAfterValidation: &preState,
 					StateAfterMerge:      &releaseState,
+					AllowedGroups:        orgAllowedGroups,
 				},
 				"my-repo-branch": {
 					ValidateByDefault:    &yes,
@@ -845,6 +851,7 @@ orgs:
 					ValidStates:          &[]BugzillaBugState{modifiedState, closedErrata},
 					StateAfterValidation: &preState,
 					StateAfterMerge:      &notabugState,
+					AllowedGroups:        repoAllowedGroups,
 				},
 				"my-org-branch": {
 					ValidateByDefault:    &no,
@@ -853,6 +860,7 @@ orgs:
 					ValidStates:          &[]BugzillaBugState{verifiedState},
 					StateAfterValidation: &postState,
 					StateAfterMerge:      &releaseState,
+					AllowedGroups:        orgAllowedGroups,
 				},
 				"my-legacy-branch": {
 					ValidateByDefault:    &yes,
@@ -862,6 +870,7 @@ orgs:
 					DependentBugStates:   &[]BugzillaBugState{verifiedState},
 					StateAfterValidation: &modifiedState,
 					StateAfterMerge:      &notabugState,
+					AllowedGroups:        orgAllowedGroups,
 				},
 			},
 		},


### PR DESCRIPTION
This PR adds a new `allowed_groups` config to the bugzilla plugin
configuration and changes the behavior of the plugin to ignore bugs
that are part of groups not in the `allowed_groups` config.

/cc @stevekuznetsov 