### PR TITLE
Update gubernator OWNERS, fix pull-test-infra-gubernator

### DIFF
--- a/gubernator/OWNERS
+++ b/gubernator/OWNERS
@@ -1,13 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- Katharine
+- MushuEE
+- spiffxp
 - stevekuznetsov
 approvers:
-- Katharine
+- spiffxp
 - stevekuznetsov
 emeritus_approvers:
 - ibzib
+- Katharine
 - rmmh
 
 labels:

--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -39,7 +39,6 @@ jobs:
   - pull-kubernetes-integration
   - pull-kubernetes-kubemark-e2e-gce-big
   - pull-kubernetes-node-e2e
-  - pull-kubernetes-node-e2e-containerd
   - pull-kubernetes-typecheck
   - pull-kubernetes-verify
 recursive_artifacts: false

--- a/gubernator/update_config.py
+++ b/gubernator/update_config.py
@@ -27,7 +27,7 @@ def main(prow_config, prow_job_config, gubernator_config):
             if name.endswith('.yaml'):
                 configs.append(os.path.join(root, name))
 
-    print configs
+    print(configs) # pylint: disable=superfluous-parens
 
     default_presubmits = set()
     periodic_names = set()

--- a/images/pull-test-infra-gubernator/OWNERS
+++ b/images/pull-test-infra-gubernator/OWNERS
@@ -1,0 +1,17 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- MushuEE
+- spiffxp
+- stevekuznetsov
+approvers:
+- fejta
+- spiffxp
+- stevekuznetsov
+emeritus_approvers:
+- ibzib
+- Katharine
+- rmmh
+
+labels:
+- area/gubernator


### PR DESCRIPTION
This is mostly to trigger another run of https://k8s-testgrid.appspot.com/sig-testing-images#gubernator since the previous one aged out of prow.k8s.io's deck for rerun