### PR TITLE
Enable kubetest2 canary job for all changes

### DIFF
--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -1,10 +1,8 @@
 presubmits:
   kubernetes-sigs/kubetest2:
   - name: gce-build-up-down
-    always_run: false
     decorate: true
-    # TODO: uncomment when job has been tested successfully
-    # run_if_changed: "kubetest2-gce/.*"
+    run_if_changed: "kubetest2-gce/.*"
     labels:
       preset-service-account: "true"
     annotations:


### PR DESCRIPTION
Successful test and merge of https://github.com/kubernetes-sigs/kubetest2/pull/5/files means this change should proceed.