### PR TITLE
Migrate cloud-provider-gcp e2e-create test to use kubetest2

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -55,4 +55,4 @@ presubmits:
           cd "${REPO_ROOT}/../kubetest2" || exit 1;
           make install;
           make install-deployer-gce;
-          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=exec -- kubectl get all --all-namespaces;
+          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=exec -- kubectl get all --all-namespaces --kubeconfig="${ARTIFACTS}/kubetest2-kubeconfig";

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -30,15 +30,29 @@ presubmits:
     path_alias: k8s.io/cloud-provider-gcp
     labels:
       preset-service-account: "true"
-      preset-k8s-ssh: "true"
     annotations:
       testgrid-dashboards: provider-gcp-presubmits
-      description: End to end cluster creation test using cluster/kube-up based on kubernetes/cloud-provider-gcp.
+      description: End to end cluster creation test using kubetest2 based on kubernetes/cloud-provider-gcp.
       testgrid-num-columns-recent: '30'
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: kubetest2
+      base_ref: master
+      path_alias: k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
         command:
         - runner.sh
         args:
-        - test/e2e.sh
+        - "/bin/bash"
+        - "-c"
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          REPO_ROOT=$(git rev-parse --show-toplevel);
+          cd "${REPO_ROOT}/../kubetest2" || exit 1;
+          make install;
+          make install-deployer-gce;
+          kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=exec -- kubectl get all --all-namespaces;


### PR DESCRIPTION
Because no current test container includes a kubetest2 binary, this test must clone and build kubetest2 before running the test. In future, the kubekins container will be replaced by one that already includes a kubetest2 binary.

The current kubetest2 exec tester does not properly handle the kubeconfig set by the deployer, probably because it can run any command and thus doesn't always need a kubeconfig. Therefore, when `kubectl` is run normally it looks for the default config location instead of the deployer-generated config location and then it fails because it tries to connect to the default (`localhost:8080`). Thus we have to manually specify the path of the deployer-generated kubeconfig to the exec test. The kubeconfig path is specific to the artifacts dir specified in prow and specific to the GCE deployer.

Tested using mkpj and mkpod on a local Kind cluster. Used a custom service account and targeted a specific project. Therefore, this did not test working with Boskos but Boskos interaction has been proven in other tests.