### PR TITLE
Use bazel transition image (2.2.0-from-0.23.2) on all release branches

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -336,7 +336,7 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: launcher.gcr.io/google/bazel:0.25.2
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
       resources: {}
 - annotations:
@@ -599,7 +599,7 @@ postsubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
 presubmits:
@@ -982,10 +982,10 @@ presubmits:
       - args:
         - -c
         - |
-          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
+          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true
@@ -1013,7 +1013,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -392,7 +392,7 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: launcher.gcr.io/google/bazel:0.25.2
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
       resources: {}
 - annotations:
@@ -654,7 +654,7 @@ postsubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
 presubmits:
@@ -1048,10 +1048,10 @@ presubmits:
       - args:
         - -c
         - |
-          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance $(bazel query --keep_going --noshow_progress "kind(.*_binary, rdeps(//... -//vendor/..., //...)) except attr('tags', 'manual', //...)") //build/release-tars
+          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true
@@ -1079,7 +1079,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -396,7 +396,7 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: launcher.gcr.io/google/bazel:0.25.2
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
       resources: {}
 - annotations:
@@ -715,7 +715,7 @@ postsubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
 presubmits:
@@ -1246,7 +1246,7 @@ presubmits:
           ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
         command:
         - bash
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true
@@ -1274,7 +1274,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: launcher.gcr.io/google/bazel:0.25.2
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
         resources: {}
   - always_run: true


### PR DESCRIPTION
**Unblocks https://github.com/kubernetes/kubernetes/pull/91348, https://github.com/kubernetes/release/issues/1410.**

We're working on updating Go (and k/repo-infra rules) on older release
branches, which require the transitional bazel image to support multiple
bazel versions within tests.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @fejta @mikedanese
cc: @kubernetes/release-engineering 