### PR TITLE
Kops - Export the "admin" user on cluster update

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -469,6 +469,7 @@ func (k kops) Up() error {
 	}
 
 	createArgs = append(createArgs, "--yes")
+	createArgs = append(createArgs, "--admin")
 
 	if err := control.FinishRunning(exec.Command(k.path, createArgs...)); err != nil {
 		return fmt.Errorf("kops create cluster failed: %v", err)


### PR DESCRIPTION
After the changes in https://github.com/kubernetes/kops/pull/9280, Kops should export the "admin" user explicitly during cluster update.

I have a suspicion that some of the periodic tests stopped working because of this:
https://testgrid.k8s.io/kops-versions#kops-aws-k8s-1.14

/cc @rifelpet @olemarkus @johngmyers 