### PR TITLE
Bump ci-kubernetes-verify-* memory to 24 Gi

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -436,10 +436,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -498,10 +498,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -503,10 +503,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -452,10 +452,10 @@ periodics:
       resources:
         limits:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: "6"
-          memory: 16Gi
+          memory: 24Gi
       securityContext:
         privileged: true
 - annotations:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -82,7 +82,7 @@ periodics:
       resources:
         limits:
           cpu: 6
-          memory: 16Gi
+          memory: 24Gi
         requests:
           cpu: 6
-          memory: 16Gi
+          memory: 24Gi


### PR DESCRIPTION
Verify jobs are routinely hitting OOM exceptions on typecheck. This
gives them a little more room but not so much that large outliers will
not surface as failures.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Part 3 of #18508 

/cc @spiffxp @BenTheElder

This will get these jobs running again but I want to look into the infrequent spikes where nearly double the amount of memory is used. Helpful query: https://console.cloud.google.com/monitoring/metrics-explorer?project=k8s-infra-prow-build&timeDomain=6h&pageState=%7B%22xyChart%22:%7B%22dataSets%22:%5B%7B%22timeSeriesFilter%22:%7B%22filter%22:%22metric.type%3D%5C%22kubernetes.io%2Fcontainer%2Fmemory%2Fused_bytes%5C%22%20resource.type%3D%5C%22k8s_container%5C%22%20metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%3Dmonitoring.regex.full_match(%5C%22ci-kubernetes-verify-.*%5C%22)%22,%22minAlignmentPeriod%22:%2260s%22,%22unitOverride%22:%22By%22,%22aggregations%22:%5B%7B%22perSeriesAligner%22:%22ALIGN_MEAN%22,%22crossSeriesReducer%22:%22REDUCE_SUM%22,%22groupByFields%22:%5B%22metadata.user_labels.%5C%22prow.k8s.io%2Fjob%5C%22%22%5D%7D,%7B%22crossSeriesReducer%22:%22REDUCE_NONE%22%7D%5D%7D,%22targetAxis%22:%22Y1%22,%22plotType%22:%22LINE%22%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22constantLines%22:%5B%5D,%22timeshiftDuration%22:%220s%22,%22y1Axis%22:%7B%22label%22:%22y1Axis%22,%22scale%22:%22LINEAR%22%7D%7D,%22isAutoRefresh%22:true,%22timeSelection%22:%7B%22timeRange%22:%226h%22%7D%7D