### PR TITLE
Revert "Kettle build and build job are hitting timeouts with the default 10m"

### DIFF
--- a/kettle/cloudbuild.yaml
+++ b/kettle/cloudbuild.yaml
@@ -2,7 +2,6 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', '.' ]
     dir: kettle/
-    timeout: 1200s
   - name: gcr.io/cloud-builders/docker
     args: [ 'tag', 'gcr.io/$PROJECT_ID/kettle:$_GIT_TAG', 'gcr.io/$PROJECT_ID/kettle:latest']
 substitutions:


### PR DESCRIPTION
Reverts kubernetes/test-infra#18376

Apparently the max time allowed is [10min...](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kettle/1285277075426512896)

