### PR TITLE
Update HNC presubmits to use Go 1.14

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-presubmit.yaml
@@ -9,6 +9,6 @@ presubmits:
     run_if_changed: "incubator/hnc/.*"
     spec:
       containers:
-      - image: golang:1.13
+      - image: golang:1.14
         command:
         - ./incubator/hnc/hack/ci-test.sh


### PR DESCRIPTION
HNC switched to Go 1.14 months ago, our presubmits should too.

Tested: none, I don't know how but I'm willing to risk a breakage.