### PR TITLE
Add python3, python3-distutils, and python3-pip to the bootstrap image

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -42,6 +42,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-dev \
     python-openssl \
     python-pip \
+    python3 \
+    python3-distutils \
+    python3-pip \
     rsync \
     unzip \
     wget \
@@ -49,7 +52,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --upgrade pip setuptools wheel
+    && python -m pip install --upgrade pip setuptools wheel \
+    && python3 -m pip install --upgrade pip setuptools wheel
 
 # Install gcloud
 


### PR DESCRIPTION
Currently we install the python2 equivalents, but not the python3 equivalents, this improves the ability to use this image for tooling that no longer supports python2.

/assign @hasheddan 