### PR TITLE
Use ID rather than ChangeID.

### DIFF
--- a/prow/gerrit/client/client.go
+++ b/prow/gerrit/client/client.go
@@ -337,7 +337,7 @@ func parseStamp(value gerrit.Timestamp) time.Time {
 }
 
 func (h *gerritInstanceHandler) injectPatchsetMessages(change *gerrit.ChangeInfo) error {
-	out, _, err := h.changeService.ListChangeComments(change.ChangeID)
+	out, _, err := h.changeService.ListChangeComments(change.ID)
 	if err != nil {
 		return err
 	}
@@ -432,7 +432,9 @@ func (h *gerritInstanceHandler) queryChangesForProject(log logrus.FieldLogger, p
 
 				created := parseStamp(rev.Created)
 				log := log.WithField("created", created)
-				h.injectPatchsetMessages(&change)
+				if err := h.injectPatchsetMessages(&change); err != nil {
+					log.WithError(err).Error("Failed to inject patchset messages")
+				}
 				changeMessages := change.Messages
 				var newMessages bool
 

--- a/prow/gerrit/client/client_test.go
+++ b/prow/gerrit/client/client_test.go
@@ -142,7 +142,7 @@ func TestQueryChange(t *testing.T) {
 				"foo": {
 					{
 						Project:         "bar",
-						ID:              "100",
+						ID:              "bar~branch~random-string",
 						ChangeID:        "random-string",
 						CurrentRevision: "1-1",
 						Updated:         makeStamp(now),
@@ -169,7 +169,7 @@ func TestQueryChange(t *testing.T) {
 				},
 			},
 			comments: map[string]map[string][]gerrit.CommentInfo{
-				"random-string": {
+				"bar~branch~random-string": {
 					"/PATCHSET_LEVEL": {
 						{
 							Message:  "before",


### PR DESCRIPTION
The latter only represents a {change-id} if it uniquely identifies a CR.
This is usually the case but not always -- for example when cherrypicking the same
commit into multiple branches.

More info, see:
* https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#list-change-comments
* https://gerrit-review.googlesource.com/Documentation/rest-api-changes.html#change-id


Also, add missing log when we fail to inject patchset message