### PR TITLE
Ensure pyyaml is available for python3

### DIFF
--- a/images/bootstrap/Dockerfile
+++ b/images/bootstrap/Dockerfile
@@ -42,6 +42,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python-dev \
     python-openssl \
     python-pip \
+    python3 \
+    python3-distutils \
+    python3-pip \
+    python3-yaml \
     rsync \
     unzip \
     wget \
@@ -49,7 +53,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     zip \
     zlib1g-dev \
     && rm -rf /var/lib/apt/lists/* \
-    && python -m pip install --upgrade pip setuptools wheel
+    && python -m pip install --upgrade pip setuptools wheel \
+    && python3 -m pip install --upgrade pip setuptools wheel
 
 # Install gcloud
 


### PR DESCRIPTION
See https://github.com/kubernetes/test-infra/pull/18603 for some context, basically the verify job was failing because pyyaml was not available

    Pull in the reverted commit 9f4fb3d8a8874449b7f4a9bfd4d818df324077de and
    add the package for python3 pyyaml.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>