### PR TITLE
Enable release-note bugging for gcp filestore

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -844,6 +844,9 @@ plugins:
   kubernetes-sigs/gcp-compute-persistent-disk-csi-driver:
   - release-note
 
+  kubernetes-sigs/gcp-filestore-csi-driver:
+  - release-note
+
   kubernetes-sigs/boskos:
   - override
 


### PR DESCRIPTION
Repository: kubernetes-sigs/gcp-filestore-csi-driver