### PR TITLE
Reduce frequency of sig-instrumentation periodic e2e tests from 30m to 12h

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 30m
+- interval: 12h
   name: ci-kubernetes-e2e-gci-gce-es-logging
   labels:
     preset-service-account: "true"
@@ -25,7 +25,7 @@ periodics:
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-es-logging
-- interval: 30m
+- interval: 12h
   name: ci-kubernetes-e2e-gci-gce-sd-logging
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Changing the frequency from 30m to 12h for instrumentation periodic e2e tests:

- ci-kubernetes-e2e-gci-gce-es-logging
- ci-kubernetes-e2e-gci-gce-sd-logging

/cc @coffeepac per our conversation in slack