### PR TITLE
Add README.md to images/bazelbuild

### DIFF
--- a/images/bazelbuild/README.md
+++ b/images/bazelbuild/README.md
@@ -1,0 +1,10 @@
+# bazelbuild
+
+This image is used for a variety of deploy/push jobs that run in the test-infra-trusted cluster. It contains:
+- two versions of bazel, to support migration from one to the other
+- gcloud
+- kubectl
+- npm
+- python2.7
+- python3
+- (and some other miscellaneous dependencies)


### PR DESCRIPTION
Mostly this is to retrigger https://k8s-testgrid.appspot.com/sig-testing-images#bazelbuild since the previous job that triggered it has aged out of prow.k8s.io's deck for re-run