### PR TITLE
force k8s-infra-prow-build jobs to be Guaranteed Pod QOS

### DIFF
--- a/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-release-blocking.yaml
@@ -45,10 +45,13 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: 14Gi
+          cpu: 7300m
         requests:
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: "9000Mi"
+          memory: 14Gi
           # during the tests more like 3-20m is used
           cpu: 7300m
 - interval: 1h
@@ -103,9 +106,12 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: 14Gi
+          cpu: 7300m
         requests:
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: "9000Mi"
+          memory: 14Gi
           # during the tests more like 3-20m is used
           cpu: 7300m

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -28,6 +28,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-gkespec
@@ -60,6 +67,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sbeta
     testgrid-tab-name: ubuntu1-k8sbeta-serial
@@ -92,6 +106,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-gkespec
@@ -124,6 +145,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable1
     testgrid-tab-name: ubuntu1-k8sstable1-serial
@@ -156,6 +184,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-gkespec
@@ -188,6 +223,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable2
     testgrid-tab-name: ubuntu1-k8sstable2-serial
@@ -220,6 +262,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-gkespec
@@ -252,6 +301,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu1-k8sstable3
     testgrid-tab-name: ubuntu1-k8sstable3-serial
@@ -284,6 +340,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-gkespec
@@ -316,6 +379,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sbeta
     testgrid-tab-name: ubuntu2-k8sbeta-serial
@@ -348,6 +418,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-gkespec
@@ -380,6 +457,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable1
     testgrid-tab-name: ubuntu2-k8sstable1-serial
@@ -412,6 +496,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-gkespec
@@ -444,6 +535,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable2
     testgrid-tab-name: ubuntu2-k8sstable2-serial
@@ -476,6 +574,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-gkespec
@@ -508,6 +613,13 @@ periodics:
       - name: GOPATH
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-dashboards: canonical-ubuntu2-k8sstable3
     testgrid-tab-name: ubuntu2-k8sstable3-serial
@@ -540,7 +652,21 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: &id001
+    requests:
+      cpu: 2000m
+      memory: 6Gi
+    limits:
+      cpu: 2000m
+      memory: 6Gi
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -573,7 +699,21 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: &id002
+    requests:
+      cpu: 1000m
+      memory: 6Gi
+    limits:
+      cpu: 1000m
+      memory: 6Gi
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sbeta
@@ -606,6 +746,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sbeta-serial
@@ -639,7 +786,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -672,7 +827,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable1
@@ -705,6 +868,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable1-serial
@@ -738,7 +908,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -771,7 +949,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable2
@@ -804,6 +990,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable2-serial
@@ -837,7 +1030,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -870,7 +1071,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu1-k8sstable3
@@ -903,6 +1112,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu1-k8sstable3-serial
@@ -936,7 +1152,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -969,7 +1193,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sbeta
@@ -1002,6 +1234,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sbeta-serial
@@ -1035,7 +1274,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1068,7 +1315,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable1
@@ -1101,6 +1356,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable1-serial
@@ -1134,7 +1396,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1167,7 +1437,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable2
@@ -1200,6 +1478,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable2-serial
@@ -1233,7 +1518,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-default
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1266,7 +1559,15 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-slow
     testgrid-dashboards: sig-release-generated, canonical-ubuntu2-k8sstable3
@@ -1299,6 +1600,13 @@ periodics:
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-ubuntu2-k8sstable3-serial
@@ -1328,6 +1636,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-reboot
@@ -1357,6 +1672,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.19-blocking
@@ -1388,7 +1710,15 @@ periodics:
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-default
     testgrid-dashboards: sig-release-1.19-blocking
@@ -1418,6 +1748,13 @@ periodics:
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-serial
@@ -1449,7 +1786,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-slow
     testgrid-dashboards: sig-release-1.19-informing
@@ -1484,6 +1829,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-alphafeatures
@@ -1513,6 +1865,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-reboot
@@ -1542,6 +1901,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.18-blocking
@@ -1572,7 +1938,15 @@ periodics:
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-default
     testgrid-dashboards: sig-release-1.18-informing
@@ -1603,6 +1977,13 @@ periodics:
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-serial
@@ -1634,7 +2015,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-slow
     testgrid-dashboards: sig-release-1.18-informing
@@ -1669,6 +2058,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-alphafeatures
@@ -1698,6 +2094,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-reboot
@@ -1727,6 +2130,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.17-blocking
@@ -1756,7 +2166,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-default
     testgrid-dashboards: sig-release-1.17-informing
@@ -1787,6 +2205,13 @@ periodics:
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-serial
@@ -1818,7 +2243,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-slow
     testgrid-dashboards: sig-release-1.17-informing
@@ -1853,6 +2286,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-alphafeatures
@@ -1882,6 +2322,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.16-blocking
@@ -1910,6 +2357,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-reboot
@@ -1940,7 +2394,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id001
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-default
     testgrid-dashboards: sig-release-1.16-informing
@@ -1971,6 +2433,13 @@ periodics:
       - --ginkgo-parallel=1
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-serial
@@ -2002,7 +2471,15 @@ periodics:
       - --ginkgo-parallel=30
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
+  resources: *id002
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-slow
     testgrid-dashboards: sig-release-1.16-informing
@@ -2037,6 +2514,13 @@ periodics:
       - --runtime-config=api/all=true
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        requests:
+          cpu: 1000m
+          memory: 3Gi
+        limits:
+          cpu: 1000m
+          memory: 3Gi
   cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-alphafeatures

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -106,6 +106,13 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 6Gi
+        requests:
+          cpu: 1
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -163,6 +170,13 @@ periodics:
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 6Gi
+        requests:
+          cpu: 1
+          memory: 6Gi
 
   annotations:
     testgrid-dashboards: sig-release-master-blocking, sig-cli-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -31,3 +31,10 @@ periodics:
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -427,6 +427,13 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-ubuntu-master-default
@@ -471,6 +478,13 @@ periodics:
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+        resources:
+          limits:
+            cpu: 2
+            memory: 6Gi
+          requests:
+            cpu: 2
+            memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
     testgrid-tab-name: gce-ubuntu-master-containerd

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -380,6 +380,13 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-default
@@ -526,6 +533,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionHash|Audit|PodPreset|RunAsGroup|TTLAfterFinished|NodeLease|CSIStorageCapacity|GenericEphemeralVolume)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-alpha-features
@@ -558,6 +572,13 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 2
+          memory: 6Gi
+        requests:
+          cpu: 2
+          memory: 6Gi
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: gce-cos-master-flaky-repro
@@ -636,6 +657,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-cos-master-reboot
@@ -667,6 +695,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-serial
@@ -698,6 +733,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+      resources:
+        limits:
+          cpu: 1
+          memory: 6Gi
+        requests:
+          cpu: 1
+          memory: 6Gi
   annotations:
     testgrid-dashboards: sig-release-master-informing, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-slow

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -33,6 +33,13 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 
 - name: ci-kubernetes-node-kubelet-alpha
   interval: 1h
@@ -159,6 +166,13 @@ periodics:
       env:
       - name: GOPATH
         value: /go
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 
 - name: ci-kubernetes-node-kubelet-flaky
   interval: 2h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -378,8 +378,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
       resources:
+        limits:
+          cpu: 6
+          memory: 20Gi
         requests:
-          cpu: "4"
+          cpu: 6
+          memory: 20Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -406,8 +406,12 @@ periodics:
       imagePullPolicy: Always
       name: ""
       resources:
+        limits:
+          cpu: "6"
+          memory: 46Gi
         requests:
           cpu: "6"
+          memory: 46Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -224,7 +224,13 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
-      resources: {}
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
   tags:
   - 'perfDashPrefix: gce-100Nodes-1.16'
   - 'perfDashJobType: performance'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -94,7 +94,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.16-informing
     testgrid-tab-name: node-kubelet-features-1.16
@@ -126,7 +132,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -522,9 +522,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 - annotations:
@@ -566,9 +569,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -28,7 +28,13 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.16
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
 - annotations:
     fork-per-release-cron: ""
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -34,7 +34,13 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 6Gi
+        requests:
+          cpu: 1
+          memory: 6Gi
 - annotations:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-alert-stale-results-hours: "24"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -434,8 +434,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
       resources:
+        limits:
+          cpu: 6
+          memory: 20Gi
         requests:
-          cpu: "4"
+          cpu: 6
+          memory: 20Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -131,7 +131,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.17-informing
     testgrid-tab-name: node-kubelet-features-1.17
@@ -163,7 +169,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -273,7 +273,13 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
-      resources: {}
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
   tags:
   - 'perfDashPrefix: gce-100Nodes-1.17'
   - 'perfDashJobType: performance'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -582,9 +582,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 - annotations:
@@ -626,9 +629,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -65,7 +65,13 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.17
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
 - annotations:
     fork-per-release-cron: 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -462,8 +462,12 @@ periodics:
       imagePullPolicy: Always
       name: ""
       resources:
+        limits:
+          cpu: "6"
+          memory: 46Gi
         requests:
           cpu: "6"
+          memory: 46Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -341,7 +341,13 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
-      resources: {}
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
   tags:
   - 'perfDashPrefix: gce-100Nodes-1.18'
   - 'perfDashJobType: performance'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -637,9 +637,12 @@ periodics:
       image: gcr.io/k8s-testimages/krte:v20200726-f8d6253-1.18
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 - annotations:
@@ -688,9 +691,12 @@ periodics:
       image: gcr.io/k8s-testimages/krte:v20200726-f8d6253-1.18
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -34,7 +34,13 @@ periodics:
       - --timeout=120m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 6Gi
+        requests:
+          cpu: 1
+          memory: 6Gi
 - annotations:
     testgrid-alert-email: kubernetes-release-team@googlegroups.com
     testgrid-alert-stale-results-hours: "24"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -439,8 +439,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
       resources:
+        limits:
+          cpu: 6
+          memory: 20Gi
         requests:
-          cpu: "4"
+          cpu: 6
+          memory: 20Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -65,7 +65,13 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
 - annotations:
     fork-per-release-cron: 0 8-23/12 * * *, 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -467,8 +467,12 @@ periodics:
       imagePullPolicy: Always
       name: ""
       resources:
+        limits:
+          cpu: "6"
+          memory: 46Gi
         requests:
           cpu: "6"
+          memory: 46Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -132,7 +132,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.18-informing
     testgrid-tab-name: node-kubelet-features-1-18
@@ -164,7 +170,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.18
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -96,7 +96,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     testgrid-dashboards: sig-node-kubelet, sig-release-1.19-informing
     testgrid-tab-name: node-kubelet-features-1.19
@@ -128,7 +134,13 @@ periodics:
         value: /go
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 6
+          memory: 6Gi
+        requests:
+          cpu: 6
+          memory: 6Gi
 - annotations:
     testgrid-alert-email: release-managers@kubernetes.io, kubernetes-release-team@googlegroups.com
     testgrid-dashboards: sig-release-1.19-blocking

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -296,7 +296,13 @@ periodics:
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
       name: ""
-      resources: {}
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi
   tags:
   - 'perfDashPrefix: gce-100Nodes-1.19'
   - 'perfDashJobType: performance'

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -586,9 +586,12 @@ periodics:
       image: gcr.io/k8s-testimages/krte:v20200726-f8d6253-1.19
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
           cpu: 7300m
-          memory: 9000Mi
+          memory: 14Gi
       securityContext:
         privileged: true
 - annotations:
@@ -637,9 +640,12 @@ periodics:
       image: gcr.io/k8s-testimages/krte:v20200726-f8d6253-1.19
       name: ""
       resources:
+        limits:
+          cpu: 7300m
+          memory: 14Gi
         requests:
-          cpu: "2"
-          memory: 9000Mi
+          cpu: 7300m
+          memory: 14Gi
       securityContext:
         privileged: true
 postsubmits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -29,7 +29,13 @@ periodics:
       - --timeout=200m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 1
+          memory: 3Gi
+        requests:
+          cpu: 1
+          memory: 3Gi
 - annotations:
     fork-per-release-cron: 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -394,8 +394,12 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-1.19
       name: ""
       resources:
+        limits:
+          cpu: 6
+          memory: 20Gi
         requests:
-          cpu: "4"
+          cpu: 6
+          memory: 20Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -422,8 +422,12 @@ periodics:
       imagePullPolicy: Always
       name: ""
       resources:
+        limits:
+          cpu: "6"
+          memory: 46Gi
         requests:
           cpu: "6"
+          memory: 46Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -169,3 +169,10 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
+      resources:
+        requests:
+          cpu: 2
+          memory: 6Gi
+        limits:
+          cpu: 2
+          memory: 6Gi

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -221,11 +221,14 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          memory: 12Gi
+          cpu: 7300m
         requests:
           # TODO(BenTheElder): adjust these everywhere
           # these are both a bit below peak usage during build
           # this is mostly for building kubernetes
-          memory: "9000Mi"
+          memory: 12Gi
           # approximately all of the build cluster node CPU, minus:
           # - GKE system reserved space based on node size
           # - network policy addon (which we shouldn't need but have enabled in wg-k8s)

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -63,5 +63,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 6
+          memory: 20Gi
         requests:
-          cpu: 4
+          cpu: 6
+          memory: 20Gi

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -80,5 +80,9 @@ periodics:
       securityContext:
         privileged: true
       resources:
+        limits:
+          cpu: 6
+          memory: 46Gi
         requests:
           cpu: 6
+          memory: 46Gi

--- a/config/tests/jobs/BUILD.bazel
+++ b/config/tests/jobs/BUILD.bazel
@@ -13,6 +13,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -960,6 +961,9 @@ func allStaticJobs() []cfg.JobBase {
 	for _, job := range c.AllPeriodics() {
 		jobs = append(jobs, job.JobBase)
 	}
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].Name < jobs[j].Name
+	})
 	return jobs
 }
 

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1006,8 +1006,8 @@ func TestK8sInfraProwBuildJobsMustHavePodQOSGuaranteed(t *testing.T) {
 func TestK8sInfraProwBuildJobsMustNotExceedTotalCapacity(t *testing.T) {
 	// k8s-infra-prow-build pool1 is 3-zonal 6-30 n1-highmem-8's
 	maxLimit := coreapi.ResourceList{
-		coreapi.ResourceCPU:    resource.MustParse("144000m"), // 3 * 6 * 8 CPUs per n1-highmem-8
-		coreapi.ResourceMemory: resource.MustParse("936Gi"),   // 3 * 6 * 52 Gi per n1-highmem-8
+		coreapi.ResourceCPU:    resource.MustParse("288000m"), // 3 * 12 * 8 CPUs per n1-highmem-8
+		coreapi.ResourceMemory: resource.MustParse("1872Gi"),  // 3 * 12 * 52 Gi per n1-highmem-8
 	}
 	resourceNames := []coreapi.ResourceName{
 		coreapi.ResourceCPU,

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -46,6 +46,13 @@ PROW_CONFIG_TEMPLATE = """
       - args:
         env:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 3Gi
+          limits:
+            cpu: 1000m
+            memory: 3Gi
 """
 
 
@@ -138,6 +145,11 @@ class E2ENodeTest:
             prow_config['cluster'] = test_suite['cluster']
         elif 'cluster' in self.job:
             prow_config['cluster'] = self.job['cluster']
+        # use resources from test_suite, or job, or default
+        if 'resources' in test_suite:
+            prow_config['resources'] = test_suite['resources']
+        elif 'resources' in self.job:
+            prow_config['resources'] = self.job['resources']
         # pull interval or cron from job
         if 'interval' in self.job:
             del prow_config['cron']
@@ -253,6 +265,11 @@ class E2ETest:
             prow_config['cluster'] = test_suite['cluster']
         elif 'cluster' in self.job:
             prow_config['cluster'] = self.job['cluster']
+        # use resources from test_suite, or job, or default
+        if 'resources' in test_suite:
+            prow_config['resources'] = test_suite['resources']
+        elif 'resources' in self.job:
+            prow_config['resources'] = self.job['resources']
         if 'interval' in self.job:
             del prow_config['cron']
             prow_config['interval'] = self.job['interval']

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -554,6 +554,13 @@ testSuites:
       --minStartupPods=8
     - --ginkgo-parallel=30
     cluster: k8s-infra-prow-build
+    resources:
+      requests:
+        cpu: 2000m
+        memory: 6Gi
+      limits:
+        cpu: 2000m
+        memory: 6Gi
   flaky:
     args:
     - --gcp-project-type=k8s-infra-gce-project
@@ -587,6 +594,13 @@ testSuites:
       --minStartupPods=8
     - --ginkgo-parallel=30
     cluster: k8s-infra-prow-build
+    resources:
+      requests:
+        cpu: 1000m
+        memory: 6Gi
+      limits:
+        cpu: 1000m
+        memory: 6Gi
   soak:
     args:
     - --check-version-skew=false


### PR DESCRIPTION
Add presubmit to enforce a policy that any jobs scheduled for k8s-infra-prow-builds must have Guaranteed Pod QOS, meaning they must have matching non-zero cpu and memory resource limits and requests.

Add guesses at resource limits for all jobs currently scheduled for k8s-infra-prow-builds.  The guesses are based off of visual inspection of memory and CPU usage on the cluster using GCP Monitoring's Metrics Explorer.  (If you can't see these links, you'll need to be a member of [k8s-infra-prow-viewers@kubernetes.io](https://github.com/kubernetes/k8s.io/blob/8e267aa1ed12b26897dbf9bb2d6c1294cdd76dbd/groups/groups.yaml#L679-L688), please PR yourself in if you'd like access):
- e.g. [memory usage for ci-kubernetes-kind-ipv2-e2e-parallel.*](https://console.cloud.google.com/monitoring/metrics-explorer?project=k8s-infra-prow-build&timeDomain=6h&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%3Dmonitoring.regex.full_match(%5C%22ci-kubernetes-kind-ipv6-e2e-parallel.*%5C%22)%22,%22minAlignmentPeriod%22:%2260s%22,%22unitOverride%22:%22By%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%226h%22%7D%7D)
- e.g. [CPU usage time for ci-kubernetes-gci-gce-scalability.*](https://console.cloud.google.com/monitoring/metrics-explorer?project=k8s-infra-prow-build&timeDomain=1h&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fcpu%2Fcore_usage_time%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%3Dmonitoring.regex.full_match(%5C%22ci-kubernetes-e2e-gci-gce-scalability.*%5C%22)%22,%22minAlignmentPeriod%22:%2260s%22,%22unitOverride%22:%22s%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_RATE%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%221d%22%7D%7D)

I erred on the side of giving some overhead for memory (avoid oomkill), and avoiding overhead for CPU spikes (some light throttling shouldn't be the end of the world)

Add a test to compare the total limits of jobs scheduled for k8s-infra-prow-build against what its current min-nodes capacity is.  It looked like we would ask for more capacity than the cluster offered with its minimum number of nodes, so I preemptively doubled the number of nodes.

The k8s-infra-prow-build cluster currently runs no presubmits, only periodics, and almost entirely release-blocking or release-informing jobs (ref: https://github.com/kubernetes/k8s.io/issues/841).  I would be interested to see if this stabilizes jobs randomly flaking over there.  If so, we could use this as a model for enforcing well behaved presubmits.