### PR TITLE
Bump bootstrap base image in kubekins to v20200801-23e4b0e

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -17,7 +17,7 @@
 
 ARG OLD_BAZEL_VERSION
 FROM launcher.gcr.io/google/bazel:${OLD_BAZEL_VERSION} as old
-FROM gcr.io/k8s-testimages/bootstrap:v20200729-ee80a02
+FROM gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
 
 # hint to kubetest that it is in CI
 ENV KUBETEST_IN_DOCKER="true"


### PR DESCRIPTION
Bump bootstrap image to version with reverted python3 addition.

See https://github.com/kubernetes/test-infra/pull/18603

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @liggitt @spiffxp 