### PR TITLE
Fix aws-janitor command

### DIFF
--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -9,7 +9,7 @@ periodics:
   spec:
     containers:
     - command:
-      - /app/boskos/aws-janitor/app.binary
+      - /app
       args:
       - --ttl=2h30m
       - --path=s3://k8s-kops-prow/objs.json


### PR DESCRIPTION
https://testgrid.k8s.io/sig-testing-maintenance#ci-aws-janitor

aws-janitor has been failing since July 23rd. The logs suggest the binary's location in the image has changed:

> could not start the process: fork/exec /app/boskos/aws-janitor/app.binary: not a directory

Pulling the image locally I found it is now located at `/app`:

```
$ docker run -it --rm --entrypoint=/app gcr.io/k8s-staging-boskos/aws-janitor:v20200717-7299d53 --help
Usage of /app:
  -all
    	Clean all resources (ignores -path)
...
```

As a side note, I noticed that with the migration to the boskos GH project the images are being [published to a new location](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-boskos-push-images/1284188402433921028) which this job does not reference. Should this job be updated to also use the new location? and if so, will the image autobumper still bump this job's image?

`gcr.io/k8s-infra-prow-build-trusted/aws-janitor:v20200717-7299d53`

