### PR TITLE
remove the use-service-account flag from prow job

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -40,8 +40,7 @@ presubmits:
         - cip
         args:
         - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        - -vuln-severity-threshold=3
-        - -use-service-account
+        - -vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     annotations:


### PR DESCRIPTION
The vulnerability presubmit check Prow job (pull-cip-vuln) is incorrectly using the -use-service-account flag, which is an unrequired auth mechanism for what the check needs. So I'm removing that flag. Additionally, I'm lowering the vulnerability severity threshold for testing purposes.