### PR TITLE
Kops - Run verify-bazel and verify-gomod presubmits only for master

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -244,6 +244,8 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-1-18
   - name: pull-kops-verify-bazel
+    branches:
+    - master
     always_run: true
     labels:
       preset-service-account: "true"
@@ -286,6 +288,8 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: verify-generated
   - name: pull-kops-verify-gomod
+    branches:
+    - master
     always_run: true
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Golang version mismatch, disabling for now for the 1.18 branch:
https://github.com/kubernetes/kops/pull/9648

/cc @mikesplain @rifelpet 