### PR TITLE
add ListenAndServe and Shutdown functions to github event server

### DIFF
--- a/prow/githubeventserver/BUILD.bazel
+++ b/prow/githubeventserver/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
-        "//prow/interrupts:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/pluginhelp/hook:go_default_library",


### PR DESCRIPTION
Instead of running the HTTP server by using the interrupts library, implement the `ListenAndServe` and `Shutdown` functions to allow users to run directly the struct with `interrupts.ListenAndServe`
Add and define the HTTP server when creating a new GitHub event server and remove the `port` and `endpoint` fields from the struct.


/cc @stevekuznetsov 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>