### PR TITLE
Remove issue comment on pull-kubernetes-node-e2e-containerd 

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -82,7 +82,6 @@ presubmits:
   - name: pull-kubernetes-node-e2e-containerd
     branches:
     - master
-    # disabled pending resolution of https://github.com/kubernetes/kubernetes/issues/89847
     always_run: false
     optional: true
     skip_report: true


### PR DESCRIPTION
This job was previously disabled in #18356 due to consistent timeout, which has
now been addressed by moving it to a new GCP project in #18409.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @dims @liggitt 