### PR TITLE
Increase Cluster API CPU requests

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -1,24 +1,4 @@
 periodics:
-- name: periodic-cluster-api-build
-  interval: 1h
-  decorate: true
-  labels:
-    preset-service-account: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: master
-    path_alias: sigs.k8s.io/cluster-api
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-1.18
-      command:
-      - "./scripts/ci-build.sh"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: build
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-test
   interval: 1h
   decorate: true
@@ -36,8 +16,7 @@ periodics:
       - "./scripts/ci-test.sh"
       resources:
         requests:
-          cpu: 3
-          memory: "6Gi"
+          cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: unit tests
@@ -65,54 +44,9 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: "6000m"
-            memory: "6Gi"
+            cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: capi e2e tests
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-build-release-0-2
-  interval: 1h
-  decorate: true
-  labels:
-    preset-service-account: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: release-0.2
-    path_alias: sigs.k8s.io/cluster-api
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-1.18
-      command:
-      - "./scripts/ci-build.sh"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: build-release-0-2
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-test-release-0-2
-  interval: 1h
-  decorate: true
-  labels:
-    preset-service-account: "true"
-  extra_refs:
-  - org: kubernetes-sigs
-    repo: cluster-api
-    base_ref: release-0.2
-    path_alias: sigs.k8s.io/cluster-api
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-1.18
-      command:
-      - "./scripts/ci-test.sh"
-      resources:
-        requests:
-          cpu: 3
-          memory: "6Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: unit tests-release-0-2
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -37,7 +37,7 @@ presubmits:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-1.18
         resources:
           requests:
-            memory: "6Gi"
+            cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-make
@@ -77,8 +77,7 @@ presubmits:
         - "verify"
         resources:
           requests:
-            cpu: "6000m"
-            memory: "6Gi"
+            cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-verify
@@ -98,8 +97,7 @@ presubmits:
         - ./scripts/ci-test.sh
         resources:
           requests:
-            cpu: "6000m"
-            memory: "6Gi"
+            cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-test
@@ -124,8 +122,7 @@ presubmits:
           privileged: true
         resources:
           requests:
-            cpu: "6000m"
-            memory: "6Gi"
+            cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-e2e


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/commit/a81e294b95401dddeb1c8fea5514f8a6b1ef11af, to reduce the number of flakes we've been seeing, this gets us to almost have a whole node for a run. The maximum request should be 7.5 or 7.4 CPUs, this sets to 7.3 to keep some headroom.

/assign @detiber 