### PR TITLE
Remove --backfill from metrics-bigquery job

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -67,7 +67,6 @@ periodics:
       - test-infra/metrics/bigquery.py
       - --
       - --bucket=gs://k8s-metrics
-      - --backfill-days=90
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json


### PR DESCRIPTION
This was removed in an earlier PR, we forgot to update the job

ref: https://github.com/kubernetes/test-infra/pull/18203