### PR TITLE
version-markers: Remove usage of the ci/k8s-master marker

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -50,10 +50,10 @@ periodics:
       args:
       - --cluster=e2e-kops-gce-latest.k8s.local
       - --deployment=kops
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --ginkgo-parallel
       # Temporarily use default service account: https://github.com/kubernetes/test-infra/issues/17558
       #- --kops-args=--gce-service-account=pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -127,9 +127,9 @@ periodics:
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --ginkgo-parallel
       - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
@@ -162,9 +162,9 @@ periodics:
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/k8s-master.txt
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release-dev/ci/latest.txt
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --ginkgo-parallel
       - --kops-args=--node-size=c6g.large --node-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20200701
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -72,7 +72,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -91,7 +91,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-releases, sig-release-master-informing
     testgrid-tab-name: gce-windows-2019-master
     description: Runs tests on a Kubernetes cluster with Windows 2019 nodes on GCE
@@ -117,7 +117,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -136,7 +136,7 @@ periodics:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200726-f8d6253-master
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/k8s-master -> --extract=ci/k8s-beta"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
     testgrid-dashboards: google-windows, sig-windows-sac, sig-windows-gce, sig-release-master-informing
     testgrid-tab-name: gce-windows-1909-master
     description: Runs tests on a Kubernetes cluster with Windows 1909 nodes on GCE
@@ -162,7 +162,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -209,7 +209,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=1
       - --provider=gce
@@ -254,7 +254,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -363,7 +363,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1
@@ -419,7 +419,7 @@ periodics:
       args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-master
+      - --extract=ci/latest
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --gcp-nodes=1


### PR DESCRIPTION
(Follow-up to https://github.com/kubernetes/test-infra/pull/18290.)

[Now](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-build/1288265272272097280) that the `ci/latest` version marker again represents a cross build of `kubernetes/kubernetes@master`, we should stop using the `ci/k8s-master` generic version marker.

ref: https://github.com/kubernetes/test-infra/blob/master/docs/kubernetes-versions.md, https://github.com/kubernetes/sig-release/issues/850

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

cc: @kubernetes/release-engineering @BenTheElder @spiffxp 
