### PR TITLE
Make Travis CI check a blocking job for k/autoscaler

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -127,6 +127,10 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        autoscaler:
+          required_status_checks:
+            contexts:
+            - continuous-integration/travis-ci/pr
         client-go:
           restrictions:
             users: []


### PR DESCRIPTION
Updates the prow config for kubernetes/autoscaler to make the automated Travis CI job blocking