### PR TITLE
don't always run pull-kubernetes-dependencies-canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -36,8 +36,7 @@ presubmits:
     decorate: true
     skip_branches:
     - release-\d+.\d+ # per-release job
-    always_run: true
-    skip_report: true
+    always_run: false
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"


### PR DESCRIPTION
see discussion at https://github.com/kubernetes/kubernetes/issues/92937#issuecomment-662177037

AFAICT @cblecker added this to test GOPROXY and we've not had a real user for it since we enabled that by default anyhow.