### PR TITLE
Fix kettle push command and docs

### DIFF
--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -27,7 +27,7 @@ push-prod:
   bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch kettle
 
 push:
-	bazel run //images/builder -- --allow-dirty kettle
+	bazel run //images/builder -- --allow-dirty --build-dir=. kettle/
 
 deploy: get-cluster-credentials
 	sed "s/:latest/:$(TAG)/g" deployment.yaml | kubectl apply -f - --record

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -7,10 +7,6 @@ JSON files for import into BigQuery.
 Results are stored in the [k8s-gubernator:build BigQuery dataset](https://bigquery.cloud.google.com/dataset/k8s-gubernator:build),
 which is publicly accessible.
 
-# Running
-
-Use `pip install -r requirements.txt` to install dependencies.
-
 # Deploying
 
 Kettle runs as a pod in the `k8s-gubernator/g8r` cluster
@@ -19,11 +15,15 @@ If you change:
 
 - `buckets.yaml`: do nothing, it's automatically fetched from GitHub
 - `deployment.yaml`: deploy with `make push deploy`
-- any code: deploy with `make push update`, revert with `make rollback` if it fails
+- any code: **Run from root** deploy with `make -C kettle push update`, revert with `make -C kettle rollback` if it fails
+    - `push` builds the continer image and pushes it to the image registry
+    - `update` sets the image of the existing kettle *Pod* which triggers a restart cycle
+    - this will build the image to [Pantheon Container Registry](https://pantheon.corp.google.com/gcr/images/k8s-gubernator/GLOBAL/kettle?project=k8s-gubernator&organizationId=433637338589&gcrImageListsize=30)
+    - See [Makefile](Makefile) for details
 
 # Restarting
 
-#### Find out when the build started failing
+#### Find out when the build started failinga
 
 eg: by looking at the logs
 
@@ -62,6 +62,10 @@ kubectl logs -f $(kubectl get pod -l app=kettle -oname)
 ```
 
 It might take a couple of hours to be fully functional and start updating BigQuery. You can always go back to the [Gubernator BigQuery page](https://bigquery.cloud.google.com/table/k8s-gubernator:build.all?pli=1&tab=details) and check to see if data collection has resumed.  Backfill should happen automatically.
+
+# CI
+
+A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L203-L210) runs that pushes Kettle on changes.
 
 # Known Issues
 


### PR DESCRIPTION
The push command was broken due to pathing and needed to be run from root.

Docs update to reflect changes. 