### PR TITLE
Make autobump with gerrit use Prow version instead of git diff to check if updates are needed.

### DIFF
--- a/prow/cmd/autobump/autobump.sh
+++ b/prow/cmd/autobump/autobump.sh
@@ -136,13 +136,12 @@ create-gerrit-pr() {
 	git fetch upstream "+refs/changes/*:refs/remotes/upstream/changes/*" 2> /dev/null
 	local pr_commit="$(git log --all --grep="Change-Id: ${change_id}" -1 --format="%H")"
 	if [[ -n "${pr_commit}" ]]; then
-		local pr_diff="$(git diff "${pr_commit}")"
-		if [[ -z "${pr_diff}" ]]; then
-			echo "Bump PR is already up to date. Aborting no-op update." >&2
+		local pr_version="$(git show "${pr_commit}:${PLANK_DEPLOYMENT_FILE}" | extract-version)"
+		if [[ "${pr_version}" == "${version}" ]]; then
+			echo "Bump PR is already up to date (version ${version}). Aborting no-op update." >&2
 			return 0
 		fi
-		echo "Bump PR is not up to date. Updating PR with the following diff:"
-		echo "${pr_diff}"
+		echo "Bump PR is not up to date, it currently updates to ${pr_version}. Updating PR to ${version}."
 	else
 		echo "Did not find an existing PR to update. A new Gerrit PR will be created."
 	fi


### PR DESCRIPTION
`git diff` will frequently indicate changes even if the bump PR doesn't need to be updated because it includes changes from other PRs that have merged in the repo since the last update to the bump PR.
This PR reverts the changes I made to address this comment: https://github.com/kubernetes/test-infra/pull/18240#discussion_r452505405

/assign @fejta 