### PR TITLE
fix github-token key name in secret

### DIFF
--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -139,7 +139,7 @@ The `github-token` is the OAuth2 token you created above for the [GitHub bot acc
 If you need to create one, go to <https://github.com/settings/tokens>.
 
 ```sh
-kubectl create secret generic github-token --from-file=github-token=/path/to/oauth/secret
+kubectl create secret generic github-token --from-file=token=/path/to/oauth/secret
 ```
 
 ### Update the sample manifest


### PR DESCRIPTION
Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

This PR fixes the github-token key name in README to match with [starter-s3.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter-s3.yaml#L369) and [starter-gcs.yaml](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/starter-gcs.yaml#L248)