### PR TITLE
presubmit (on demand) dual stack job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -1,3 +1,57 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-e2e-kind-dual-canary
+    optional: true
+    always_run: false
+    skip_report: false
+    decorate: true
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/krte:v20200720-4766100-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://github.com/aojea/kind/releases/download/dualstack/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FOCUS
+          value: \[Conformance\]|DualStack
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
+        # tell kind CI script to use DualStack
+        - name: "IP_FAMILY"
+          value: "DualStack"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "4000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-network-kind
+      testgrid-tab-name: sig-network-kind, dual
+      description: Runs tests against a Dual Stack Kubernetes in Docker cluster
+      testgrid-alert-email: antonio.ojea.garcia@gmail.com
+
 periodics:
 # network test against kubernetes master branch with `kind`
 - interval: 6h

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -410,6 +410,11 @@ dashboards:
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
+  - name: pull-kubernetes-e2e-kind-dual-canary
+    test_group_name: pull-kubernetes-e2e-kind-dual-canary
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: antonio.ojea.garcia@gmail.com
   - name: pull-kubernetes-e2e-aks-engine-azure
     test_group_name: pull-kubernetes-e2e-aks-engine-azure
     base_options: width=10


### PR DESCRIPTION
This will allow to run an e2e test with a temporal kind version
that supports dual stack. It just need to add a comment in the PR

`/test pull-kubernetes-e2e-kind-conformance-dual`

Adding the job will help to review PRs related to dual stack and
avoid regressions.