### PR TITLE
fix gubernator presubmit, try catching this in the future

### DIFF
--- a/gubernator/config.yaml
+++ b/gubernator/config.yaml
@@ -28,7 +28,6 @@ jobs:
   - pull-kubernetes-bazel-test
   - pull-kubernetes-conformance-kind-ga-only-parallel
   - pull-kubernetes-dependencies
-  - pull-kubernetes-dependencies-canary
   - pull-kubernetes-e2e-gce
   - pull-kubernetes-e2e-gce-100-performance
   - pull-kubernetes-e2e-gce-device-plugin-gpu

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -19,3 +19,4 @@ set -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 find hack -name 'verify-*.sh' -not -name "$(basename "$0")" \( -print -exec '{}' ';' -o -quit \)
+./guberantor/verify_config.sh


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/18421 caused pull-test-infra-gubernator to start failing again

this should hopefully cause presubmits to fail if a similar job config change occurs