### PR TITLE
Kettle parsing fails if 'time' key is ''

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -126,7 +126,7 @@ def parse_junit(xml):
     # isn't very interesting.
 
     def parse_result(child_node):
-        time = float(child_node.attrib.get('time', 0))
+        time = float(child_node.attrib.get('time', 0) or 0) #time val can be ''
         failure_text = None
         for param in child_node.findall('failure'):
             failure_text = param.text

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -126,7 +126,7 @@ def parse_junit(xml):
     # isn't very interesting.
 
     def parse_result(child_node):
-        time = float(child_node.attrib.get('time', 0) or 0) #time val can be ''
+        time = float(child_node.attrib.get('time') or 0) #time val can be ''
         failure_text = None
         for param in child_node.findall('failure'):
             failure_text = param.text


### PR DESCRIPTION
Quick fix, hit
```
Traceback (most recent call last):
  File "make_json.py", line 278, in make_rows
    yield rowid, row_for_build(path, started, finished, results)
  File "make_json.py", line 218, in row_for_build
    for test in parse_junit(result):
  File "make_json.py", line 139, in parse_junit
    time, failure_text, skipped = parse_result(child)
  File "make_json.py", line 129, in parse_result
    time = float(child_node.attrib.get('time', 0))
ValueError: could not convert string to float: ''
```
If time is empty str
/assign @spiffxp 