### PR TITLE
Pass prowjob.json to metadata lens

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -53,7 +53,7 @@ deck:
       required_files:
       - started.json|finished.json
       optional_files:
-      - podinfo.json
+      - podinfo.json|prowjob.json
     - lens:
         name: buildlog
       required_files:


### PR DESCRIPTION
The metadata lens will pass hints from an errored prow job, but it
currently never gets the prowjob.json passed as an artifact so hints are
never surfaced.

From running locally, you can see the hint is surfaced for the same job in which it is not on prow.k8s.io (https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/periodic-kubernetes-bazel-build-master/1288775099830243328)

![error-hint](https://user-images.githubusercontent.com/31777345/88917429-59318400-d22d-11ea-870d-d37ab223c5a0.png)


Partially addresses https://github.com/kubernetes/test-infra/issues/18528 but I am going to work on surfacing a little more information and reporting `error` instead of `failed` as suggested in the issue.

/cc @cjwagner @cblecker 

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>