### PR TITLE
Kops - Switch to newer ARM64 instance types

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -99,7 +99,7 @@ periodics:
       - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
+      - --kops-zones=eu-west-1a,eu-west-1b
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
@@ -134,7 +134,7 @@ periodics:
       - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
+      - --kops-zones=eu-west-1a,eu-west-1b
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
@@ -169,7 +169,7 @@ periodics:
       - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
+      - --kops-zones=eu-west-1a
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=120m

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -96,7 +96,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/latest
       - --ginkgo-parallel
-      - --kops-args=--node-size=a1.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
+      - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
@@ -131,7 +131,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=ci/k8s-master
       - --ginkgo-parallel
-      - --kops-args=--node-size=a1.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
+      - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c
@@ -166,7 +166,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=ci/k8s-master
       - --ginkgo-parallel
-      - --kops-args=--node-size=a1.xlarge --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
+      - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --kops-zones=eu-west-1a,eu-west-1b,eu-west-1c


### PR DESCRIPTION
Seems `a1` instance type is being removed or just unavailable:
```
W0719 02:53:37.585087     156 executor.go:128] error running task
"AutoscalingGroup/nodes-eu-west-1c.e2e-kops-aws-arm64-latest.test-cncf-aws.k8s.io" (6m7s remaining to succeed):
error creating AutoscalingGroup: ValidationError: You must use a valid fully-formed launch template.
Your requested instance type (a1.large) is not supported in your requested Availability Zone (eu-west-1c).
Please retry your request by not specifying an Availability Zone or choosing eu-west-1a, eu-west-1b.
```

/cc @rifelpet @MoShitrit 