### PR TITLE
Revert "Merge pull request

### DIFF
--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -72,7 +72,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -91,7 +91,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-master-informing
     testgrid-tab-name: gce-windows-2019-master
     description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
@@ -117,7 +117,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -136,7 +136,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
     testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing
     testgrid-tab-name: gce-windows-1909-master
     description: Runs tests on a Kubernetes cluster with Windows 1909 nodes on GCE
@@ -162,7 +162,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -209,7 +209,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
       - --provider=gce
@@ -254,7 +254,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -363,7 +363,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1
@@ -419,7 +419,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/latest
+      - --extract=ci/k8s-master
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1


### PR DESCRIPTION
The cross builds are known to be behind: https://github.com/kubernetes/test-infra/pull/18290#issuecomment-658547088 and there is work for this to be resolved. 

According to https://github.com/kubernetes/test-infra/pull/14030:  Use ci/k8s-master marker for Windows node jobs (--ginkgo.skip=\[LinuxOnly\])

Revert  #18435 
This reverts commit 145428705114c78ef42c0e1c8595bffcbb673d84, reversing
changes made to b942f8218daa0a5ae62afc5536df7a26637d6316.  The build failed due to not being built for windows: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-windows-gce-1909/1286046479575683077

```
U=https://storage.googleapis.com/kubernetes-release-dev/ci R=v1.20.0-alpha.0.307+ae7dce72ce8aa7 get-kube.sh failed: error during /workspace/get-kube.sh: exit status 22
```

For now the tests will have to wait to get the latest bits to be passing in https://github.com/kubernetes/kubernetes/issues/88974 unless someone else knows how the right tags.

/sig windows
/sig release

/cc @michmike @pjh @hasheddan

/assign @ddebroy
/assign @yliaog