### PR TITLE
update ci-kubernetes-e2e-gci-gce-ipvs to use gci node image

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -346,7 +346,7 @@ periodics:
       - --env=KUBE_PROXY_MODE=ipvs
       - --extract=ci/latest
       - --gcp-master-image=gci
-      - --gcp-node-image=ubuntu
+      - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=30
       - --provider=gce


### PR DESCRIPTION
Flex volume tests are failing with the ubuntu image, update to gci to fix this failure

Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>