### PR TITLE
Fixed script path in kubetest2 canary for the new kubetest2 repo

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest2-canaries.yaml
@@ -19,4 +19,4 @@ presubmits:
         command:
         - "runner.sh"
         args:
-        - "./kubetest2/kubetest2-gce/ci-tests/buildupdown.sh"
+        - "./kubetest2-gce/ci-tests/buildupdown.sh"


### PR DESCRIPTION
Missed editing one path after the repo move for kubetest2 (kubetest2 was moved out of test-infra into its own repo). First PR: https://github.com/kubernetes/test-infra/pull/18144