### PR TITLE
add golangci-lint verification for vSphere CSI Driver

### DIFF
--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -55,6 +55,24 @@ presubmits:
       testgrid-tab-name: pr-verify-vet
       description: Vets the Golang sources have been vetted
 
+  - name: pull-vsphere-csi-driver-verify-golangci-lint
+    always_run: false
+    run_if_changed: '\.go'
+    decorate: true
+    path_alias: sigs.k8s.io/vsphere-csi-driver
+    spec:
+      containers:
+        - image: golangci/golangci-lint:v1.29.0
+          command:
+            - make
+          args:
+            - golangci-lint
+    annotations:
+      testgrid-dashboards: vmware-presubmits-vsphere-csi-driver
+      testgrid-alert-email: k8s-testing-cloud-provider-vsphere+alerts@groups.vmware.com
+      testgrid-tab-name: pr-verify-golangci-lint
+      description: Verifies the Golang sources are verified with golangci-lint
+
   # Runs 'shellcheck' on appropriate sources
   - name: pull-vsphere-csi-driver-verify-shell
     always_run: false


### PR DESCRIPTION
Adding `golangci-lint` verification for vSphere CSI Driver Pull Requests.

We have recently added support for validating vSphere CSI Driver code using  `golangci-lint` and `make golangci-lint` target is added to do this verification. - https://github.com/kubernetes-sigs/vsphere-csi-driver/blob/master/Makefile#L363-L364
