### PR TITLE
Fix ssh username for FCOS host 

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -269,10 +269,9 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200903-fd282bc-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200831-9529f9c-master
         args:
         - --root=/go/src
-        - --env=KUBE_SSH_USER=core
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--service-account=/etc/service-account/service-account.json"
@@ -281,6 +280,7 @@ presubmits:
         - --scenario=kubernetes_e2e
         - -- # end bootstrap args, scenario args below
         - --deployment=node
+        - --env=KUBE_SSH_USER=core
         - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/crio/crio.sock --container-runtime-process-name=/usr/local/sbin/crio-v1.18.3/bin/crio-static --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'


### PR DESCRIPTION
Hello, 

When I try to run,
```
/test pull-kubernetes-node-crio1-18-e2e
```
It fails with following error,

```
Cloning into 'test-infra'...
Activated service account credentials for: [pr-kubekins@kubernetes-jenkins-pull.iam.gserviceaccount.com]
fatal: not a git repository (or any of the parent directories): .git
+ ./test-infra/jenkins/bootstrap.py --job=pull-kubernetes-node-crio1-18-e2e --service-account=/etc/service-account/service-account.json --upload=gs://kubernetes-jenkins/logs --root=/go/src --env=KUBE_SSH_USER=core --job=pull-kubernetes-node-crio1-18-e2e --repo=k8s.io/kubernetes=master:db28b0239a1d09e46507e0b320f0b4ffa1cbc8b6,93486:602a517b794edcc79a623041af849f0ba2a22827 --service-account=/etc/service-account/service-account.json --upload=gs://kubernetes-jenkins/pr-logs --timeout=240 --scenario=kubernetes_e2e -- --deployment=node --gcp-project=k8s-jkns-pr-node-e2e --gcp-zone=us-west1-b '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/crio/crio.sock --container-runtime-process-name=/usr/local/sbin/crio-v1.18.3/bin/crio-static --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"' --node-tests=true --provider=gce '--test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"' --timeout=180m --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/crio/1.18/image-config.yaml
usage: bootstrap.py [-h] [--root ROOT] [--timeout TIMEOUT] [--compress]
                    [--repo REPO] [--bare] --job JOB [--upload UPLOAD]
                    [--service-account SERVICE_ACCOUNT] [--ssh SSH]
                    [--git-cache GIT_CACHE] [--clean] [--scenario SCENARIO]
bootstrap.py: error: unrecognized arguments: --env=KUBE_SSH_USER=core
+ EXIT_VALUE=2
+ set +o xtrace
```

Since those node tests use Fedora CoreOS as host, while doing ssh to the host `core` user must be used. 