### PR TITLE
Adds windows-private-registry-cred preset

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -813,6 +813,7 @@ periodics:
     preset-azure-cred: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
+    preset-windows-private-registry-cred: "true"
   extra_refs:
   - org: kubernetes
     repo: kubernetes

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -688,6 +688,19 @@ presets:
     mountPath: /etc/aws-ssh
     readOnly: true
 - labels:
+    preset-windows-private-registry-cred: "true"
+  env:
+  - name: DOCKER_CONFIG_FILE
+    value: /etc/docker-cred/config.json
+  volumes:
+  - name: windows-private-registry-cred
+    secret:
+      secretName: windows-private-registry-docker-config
+  volumeMounts:
+  - name: windows-private-registry-cred
+    mountPath: /etc/docker-cred/
+    readOnly: true
+- labels:
     preset-azure-cred: "true"
   env:
   - name: AZURE_CREDENTIALS


### PR DESCRIPTION
The secret windows-private-registry-docker-config has been created recently, and it contains a docker ``config.json`` file that contains credentials to a private docker registry image, that can be used for the test:

    [k8s.io] Container Runtime blackbox test when running a container with a new image should be able to pull from private registry with secret [NodeConformance]

The image is ``e2eprivate/windows-nanoserver:v1`` is a manifest list that contains a nanoserver image for 1809, 1903, 1909, 2004, and will contain future releases as well.

/sig windows
/sig testing

Fixes-Issue: https://github.com/kubernetes/kubernetes/issues/93048