### PR TITLE
Redo BigQuery influx purge without breaking metric job

### DIFF
--- a/metrics/BUILD.bazel
+++ b/metrics/BUILD.bazel
@@ -39,7 +39,6 @@ py_binary(
         requirement("certifi"),
         requirement("chardet"),
         requirement("idna"),
-        requirement("influxdb"),
         requirement("python-dateutil"),
         requirement("pytz"),
         requirement("ruamel.yaml"),

--- a/metrics/bigquery.py
+++ b/metrics/bigquery.py
@@ -17,9 +17,7 @@
 """Runs bigquery metrics and uploads the result to GCS."""
 
 import argparse
-import calendar
 import glob
-import json
 import os
 import pipes
 import re
@@ -28,10 +26,10 @@ import sys
 import time
 import traceback
 
-import influxdb
 import requests
 import ruamel.yaml as yaml
 
+BACKFILL_DAYS = 30
 
 def check(cmd, **kwargs):
     """Logs and runs the command, raising on errors."""
@@ -66,16 +64,13 @@ def do_jq(jq_filter, data_filename, out_filename, jq_bin='jq'):
 
 
 class BigQuerier:
-    def __init__(self, project, bucket_path, backfill_days, influx_client):
+    def __init__(self, project, bucket_path):
         if not project:
             raise ValueError('project', project)
         self.project = project
         if not bucket_path:
             print('Not uploading results, no bucket specified.', file=sys.stderr)
         self.prefix = bucket_path
-
-        self.influx = influx_client
-        self.backfill_days = backfill_days
 
     def do_query(self, query, out_filename):
         """Executes a bigquery query, outputting the results to a file."""
@@ -87,7 +82,7 @@ class BigQuerier:
         ]
         with open(out_filename, 'w') as out_file:
             check(cmd, stdout=out_file)
-            print()  # bq doesn't output a trailing newline
+            out_file.write('\n')
 
     def jq_upload(self, config, data_filename):
         """Filters a data file with jq and uploads the results to GCS."""
@@ -98,38 +93,16 @@ class BigQuerier:
         self.copy(filtered, os.path.join(config['metric'], filtered))
         self.copy(filtered, latest)
 
-    def influx_upload(self, config, data_filename):
-        """Uses jq to extract InfluxDB time series points then uploads to DB."""
-        points = '%s-data-points.json' % config['metric']
-        jq_point = config.get('measurements', {}).get('jq', None)
-        if not jq_point:
-            return
-        do_jq(jq_point, data_filename, points)
-        with open(points) as points_file:
-            try:
-                points = json.load(points_file)
-            except ValueError:
-                print("No influxdb points to upload.\n", file=sys.stderr)
-                return
-        if not self.influx:
-            print((
-                'Skipping influxdb upload of metric %s, no db configured.\n'
-                % config['metric']
-            ), file=sys.stderr)
-            return
-        points = [ints_to_floats(point) for point in points]
-        self.influx.write_points(points, time_precision='s', batch_size=100)
-
     def run_metric(self, config):
         """Runs query and filters results, uploading data to GCS."""
-        raw = 'raw-%s.json' % time.strftime('%Y-%m-%d')
+        raw = '/tmp/raw-%s.json' % time.strftime('%Y-%m-%d')
 
         self.update_query(config)
         self.do_query(config['query'], raw)
         self.copy(raw, os.path.join(config['metric'], raw))
 
         consumer_error = False
-        for consumer in [self.jq_upload, self.influx_upload]:
+        for consumer in [self.jq_upload]:
             try:
                 consumer(config, raw)
             except (
@@ -137,8 +110,6 @@ class BigQuerier:
                     KeyError,
                     IOError,
                     requests.exceptions.ConnectionError,
-                    influxdb.client.InfluxDBClientError,
-                    influxdb.client.InfluxDBServerError,
                 ):
                 print(traceback.format_exc(), file=sys.stderr)
                 consumer_error = True
@@ -152,39 +123,10 @@ class BigQuerier:
         dest = os.path.join(self.prefix, dest)
         check(['gsutil', '-h', 'Cache-Control:max-age=60', 'cp', src, dest])
 
-    def update_query(self, config):
+    @staticmethod
+    def update_query(config):
         """Modifies config['query'] based on the metric configuration."""
-
-        # Currently the only modification that is supported is injecting the
-        # timestamp of the most recent influxdb data for a given metric.
-        # (For backfilling)
-        measure = config.get('measurements', {}).get('backfill')
-        if not measure:
-            return
-        if self.influx:
-            # To get the last data point timestamp we must also fetch a field.
-            # So first find a field that we can query if the metric exists.
-            points = self.influx.query('show field keys from %s limit 1' % measure)
-            points = list(points.get_points())
-
-            field = points and points[0].get('fieldKey')
-            last_time = None
-            if field:
-                results = self.influx.query(
-                    'select last(%s), time from %s limit 1' % (field, measure)
-                )
-                last_time = next(results.get_points(), {}).get('time')
-                if last_time:
-                    # format time properly
-                    last_time = time.strptime(last_time, '%Y-%m-%dT%H:%M:%SZ')
-                    last_time = calendar.timegm(last_time)
-            if not last_time:
-                last_time = int(time.time() - (60*60*24*self.backfill_days))
-        else:
-            # InfluxDB is not enabled so skip backfill so use default
-            last_time = int(time.time() - (60*60*24)*self.backfill_days)
-
-        # replace tag with formatted time
+        last_time = int(time.time() - (60*60*24)*BACKFILL_DAYS)
         config['query'] = config['query'].replace('<LAST_DATA_TIME>', str(last_time))
 
 
@@ -192,30 +134,6 @@ def all_configs(search='**.yaml'):
     """Returns config files in the metrics dir."""
     return glob.glob(os.path.join(
         os.path.dirname(__file__), 'configs', search))
-
-
-def make_influx_client():
-    """Make an InfluxDB client from config at path $VELODROME_INFLUXDB_CONFIG"""
-    if 'VELODROME_INFLUXDB_CONFIG' not in os.environ:
-        return None
-
-    with open(os.environ['VELODROME_INFLUXDB_CONFIG']) as config_file:
-        config = json.load(config_file)
-
-    def check_config(field):
-        if not field in config:
-            raise ValueError('DB client config needs field \'%s\'' % field)
-    check_config('host')
-    check_config('port')
-    check_config('user')
-    check_config('password')
-    return influxdb.InfluxDBClient(
-        host=config['host'],
-        port=config['port'],
-        username=config['user'],
-        password=config['password'],
-        database='metrics',
-    )
 
 
 def ints_to_floats(point):
@@ -229,9 +147,9 @@ def ints_to_floats(point):
     return point
 
 
-def main(configs, project, bucket_path, backfill_days):
+def main(configs, project, bucket_path):
     """Loads metric config files and runs each metric."""
-    queryer = BigQuerier(project, bucket_path, backfill_days, make_influx_client())
+    queryer = BigQuerier(project, bucket_path)
 
     # the 'bq show' command is called as a hack to dodge the config prompts that bq presents
     # the first time it is run. A newline is passed to stdin to skip the prompt for default project
@@ -273,11 +191,6 @@ if __name__ == '__main__':
     PARSER.add_argument(
         '--bucket',
         help='Upload results to the specified gcs bucket.')
-    PARSER.add_argument(
-        '--backfill-days',
-        default=30,
-        type=int,
-        help='Number of days to backfill influxdb data.')
 
     ARGS = PARSER.parse_args()
-    main(ARGS.config, ARGS.project, ARGS.bucket, ARGS.backfill_days)
+    main(ARGS.config, ARGS.project, ARGS.bucket)

--- a/metrics/bigquery.py
+++ b/metrics/bigquery.py
@@ -95,7 +95,7 @@ class BigQuerier:
 
     def run_metric(self, config):
         """Runs query and filters results, uploading data to GCS."""
-        raw = '/tmp/raw-%s.json' % time.strftime('%Y-%m-%d')
+        raw = 'raw-%s.json' % time.strftime('%Y-%m-%d')
 
         self.update_query(config)
         self.do_query(config['query'], raw)

--- a/metrics/configs/build-stats.yaml
+++ b/metrics/configs/build-stats.yaml
@@ -30,19 +30,3 @@ jqfilter: |
     passes: (.passes|tonumber),
     rate: (.rate|tonumber)
   })]
-
-measurements:
-  backfill: build_stats
-  jq: |
-    [(.[] | {
-      measurement: "build_stats",
-      time: (.day|tonumber),
-      tags: {
-        day: (.day|tonumber)
-      },
-      fields: {
-        invocations: (.invocations|tonumber),
-        passes: (.passes|tonumber),
-        rate: (.rate|tonumber)
-      }
-    })]

--- a/metrics/configs/failures-config.yaml
+++ b/metrics/configs/failures-config.yaml
@@ -39,21 +39,9 @@ query: |
   ) passes
   on jobs.job = passes.job
   order by broken_days desc, latest_pass, first_run, weekly_builds desc, jobs.job
-  
+
 jqfilter: |
   [(.[] | select((.latest_pass|length) == 0 or (.broken_days|tonumber) > 30)
   | {(.job): {
       failing_days: (.broken_days|tonumber)
   }})] | add
-
-measurements:
-  jq: |
-    [(.[] | {
-      measurement: "failures",
-      tags: {
-        job: (.job)
-      },
-      fields: {
-        job: (.job),
-        failing_days: (.broken_days|tonumber)
-    }})]

--- a/metrics/configs/flakes-config.yaml
+++ b/metrics/configs/flakes-config.yaml
@@ -98,20 +98,3 @@ jqfilter: |
       flakiest: ([(.flakiest[] | select(.flakes|tonumber >= 4) | {
         (.name): (.flakes|tonumber)}) ])| add
   }})] | add
-
-# No backfilling is used since this metric is only used to display a table with the currently flaky jobs/tests.
-measurements:
-  jq: |
-    [(.[] | {
-      measurement: "flakes",
-      tags: {
-        job: (.job)
-      },
-      fields: {
-        consistency: (.commit_consistency|tonumber),
-        flakes: (.flakes|tonumber),
-        flakiest: (if (.flakiest | has(0)) then (.flakiest[0].flakes + " flakes: " + .flakiest[0].name) else ("") end),
-        flakier: (if (.flakiest | has(1)) then (.flakiest[1].flakes + " flakes: " + .flakiest[1].name) else ("") end),
-        flaky: (if (.flakiest | has(2)) then (.flakiest[2].flakes + " flakes: " + .flakiest[2].name) else ("") end)
-      }
-    })]

--- a/metrics/configs/flakes-daily-config.yaml
+++ b/metrics/configs/flakes-daily-config.yaml
@@ -87,24 +87,3 @@ jqfilter: |
     build: (.builds|tonumber),
     consistent_builds: (.consistent_builds|tonumber)
   }})] | add
-
-measurements:
-  backfill: flakes_daily
-  jq: |
-    [(.[] | {
-      measurement: "flakes_daily",
-      time: (.day|tonumber),
-      tags: {
-        job: (.job),
-        day: (.day|tonumber)
-      },
-      fields: {
-        flakes: (.flakes|tonumber),
-        commit_consistency: (.commit_consistency|tonumber),
-        commits: (.commits|tonumber),
-        consistent_commits: (.consistent_commits|tonumber),
-        build_consistency: (.build_consistency|tonumber),
-        builds: (.builds|tonumber),
-        consistent_builds: (.consistent_builds|tonumber)
-      }
-    })]

--- a/metrics/configs/job-health.yaml
+++ b/metrics/configs/job-health.yaml
@@ -65,22 +65,3 @@ jqfilter: |
     p75_duration: (.p75_duration|tonumber),
     p99_duration: (.p99_duration|tonumber),
   })]
-measurements:
-  backfill: job_health
-  jq: |
-    [(.[] | {
-      measurement: "job_health",
-      time: (.day|tonumber),
-      tags: {
-        job: .job,
-      },
-      fields: {
-        runs: (.runs|tonumber),
-        failure_rate: (.failure_rate|tonumber),
-        tests: (.tests|tonumber),
-        test_failure_rate: (.test_failure_rate|tonumber),
-        p50_duration: (.p50_duration|tonumber),
-        p75_duration: (.p75_duration|tonumber),
-        p99_duration: (.p99_duration|tonumber),
-      }
-    })]

--- a/metrics/configs/pr-consistency-config.yaml
+++ b/metrics/configs/pr-consistency-config.yaml
@@ -70,23 +70,3 @@ jqfilter: |
     consistent_runs: (.consistent_runs|tonumber),
     builds: (.builds|tonumber)
   })]
-
-measurements: 
-  backfill: pr_consistency
-  jq: |
-    [(.[] | {
-      measurement: "pr_consistency",
-      time: (.day|tonumber),
-      tags: {
-        day: (.day|tonumber)
-      },
-      fields: {
-        commit_consistency: (.commit_consistency|tonumber),
-        commits: (.commits|tonumber),
-        consistent_commits: (.consistent_commits|tonumber),
-        run_consistency: (.run_consistency|tonumber),
-        runs: (.runs|tonumber),
-        consistent_runs: (.consistent_runs|tonumber),
-        builds: (.builds|tonumber)
-      }
-    })]

--- a/metrics/configs/presubmit-health.yaml
+++ b/metrics/configs/presubmit-health.yaml
@@ -71,21 +71,3 @@ jqfilter: |
     avg_run_time_minutes: (.avg_run_time_minutes|tonumber),
     avg_pass_time_minutes: (.avg_pass_time_minutes|tonumber),
   })]
-measurements:
-  backfill: presubmit_health
-  jq: |
-    [(.[] | {
-      measurement: "presubmit_health",
-      time: (.day|tonumber),
-      tags: {
-        job: .job,
-      },
-      fields: {
-        pr_failure_perc: (.pr_failure_perc|tonumber),
-        prs: (.prs|tonumber),
-        prs_failed: (.prs_failed|tonumber),
-        total_runs: (.total_runs|tonumber),
-        avg_run_time_minutes: (.avg_run_time_minutes|tonumber),
-        avg_pass_time_minutes: (.avg_pass_time_minutes|tonumber),
-      }
-    })]


### PR DESCRIPTION
This was done previously as part of #18394 but had an issue with config update
That issue was fixed and tested as well as extra cleanup
/assign @spiffxp 

@spiffxp you were correct the LAST_DATA_TIME was not being replace and it was causing the query to break