### PR TITLE
increase default grace priod to match bootstrap.py

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -9,7 +9,7 @@ plank:
   default_decoration_configs:
     '*':
       timeout: 2h
-      grace_period: 15s
+      grace_period: 15m
       utility_images:
         clonerefs: "gcr.io/k8s-prow/clonerefs:v20200723-63369bbebd"
         initupload: "gcr.io/k8s-prow/initupload:v20200723-63369bbebd"


### PR DESCRIPTION
we've been moving more jobs over to `decroate: true`

currently the default grace period for handling timeout interrupt is only 15s, on an overloaded cluster / with non trivial cleanup this is too short, and we wind up falling back on e.g. boskos.

bootstrap.py had a fixed grace period of 15m, and plenty of things rely on that. 
for kubernetes prow.k8s.io only I am moving the default grace period to match bootstrap.py.

individual jobs can still choose to have shorter grace periods, and well behaved signal handlers with trivial cleanup should exit quickly anyhow

/cc @amwat @MushuEE 
FYI @liggitt 