### PR TITLE
Set resource requests/limits for kops grid jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -48,6 +48,12 @@ template = """
       - --test_args={{test_args}}
       - --timeout=60m
       image: {{e2e_image}}
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-{{distro}}, kops-k8s-{{k8s_version}}
     testgrid-tab-name: {{tab}}

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -34,6 +34,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2
@@ -71,6 +77,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko18
@@ -108,6 +120,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-amzn2-k16
@@ -145,6 +163,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-amzn2-k16-ko18
@@ -182,6 +206,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17
@@ -219,6 +249,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-ko18
@@ -256,6 +292,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18
@@ -293,6 +335,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18
@@ -330,6 +378,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-centos7
@@ -367,6 +421,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-centos7-ko18
@@ -404,6 +464,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-centos7-k16
@@ -441,6 +507,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-centos7-k16-ko18
@@ -478,6 +550,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-centos7-k17
@@ -515,6 +593,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-centos7-k17-ko18
@@ -552,6 +636,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-centos7-k18
@@ -589,6 +679,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-centos7-k18-ko18
@@ -626,6 +722,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9
@@ -663,6 +765,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko18
@@ -700,6 +808,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-deb9-k16
@@ -737,6 +851,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-deb9-k16-ko18
@@ -774,6 +894,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17
@@ -811,6 +937,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-ko18
@@ -848,6 +980,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18
@@ -885,6 +1023,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18
@@ -922,6 +1066,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10
@@ -959,6 +1109,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko18
@@ -996,6 +1152,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-deb10-k16
@@ -1033,6 +1195,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-deb10-k16-ko18
@@ -1070,6 +1238,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17
@@ -1107,6 +1281,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-ko18
@@ -1144,6 +1324,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18
@@ -1181,6 +1367,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18
@@ -1218,6 +1410,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar
@@ -1255,6 +1453,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko18
@@ -1292,6 +1496,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flatcar-k16
@@ -1329,6 +1539,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flatcar-k16-ko18
@@ -1366,6 +1582,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17
@@ -1403,6 +1625,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-ko18
@@ -1440,6 +1668,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18
@@ -1477,6 +1711,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18
@@ -1514,6 +1754,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7
@@ -1551,6 +1797,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko18
@@ -1588,6 +1840,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-rhel7-k16
@@ -1625,6 +1883,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-rhel7-k16-ko18
@@ -1662,6 +1926,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17
@@ -1699,6 +1969,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-ko18
@@ -1736,6 +2012,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18
@@ -1773,6 +2055,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18
@@ -1810,6 +2098,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8
@@ -1847,6 +2141,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko18
@@ -1884,6 +2184,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-rhel8-k16
@@ -1921,6 +2227,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-rhel8-k16-ko18
@@ -1958,6 +2270,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17
@@ -1995,6 +2313,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-ko18
@@ -2032,6 +2356,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18
@@ -2069,6 +2399,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18
@@ -2106,6 +2442,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1604
@@ -2143,6 +2485,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1604-ko18
@@ -2180,6 +2528,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u1604-k16
@@ -2217,6 +2571,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u1604-k16-ko18
@@ -2254,6 +2614,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1604-k17
@@ -2291,6 +2657,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1604-k17-ko18
@@ -2328,6 +2700,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1604-k18
@@ -2365,6 +2743,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1604-k18-ko18
@@ -2402,6 +2786,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804
@@ -2439,6 +2829,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko18
@@ -2476,6 +2872,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u1804-k16
@@ -2513,6 +2915,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u1804-k16-ko18
@@ -2550,6 +2958,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17
@@ -2587,6 +3001,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-ko18
@@ -2624,6 +3044,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18
@@ -2661,6 +3087,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18
@@ -2698,6 +3130,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004
@@ -2735,6 +3173,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko18
@@ -2772,6 +3216,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u2004-k16
@@ -2809,6 +3259,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-u2004-k16-ko18
@@ -2846,6 +3302,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17
@@ -2883,6 +3345,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-ko18
@@ -2920,6 +3388,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18
@@ -2957,6 +3431,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18
@@ -2994,6 +3474,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2
@@ -3031,6 +3517,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko18
@@ -3068,6 +3560,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-amzn2-k16
@@ -3105,6 +3603,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-amzn2-k16-ko18
@@ -3142,6 +3646,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17
@@ -3179,6 +3689,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18
@@ -3216,6 +3732,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18
@@ -3253,6 +3775,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18
@@ -3290,6 +3818,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-centos7
@@ -3327,6 +3861,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-centos7-ko18
@@ -3364,6 +3904,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-centos7-k16
@@ -3401,6 +3947,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-centos7-k16-ko18
@@ -3438,6 +3990,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-centos7-k17
@@ -3475,6 +4033,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-centos7-k17-ko18
@@ -3512,6 +4076,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-centos7-k18
@@ -3549,6 +4119,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-centos7-k18-ko18
@@ -3586,6 +4162,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9
@@ -3623,6 +4205,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko18
@@ -3660,6 +4248,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-deb9-k16
@@ -3697,6 +4291,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-deb9-k16-ko18
@@ -3734,6 +4334,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17
@@ -3771,6 +4377,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18
@@ -3808,6 +4420,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18
@@ -3845,6 +4463,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18
@@ -3882,6 +4506,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10
@@ -3919,6 +4549,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko18
@@ -3956,6 +4592,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-deb10-k16
@@ -3993,6 +4635,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-deb10-k16-ko18
@@ -4030,6 +4678,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17
@@ -4067,6 +4721,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18
@@ -4104,6 +4764,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18
@@ -4141,6 +4807,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18
@@ -4178,6 +4850,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar
@@ -4215,6 +4893,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko18
@@ -4252,6 +4936,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-flatcar-k16
@@ -4289,6 +4979,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-flatcar-k16-ko18
@@ -4326,6 +5022,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17
@@ -4363,6 +5065,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18
@@ -4400,6 +5108,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18
@@ -4437,6 +5151,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18
@@ -4474,6 +5194,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7
@@ -4511,6 +5237,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko18
@@ -4548,6 +5280,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-rhel7-k16
@@ -4585,6 +5323,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-rhel7-k16-ko18
@@ -4622,6 +5366,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17
@@ -4659,6 +5409,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18
@@ -4696,6 +5452,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18
@@ -4733,6 +5495,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18
@@ -4770,6 +5538,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8
@@ -4807,6 +5581,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko18
@@ -4844,6 +5624,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-rhel8-k16
@@ -4881,6 +5667,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-rhel8-k16-ko18
@@ -4918,6 +5710,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17
@@ -4955,6 +5753,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18
@@ -4992,6 +5796,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18
@@ -5029,6 +5839,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18
@@ -5066,6 +5882,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1604
@@ -5103,6 +5925,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1604-ko18
@@ -5140,6 +5968,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u1604-k16
@@ -5177,6 +6011,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u1604-k16-ko18
@@ -5214,6 +6054,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1604-k17
@@ -5251,6 +6097,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1604-k17-ko18
@@ -5288,6 +6140,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1604-k18
@@ -5325,6 +6183,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1604-k18-ko18
@@ -5362,6 +6226,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804
@@ -5399,6 +6269,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko18
@@ -5436,6 +6312,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u1804-k16
@@ -5473,6 +6355,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u1804-k16-ko18
@@ -5510,6 +6398,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17
@@ -5547,6 +6441,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18
@@ -5584,6 +6484,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18
@@ -5621,6 +6527,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18
@@ -5658,6 +6570,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004
@@ -5695,6 +6613,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko18
@@ -5732,6 +6656,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u2004-k16
@@ -5769,6 +6699,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-calico-u2004-k16-ko18
@@ -5806,6 +6742,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17
@@ -5843,6 +6785,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18
@@ -5880,6 +6828,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18
@@ -5917,6 +6871,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18
@@ -5954,6 +6914,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2
@@ -5991,6 +6957,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko18
@@ -6028,6 +7000,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-amzn2-k16
@@ -6065,6 +7043,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-amzn2-k16-ko18
@@ -6102,6 +7086,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17
@@ -6139,6 +7129,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18
@@ -6176,6 +7172,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18
@@ -6213,6 +7215,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18
@@ -6250,6 +7258,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-centos7
@@ -6287,6 +7301,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-centos7-ko18
@@ -6324,6 +7344,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-centos7-k16
@@ -6361,6 +7387,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-centos7-k16-ko18
@@ -6398,6 +7430,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-centos7-k17
@@ -6435,6 +7473,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-centos7-k17-ko18
@@ -6472,6 +7516,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-centos7-k18
@@ -6509,6 +7559,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-centos7-k18-ko18
@@ -6546,6 +7602,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9
@@ -6583,6 +7645,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko18
@@ -6620,6 +7688,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-deb9-k16
@@ -6657,6 +7731,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-deb9-k16-ko18
@@ -6694,6 +7774,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17
@@ -6731,6 +7817,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18
@@ -6768,6 +7860,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18
@@ -6805,6 +7903,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18
@@ -6842,6 +7946,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10
@@ -6879,6 +7989,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko18
@@ -6916,6 +8032,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-deb10-k16
@@ -6953,6 +8075,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-deb10-k16-ko18
@@ -6990,6 +8118,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17
@@ -7027,6 +8161,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18
@@ -7064,6 +8204,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18
@@ -7101,6 +8247,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18
@@ -7138,6 +8290,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar
@@ -7175,6 +8333,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko18
@@ -7212,6 +8376,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-flatcar-k16
@@ -7249,6 +8419,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-flatcar-k16-ko18
@@ -7286,6 +8462,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17
@@ -7323,6 +8505,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18
@@ -7360,6 +8548,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18
@@ -7397,6 +8591,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18
@@ -7434,6 +8634,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7
@@ -7471,6 +8677,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-ko18
@@ -7508,6 +8720,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-rhel7-k16
@@ -7545,6 +8763,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-rhel7-k16-ko18
@@ -7582,6 +8806,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17
@@ -7619,6 +8849,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18
@@ -7656,6 +8892,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18
@@ -7693,6 +8935,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18
@@ -7730,6 +8978,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8
@@ -7767,6 +9021,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko18
@@ -7804,6 +9064,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-rhel8-k16
@@ -7841,6 +9107,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-rhel8-k16-ko18
@@ -7878,6 +9150,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17
@@ -7915,6 +9193,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18
@@ -7952,6 +9236,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18
@@ -7989,6 +9279,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18
@@ -8026,6 +9322,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1604
@@ -8063,6 +9365,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1604-ko18
@@ -8100,6 +9408,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u1604-k16
@@ -8137,6 +9451,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u1604-k16-ko18
@@ -8174,6 +9494,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1604-k17
@@ -8211,6 +9537,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1604-k17-ko18
@@ -8248,6 +9580,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1604-k18
@@ -8285,6 +9623,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1604-k18-ko18
@@ -8322,6 +9666,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804
@@ -8359,6 +9709,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko18
@@ -8396,6 +9752,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u1804-k16
@@ -8433,6 +9795,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u1804-k16-ko18
@@ -8470,6 +9838,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17
@@ -8507,6 +9881,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18
@@ -8544,6 +9924,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18
@@ -8581,6 +9967,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18
@@ -8618,6 +10010,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004
@@ -8655,6 +10053,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko18
@@ -8692,6 +10096,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u2004-k16
@@ -8729,6 +10139,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-cilium-u2004-k16-ko18
@@ -8766,6 +10182,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17
@@ -8803,6 +10225,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18
@@ -8840,6 +10268,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18
@@ -8877,6 +10311,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18
@@ -8914,6 +10354,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2
@@ -8951,6 +10397,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko18
@@ -8988,6 +10440,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-amzn2-k16
@@ -9025,6 +10483,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-amzn2-k16-ko18
@@ -9062,6 +10526,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17
@@ -9099,6 +10569,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18
@@ -9136,6 +10612,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18
@@ -9173,6 +10655,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18
@@ -9210,6 +10698,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-centos7
@@ -9247,6 +10741,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-centos7-ko18
@@ -9284,6 +10784,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-centos7-k16
@@ -9321,6 +10827,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-centos7-k16-ko18
@@ -9358,6 +10870,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-centos7-k17
@@ -9395,6 +10913,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-centos7-k17-ko18
@@ -9432,6 +10956,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-centos7-k18
@@ -9469,6 +10999,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-centos7-k18-ko18
@@ -9506,6 +11042,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9
@@ -9543,6 +11085,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko18
@@ -9580,6 +11128,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-deb9-k16
@@ -9617,6 +11171,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-deb9-k16-ko18
@@ -9654,6 +11214,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17
@@ -9691,6 +11257,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18
@@ -9728,6 +11300,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18
@@ -9765,6 +11343,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18
@@ -9802,6 +11386,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10
@@ -9839,6 +11429,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko18
@@ -9876,6 +11472,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-deb10-k16
@@ -9913,6 +11515,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-deb10-k16-ko18
@@ -9950,6 +11558,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17
@@ -9987,6 +11601,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18
@@ -10024,6 +11644,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18
@@ -10061,6 +11687,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18
@@ -10098,6 +11730,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar
@@ -10135,6 +11773,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko18
@@ -10172,6 +11816,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-flatcar-k16
@@ -10209,6 +11859,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-flatcar-k16-ko18
@@ -10246,6 +11902,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17
@@ -10283,6 +11945,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18
@@ -10320,6 +11988,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18
@@ -10357,6 +12031,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18
@@ -10394,6 +12074,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7
@@ -10431,6 +12117,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko18
@@ -10468,6 +12160,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-rhel7-k16
@@ -10505,6 +12203,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-rhel7-k16-ko18
@@ -10542,6 +12246,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17
@@ -10579,6 +12289,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18
@@ -10616,6 +12332,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18
@@ -10653,6 +12375,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18
@@ -10690,6 +12418,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8
@@ -10727,6 +12461,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko18
@@ -10764,6 +12504,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-rhel8-k16
@@ -10801,6 +12547,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-rhel8-k16-ko18
@@ -10838,6 +12590,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17
@@ -10875,6 +12633,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18
@@ -10912,6 +12676,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18
@@ -10949,6 +12719,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18
@@ -10986,6 +12762,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1604
@@ -11023,6 +12805,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1604-ko18
@@ -11060,6 +12848,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u1604-k16
@@ -11097,6 +12891,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u1604-k16-ko18
@@ -11134,6 +12934,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1604-k17
@@ -11171,6 +12977,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1604-k17-ko18
@@ -11208,6 +13020,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1604-k18
@@ -11245,6 +13063,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1604-k18-ko18
@@ -11282,6 +13106,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804
@@ -11319,6 +13149,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko18
@@ -11356,6 +13192,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u1804-k16
@@ -11393,6 +13235,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u1804-k16-ko18
@@ -11430,6 +13278,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17
@@ -11467,6 +13321,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18
@@ -11504,6 +13364,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18
@@ -11541,6 +13407,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18
@@ -11578,6 +13450,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004
@@ -11615,6 +13493,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko18
@@ -11652,6 +13536,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u2004-k16
@@ -11689,6 +13579,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-flannel-u2004-k16-ko18
@@ -11726,6 +13622,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17
@@ -11763,6 +13665,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18
@@ -11800,6 +13708,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18
@@ -11837,6 +13751,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18
@@ -11874,6 +13794,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2
@@ -11911,6 +13837,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko18
@@ -11948,6 +13880,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-amzn2-k16
@@ -11985,6 +13923,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-amzn2-k16-ko18
@@ -12022,6 +13966,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17
@@ -12059,6 +14009,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18
@@ -12096,6 +14052,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18
@@ -12133,6 +14095,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18
@@ -12170,6 +14138,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-centos7
@@ -12207,6 +14181,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-centos7-ko18
@@ -12244,6 +14224,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-centos7-k16
@@ -12281,6 +14267,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-centos7-k16-ko18
@@ -12318,6 +14310,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-centos7-k17
@@ -12355,6 +14353,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-centos7-k17-ko18
@@ -12392,6 +14396,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-centos7-k18
@@ -12429,6 +14439,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-centos7-k18-ko18
@@ -12466,6 +14482,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9
@@ -12503,6 +14525,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko18
@@ -12540,6 +14568,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-deb9-k16
@@ -12577,6 +14611,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-deb9-k16-ko18
@@ -12614,6 +14654,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17
@@ -12651,6 +14697,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18
@@ -12688,6 +14740,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18
@@ -12725,6 +14783,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18
@@ -12762,6 +14826,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10
@@ -12799,6 +14869,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko18
@@ -12836,6 +14912,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-deb10-k16
@@ -12873,6 +14955,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-deb10-k16-ko18
@@ -12910,6 +14998,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17
@@ -12947,6 +15041,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18
@@ -12984,6 +15084,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18
@@ -13021,6 +15127,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18
@@ -13058,6 +15170,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar
@@ -13095,6 +15213,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko18
@@ -13132,6 +15256,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-flatcar-k16
@@ -13169,6 +15299,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-flatcar-k16-ko18
@@ -13206,6 +15342,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17
@@ -13243,6 +15385,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18
@@ -13280,6 +15428,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18
@@ -13317,6 +15471,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18
@@ -13354,6 +15514,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7
@@ -13391,6 +15557,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko18
@@ -13428,6 +15600,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-rhel7-k16
@@ -13465,6 +15643,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-rhel7-k16-ko18
@@ -13502,6 +15686,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17
@@ -13539,6 +15729,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18
@@ -13576,6 +15772,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18
@@ -13613,6 +15815,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18
@@ -13650,6 +15858,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8
@@ -13687,6 +15901,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko18
@@ -13724,6 +15944,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-rhel8-k16
@@ -13761,6 +15987,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-rhel8-k16-ko18
@@ -13798,6 +16030,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17
@@ -13835,6 +16073,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18
@@ -13872,6 +16116,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18
@@ -13909,6 +16159,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18
@@ -13946,6 +16202,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1604
@@ -13983,6 +16245,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1604-ko18
@@ -14020,6 +16288,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u1604-k16
@@ -14057,6 +16331,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u1604-k16-ko18
@@ -14094,6 +16374,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1604-k17
@@ -14131,6 +16417,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1604-k17-ko18
@@ -14168,6 +16460,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1604-k18
@@ -14205,6 +16503,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1604-k18-ko18
@@ -14242,6 +16546,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804
@@ -14279,6 +16589,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko18
@@ -14316,6 +16632,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u1804-k16
@@ -14353,6 +16675,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u1804-k16-ko18
@@ -14390,6 +16718,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17
@@ -14427,6 +16761,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18
@@ -14464,6 +16804,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18
@@ -14501,6 +16847,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18
@@ -14538,6 +16890,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004
@@ -14575,6 +16933,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko18
@@ -14612,6 +16976,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u2004-k16
@@ -14649,6 +17019,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
     testgrid-tab-name: kops-grid-kopeio-u2004-k16-ko18
@@ -14686,6 +17062,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17
@@ -14723,6 +17105,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18
@@ -14760,6 +17148,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18
@@ -14797,6 +17191,12 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18


### PR DESCRIPTION
Part of the CI reliability drive.  These jobs don't need much resources;
just enough to run the e2e tests.