### PR TITLE
Update kubekins-e2e to use latest bootstrap image

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-testimages/bootstrap:v20200728-3f8a003
+FROM gcr.io/k8s-prow/bootstrap:v20200729-ee80a02
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
This pulls in python3 updates from https://github.com/kubernetes/test-infra/pull/18531