### PR TITLE
Auto redirect to spyglass for jobs with Spyglass link

### DIFF
--- a/gubernator/templates/build.html
+++ b/gubernator/templates/build.html
@@ -8,13 +8,6 @@
 <link rel="icon" type="image/png" href="{{'favicon-green.png'|static}}" />
 % endif
 % endblock
-% block banner
-% if spyglass_link
-<div id="page-top-banner">
-	This job view page is being replaced by Spyglass soon. <a href="{{spyglass_link}}">Check out the new job view</a>.
-</div>
-% endif
-% endblock
 % block header
 <h1>{% if pr and pr != "batch"  %}<a href="/pr/{{pr_path}}{{pr}}">{% if repo != "kubernetes/kubernetes"%}{{repo}} {% endif %}PR #{{pr}}</a> {% endif %}
 	% if testgrid_query
@@ -24,9 +17,6 @@
 	% endif
 	#{{build}}</h1>
 	<p><a href="/builds{{job_dir}}">Recent runs</a>
-	% if spyglass_link
-	|| <a href="{{spyglass_link}}">View in Spyglass</a>
-	% endif
 	</p><br>
 % endblock
 % block content

--- a/gubernator/view_build.py
+++ b/gubernator/view_build.py
@@ -259,6 +259,8 @@ class BuildHandler(view_base.BaseHandler):
         if external_config is not None:
             if external_config.get('spyglass'):
                 spyglass_link = 'https://' + external_config['prow_url'] + '/view/gcs/' + build_dir
+                self.redirect(spyglass_link)
+                return
             if '/pull/' in prefix:
                 pr, pr_path, pr_digest, repo = get_pr_info(prefix, self.app.config)
             if want_build_log and not build_log:
@@ -286,7 +288,7 @@ class BuildHandler(view_base.BaseHandler):
             build_log=build_log, build_log_src=build_log_src,
             issues=issues_fut.get_result(), repo=repo,
             pr_path=pr_path, pr=pr, pr_digest=pr_digest,
-            testgrid_query=testgrid_query, spyglass_link=spyglass_link))
+            testgrid_query=testgrid_query))
 
 
 def get_build_config(prefix, config):


### PR DESCRIPTION
Spyglass is now the de facto view for jobs, it is no longer "New" I don't see a reason to not direct traffic there for jobs that have the option. I don't think many are using Gubernator for this anymore either. I can follow up with a PR that also directs the job history to the Spyglass version as well. 