### PR TITLE
Fix seccomp-operator bucket name

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -14,7 +14,7 @@ postsubmits:
               - /run.sh
             args:
               - --project=k8s-infra-staging-seccomp-operator
-              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator-gcb
+              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator
               - .
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
The suffix should not be needed for the bucket.

Ref: https://prow.k8s.io/log?job=post-seccomp-operator-push-image&id=1288855630882279424
/assign @hasheddan 