### PR TITLE
Revert verify jobs to last known good kubekins version (v20200730-e636ee2)

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -427,7 +427,7 @@ periodics:
         value: release-1.16
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1202,7 +1202,7 @@ presubmits:
           value: release-1.16
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.16
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -488,7 +488,7 @@ periodics:
         value: release-1.17
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1210,7 +1210,7 @@ presubmits:
           value: release-1.17
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.17
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -493,7 +493,7 @@ periodics:
         value: release-1.18
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1445,7 +1445,7 @@ presubmits:
           value: release-1.18
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.18
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -443,7 +443,7 @@ periodics:
         value: release-1.19
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.19
       imagePullPolicy: Always
       name: ""
       resources:
@@ -1406,7 +1406,7 @@ presubmits:
           value: release-1.19
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-1.19
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -62,7 +62,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200731-2efbce0-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200730-e636ee2-master
       imagePullPolicy: Always
       command:
       - runner.sh


### PR DESCRIPTION
verify-publishing-bot is failing in the verify jobs due to issue with
pyyaml import. This gets the jobs running again until that issue is
resolved.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @liggitt @spiffxp 

/priority critical-urgent