### PR TITLE
Kettle build and build job are hitting timeouts with the default 10m

### DIFF
--- a/kettle/cloudbuild.yaml
+++ b/kettle/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', '.' ]
     dir: kettle/
+    timeout: 1200s
   - name: gcr.io/cloud-builders/docker
     args: [ 'tag', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', 'gcr.io/$PROJECT_ID/kettle:latest']
 substitutions:


### PR DESCRIPTION
Upped to 20m, see [Prow run](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/post-test-infra-push-kettle/1281649864257572864) for example of timeout