### PR TITLE
add more info to oncall page

### DIFF
--- a/maintenance/oncall.html
+++ b/maintenance/oncall.html
@@ -2,6 +2,25 @@
 <!-- To "deploy": gsutil cp -Z oncall.html gs://test-infra-oncall/ -->
 <html lang="en">
 <script>
+  var rotationsMetadata = {
+    "google-build-admin": {
+      "prettyName": "Google Build Admin",
+      "slack": "@google-build-admin",
+      "timezone": '<a href="https://time.is/PT">PT</a>',
+      "description": 'Debian / RPM package build & publishing for releases',
+    },
+    "testinfra": {
+      "prettyName": "Test Infra",
+      "slack": "@test-infra-oncall",
+      "timezone": '<a href="https://time.is/PT">PT</a>',
+      "description": "Prow, TestGrid, and other Google hosted infrastructure"
+    },
+    "scalability": {
+      "prettyName": "Scalability",
+      "timezone": '<a href="https://time.is/CET">CET</a>',
+      // TODO: description
+    }
+  };
   // extracted/modified from kubernetes/test-infra/gubernator/static/build.js
   function get(uri, callback) {
     if (uri[0] === '/') {
@@ -28,16 +47,40 @@
 
     var html = '';
     html += '<table>';
-    html += '<thead> <tr> <th> Rotation </th> <th colspan=2> GitHub </th> </tr>';
+    html += '<thead> <tr> <th> Rotation </th> <th> Slack </th> <th colspan=2> Current </th> <th> Time Zone </th> <th> Description </th> </tr>';
     html += '<tbody>';
     for (var i = 0; i < keys.length; i++) {
       var key = keys[i];
       var person = oncall[key];
+      // get info about this rotation
+      var rotationInfo = rotationsMetadata[key];
+      var name = key;
+      var description = "";
+      var timezone = "";
+      var slack = "";
+      if (rotationInfo) {
+        if ("prettyName" in rotationInfo) {
+          name = rotationInfo["prettyName"];
+        }
+        if ("slack" in rotationInfo) {
+          slack = rotationInfo["slack"];
+        }
+        if ("description" in rotationInfo) {
+          description = rotationInfo["description"];
+        }
+        if ("timezone" in rotationInfo) {
+          timezone = rotationInfo["timezone"];
+        }
+      }
+      // add to table
       html += '<tr>';
-      html += '<td>' + key + '</td>';
+      html += '<td style="font-weight: bold">' + name + '</td>';
       if (person) {
+        html += '<td><code>' + slack + '</code></td>';
         html += '<td> <a href="https://github.com/' + person + '">' + person + ' </td>';
         html += '<td> <img src="https://github.com/' + person + '.png?size=125" alt=""></a> </td>';
+        html += '<td>' + timezone + '</td>';
+        html += '<td>' + description + '</td>';
       } else {
         html += 'None';
       }
@@ -54,11 +97,13 @@
 
   get('/kubernetes-jenkins/oncall.json', build_table);
 </script>
-<title>K8S Oncall Rotation</title>
+<title>K8s Oncall Rotations</title>
 <style>
   body {
     background-color: #eee;
-    padding-left: 30%;
+    margin-left: auto;
+    margin-right: auto;
+    text-align: center;
   }
 
   img {
@@ -74,14 +119,16 @@
     padding: 5px;
     text-align: center;
   }
+
+  #oncall {
+    display: inline-block;
+  }
 </style>
 <body>
-<h1>Kubernetes Oncall Rotation</h1>
+<h1>Kubernetes Oncall Rotations</h1>
 <p>Updated: <span id="updated">Never</span>
+<h2>NOTE: Rotations are Google-staffed, volunteer, best-effort during business-hours.</h2>
 <div id="oncall">Loading...</div>
-<div><h2>release managers: <a
-    href="https://git.k8s.io/sig-release/release-managers.md#release-managers">on GitHub</a></h2>
-</div>
-<sub><a href="https://storage.googleapis.com/kubernetes-jenkins/oncall.json">data source</a></sub>
+<div><a href="https://storage.googleapis.com/kubernetes-jenkins/oncall.json">data source</a></div>
 </body>
 </html>


### PR DESCRIPTION
- clarify scope of rotations
- add more fields to each including the slack alias, timezone, description
- remove release managers (it's confusingly unrelated / not an oncall rotation, seems to be a legacy thing going back years)
- minor nits / cleanup / CSS

it's still not the prettiest page, but it's a bit more informative.

/cc @amwat @spiffxp @MushuEE 
<img width="1155" alt="Screen Shot 2020-07-24 at 12 29 25 AM" src="https://user-images.githubusercontent.com/917931/88369656-59b9ae80-cd45-11ea-9770-135aadcac71a.png">
