### PR TITLE
Use fast builds on release-master-blocking

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -201,7 +201,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -22,7 +22,7 @@ periodics:
       - --bare
       - --scenario=kubernetes_e2e
       - --
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -369,7 +369,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-master-image=gci
       - --gcp-node-image=gci
@@ -455,7 +455,7 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          - --extract=ci/latest
+          - --extract=ci/latest-fast
           - --env=KUBE_CONTAINER_RUNTIME=containerd
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
@@ -538,7 +538,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
@@ -663,7 +663,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --cluster=err-e2e
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-project-type=k8s-infra-gce-project
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -34,7 +34,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -261,7 +261,7 @@ periodics:
       - --check-leaked-resources
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-node-image=gci
       - --gcp-project-type=ingress-project
       - --gcp-zone=asia-southeast1-a

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -22,7 +22,7 @@ periodics:
       - --cluster=gce-scale-cluster
       - --env=CONCURRENT_SERVICE_SYNCS=5
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-node-size=g1-small
@@ -75,7 +75,7 @@ periodics:
       # TODO(mborsz): Adjust or remove this change once we understand coredns
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
@@ -144,7 +144,7 @@ periodics:
       # TODO(oxddr): remove once debugging is finished
       - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project


### PR DESCRIPTION
Fast (`linux/amd64`-only) builds used to land at `ci/latest`. Now they live at `ci/latest-fast`, and cross builds live at `ci/latest`. This means jobs that used to pick up the latest merged PR within 20-30m are now taking 90m-2h to do so.

Unless a job needs to use the cross build, it should switch to using `ci/latest-fast`.

Updates the follopwing release-master-blocking jobs:
- ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
- ci-kubernetes-gce-conformance-latest
- ci-kubernetes-e2e-gci-gce
- ci-kubernetes-e2e-ubuntu-gce-containerd
- ci-kubernetes-e2e-gci-gce-alpha-features
- ci-kubernetes-e2e-gci-gce-reboot
- ci-kubernetes-e2e-gce-device-plugin-gpu
- ci-kubernetes-e2e-gci-gce-ingress
- ci-kubernetes-e2e-gci-gce-scalability

Updates the following release-master-informing jobs:
- ci-kubernetes-e2e-gce-scale-correctness
- ci-kubernetes-e2e-gce-scale-performance

ref: https://github.com/kubernetes/test-infra/pull/18290#discussion_r461858097