### PR TITLE
image-builder: add jobs config for Azure presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/OWNERS
+++ b/config/jobs/kubernetes-sigs/image-builder/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - akutz
+  - CecileRobertMichon
+  - codenrhoden
+  - figo
+  - justinsb
+  - luxas
+  - moshloop
+  - timothysc

--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -1,0 +1,24 @@
+presubmits:
+  kubernetes-sigs/image-builder:
+  - name: pull-azure-all
+    labels:
+      preset-azure-cred: "true"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 12
+    path_alias: sigs.k8s.io/image-builder
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200728-3610e67-1.18
+        args:
+          - runner.sh
+          - "./images/capi/packer/azure/scripts/ci-azure-e2e.sh"
+        resources:
+          requests:
+            cpu: 1000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-image-builder
+      testgrid-tab-name: pr-azure-all

--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -20,6 +20,7 @@ dashboard_groups:
     - sig-cluster-lifecycle-image-pushes
     - sig-cluster-lifecycle-system-validators
     - sig-cluster-lifecycle-kubespray
+    - sig-cluster-lifecycle-image-builder
 
 dashboards:
 - name: sig-cluster-lifecycle-all
@@ -53,6 +54,7 @@ dashboards:
 - name: sig-cluster-lifecycle-image-pushes
 - name: sig-cluster-lifecycle-system-validators
 - name: sig-cluster-lifecycle-kubespray
+- name: sig-cluster-lifecycle-image-builder
 
 test_groups:
 # @luxas' multiarch e2e results


### PR DESCRIPTION
This adds a new job config for https://github.com/kubernetes-sigs/image-builder.

For now only an optional presubmit is added in order to test https://github.com/kubernetes-sigs/image-builder/pull/313. In the future, the goal is to make the job and other builder tests run by default and be required on PRs.

/assign @codenrhoden 
/cc @timothysc @justinsb @luxas @moshloop @figo @akutz 