### PR TITLE
update windows release informing to use 1.19

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -446,7 +446,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.19
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -489,7 +489,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.19
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/93278 where the tests

https://testgrid.k8s.io/sig-release-1.19-informing#gce-windows-1909-1.19
https://testgrid.k8s.io/sig-release-1.19-informing#gce-windows-2019-1.19

where using release 1.18+ instead of 1.19 (https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce-2019-1-19/1285390419726700549/build-log.txt)

```
2020/07/21 01:45:45 extract_k8s.go:288: U=https://storage.googleapis.com/kubernetes-release-dev/ci R=v1.18.6-rc.0.15+e38139724f8f00 get-kube.sh
2020/07/21 01:45:45 process.go:153: Running: /workspace/get-kube.sh
Downloading kubernetes release v1.18.6-rc.0.15+e38139724f8f00
```

the `latest-1.19` should return the latest ci build from: https://storage.googleapis.com/kubernetes-release-dev/ci/latest-1.19.txt:

```
v1.19.0-rc.1.101+1b8da4c5741f13
```

/sig windows
