### PR TITLE
releng: Move Debian base image postsubmits to k/release

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -27,13 +27,13 @@ postsubmits:
         github_team_ids:
           - 2241179 # release-managers
   kubernetes/release:
-    - name: post-kubernetes-push-image-debian-base
+    - name: post-release-push-image-debian-base
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
-      run_if_changed: '^build\/debian-base\/'
+      run_if_changed: '^images\/build\/debian-base\/'
       branches:
         - ^master$
       spec:
@@ -46,50 +46,26 @@ postsubmits:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
               - --build-dir=.
-              - build/debian-base
+              - images/build/debian-base
             env:
               - name: LOG_TO_STDOUT
                 value: "y"
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    - name: post-kubernetes-push-image-debian-hyperkube-base
+    # TODO(releng): While hyperkube is deprecated in 1.19, we still need to
+    #               maintain its base image to support publishing it for the
+    #               1.18, 1.17, and 1.16 releases.
+    #               DO NOT REMOVE THIS UNTIL AFTER KUBERNETES 1.21 IS RELEASED
+    #               AND YOU'VE CONFIRMED WITH RELEASE MANAGERS THAT IT'S OKAY
+    #               TO DO SO.
+    - name: post-release-push-image-debian-hyperkube-base
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
         testgrid-alert-email: release-managers@kubernetes.io
       decorate: true
-      run_if_changed: '^build\/debian-hyperkube-base\/'
-      branches:
-        # TODO(releng): While hyperkube is deprecated in 1.19, we still need to
-        #               maintain its base image to support publishing it for
-        #               the 1.18, 1.17, and 1.16 releases.
-        #               Here we configure image building only for 1.18.
-        - ^release-1.18$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200730-a4aba30
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-build-image
-              - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --build-dir=.
-              - build/debian-hyperkube-base
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers
-    - name: post-kubernetes-push-image-debian-iptables
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/debian-iptables\/'
+      run_if_changed: '^images\/build\/debian-hyperkube-base\/'
       branches:
         - ^master$
       spec:
@@ -102,7 +78,33 @@ postsubmits:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
               - --build-dir=.
-              - build/debian-iptables
+              - images/build/debian-hyperkube-base
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
+    - name: post-release-push-image-debian-iptables
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^images\/build\/debian-iptables\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200730-a4aba30
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --build-dir=.
+              - images/build/debian-iptables
             env:
               - name: LOG_TO_STDOUT
                 value: "y"

--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -1,5 +1,32 @@
 postsubmits:
   kubernetes/kubernetes:
+    - name: post-kubernetes-push-image-go-runner
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^build\/go-runner\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200730-a4aba30
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --build-dir=.
+              - build/go-runner
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
+  kubernetes/release:
     - name: post-kubernetes-push-image-debian-base
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -82,33 +109,6 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    - name: post-kubernetes-push-image-go-runner
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/go-runner\/'
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200730-a4aba30
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-build-image
-              - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --build-dir=.
-              - build/go-runner
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers
-  kubernetes/release:
     - name: post-release-push-image-kube-cross
       cluster: k8s-infra-prow-build-trusted
       annotations:


### PR DESCRIPTION
(Companion PR for https://github.com/kubernetes/release/pull/1450.)
(I split this into two commits because the diff looks confusing otherwise.)

/hold for any discussion
cc: @kubernetes/release-engineering
/assign @dims 
cc: @tallclair 