### PR TITLE
Kettle repos was getting overwrote if metadata didn't exist

### DIFF
--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -240,6 +240,7 @@ py_binary(
         requirement("influxdb"),
         requirement("isort"),
         requirement("lazy-object-proxy"),
+        requirement("parameterized"),
         requirement("pylint"),
         requirement("pytz"),
         requirement("PyYAML"),

--- a/kettle/BUILD.bazel
+++ b/kettle/BUILD.bazel
@@ -82,7 +82,10 @@ py_test(
     ],
     data = [":buckets.yaml"],
     python_version = "PY3",
-    deps = [requirement("ruamel.yaml")],
+    deps = [
+        requirement("ruamel.yaml"),
+        requirement("parameterized"),
+    ],
 )
 
 filegroup(

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -98,7 +98,7 @@ class Build:
 
     def populate_meta(self, metadata, repos):
         self.metadata = metadata
-        self.repos = repos
+        self.repos = self.repos if self.repos else repos
 
     def set_elapsed(self):
         if self.started and self.finished:
@@ -126,7 +126,7 @@ def parse_junit(xml):
     # isn't very interesting.
 
     def parse_result(child_node):
-        time = float(child_node.attrib.get('time', 0))
+        time = float(child_node.attrib.get('time') or 0) #time val can be ''
         failure_text = None
         for param in child_node.findall('failure'):
             failure_text = param.text

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -19,6 +19,8 @@ import json
 import time
 import unittest
 
+from parameterized import parameterized
+
 import make_json
 import model
 
@@ -33,6 +35,257 @@ class ValidateBuckets(unittest.TestCase):
             self.assertNotEqual(prefix, '', 'bucket %s must have a prefix' % name)
             self.assertNotIn(prefix, prefixes, "bucket %s prefix %r isn't unique" % (name, prefix))
             self.assertEqual(prefix[-1], ':', "bucket %s prefix should be %s:" % (name, prefix))
+
+
+class GenerateBuilds(unittest.TestCase):
+    @parameterized.expand([
+        (
+            "Basic_pass",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': False}],
+            None,
+            None,
+            None,
+            None,
+            {
+                'job': 'pr:pr-logs',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': False}],
+                'tests_run': 1,
+                'tests_failed':0,
+            },
+        ),
+        (
+            "Basic_fail",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': True}],
+            None,
+            None,
+            None,
+            None,
+            {
+                'job': 'pr:pr-logs',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': True}],
+                'tests_run': 1,
+                'tests_failed':1,
+            },
+        ),
+        (
+            "Ci_decorated",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': True}],
+            {
+                "timestamp":1595284709,
+                "repos":{"kubernetes/kubernetes":"master"},
+                "repo-version":"5a529aa3a0dd3a050c5302329681e871ef6c162e",
+            },
+            {
+                "timestamp":1595286616,
+                "passed":True,
+                "result":"SUCCESS",
+                "revision":"master",
+            },
+            None,
+            None,
+            {
+                'job': 'pr:pr-logs',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': True}],
+                'passed': True,
+                'result': 'SUCCESS',
+                'elapsed': 1907,
+                'tests_run': 1,
+                'tests_failed':1,
+                'started': 1595284709,
+                'finished': 1595286616,
+                'repo_commit': '5a529aa3a0dd3a050c5302329681e871ef6c162e',
+                'repos': {"kubernetes/kubernetes":"master"},
+            },
+        ),
+        (
+            "Pr_decorated",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': True}],
+            {
+                "timestamp":1595277241,
+                "pull":"93264",
+                "repos":{"kubernetes/kubernetes":"master:5feab0"},
+                "repo-version":"30f64c5b1fc57a3beb1476f9beb29280166954d1",
+            },
+            {
+                "timestamp":1595279434,
+                "passed":True,
+                "result":"SUCCESS",
+                "revision":"5dd9241d43f256984358354d1fec468f274f9ac4"
+            },
+            None,
+            None,
+            {
+                'job': 'pr:pr-logs',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': True}],
+                'passed': True,
+                'result': 'SUCCESS',
+                'elapsed': 2193,
+                'tests_run': 1,
+                'tests_failed':1,
+                'started': 1595277241,
+                'finished': 1595279434,
+                'repo_commit': '30f64c5b1fc57a3beb1476f9beb29280166954d1',
+                'repos': {"kubernetes/kubernetes":"master:5feab0"},
+            },
+        ),
+        (
+            "Pr_bootstrap",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': True}],
+            {
+                "node": "0790211c-cacb-11ea-a4b9-4a19d9b965b2",
+                "pull": "master:5a529",
+                "repo-version": "v1.20.0-alpha.0.261+06ea384605f172",
+                "timestamp": 1595278460,
+                "repos": {
+                    "k8s.io/kubernetes": "master:5a529",
+                    "k8s.io/release": "master"
+                },
+                "version": "v1.20.0-alpha.0.261+06ea384605f172"
+            },
+            {
+                "timestamp": 1595282312,
+                "version": "v1.20.0-alpha.0.261+06ea384605f172",
+                "result": "SUCCESS",
+                "passed": True,
+                "job-version": "v1.20.0-alpha.0.261+06ea384605f172",
+            },
+            {
+                "node_os_image": "cos-81-12871-59-0",
+                "infra-commit": "2a9a0f868",
+                "repo": "k8s.io/kubernetes",
+                "master_os_image": "cos-81-12871-59-0",
+            },
+            {
+                "k8s.io/kubernetes": "master:5a529",
+                "k8s.io/release": "master"
+            },
+            {
+                'job': 'pr:pr-logs',
+                'executor': '0790211c-cacb-11ea-a4b9-4a19d9b965b2',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': True}],
+                'passed': True,
+                'result': 'SUCCESS',
+                'elapsed': 3852,
+                'tests_run': 1,
+                'tests_failed':1,
+                'started': 1595278460,
+                'finished': 1595282312,
+                'version': 'v1.20.0-alpha.0.261+06ea384605f172',
+                'repo_commit': 'v1.20.0-alpha.0.261+06ea384605f172',
+                'repos': {'k8s.io/kubernetes': 'master:5a529', 'k8s.io/release': 'master'},
+                'metadata': {
+                    "node_os_image": "cos-81-12871-59-0",
+                    "infra-commit": "2a9a0f868",
+                    "repo": "k8s.io/kubernetes",
+                    "master_os_image": "cos-81-12871-59-0",
+                },
+            },
+        ),
+        (
+            "Ci_bootstrap",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': True}],
+            {
+                "timestamp":1595263104,
+                "node":"592473ae-caa7-11ea-b130-525df2b76a8d",
+                "repos":{
+                    "k8s.io/kubernetes":"master",
+                    "k8s.io/release":"master"
+                },
+                "repo-version":"v1.20.0-alpha.0.255+5feab0aa1e592a",
+            },
+            {
+                "timestamp": 1595263185,
+                "version": "v1.20.0-alpha.0.255+5feab0aa1e592a",
+                "result": "SUCCESS",
+                "passed": True,
+                "job-version": "v1.20.0-alpha.0.255+5feab0aa1e592a",
+            },
+            {
+                "repo": "k8s.io/kubernetes",
+                "repos": {
+                    "k8s.io/kubernetes": "master",
+                    "k8s.io/release": "master"
+                },
+                "infra-commit": "5f39b744b",
+                "repo-commit": "5feab0aa1e592ab413b461bc3ad08a6b74a427b4"
+            },
+            {
+                "k8s.io/kubernetes":"master",
+                "k8s.io/release":"master"
+            },
+            {
+                'job': 'pr:pr-logs',
+                'executor': '592473ae-caa7-11ea-b130-525df2b76a8d',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': True}],
+                'passed': True,
+                'result': 'SUCCESS',
+                'elapsed': 81,
+                'tests_run': 1,
+                'tests_failed':1,
+                'started': 1595263104,
+                'finished': 1595263185,
+                'version': 'v1.20.0-alpha.0.255+5feab0aa1e592a',
+                'repo_commit': 'v1.20.0-alpha.0.255+5feab0aa1e592a',
+                'repos': {'k8s.io/kubernetes': 'master', 'k8s.io/release': 'master'},
+                'metadata': {
+                    "repo": "k8s.io/kubernetes",
+                    "repos": {
+                        "k8s.io/kubernetes": "master",
+                        "k8s.io/release": "master"
+                    },
+                    "infra-commit": "5f39b744b",
+                    "repo-commit": "5feab0aa1e592ab413b461bc3ad08a6b74a427b4"
+                },
+            },
+        ),
+        (
+            "Started_no_meta_repo",
+            "gs://kubernetes-jenkins/pr-logs/path",
+            [{'name': "Test1", 'failed': False}],
+            {
+                "timestamp":1595263104,
+                "node":"592473ae-caa7-11ea-b130-525df2b76a8d",
+                "repos":{
+                    "k8s.io/kubernetes":"master",
+                    "k8s.io/release":"master"
+                },
+                "repo-version":"v1.20.0-alpha.0.255+5feab0aa1e592a",
+            },
+            None,
+            None,
+            None,
+            {
+                'job': 'pr:pr-logs',
+                'executor': '592473ae-caa7-11ea-b130-525df2b76a8d',
+                'path': 'gs://kubernetes-jenkins/pr-logs/path',
+                'test': [{'name': 'Test1', 'failed': False}],
+                'tests_run': 1,
+                'tests_failed':0,
+                'repo_commit': 'v1.20.0-alpha.0.255+5feab0aa1e592a',
+                'repos': {'k8s.io/kubernetes': 'master', 'k8s.io/release': 'master'},
+                'started': 1595263104,
+            },
+        ),
+    ])
+    def test_gen_build(self, _, path, tests, started, finished, metadata, repos, expected):
+        self.maxDiff = None
+        build = make_json.Build.generate(path, tests, started, finished, metadata, repos)
+        build_dict = build.as_dict()
+        self.assertEqual(build_dict, expected)
+
+
 
 
 class MakeJsonTest(unittest.TestCase):

--- a/requirements3.txt
+++ b/requirements3.txt
@@ -4,6 +4,7 @@ configparser==4.0.2
 influxdb==5.2.3
 isort==4.3.21
 pylint==2.4.4
+parameterized==0.7.4
 PyYAML==5.3
 ruamel.yaml==0.16.5
 setuptools==44.0.0


### PR DESCRIPTION
Small bug, code was overwriting the `repos` attr after being set in started, so if `repos` was None from Metadata, it would be set back to None and not populated in BQ