### PR TITLE
Add ability to define TestGrid TestGroup days_of_results through ProwJob annotations.

### DIFF
--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -40,7 +40,7 @@ const testgridEmailAnnotation = "testgrid-alert-email"
 const testgridNumColumnsRecentAnnotation = "testgrid-num-columns-recent"
 const testgridAlertStaleResultsHoursAnnotation = "testgrid-alert-stale-results-hours"
 const testgridNumFailuresToAlertAnnotation = "testgrid-num-failures-to-alert"
-const testgridDaysOfResultAnnotation = "testgrid-days-of-result"
+const testgridDaysOfResultsAnnotation = "testgrid-days-of-results"
 const descriptionAnnotation = "description"
 const minPresubmitNumColumnsRecent = 20
 
@@ -87,7 +87,7 @@ func applySingleProwjobAnnotations(c *configpb.Configuration, pc *prowConfig.Con
 
 	if testGroup == nil {
 		for _, a := range []string{testgridNumColumnsRecentAnnotation, testgridAlertStaleResultsHoursAnnotation,
-			testgridNumFailuresToAlertAnnotation, testgridDaysOfResultAnnotation, testgridTabNameAnnotation, testgridEmailAnnotation} {
+			testgridNumFailuresToAlertAnnotation, testgridDaysOfResultsAnnotation, testgridTabNameAnnotation, testgridEmailAnnotation} {
 			_, ok := j.Annotations[a]
 			if ok {
 				return fmt.Errorf("no testgroup exists for job %q, but annotation %q implies one should exist", j.Name, a)
@@ -123,10 +123,10 @@ func applySingleProwjobAnnotations(c *configpb.Configuration, pc *prowConfig.Con
 		testGroup.NumFailuresToAlert = int32(nftaInt)
 	}
 
-	if dora, ok := j.Annotations[testgridDaysOfResultAnnotation]; ok {
+	if dora, ok := j.Annotations[testgridDaysOfResultsAnnotation]; ok {
 		doraInt, err := strconv.ParseInt(dora, 10, 32)
 		if err != nil {
-			return fmt.Errorf("%s value %q is not a valid integer", testgridDaysOfResultAnnotation, dora)
+			return fmt.Errorf("%s value %q is not a valid integer", testgridDaysOfResultsAnnotation, dora)
 		}
 		testGroup.DaysOfResults = int32(doraInt)
 	}

--- a/testgrid/cmd/configurator/prow.go
+++ b/testgrid/cmd/configurator/prow.go
@@ -40,6 +40,7 @@ const testgridEmailAnnotation = "testgrid-alert-email"
 const testgridNumColumnsRecentAnnotation = "testgrid-num-columns-recent"
 const testgridAlertStaleResultsHoursAnnotation = "testgrid-alert-stale-results-hours"
 const testgridNumFailuresToAlertAnnotation = "testgrid-num-failures-to-alert"
+const testgridDaysOfResultAnnotation = "testgrid-days-of-result"
 const descriptionAnnotation = "description"
 const minPresubmitNumColumnsRecent = 20
 
@@ -86,7 +87,7 @@ func applySingleProwjobAnnotations(c *configpb.Configuration, pc *prowConfig.Con
 
 	if testGroup == nil {
 		for _, a := range []string{testgridNumColumnsRecentAnnotation, testgridAlertStaleResultsHoursAnnotation,
-			testgridNumFailuresToAlertAnnotation, testgridTabNameAnnotation, testgridEmailAnnotation} {
+			testgridNumFailuresToAlertAnnotation, testgridDaysOfResultAnnotation, testgridTabNameAnnotation, testgridEmailAnnotation} {
 			_, ok := j.Annotations[a]
 			if ok {
 				return fmt.Errorf("no testgroup exists for job %q, but annotation %q implies one should exist", j.Name, a)
@@ -120,6 +121,14 @@ func applySingleProwjobAnnotations(c *configpb.Configuration, pc *prowConfig.Con
 			return fmt.Errorf("%s value %q is not a valid integer", testgridNumFailuresToAlertAnnotation, nfta)
 		}
 		testGroup.NumFailuresToAlert = int32(nftaInt)
+	}
+
+	if dora, ok := j.Annotations[testgridDaysOfResultAnnotation]; ok {
+		doraInt, err := strconv.ParseInt(dora, 10, 32)
+		if err != nil {
+			return fmt.Errorf("%s value %q is not a valid integer", testgridDaysOfResultAnnotation, dora)
+		}
+		testGroup.DaysOfResults = int32(doraInt)
 	}
 
 	if tn, ok := j.Annotations[testgridTabNameAnnotation]; ok {

--- a/testgrid/cmd/configurator/prow_test.go
+++ b/testgrid/cmd/configurator/prow_test.go
@@ -290,7 +290,7 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 				"testgrid-num-columns-recent":        "13",
 				"testgrid-num-failures-to-alert":     "4",
 				"testgrid-alert-stale-results-hours": "24",
-				"testgrid-days-of-result":            "30",
+				"testgrid-days-of-results":           "30",
 			},
 			expectedConfig: config.Configuration{
 				TestGroups: []*config.TestGroup{

--- a/testgrid/cmd/configurator/prow_test.go
+++ b/testgrid/cmd/configurator/prow_test.go
@@ -290,6 +290,7 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 				"testgrid-num-columns-recent":        "13",
 				"testgrid-num-failures-to-alert":     "4",
 				"testgrid-alert-stale-results-hours": "24",
+				"testgrid-days-of-result":            "30",
 			},
 			expectedConfig: config.Configuration{
 				TestGroups: []*config.TestGroup{
@@ -299,6 +300,7 @@ func Test_applySingleProwjobAnnotations(t *testing.T) {
 						NumColumnsRecent:       13,
 						NumFailuresToAlert:     4,
 						AlertStaleResultsHours: 24,
+						DaysOfResults:          30,
 					},
 				},
 				Dashboards: []*config.Dashboard{


### PR DESCRIPTION
As I mentioned in my post in sig-testing Slack channel I've added the functionality of defining `days_of_result` field to the `configurator` and added new annotation to the tests.

Link to the conversation: https://kubernetes.slack.com/archives/C09QZ4DQB/p1594986830198500