### PR TITLE
Remove duplicate fast flag from kubernetes build

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -147,7 +147,6 @@ def main(args):
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(
         'Build and push.')
-    PARSER.add_argument('--fast', action='store_true', help='Build quickly')
     PARSER.add_argument(
         '--release', help='Upload binaries to the specified gs:// path')
     PARSER.add_argument(


### PR DESCRIPTION
The --fast flag is specified twice in kubernetes_build.py, causing
argparse to error with conflicts when passing arguments.

See https://github.com/kubernetes/test-infra/pull/18290/commits/751e5de21c0724fd607b1d0ebc96376035b9a744 for context.

Causing failure in `build-master-fast`: https://testgrid.k8s.io/sig-release-master-blocking#build-master-fast

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @justaugustus 