### PR TITLE
pass s3-credentials-file arg to deck

### DIFF
--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -371,6 +371,7 @@ spec:
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
         - --plugin-config=/etc/plugins/plugins.yaml
+        - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --spyglass=true
         ports:
           - name: http


### PR DESCRIPTION
Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

This PR adds missing s3-credentials-file in deck args to starter-s3.yaml.

Error:
```error rendering spyglass page: error when resolving real path s3/prow-logs/logs/echo-test/1287312016553283584: blob (key "logs/echo-test/1287312016553283584.txt") (code=Unknown): MissingRegion: could not find region configuration```