### PR TITLE
Add owners for kubetest2 jobs.

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/OWNERS
+++ b/config/jobs/kubernetes-sigs/kubetest2/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- BenTheElder
+- amwat
+- cofyc
+approvers:
+- BenTheElder
+- amwat
+- spiffxp


### PR DESCRIPTION
Copied over from https://github.com/kubernetes-sigs/kubetest2/blob/master/OWNERS

/cc @BenTheElder @spiffxp 