### PR TITLE
Fix parsing of --tag-match image builder flag

### DIFF
--- a/images/builder/main.go
+++ b/images/builder/main.go
@@ -271,7 +271,7 @@ func runBuildJobs(o options) []error {
 	log.Println("Running build jobs...")
 	tagFlags := []string{"--tags", "--always", "--dirty"}
 	if len(o.tagMatch) > 0 {
-		tagFlags = append(tagFlags, "--match "+o.tagMatch)
+		tagFlags = append(tagFlags, fmt.Sprintf(`--match "%s"`, o.tagMatch))
 	}
 	tag, err := getVersion(tagFlags)
 	if err != nil {


### PR DESCRIPTION
https://github.com/kubernetes/test-infra/pull/18506 introduced this flag, but when the flag is parsed (for example, `--tag-match="v*"`), the quotes around the pattern get dropped and the pattern is invalid (`git describe --tags --match v*` doesn't match anything without quotes around `"v*"`. This ensures that the quotes around the pattern will persist