### PR TITLE
Revert "Temporarily switch 1.19 scalability jobs to use perf-tests master"

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -178,8 +178,7 @@ periodics:
     containers:
     - args:
       - --repo=k8s.io/kubernetes=release-1.19
-      # TODO(https://github.com/kubernetes/perf-tests/issues/1384): Switch to release 1.19
-      - --repo=k8s.io/perf-tests=master
+      - --repo=k8s.io/perf-tests=release-1.19
       - --root=/go/src
       - --timeout=140
       - --scenario=kubernetes_e2e
@@ -242,8 +241,7 @@ periodics:
     - args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=release-1.19
-      # TODO(https://github.com/kubernetes/perf-tests/issues/1384): Switch to release 1.19
-      - --repo=k8s.io/perf-tests=master
+      - --repo=k8s.io/perf-tests=release-1.19
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --


### PR DESCRIPTION
Reverts kubernetes/test-infra#18291

1.19 perf-tests branch has been cut.

/assign @jkaniuk @mm4tt 