### PR TITLE
Add kind jobs to sig-network

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1,0 +1,220 @@
+periodics:
+# network test against kubernetes master branch with `kind`
+- interval: 6h
+  name: ci-kubernetes-kind-network
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 150m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200720-4766100-master
+      command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      # don't retry network tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: BUILD_TYPE
+        value: bazel
+      - name: FOCUS
+        value: \[sig-network\]
+      - name: SKIP
+        value: \[Feature:Networking-IPv6\]
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "4000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-network-kind, sig-testing-kind
+    testgrid-tab-name: sig-network-kind, master
+    description: Runs network tests using KIND against latest kubernetes master with a kubernetes-in-docker cluster
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-num-columns-recent: '3'
+# network test against kubernetes master branch with `kind` ipv6
+- interval: 6h
+  name: ci-kubernetes-kind-network-ipv6
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 150m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200720-4766100-master
+      command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      env:
+      # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
+      # tell kind CI script to use ipv6
+      - name: "IP_FAMILY"
+        value: "ipv6"
+      # don't retry network tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: BUILD_TYPE
+        value: bazel
+      - name: FOCUS
+        value: \[sig-network\]
+      - name: SKIP
+        value: \[Feature:Networking-IPv4\]
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "4000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-network-kind, sig-testing-kind
+    testgrid-tab-name: sig-network-kind, IPv6, master
+    description: Runs network tests using KIND against latest kubernetes master with an IPv6 kubernetes-in-docker cluster
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-num-columns-recent: '3'
+# network test against kubernetes master branch with `kind`, skipping
+# serial tests so it runs in ~20m
+- interval: 6h
+  name: ci-kubernetes-kind-network-parallel
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200720-4766100-master
+      env:
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      # don't retry network tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: BUILD_TYPE
+        value: bazel
+      - name: FOCUS
+        value: \[sig-network\]
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+      command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "4000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-network-kind, sig-testing-kind
+    testgrid-tab-name: sig-network-kind, master [non-serial]
+    description: Runs network tests using KIND against latest kubernetes master with a kubernetes-in-docker cluster, skipping [Serial] tests
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-num-columns-recent: '3'
+# network test against kubernetes master branch with `kind` ipv6
+- interval: 6h
+  name: ci-kubernetes-kind-network-parallel-ipv6
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200720-4766100-master
+      env:
+      # enable IPV6 in bootstrap image
+      - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+        value: "true"
+      # tell kind CI script to use ipv6
+      - name: "IP_FAMILY"
+        value: "ipv6"
+      # skip serial tests and run with --ginkgo-parallel
+      - name: "PARALLEL"
+        value: "true"
+      # don't retry network tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: BUILD_TYPE
+        value: bazel
+      - name: FOCUS
+        value: \[sig-network\]
+      - name: SKIP
+        value: \[Slow\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
+      command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "4000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-network-kind, sig-testing-kind
+    testgrid-tab-name: sig-network-kind, IPv6, master [non-serial]
+    description: Runs network tests using KIND against latest kubernetes master with an IPv6 kubernetes-in-docker cluster, skipping [Serial] tests
+    testgrid-alert-email: antonio.ojea.garcia@gmail.com, kubernetes-sig-network-test-failures@googlegroups.com
+    testgrid-num-columns-recent: '3'

--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -10,6 +10,7 @@ dashboard_groups:
     - sig-network-netd
     - sig-network-service-apis
     - sig-network-ingress-controller-conformance
+    - sig-network-kind
 
 dashboards:
 - name: sig-network-dns
@@ -120,3 +121,4 @@ dashboards:
 - name: sig-network-netd
 - name: sig-network-service-apis
 - name: sig-network-ingress-controller-conformance
+- name: sig-network-kind


### PR DESCRIPTION
I've realized that we don't have coverage with KIND of all sig-network tests

This also will allow us to include the dual-stack e2e testing with kind later.

xref: https://github.com/kubernetes/kubernetes/issues/93281