### PR TITLE
Add --tag-match flag to image builder

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -27,4 +27,6 @@ postsubmits:
               # This is the same as above, but with -gcb appended.
               - --scratch-bucket=gs://k8s-staging-descheduler-gcb
               - --env-passthrough=PULL_BASE_REF
+              # This makes sure that only tags matching, eg v0.18.0 get published (and not Helm chart tags)
+              - --tag-match="v*"
               - .


### PR DESCRIPTION
This adds an optional --tag-match flag to the image builder, which is ultimately just
parsed into the `--matches` flag for `git describe --tags`, when determining the version to
tag the image.

The use case for this is to set a specific format of tag for a particular job, rather than
defaulting to the latest tag on the branch.

For example, in the Descheduler (https://github.com/kubernetes-sigs/descheduler) we publish
a tag for our release, followed by an automated tag for our Helm chart release. Because the Helm
chart tag comes after the actual release tag, all the staging images pushed after that are tagged
with the *Helm chart's* version, rather than the *Descheduler's* version (these 2 versions can
technically differ).

With this, we will be able to set `--tag-match="v*"` to make sure our staging images are tagged
with the actual version tag, rather than just the Helm chart.