### PR TITLE
kops updown jobs: write to kops-ci bucket

### DIFF
--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -51,7 +51,9 @@ template = """
       - --kops-state=s3://k8s-kops-prow/
       - --kops-ssh-key=$(AWS_SSH_PRIVATE_KEY_FILE)
       - --kops-ssh-public-key=$(AWS_SSH_PUBLIC_KEY_FILE)
-      - --kops-publish=gs://k8s-staging-kops/kops/releases/markers/{{branch}}/latest-ci-updown-green.txt
+      # We don't have permission to write to gs://k8s-staging-kops
+      - --kops-publish=gs://kops-ci/markers/{{branch}}/latest-ci-updown-green.txt
+      # Published by the kops staging build jobs
       - --kops-version=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/{{branch}}/latest-ci.txt
       #- --kops-kubernetes-version should be inferred by kubetest from --extract
       #- --kops-zone should be randomized by kubetest

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -38,7 +38,9 @@ periodics:
       - --kops-state=s3://k8s-kops-prow/
       - --kops-ssh-key=$(AWS_SSH_PRIVATE_KEY_FILE)
       - --kops-ssh-public-key=$(AWS_SSH_PUBLIC_KEY_FILE)
-      - --kops-publish=gs://k8s-staging-kops/kops/releases/markers/master/latest-ci-updown-green.txt
+      # We don't have permission to write to gs://k8s-staging-kops
+      - --kops-publish=gs://kops-ci/markers/master/latest-ci-updown-green.txt
+      # Published by the kops staging build jobs
       - --kops-version=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/master/latest-ci.txt
       #- --kops-kubernetes-version should be inferred by kubetest from --extract
       #- --kops-zone should be randomized by kubetest
@@ -86,7 +88,9 @@ periodics:
       - --kops-state=s3://k8s-kops-prow/
       - --kops-ssh-key=$(AWS_SSH_PRIVATE_KEY_FILE)
       - --kops-ssh-public-key=$(AWS_SSH_PUBLIC_KEY_FILE)
-      - --kops-publish=gs://k8s-staging-kops/kops/releases/markers/release-1.16/latest-ci-updown-green.txt
+      # We don't have permission to write to gs://k8s-staging-kops
+      - --kops-publish=gs://kops-ci/markers/release-1.16/latest-ci-updown-green.txt
+      # Published by the kops staging build jobs
       - --kops-version=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.16/latest-ci.txt
       #- --kops-kubernetes-version should be inferred by kubetest from --extract
       #- --kops-zone should be randomized by kubetest
@@ -134,7 +138,9 @@ periodics:
       - --kops-state=s3://k8s-kops-prow/
       - --kops-ssh-key=$(AWS_SSH_PRIVATE_KEY_FILE)
       - --kops-ssh-public-key=$(AWS_SSH_PUBLIC_KEY_FILE)
-      - --kops-publish=gs://k8s-staging-kops/kops/releases/markers/release-1.17/latest-ci-updown-green.txt
+      # We don't have permission to write to gs://k8s-staging-kops
+      - --kops-publish=gs://kops-ci/markers/release-1.17/latest-ci-updown-green.txt
+      # Published by the kops staging build jobs
       - --kops-version=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.17/latest-ci.txt
       #- --kops-kubernetes-version should be inferred by kubetest from --extract
       #- --kops-zone should be randomized by kubetest
@@ -182,7 +188,9 @@ periodics:
       - --kops-state=s3://k8s-kops-prow/
       - --kops-ssh-key=$(AWS_SSH_PRIVATE_KEY_FILE)
       - --kops-ssh-public-key=$(AWS_SSH_PUBLIC_KEY_FILE)
-      - --kops-publish=gs://k8s-staging-kops/kops/releases/markers/release-1.18/latest-ci-updown-green.txt
+      # We don't have permission to write to gs://k8s-staging-kops
+      - --kops-publish=gs://kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      # Published by the kops staging build jobs
       - --kops-version=https://storage.googleapis.com/k8s-staging-kops/kops/releases/markers/release-1.18/latest-ci.txt
       #- --kops-kubernetes-version should be inferred by kubetest from --extract
       #- --kops-zone should be randomized by kubetest


### PR DESCRIPTION
The CI jobs don't have permission to write to the k8s-staging-kops
bucket, so we write here instead.