### PR TITLE
Onboard kubernetes-client org to the hmac tool

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -93,6 +93,8 @@ managed_webhooks:
   org_repo_config:
     bazelbuild/rules_k8s:
       token_created_after: 2020-06-24T00:10:00Z
+    kubernetes-client:
+      token_created_after: 2020-07-24T00:00:00Z
 
 slack_reporter_configs:
   '*':


### PR DESCRIPTION
Onboard kubernetes-client org to the hmac tool.

/cc @cjwagner 

Note:
https://github.com/kubernetes/org/blob/master/config/kubernetes-client/org.yaml#L12 shows `k8s-ci-robot` is admin of this org, but https://github.com/orgs/kubernetes-client/people?query=k8s-ci-robot shows it does not exist, we need to double check before getting this PR merged.