### PR TITLE
Remove Velodrome references in periodic jobs

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -70,25 +70,14 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-    # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-    # - name: VELODROME_INFLUXDB_CONFIG
-    #   value: /etc/velodrome-influxdb/config.json
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
         readOnly: true
-    # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-    # - name: influxdb
-    #   mountPath: /etc/velodrome-influxdb
-    #   readOnly: true
     volumes:
     - name: service
       secret:
         secretName: triage-service-account
-  # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-  # - name: influxdb
-  #   secret:
-  #     secretName: velodrome-influxdb
   annotations:
     testgrid-dashboards: sig-testing-misc
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
@@ -113,25 +102,14 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
-      # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-      # - name: VELODROME_INFLUXDB_CONFIG
-      #   value: /etc/velodrome-influxdb/config.json
       volumeMounts:
       - name: service
         mountPath: /etc/service-account
         readOnly: true
-      # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-      # - name: influxdb
-      #   mountPath: /etc/velodrome-influxdb
-      #   readOnly: true
     volumes:
     - name: service
       secret:
         secretName: triage-service-account
-    # TODO(https://github.com/kubernetes/test-infra/issues/16836): re-enable if velodrome.k8s.io becomes available
-    # - name: influxdb
-    #   secret:
-    #     secretName: velodrome-influxdb
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '12'


### PR DESCRIPTION
#16836 was created to track velodrome security issues and its once temporary removal. There are no plans to bring it back so I am am performing cleanup. 