### PR TITLE
Raise monitoring.prow.k8s.io prometheus retention to 90d

### DIFF
--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -16,7 +16,7 @@ spec:
         resources:
           requests:
             storage: 100Gi
-  retention: "30d"
+  retention: "90d"
   serviceAccountName: prometheus-prow
   alerting:
     alertmanagers:


### PR DESCRIPTION
I don't have any insight into how much disk prometheus is using right now at 30d retention. Ultimately I'd like to raise to a year

/cc @cjwagner @BenTheElder