### PR TITLE
Switch boskos images to use new registry and update to v20200717-7299d53.

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -13,7 +13,7 @@ periodics:
       args:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json
-      image: gcr.io/k8s-prow/boskos/aws-janitor:v20200526-f1438e04b0
+      image: gcr.io/k8s-staging-boskos/aws-janitor:v20200717-7299d53
   annotations:
     testgrid-dashboards: sig-testing-maintenance
     testgrid-tab-name: ci-aws-janitor

--- a/config/prow/cluster/boskos-janitor.yaml
+++ b/config/prow/cluster/boskos-janitor.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor
-        image: gcr.io/k8s-prow/boskos/janitor:v20200526-f1438e04b0
+        image: gcr.io/k8s-staging-boskos/janitor:v20200717-7299d53
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gke-project
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: boskos-janitor
       containers:
       - name: boskos-janitor-nongke
-        image: gcr.io/k8s-prow/boskos/janitor:v20200526-f1438e04b0
+        image: gcr.io/k8s-staging-boskos/janitor:v20200717-7299d53
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,node-e2e-project
@@ -76,7 +76,7 @@ spec:
       terminationGracePeriodSeconds: 300
       containers:
       - name: boskos-janitor-aws
-        image: gcr.io/k8s-prow/boskos/aws-janitor-boskos:v20200526-f1438e04b0
+        image: gcr.io/k8s-staging-boskos/aws-janitor-boskos:v20200717-7299d53
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
 ---

--- a/config/prow/cluster/boskos-reaper_deployment.yaml
+++ b/config/prow/cluster/boskos-reaper_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos-reaper
-        image: gcr.io/k8s-prow/boskos/reaper:v20200526-f1438e04b0
+        image: gcr.io/k8s-staging-boskos/reaper:v20200717-7299d53
         args:
         - --boskos-url=http://boskos.test-pods.svc.cluster.local.
         - --resource-type=gce-project,gke-project,gpu-project,ingress-project,istio-project,scalability-presubmit-project,scalability-project,aws-account,node-e2e-project

--- a/config/prow/cluster/boskos.yaml
+++ b/config/prow/cluster/boskos.yaml
@@ -125,7 +125,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: boskos
-        image: gcr.io/k8s-prow/boskos/boskos:v20200526-f1438e04b0
+        image: gcr.io/k8s-staging-boskos/boskos:v20200717-7299d53
         args:
         - --config=/etc/config/config
         - --namespace=test-pods


### PR DESCRIPTION
This should resolve the problem with the bump PRs displaying the wrong version tag in the title since boskos images will no longer be conflated with Prow images.

Note that this does not resolve the problem with boskos images not being automatically bumped. I think there will need to be some minor updates to the experiment autobumper to handle that.

/assign @chizhg @chaodaiG @e-blackwelder 