### PR TITLE
Cleanup cross

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -1,7 +1,8 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-cross
-    run_if_changed: '^((build\/|hack\/lib\/).*)|(.*Makefile.*)$'
+    optional: true
+    always_run: false
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -3,22 +3,18 @@ presubmits:
   - name: pull-kubernetes-cross
     optional: true
     always_run: false
+    decorate: true
     labels:
-      preset-service-account: "true"
       preset-dind-enabled: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/bootstrap:v20200729-ee80a02
+        command:
+        - runner.sh
         args:
-        - "--job=$(JOB_NAME)"
-        - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
-        - "--service-account=/etc/service-account/service-account.json"
-        - "--upload=gs://kubernetes-jenkins/pr-logs"
-        - --scenario=execute
-        - --
-        - --env=KUBE_RELEASE_RUN_TESTS=n
         - make
         - release
+        - KUBE_RELEASE_RUN_TESTS=n
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -374,9 +374,6 @@ dashboards:
   - name: pull-kubernetes-dependencies
     test_group_name: pull-kubernetes-dependencies
     base_options: width=10
-  - name: pull-kubernetes-cross
-    test_group_name: pull-kubernetes-cross
-    base_options: width=10
 
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
@@ -443,6 +440,9 @@ dashboards:
     base_options: width=10
   - name: pull-kubernetes-e2e-gce-storage-disruptive
     test_group_name: pull-kubernetes-e2e-gce-storage-disruptive
+    base_options: width=10
+  - name: pull-kubernetes-cross
+    test_group_name: pull-kubernetes-cross
     base_options: width=10
 
 - name: presubmits-cloud-provider-vsphere-blocking


### PR DESCRIPTION
- move cross to purely optional presubmit
  - typecheck already catches go issues
  - cross building is release blocking
  - I can't find evidence that this job has caught any failures that weren't caught by typecheck
- move off of deprecated bootstrap.py to decorated job

/cc @liggitt @spiffxp 
xref: https://github.com/kubernetes/kubernetes/issues/92937, https://github.com/kubernetes/test-infra/issues/18586, https://github.com/kubernetes/test-infra/issues/18551