### PR TITLE
Supply get-kube.sh with correct fast build source URL

### DIFF
--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -181,7 +181,7 @@ func TestExtractStrategies(t *testing.T) {
 		},
 		{
 			"ci/latest-fast",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci",
+			"https://storage.googleapis.com/kubernetes-release-dev/ci/fast",
 			"v1.2.3+abcde",
 		},
 		{


### PR DESCRIPTION
Fast builds publish the lastest version marker to
`kubernetes-release-dev/ci/<version>-fast.txt` but the build source is
actually at
`kubernetes-release-dev/ci/fast/<version>/kubernetes.tar.gz`. This
updates extraction to use the correct URL for each purpose.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Example failed run: https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gci-gce-ingress/1289724502317469699

Follow up to #18572 

Note: jobs will only fail intermittently right now (with low traffic on k/k) because eventually the regular CI build (i.e. not fast build) appears at the source URL currently being used. This will fix the issue after a `kubekins` image bump. I would also like to circle back and clean up some of the logic here / potentially have fast build latest version marker published to `kubernetes-release-dev/ci/fast/<version>.txt`

/cc @justaugustus @dims @spiffxp @BenTheElder 