### PR TITLE
report ipv6 status on presubmits

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -96,7 +96,7 @@ presubmits:
   - name: pull-kubernetes-e2e-kind-ipv6
     optional: true
     always_run: true
-    skip_report: true
+    skip_report: false
     decorate: true
     skip_branches:
     - release-\d+\.\d+ # per-release settings
@@ -122,7 +122,7 @@ presubmits:
           value: "."
         # TODO(bentheelder): reduce the skip list further
         - name: SKIP
-          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
+          value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[sig-storage\]|PodSecurityPolicy|LoadBalancer|load.balancer|In-tree.Volumes.\[Driver:.nfs\]|PersistentVolumes.NFS|Simple.pod.should.support.exec.through.an.HTTP.proxy|subPath.should.support.existing
         - name: PARALLEL
           value: "true"
         - name: BUILD_TYPE


### PR DESCRIPTION
we had to remove the job because the job was unstable, confusing
developers.

KIND IPv6 jobs are more stable now, we also don't run storage tests
to avoid flakiness.

Fixes: https://github.com/kubernetes/kubernetes/issues/92886