### PR TITLE
Remove Velodrome build job as it no longer exists

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -185,29 +185,6 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: builds and pushes all prow on each commit by running prow/push.sh
-  - name: post-test-infra-push-velodrome
-    cluster: test-infra-trusted
-    run_if_changed: '^velodrome/'
-    annotations:
-      testgrid-dashboards: "sig-testing-images"
-      testgrid-tab-name: "velodrome"
-      testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
-      testgrid-num-failures-to-alert: '1'
-      description: builds and pushes the images under velodrome/
-    decorate: true
-    branches:
-    - master
-    spec:
-      serviceAccountName: deployer # TODO(fejta): should be pusher
-      containers:
-      - image: gcr.io/k8s-testimages/gcloud-bazel:v20200520-v0.4-30-g9d6313a
-        command:
-        - images/builder/ci-runner.sh
-        args:
-        - --scratch-bucket=gs://k8s-testimages-scratch
-        - --project=k8s-testimages
-        - --build-dir=.
-        - velodrome/
   - name: post-test-infra-push-kettle
     cluster: test-infra-trusted
     annotations:

--- a/velodrome/README.md
+++ b/velodrome/README.md
@@ -1,6 +1,8 @@
 [Velodrome](http://velodrome.k8s.io/)
 =========
 
+ > # :warning: **Velodrome no longer exists**: Cleanup is in progress
+
 Overview
 --------
 


### PR DESCRIPTION
I added a warning in the README, should I add an issue for further cleanup?