### PR TITLE
Add aojea to sig-network testgrid owners

### DIFF
--- a/config/testgrids/kubernetes/sig-network/OWNERS
+++ b/config/testgrids/kubernetes/sig-network/OWNERS
@@ -1,10 +1,12 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+- aojea
 - bowei
 - rramkumar1
 - mrhohn
 approvers:
+- aojea
 - bowei
 - rramkumar1
 - mrhohn


### PR DESCRIPTION
I'm approver in the config/jobs/kubernetes/sig-network/OWNERS , I forget to ask for this one :sweat_smile: 