### PR TITLE
Update to new Flatcar image with Linux kernel 5.4

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -348,7 +348,7 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/stable
       - --ginkgo-parallel
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-image=075585003325/Flatcar-beta-2513.2.0-hvm
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws


### PR DESCRIPTION
Flatcar tests are flaking consistently, maybe this will help (even if Beta):
https://testgrid.k8s.io/kops-distros#kops-aws-distro-flatcar
https://www.flatcar-linux.org/releases/#release-2513.2.0