### PR TITLE
Ensure fast builds match fast extraction strategy

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -96,6 +96,10 @@ func (l *extractStrategies) Set(value string) error {
 		if mat == nil {
 			continue
 		}
+		if mode == ci && strings.HasSuffix(value, "-fast") {
+			// do not match ci mode if will also match ciFast
+			continue
+		}
 		e := extractStrategy{
 			mode:   mode,
 			option: mat[1],
@@ -105,6 +109,7 @@ func (l *extractStrategies) Set(value string) error {
 			e.ciVersion = mat[2]
 		}
 		*l = append(*l, e)
+		log.Printf("Matched extraction strategy: %s", search)
 		return nil
 	}
 	return fmt.Errorf("Unknown extraction strategy: %v", value)

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -180,6 +180,11 @@ func TestExtractStrategies(t *testing.T) {
 			"v1.2.3+abcde",
 		},
 		{
+			"ci/latest-fast",
+			"https://storage.googleapis.com/kubernetes-release-dev/ci/fast",
+			"v1.2.3+abcde",
+		},
+		{
 			"ci/gke-staging-latest",
 			"https://storage.googleapis.com/gke-release-staging/kubernetes/release",
 			"v1.2.3+abcde",


### PR DESCRIPTION
Currently ci/*-fast extraction strategies may incorrectly match to ci
mode instead of ciFast mode due to the regex being used. This ensures
that ci/*-fast extraction strategies will keep checking for ciFast if
they first match ci.

Fixes https://github.com/kubernetes/kubernetes/issues/93561

/cc @justaugustus @spiffxp 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>