### PR TITLE
Remove gcs/ suffix from job_url_prefix_config.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -3,7 +3,7 @@ plank:
   report_templates:
     '*': '[Full PR test history](https://prow.k8s.io/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}). [Your PR dashboard](https://prow.k8s.io/pr?query=is%3Apr%20state%3Aopen%20author%3{{with index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}). Please help us cut down on flakes by [linking to](https://git.k8s.io/community/contributors/devel/sig-testing/flaky-tests.md#filing-issues-for-flaky-tests) an [open issue](https://github.com/{{.Spec.Refs.Org}}/{{.Spec.Refs.Repo}}/issues?q=is:issue+is:open) when you hit one in your PR.'
   job_url_prefix_config:
-    '*': https://prow.k8s.io/view/gcs/
+    '*': https://prow.k8s.io/view/
   pod_pending_timeout: 15m
   pod_unscheduled_timeout: 1m
   default_decoration_configs:


### PR DESCRIPTION
Update to address the change here: https://github.com/kubernetes/test-infra/pull/17779

I don't think we should be deprecating the old job url format, but I'm raising my concerns on that PR. Changing this for now since it is causing tons of log spam.

/assign @chaodaiG @e-blackwelder