### PR TITLE
Kettle image now pushed to k8s-testimages  registry

### DIFF
--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/k8s-testimages/kettle
+IMG = gcr.io/k8s-gubernator/kettle
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # These are the usual GKE variables.

--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-IMG = gcr.io/k8s-gubernator/kettle
+IMG = gcr.io/k8s-testimages/kettle
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)
 
 # These are the usual GKE variables.
@@ -27,7 +27,7 @@ push-prod:
   bazel run //images/builder -- --project=k8s-testimages --scratch-bucket=gs://k8s-testimages-scratch kettle
 
 push:
-	bazel run //images/builder -- --allow-dirty --build-dir=. kettle/
+	bazel run //images/builder -- --project=k8s-testimages --allow-dirty --build-dir=. kettle/
 
 deploy: get-cluster-credentials
 	sed "s/:latest/:$(TAG)/g" deployment.yaml | kubectl apply -f - --record

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -9,7 +9,7 @@ which is publicly accessible.
 
 # Deploying
 
-Kettle runs as a pod in the `k8s-gubernator/g8r` cluster
+Kettle runs as a pod in the `k8s-gubernator/g8r` cluster. To drop into it's context, run `<root>$ make -C kettle get-cluster-credentials`
 
 If you change:
 
@@ -20,6 +20,9 @@ If you change:
     - `update` sets the image of the existing kettle *Pod* which triggers a restart cycle
     - this will build the image to [Pantheon Container Registry](https://pantheon.corp.google.com/gcr/images/k8s-gubernator/GLOBAL/kettle?project=k8s-gubernator&organizationId=433637338589&gcrImageListsize=30)
     - See [Makefile](Makefile) for details
+
+#### Note:
+ - If you make local changes in the branch prior to `make push/update` the image will be uploaded with `-dirty` in the tag. Keep this in mind when seeting the image. If you see a Pod in a `ImagePullBackOff` loop, there is likely an issue when `kubectl image set` was run, where the image does not exist in the specified location.
 
 # Restarting
 


### PR DESCRIPTION
It should be pointed to k8s-gubernator project registry, I also extended the docs to help anyone that hits an image pull issue