### PR TITLE
Disable NodePort tests for Cilium presubmit

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits-network-plugins.yaml
@@ -197,7 +197,7 @@ presubmits:
         - --kops-args=--networking=cilium
         - --kops-priority-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64
         - --provider=aws
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|affinity.*clusterIP|CLOSE_WAIT
+        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|affinity.*clusterIP|CLOSE_WAIT|NodePort
         - --timeout=55m
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
We have to unblock presubmits.
Ref: https://github.com/kubernetes/kops/pull/9625
/cc @rifelpet @zetaab 