### PR TITLE
Update CI job for csi gce pd driver

### DIFF
--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -12,6 +12,9 @@ periodics:
     preset-service-account: "true"
     preset-common-gce-windows: "true"
     preset-e2e-gce-windows: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
   spec:
     containers:
     - command:
@@ -20,7 +23,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -34,6 +37,8 @@ periodics:
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200720-4766100-master
+      securityContext:
+          privileged: true
   annotations:
     testgrid-dashboards: provider-gcp-compute-persistent-disk-csi-driver
     testgrid-tab-name: ci-windows-provider-gcp-compute-persistent-disk-csi-driver
@@ -66,7 +71,7 @@ presubmits:
         args:
         - --check-leaked-resources
         - --cluster=
-        - --extract=ci/k8s-master
+        - --extract=ci/latest
         - --gcp-zone=us-west1-b
         - --ginkgo-parallel=8
         - --provider=gce


### PR DESCRIPTION
Temperal set k8s version to 1.20 because current master does not has csi
proxy change. Also update job config because it needs docker to build driver image