### PR TITLE
Remove unnecessary label from kubetest2 canary job

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -7,7 +7,6 @@ presubmits:
     # run_if_changed: "kubetest2-gce/.*"
     labels:
       preset-service-account: "true"
-      preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: sig-testing-canaries
     extra_refs:


### PR DESCRIPTION
This label is being removed because, while it fixes an issue that was occurring, it does more than it needs to and obscures intent. The preset-k8s-ssh label fixes an issue with the GCE deployer's log dump script by setting USER to "prow". It also does extra, unnecessary work with SSH keys and does not resolve the underlying issue. We have opted to fix this issue in the deployer itself by adding logic around the USER env var.

See https://github.com/kubernetes-sigs/kubetest2/pull/5/files#diff-422d106fe92c0dc46364ac8c293a13e2R101 for details.

Is effectively a revert of https://github.com/kubernetes/test-infra/pull/18387 which includes more details about test failures.