### PR TITLE
Switch gcp project for pull-kubernetes-node-e2e-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -103,7 +103,7 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project=k8s-c8d-pr-node-e2e
+        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true


### PR DESCRIPTION
k8s-c8d-pr-node-e2e went stale a while ago, this is one of the last jobs
that still references this gcp project. Switching this over to the pool
meant for the node-e2e jobs

References:
- https://github.com/kubernetes/test-infra/pull/17452
- https://github.com/kubernetes/test-infra/pull/17349
- https://github.com/kubernetes/test-infra/pull/17284

Note that this job was essentially switched off in https://github.com/kubernetes/test-infra/pull/18356, will switch it back on in a subsequent PR if this works

Signed-off-by: Davanum Srinivas <davanum@gmail.com>