### PR TITLE
Revert "Add python3, python3-distutils, and python3-pip to the bootstrap image"

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -42,9 +42,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-dev \
     python-openssl \
     python-pip \
-    python3 \
-    python3-distutils \
-    python3-pip \
     rsync \
     unzip \
     wget \
@@ -52,8 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --upgrade pip setuptools wheel \
-    && python3 -m pip install --upgrade pip setuptools wheel
+    && python -m pip install --upgrade pip setuptools wheel
 
 # Install gcloud
 


### PR DESCRIPTION
This is causing https://github.com/kubernetes/kubernetes/issues/93623. Will reintroduce when it can be done safely.

See https://github.com/kubernetes/test-infra/pull/18602 and https://github.com/kubernetes/kubernetes/pull/93627

Reverts kubernetes/test-infra#18531

/cc @liggitt @spiffxp @detiber 