### PR TITLE
releng: Version marker cleanup continued

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -4,7 +4,7 @@ periodics:
   name: ci-kubernetes-gce-conformance-latest
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
+    fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, conformance-all, conformance-gce
     testgrid-tab-name: Conformance - GCE - master
     description: Runs conformance tests using kubetest against kubernetes master on GCE

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -18,7 +18,7 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
   annotations:
     fork-per-release: "true"
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
+    fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}"
     fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-device-plugin-gpu-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -18,7 +18,7 @@ periodics:
     preset-ci-gce-device-plugin-gpu: "true"
   annotations:
     fork-per-release: "true"
-    fork-per-release-generic-suffix: "true"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
     fork-per-release-cron: 0 0-23/2 * * *, 0 3-23/6 * * *, 0 8-23/12 * * *, 0 8-23/24 * * *
     testgrid-dashboards: sig-release-master-blocking, google-gce
     testgrid-tab-name: gce-device-plugin-gpu-master

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -100,7 +100,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --extract=ci/latest
+      - --extract=ci/latest-1.18
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -312,7 +312,7 @@ periodics:
       - --check-leaked-resources
       - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
-      - --extract=ci/latest
+      - --extract=ci/latest-1.18
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -530,7 +530,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.18
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce
@@ -573,7 +573,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-stable1
+      - --extract=ci/latest-1.18
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -58,7 +58,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --extract=ci/latest
+      - --extract=ci/latest-1.19
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -266,7 +266,7 @@ periodics:
       - --check-leaked-resources
       - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
-      - --extract=ci/latest
+      - --extract=ci/latest-1.19
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -155,7 +155,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 3 * * *, 0 9 * * *, 0 15 * * *, 0 21 * * *
-    fork-per-release-generic-suffix: "true"
     fork-per-release-replacements: "kubemark-500Nodes -> kubemark-500Nodes-{{.Version}}, extract=ci/latest -> extract=ci/latest-{{.Version}}, perf-tests=master -> perf-tests=release-{{.Version}}, gcp-project=k8s-jenkins-blocking-kubemark -> gcp-project-type=scalability-project, us-central1-f -> us-east1-b"
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-master-500

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -123,7 +123,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
+    fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -123,8 +123,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
-    fork-per-release-generic-suffix: "true"
-    fork-per-release-replacements: "gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
+    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -44,7 +44,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: integration-master
     testgrid-alert-email: kubernetes-release-team@googlegroups.com

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -50,7 +50,6 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-periodic-interval: 2h 2h 6h 24h
-    fork-per-release-generic-suffix: "true"
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: verify-master
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers@kubernetes.io

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -297,7 +297,7 @@ periodics:
     - args:
       - --check-leaked-resources
       - --cluster=
-      - --extract=ci/k8s-beta
+      - --extract=ci/latest-1.18
       - --gcp-zone=us-west1-b
       - --ginkgo-parallel=8
       - --provider=gce


### PR DESCRIPTION
(Continuation of version marker cleanup tracking: https://github.com/kubernetes/sig-release/issues/850)

- Cleanup version markers in generically forked jobs
- Remove unnecessary "fork-per-release-generic-suffix" annotations
- Use explicit version markers for non-generic jobs
- Update latest-fast version marker fork replacements 

cc: @kubernetes/release-engineering 
/assign @BenTheElder @spiffxp 