### PR TITLE
Fix ci/fast URL for setting k8s release

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -536,7 +536,7 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 
 		return setReleaseFromHTTP("kubernetes-release-dev/ci", e.option, extractSrc)
 	case ciFast:
-		return setReleaseFromHTTP("kubernetes-release-dev/ci/fast", e.option, extractSrc)
+		return setReleaseFromHTTP("kubernetes-release-dev/ci", fmt.Sprintf("%s-fast", e.option), extractSrc)
 	case rc, stable:
 		return setReleaseFromHTTP("kubernetes-release/release", e.option, extractSrc)
 	case version:

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -181,7 +181,7 @@ func TestExtractStrategies(t *testing.T) {
 		},
 		{
 			"ci/latest-fast",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci/fast",
+			"https://storage.googleapis.com/kubernetes-release-dev/ci",
 			"v1.2.3+abcde",
 		},
 		{


### PR DESCRIPTION
`Currently CI jobs are being pointed to /ci/fast/*.txt but the correct
URL is /ci/*-fast.txt.`

URL currently being used: https://storage.googleapis.com/kubernetes-release-dev/ci/fast/latest.txt

Correct URL: https://storage.googleapis.com/kubernetes-release-dev/ci/latest-fast.txt

Example job run: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress/1289287120283766784

Fixes https://github.com/kubernetes/kubernetes/issues/93561

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @justaugustus @BenTheElder @spiffxp 
/priority critical-urgent