### PR TITLE
Tune memory down for ci-kubernetes-verify jobs

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -436,10 +436,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
         requests:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -498,10 +498,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
         requests:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -503,10 +503,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
         requests:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -452,10 +452,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
         requests:
           cpu: "6"
-          memory: 46Gi
+          memory: 42Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -82,7 +82,7 @@ periodics:
       resources:
         limits:
           cpu: 6
-          memory: 46Gi
+          memory: 42Gi
         requests:
           cpu: 6
-          memory: 46Gi
+          memory: 42Gi


### PR DESCRIPTION
46Gb seems to be unschedulable

Followup to https://github.com/kubernetes/test-infra/pull/18471