### PR TITLE
Azure: do not set node distro to ubuntu

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -493,15 +493,6 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 		return fmt.Errorf("No template file specified %v", err)
 	}
 
-	// set default distro so we do not use prebuilt os image
-	if v.Properties.MasterProfile.Distro == "" {
-		v.Properties.MasterProfile.Distro = "ubuntu"
-	}
-	for _, agentPool := range v.Properties.AgentPoolProfiles {
-		if agentPool.Distro == "" {
-			agentPool.Distro = "ubuntu"
-		}
-	}
 	// replace APIModel template properties from flags
 	if c.location != "" {
 		v.Location = c.location


### PR DESCRIPTION
We should use VHD for all Linux nodes by default to prevent machine rebooting during cluster provision, which might lead to test failure.

Fixes test failure in https://testgrid.k8s.io/provider-azure-upstream#pr-k8s-e2e-master.

/assign @feiskyer 