### PR TITLE
Limit Kettle post-submit job timeout

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -195,6 +195,9 @@ postsubmits:
       description: builds and pushes the kettle image
     run_if_changed: '^kettle/'
     decorate: true
+    decoration_config:
+      timeout: 50m
+      grace_period: 10m
     branches:
     - master
     spec:


### PR DESCRIPTION
Just adding a little more control in the off chance the job hangs