### PR TITLE
add hmac generator and a logger as an argument when creating a new github event server

### DIFF
--- a/prow/githubeventserver/githubeventserver.go
+++ b/prow/githubeventserver/githubeventserver.go
@@ -61,9 +61,9 @@ type GitHubEventServer struct {
 	httpServeMux    *http.ServeMux
 }
 
-// NewGitHubEventServer creates a new *GitHubEventServer from the given arguments.
+// New creates a new GitHubEventServer from the given arguments.
 // It also assigns the serveMuxHandler in the http.ServeMux.
-func NewGitHubEventServer(o Options) *GitHubEventServer {
+func New(o Options, hmacTokenGenerator func() []byte, logger *logrus.Entry) *GitHubEventServer {
 	var wg sync.WaitGroup
 
 	httpServeMux := http.NewServeMux()
@@ -72,8 +72,8 @@ func NewGitHubEventServer(o Options) *GitHubEventServer {
 		port:     o.port,
 		wg:       &wg,
 		serveMuxHandler: &serveMuxHandler{
-			hmacTokenGenerator: o.HmacTokenGenerator,
-			log:                o.Logger,
+			hmacTokenGenerator: hmacTokenGenerator,
+			log:                logger,
 			metrics:            o.Metrics,
 			wg:                 &wg,
 		},

--- a/prow/githubeventserver/options.go
+++ b/prow/githubeventserver/options.go
@@ -20,23 +20,14 @@ import (
 	"flag"
 	"fmt"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
 
 // Options holds the endpoint and port information that can be used
 // to create a new github event server
 type Options struct {
-	// HmacTokenGenerator is a function that holds a hmac token that will be used
-	// in a github event server
-	HmacTokenGenerator func() []byte
-
 	// Metrics will be used to expose prometheus metrics from the
 	// github event server operations.
 	Metrics *Metrics
-
-	// Logger is the logger that the github event server will use.
-	Logger *logrus.Entry
 
 	// endpoint is the main url path that the github event server will be served.
 	endpoint string
@@ -50,16 +41,8 @@ func (o *Options) DefaultAndValidate() error {
 		return fmt.Errorf("endpoint %s is not a valid url path", o.endpoint)
 	}
 
-	if o.HmacTokenGenerator == nil {
-		o.HmacTokenGenerator = func() []byte { return []byte("") }
-	}
-
 	if o.Metrics == nil {
 		o.Metrics = NewMetrics()
-	}
-
-	if o.Logger == nil {
-		o.Logger = logrus.NewEntry(logrus.New())
 	}
 
 	return nil


### PR DESCRIPTION
Since all users will always want the  hmac generator, this PR adds it as arg when creating a new github event server and removing them from the github event server options.

/cc @stevekuznetsov 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>