### PR TITLE
Use the main branch to get latest updates for master-informing

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -72,7 +72,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -91,7 +91,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-master-informing
     testgrid-tab-name: gce-windows-2019-master
     description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
@@ -117,7 +117,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -136,7 +136,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing
     testgrid-tab-name: gce-windows-1909-master
     description: Runs tests on a Kubernetes cluster with Windows 1909 nodes on GCE
@@ -162,7 +162,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -209,7 +209,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
       - --provider=gce
@@ -254,7 +254,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -363,7 +363,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1
@@ -419,7 +419,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/87389 and https://github.com/kubernetes/kubernetes/issues/88974

In my previous pr #18401 I noticed 1.19 informing was on the wrong branch.  After looking into https://github.com/kubernetes/kubernetes/issues/87389 and https://github.com/kubernetes/kubernetes/issues/88974 I noticed some tests should [have been removed but weren't](https://github.com/kubernetes/kubernetes/issues/87389#issuecomment-662626272).

I appears `ci/k8s-master.txt` returns `v1.19.0-beta.2.607+4c853bb28f57f8`: https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt

where as `ci/latest` returns `v1.20.0-alpha.0.307+ae7dce72ce8aa7`: https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt

which is the one we want that doesn't have the tests that were removed in it.

/sig windows
/sig release

/cc @michmike @pjh 

