### PR TITLE
Revert "Azure: remove Azure CLI installation step"

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -418,7 +418,36 @@ func newAKSEngine() (*aksEngineDeployer, error) {
 		return nil, err
 	}
 
+	if err := c.azLogin(); err != nil {
+		return nil, err
+	}
+
 	return &c, nil
+}
+
+func (c *aksEngineDeployer) azLogin() error {
+	// Check if azure-cli has been installed
+	if err := control.FinishRunning(exec.Command("az")); err != nil {
+		if err := installAzureCLI(); err != nil {
+			return err
+		}
+	}
+
+	cmd := exec.Command("az", "login", "--service-principal",
+		fmt.Sprintf("-u=%s", c.credentials.ClientID),
+		fmt.Sprintf("-p=%s", c.credentials.ClientSecret),
+		fmt.Sprintf("-t=%s", c.credentials.TenantID))
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed az login with error: %v", err)
+	}
+
+	cmd = exec.Command("az", "account", "set", "-s", c.credentials.SubscriptionID)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to az account set: %v", err)
+	}
+
+	log.Println("az login success.")
+	return nil
 }
 
 func getAKSDeploymentMethod(k8sRelease string) aksDeploymentMethod {


### PR DESCRIPTION
Reverts kubernetes/test-infra#18332

We still needs `az cli` command in all csi driver tests:
https://storage.googleapis.com/kubernetes-jenkins/pr-logs/pull/kubernetes-sigs_azuredisk-csi-driver/454/pull-azuredisk-csi-driver-e2e-multi-az/1284311965778317316/build-log.txt
```
Error response from daemon: manifest for k8sprow.azurecr.io/azuredisk-csi:e2e-7eba3135b85a6e1c87a2dc3314d6028a3249efff not found: manifest unknown: manifest tagged by "e2e-7eba3135b85a6e1c87a2dc3314d6028a3249efff" is not found
make[2]: Entering directory '/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver'
docker buildx rm container-builder || true
no builder "container-builder" found
docker buildx create --use --name=container-builder
container-builder
az acr login --name k8sprow
make[2]: az: Command not found
make[2]: *** [Makefile:112: azuredisk-container] Error 127
make[2]: Leaving directory '/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver'
make[1]: *** [Makefile:73: e2e-bootstrap] Error 2
make[1]: Leaving directory '/home/prow/go/src/sigs.k8s.io/azuredisk-csi-driver'
Failure [9.839 seconds]
```

/assign @chewong @feiskyer 