### PR TITLE
Add k8s-infra's gce-project pool to boskos dashboard

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/boskos.jsonnet
@@ -36,7 +36,8 @@ dashboard.new(
       for resource in [
         {instance: "104.197.27.114:9090", type: "aws-account", friendly: "AWS account"},
         {instance: "104.197.27.114:9090", type: "gce-project", friendly: "GCE project"},
-        {instance: "35.225.208.117:9090", type: "k8s-infra-gce-project", friendly: "GCE project (k8s-infra)"},
+        {instance: "35.225.208.117:9090", type: "gce-project", friendly: "GCE project (k8s-infra)"},
+        {instance: "35.225.208.117:9090", type: "k8s-infra-gce-project", friendly: "GCE project (old) (k8s-infra)"},
         {instance: "104.197.27.114:9090", type: "gke-project", friendly: "GKE project"},
         {instance: "104.197.27.114:9090", type: "gpu-project", friendly: "GPU project"},
         {instance: "104.197.27.114:9090", type: "ingress-project", friendly: "Ingress project"},


### PR DESCRIPTION
Plan is to remove the k8s-infra-gce-project pool once jobs are
setup to move to the gce-project pool

ref: https://github.com/kubernetes/test-infra/issues/18552 - migrating away from k8s-infra-gce-project pool
ref: https://github.com/kubernetes/k8s.io/issues/1078 - adding gce-project pool