### PR TITLE
Report error if job fails due to pod scheduling timeout

### DIFF
--- a/prow/spyglass/lenses/metadata/lens_test.go
+++ b/prow/spyglass/lenses/metadata/lens_test.go
@@ -344,13 +344,15 @@ func TestHintFromPodInfo(t *testing.T) {
 
 func TestHintFromProwJob(t *testing.T) {
 	tests := []struct {
-		name     string
-		expected string
-		pj       prowv1.ProwJob
+		name            string
+		expected        string
+		expectedErrored bool
+		pj              prowv1.ProwJob
 	}{
 		{
-			name:     "errored job has its description reported",
-			expected: "Job execution failed: this is the description",
+			name:            "errored job has its description reported",
+			expected:        "Job execution failed: this is the description",
+			expectedErrored: true,
 			pj: prowv1.ProwJob{
 				Status: prowv1.ProwJobStatus{
 					State:       prowv1.ErrorState,
@@ -416,9 +418,12 @@ func TestHintFromProwJob(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Unexpected failed to marshal prowjob to JSON (this wasn't even part of the test!): %v", err)
 			}
-			result := hintFromProwJob(b)
+			result, errored := hintFromProwJob(b)
 			if result != tc.expected {
 				t.Errorf("Expected hint %q, but got %q", tc.expected, result)
+			}
+			if errored != tc.expectedErrored {
+				t.Errorf("Expected errored to be %t, but got %t", tc.expectedErrored, errored)
 			}
 		})
 	}

--- a/prow/spyglass/lenses/metadata/template.html
+++ b/prow/spyglass/lenses/metadata/template.html
@@ -8,6 +8,8 @@
 <p class="test-summary">Test started <abbr id="summary-start-time" title="{{.StartTime}}">{{.StartTime}}</abbr> {{if .Finished -}}
 {{- if .Passed -}}
   <span class="passed">passed</span>
+{{- else if .Errored -}}
+  <span class="failed">error</span>
 {{- else -}}
   <span class="failed">failed</span>
 {{- end -}}


### PR DESCRIPTION
Updates metadata spyglass lens to show error instead of failed if a job
was not run successfully due to a pod scheduling timeout or other
infrastructure issue.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Example screenshot:

![err](https://user-images.githubusercontent.com/31777345/89125905-40340780-d4a7-11ea-84ec-f9dea4481578.png)


Fixes #18528 
xref #18530 

/cc @cjwagner @dims 