### PR TITLE
Enable mergecommitblocker for image-builder repo

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -892,6 +892,9 @@ plugins:
   kubernetes-sigs/cluster-api-bootstrap-provider-kubeadm:
   - milestone
 
+  kubernetes-sigs/image-builder:
+  - mergecommitblocker
+
   kubernetes-sigs/etcdadm:
   - milestone
 


### PR DESCRIPTION
This PR enables the `mergecommitblocker` plugin on the `kubernetes-sigs/image-builder` repo. This is to discourage (block) PRs that include merge commits -- PRs should be rebased off the default branch instead.

/cc @cblecker @dims 