### PR TITLE
releng: Update variants (kubekins, krte) to use go1.15rc1

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,26 +1,26 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.14.6
+    GO_VERSION: 1.15rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15beta1
+    GO_VERSION: 1.15rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   master:
     CONFIG: master
-    GO_VERSION: 1.14.6
+    GO_VERSION: 1.15rc1
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.14.6
+    GO_VERSION: 1.15rc1
     K8S_RELEASE: latest-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Update variants (kubekins, krte) to use go1.15rc1 (https://github.com/kubernetes/release/issues/1421)

/assign @BenTheElder @spiffxp 
cc: @kubernetes/release-engineering @liggitt @dims  

/hold for the k/k update in https://github.com/kubernetes/kubernetes/pull/93264