### PR TITLE
Bump kubekins-e2e to v20200802-ff98b58

### DIFF
--- a/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
+++ b/config/jobs/GoogleCloudPlatform/k8s-multicluster-ingress/k8s-multicluster-ingress-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=github.com/GoogleCloudPlatform/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -43,7 +43,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=k8s.io/test-infra=master"
         - "--root=/go/src/"
@@ -69,7 +69,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/GoogleCloudPlatform/k8s-multicluster-ingress=master
       - --root=/go/src

--- a/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
+++ b/config/jobs/apache-spark-on-k8s/spark-integration/spark-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"
@@ -46,7 +46,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--job=$(JOB_NAME)"
       - "--repo=github.com/apache-spark-on-k8s/spark-integration=master"

--- a/config/jobs/cadvisor/cadvisor.yaml
+++ b/config/jobs/cadvisor/cadvisor.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/kubernetes"
@@ -81,7 +81,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --job=$(JOB_NAME)
       - --root=/go/src

--- a/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
+++ b/config/jobs/containerd/cri/containerd-cri-presubmit-jobs.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -41,7 +41,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-node-e2e
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - sh
         - -c
@@ -90,7 +90,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=github.com/containerd/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -117,7 +117,7 @@ presubmits:
     spec:
       containers:
       - name: pull-cri-containerd-windows-cri
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/helm/charts/charts.yaml
+++ b/config/jobs/helm/charts/charts.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=github.com/helm/charts=$(PULL_REFS)"
         - "--root=/go/src/"
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test=false
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-apps
     testgrid-tab-name: charts-gce

--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -257,7 +257,7 @@ periodics:
     workdir: true
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         imagePullPolicy: Always
         command:
         - "./test/tools/project-cleaner/project_cleaner.sh"

--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -274,7 +274,7 @@ postsubmits:
       mountPath: /var/lib/docker
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:
@@ -296,7 +296,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -320,7 +320,7 @@ postsubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/postsubmit-tests-with-pipeline-deployment.sh
         args:

--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -354,7 +354,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -370,7 +370,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -388,7 +388,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/presubmit-tests-with-pipeline-deployment.sh
         args:
@@ -408,7 +408,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/presubmit-tests-mkp.sh
   - name: kubeflow-pipeline-upgrade-test
@@ -419,7 +419,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/upgrade-tests.sh
         args:
@@ -547,7 +547,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ./test/multiuser-tests.sh
         args:
@@ -579,7 +579,7 @@ presubmits:
 #       preset-service-account: "true"
 #     spec:
 #       containers:
-#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+#       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 #         command:
 #         - ./test/presubmit-tests-gce-minikube.sh
 #         args:

--- a/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-flex/csi-driver-flex-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-host-path/csi-driver-host-path-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -395,7 +395,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -435,7 +435,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -475,7 +475,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -515,7 +515,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -555,7 +555,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -595,7 +595,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -635,7 +635,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -675,7 +675,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -715,7 +715,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -755,7 +755,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -795,7 +795,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -841,7 +841,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -887,7 +887,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -933,7 +933,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -979,7 +979,7 @@ periodics:
   spec:
     containers:
     # We need this image because it has Docker in Docker and go.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-iscsi/csi-driver-iscsi-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-smb/csi-driver-smb-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -104,7 +104,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-windows-poc/csi-driver-windows-poc-config.yaml
@@ -17,7 +17,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-lib-utils/csi-lib-utils-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-proxy/csi-proxy-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-release-tools/csi-release-tools-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
+++ b/config/jobs/kubernetes-csi/csi-test/csi-test-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
+++ b/config/jobs/kubernetes-csi/external-attacher/external-attacher-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
+++ b/config/jobs/kubernetes-csi/external-health-monitor/external-health-monitor-config.yaml
@@ -18,7 +18,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
+++ b/config/jobs/kubernetes-csi/external-provisioner/external-provisioner-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
+++ b/config/jobs/kubernetes-csi/external-resizer/external-resizer-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
+++ b/config/jobs/kubernetes-csi/external-snapshotter/external-snapshotter-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
+++ b/config/jobs/kubernetes-csi/livenessprobe/livenessprobe-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
+++ b/config/jobs/kubernetes-csi/node-driver-registrar/node-driver-registrar-config.yaml
@@ -19,7 +19,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -64,7 +64,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -103,7 +103,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -148,7 +148,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -187,7 +187,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -232,7 +232,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -271,7 +271,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -316,7 +316,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -355,7 +355,7 @@ presubmits:
     spec:
       containers:
       # We need this image because it has Docker in Docker and go.
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/alibaba-cloud-csi-driver/alibaba-cloud-csi-driver.yaml
@@ -6,7 +6,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -36,7 +36,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -51,7 +51,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:

--- a/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/apiserver-network-proxy/apiserver-network-proxy-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-alb-ingress-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -54,7 +54,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -14,7 +14,7 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -67,7 +67,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -89,7 +89,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             - runner.sh
           args:

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -25,7 +25,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -45,7 +45,7 @@ presubmits:
       preset-aws-credential-aws-oss-testing: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -112,7 +112,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -162,7 +162,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -212,7 +212,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -266,7 +266,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -319,7 +319,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -372,7 +372,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -418,7 +418,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -448,7 +448,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -112,7 +112,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -159,7 +159,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -208,7 +208,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -252,7 +252,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blobfuse-csi-driver/blobfuse-csi-driver-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -33,7 +33,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -57,7 +57,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -81,7 +81,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -112,7 +112,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -161,7 +161,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest

--- a/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
+++ b/config/jobs/kubernetes-sigs/cli-utils/cli-utils-presubmit-master.yaml
@@ -31,7 +31,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -42,7 +42,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -100,7 +100,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -147,7 +147,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -180,7 +180,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -238,7 +238,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -299,7 +299,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -357,7 +357,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -416,7 +416,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -482,7 +482,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -540,7 +540,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -598,7 +598,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -656,7 +656,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -712,7 +712,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -775,7 +775,7 @@ periodics:
     path_alias: sigs.k8s.io/cloud-provider-azure
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-boostrap-provider-kubeadm/cluster-api-bootstrap-provider-kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -55,7 +55,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -95,7 +95,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -133,7 +133,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-conformance.sh"
@@ -171,7 +171,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-conformance.sh"
@@ -220,7 +220,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -276,7 +276,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -48,7 +48,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -84,7 +84,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
             command:
               - "runner.sh"
               - "./scripts/ci-e2e-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -53,7 +53,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "make"
         - "verify"
@@ -88,7 +88,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -128,7 +128,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -163,7 +163,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"
@@ -200,7 +200,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-e2e-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -19,7 +19,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
           - "runner.sh"
           - "./scripts/ci-entrypoint.sh"
@@ -57,7 +57,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - "runner.sh"
       - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -37,7 +37,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-integration.sh"
@@ -75,7 +75,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -103,7 +103,7 @@ presubmits:
       preset-azure-cred: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -124,7 +124,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "make"
@@ -142,7 +142,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         imagePullPolicy: Always
         command:
         - "./hack/verify-bazel.sh"
@@ -159,7 +159,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-test.sh"
@@ -176,7 +176,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         imagePullPolicy: Always
         command:
         - "./scripts/ci-bazel-build.sh"
@@ -193,7 +193,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         imagePullPolicy: Always
         command:
         - "./hack/verify_boilerplate.py"
@@ -219,7 +219,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-entrypoint.sh"
@@ -259,7 +259,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
           command:
             - "runner.sh"
             - "./scripts/ci-entrypoint.sh"
@@ -297,7 +297,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pr-apidiff

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -33,7 +33,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
       preset-do-credential: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-docker/cluster-api-provider-docker-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - "runner.sh"
         - "./hack/verify-all.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - "runner.sh"
       - "./scripts/ci-build.sh"
@@ -34,7 +34,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "runner.sh"
       - "./scripts/ci-test.sh"
@@ -67,7 +67,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -115,7 +115,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -163,7 +163,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"
@@ -212,7 +212,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
           - name: "BOSKOS_HOST"
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -36,7 +36,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -74,7 +74,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           env:
             - name: "BOSKOS_HOST"
               value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-openstack/cluster-api-provider-openstack-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -29,7 +29,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./scripts/ci-test.sh"
     annotations:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-ci.yaml
@@ -13,7 +13,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       args:
@@ -51,7 +51,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         resources:
           requests:
             cpu: "1000m"
@@ -82,7 +82,7 @@ postsubmits:
     max_concurrency: 1
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-vsphere/cluster-api-provider-vsphere-presubmits.yaml
@@ -97,7 +97,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - hack/check-lint.sh
     annotations:
@@ -152,7 +152,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - hack/verify-crds.sh
     annotations:
@@ -168,7 +168,7 @@ presubmits:
     path_alias: sigs.k8s.io/cluster-api-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         resources:
           requests:
             cpu: "500m"
@@ -196,7 +196,7 @@ presubmits:
     max_concurrency: 3
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - "./scripts/ci-test.sh"
       resources:
@@ -35,7 +35,7 @@ periodics:
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -10,7 +10,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - ./scripts/ci-build.sh
@@ -34,7 +34,7 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         resources:
           requests:
             cpu: 7300m
@@ -56,7 +56,7 @@ presubmits:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-apidiff
@@ -70,7 +70,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - "runner.sh"
         - "make"
@@ -91,7 +91,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -113,7 +113,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -67,7 +67,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.17.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.17$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-release-1.18.yaml
@@ -67,7 +67,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -97,7 +97,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -127,7 +127,7 @@ presubmits:
     - ^release-1.18$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh

--- a/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/etcdadm/etcdadm-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./hack/verify-all.sh"
     annotations:
@@ -21,7 +21,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/config.yaml
@@ -91,7 +91,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=sigs.k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-postsubmits.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver=release-0.7"
       - "--root=/go/src"
@@ -41,7 +41,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -76,7 +76,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"
@@ -112,7 +112,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--repo=sigs.k8s.io/gcp-compute-persistent-disk-csi-driver"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
+++ b/config/jobs/kubernetes-sigs/gcp-compute-persistent-disk-csi-driver/gcp-compute-persistent-disk-csi-driver-windows.yaml
@@ -36,7 +36,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       securityContext:
           privileged: true
   annotations:
@@ -84,7 +84,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         securityContext:
           privileged: true
     annotations:
@@ -131,7 +131,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         securityContext:
           privileged: true
     annotations:

--- a/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
+++ b/config/jobs/kubernetes-sigs/ingress-controller-conformance/ingress-controller-conformance.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -32,7 +32,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -51,7 +51,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -71,7 +71,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -91,7 +91,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kind/kind-postsubmits.yaml
@@ -9,7 +9,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - make

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -9,7 +9,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -5,7 +5,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         - test
@@ -22,7 +22,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
@@ -52,7 +52,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py

--- a/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder-declarative-pattern/kubebuilder-declarative-pattern-presubmits.yaml
@@ -6,6 +6,6 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./hack/ci/test.sh"

--- a/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kubebuilder/kubebuilder-presubmits.yaml
@@ -29,7 +29,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -59,7 +59,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -89,7 +89,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh
@@ -119,7 +119,7 @@ presubmits:
     - ^feature/plugins-.+$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # see https://github.com/kubernetes/test-infra/blob/bb41c9ee91b50fffa843e2a6fbc0fe361999f682/config/prow/config.yaml#L590-L613
         - runner.sh

--- a/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
+++ b/config/jobs/kubernetes-sigs/kubetest2/kubetest2-canaries.yaml
@@ -14,7 +14,7 @@ presubmits:
       repo: cloud-provider-gcp
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "runner.sh"
         args:

--- a/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
+++ b/config/jobs/kubernetes-sigs/kustomize/kustomize-config.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/metrics-server/metrics-server-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - make
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - make
@@ -48,7 +48,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - make
@@ -74,7 +74,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
           - runner.sh
           - make

--- a/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
+++ b/config/jobs/kubernetes-sigs/poseidon/poseidon-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"
@@ -39,7 +39,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=github.com/$(REPO_OWNER)/$(REPO_NAME)=$(PULL_REFS)"

--- a/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
@@ -48,7 +48,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         securityContext:
           privileged: true  # for dind
         resources:
@@ -73,7 +73,7 @@ presubmits:
     spec:
       hostNetwork: true
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         securityContext:
           privileged: true  # for dind
         resources:

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -12,7 +12,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -35,7 +35,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -60,7 +60,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -89,7 +89,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -124,7 +124,7 @@ presubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -165,7 +165,7 @@ presubmits:
       workdir: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -211,7 +211,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -243,7 +243,7 @@ postsubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -278,7 +278,7 @@ postsubmits:
       preset-azure-secrets-store-creds: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
+++ b/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
@@ -12,7 +12,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh
@@ -34,7 +34,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
           # generic runner script, handles DIND, bazelrc for caching, etc.
           - runner.sh

--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -44,7 +44,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -64,7 +64,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -88,7 +88,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -117,7 +117,7 @@ presubmits:
       - master
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -132,7 +132,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         # generic runner script, handles DIND, bazelrc for caching, etc.
         - runner.sh
@@ -148,7 +148,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -164,7 +164,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -180,7 +180,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -196,7 +196,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh
@@ -212,7 +212,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             # generic runner script, handles DIND, bazelrc for caching, etc.
             - runner.sh

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner-trusted.yaml
@@ -12,7 +12,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -56,7 +56,7 @@ postsubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
+++ b/config/jobs/kubernetes-sigs/sig-storage-local-static-provisioner/sig-storage-local-static-provisioner.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -22,7 +22,7 @@ presubmits:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -36,7 +36,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -55,7 +55,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -74,7 +74,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -106,7 +106,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -136,7 +136,7 @@ periodics:
     path_alias: sigs.k8s.io/sig-storage-local-static-provisioner
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -78,7 +78,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -133,7 +133,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -186,7 +186,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -21,7 +21,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -79,7 +79,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -135,7 +135,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -39,7 +39,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -99,7 +99,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -162,7 +162,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -220,7 +220,7 @@ periodics:
 #     path_alias: k8s.io/kubernetes
 #   spec:
 #     containers:
-#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+#     - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 #       command:
 #       - runner.sh
 #       - kubetest
@@ -275,7 +275,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -328,7 +328,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -382,7 +382,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -440,7 +440,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -497,7 +497,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -551,7 +551,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -609,7 +609,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -672,7 +672,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -731,7 +731,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -786,7 +786,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -842,7 +842,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-kubeadm.yaml
@@ -21,7 +21,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - "runner.sh"
       - "./kubeadm/hack/ci-e2e.sh"

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-ci.yaml
@@ -11,7 +11,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - go
       args:
@@ -33,7 +33,7 @@ periodics:
     path_alias: sigs.k8s.io/structured-merge-diff
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - bash
       - -c

--- a/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/structured-merge-diff/structured-merge-diff-presubmits.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - go
         args:
@@ -27,7 +27,7 @@ presubmits:
     path_alias: sigs.k8s.io/structured-merge-diff
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - bash
         - -c

--- a/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
+++ b/config/jobs/kubernetes-sigs/vsphere-csi-driver/vsphere-csi-driver.yaml
@@ -8,7 +8,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -26,7 +26,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -44,7 +44,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -118,7 +118,7 @@ presubmits:
     path_alias: sigs.k8s.io/vsphere-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -139,7 +139,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -158,7 +158,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -184,7 +184,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -209,7 +209,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -27,7 +27,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -41,7 +41,7 @@ presubmits:
       path_alias: k8s.io/kubetest2
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-openstack/cloud-provider-openstack-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"
@@ -26,7 +26,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/cloud-provider-vsphere-config.yaml
@@ -34,7 +34,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -52,7 +52,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -70,7 +70,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -127,7 +127,7 @@ presubmits:
     path_alias: k8s.io/cloud-provider-vsphere
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - make
         args:
@@ -150,7 +150,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -171,7 +171,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -195,7 +195,7 @@ presubmits:
     skip_report: false
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:
@@ -226,7 +226,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             cpu: "1000m"
@@ -257,7 +257,7 @@ postsubmits:
     skip_submodules: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             cpu: "1000m"

--- a/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
+++ b/config/jobs/kubernetes/cluster-registry/cluster-registry-config.yaml
@@ -8,7 +8,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -29,7 +29,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"

--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -27,7 +27,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       resources:
         requests:
           cpu: 1000m
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       resources:
         requests:
           cpu: 1000m
@@ -105,7 +105,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         requests:
           cpu: 1000m
@@ -144,7 +144,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         requests:
           cpu: 1000m
@@ -183,7 +183,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         requests:
           cpu: 1000m
@@ -222,7 +222,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         requests:
           cpu: 1000m
@@ -261,7 +261,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         requests:
           cpu: 1000m
@@ -300,7 +300,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         requests:
           cpu: 1000m
@@ -339,7 +339,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       resources:
         requests:
           cpu: 1000m
@@ -378,7 +378,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       resources:
         requests:
           cpu: 1000m
@@ -417,7 +417,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         requests:
           cpu: 1000m
@@ -456,7 +456,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         requests:
           cpu: 1000m
@@ -495,7 +495,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         requests:
           cpu: 1000m
@@ -534,7 +534,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         requests:
           cpu: 1000m
@@ -573,7 +573,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         requests:
           cpu: 1000m
@@ -612,7 +612,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         requests:
           cpu: 1000m
@@ -650,7 +650,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -696,7 +696,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -742,7 +742,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -781,7 +781,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -821,7 +821,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -861,7 +861,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -900,7 +900,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -940,7 +940,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -980,7 +980,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1019,7 +1019,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1059,7 +1059,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1099,7 +1099,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1138,7 +1138,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1178,7 +1178,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1218,7 +1218,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1257,7 +1257,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1297,7 +1297,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1337,7 +1337,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1376,7 +1376,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1416,7 +1416,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1456,7 +1456,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1495,7 +1495,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1535,7 +1535,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1575,7 +1575,7 @@ periodics:
       - --check-leaked-resources=false
       - --gcp-project=ubuntu-os-gke-cloud-dev-tests
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1610,7 +1610,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1646,7 +1646,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1683,7 +1683,7 @@ periodics:
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1720,7 +1720,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1757,7 +1757,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1799,7 +1799,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1834,7 +1834,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1870,7 +1870,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1906,7 +1906,7 @@ periodics:
       - --ginkgo-parallel=30
       - --env=ENABLE_POD_SECURITY_POLICY=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1944,7 +1944,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -1981,7 +1981,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2023,7 +2023,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2058,7 +2058,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2094,7 +2094,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2129,7 +2129,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2167,7 +2167,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2204,7 +2204,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2246,7 +2246,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2282,7 +2282,7 @@ periodics:
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2316,7 +2316,7 @@ periodics:
       - --timeout=180m
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2352,7 +2352,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2390,7 +2390,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=1
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2427,7 +2427,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --ginkgo-parallel=30
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m
@@ -2469,7 +2469,7 @@ periodics:
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 1000m

--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -170,12 +170,12 @@ def build_test(cloud='aws', distro=None, networking=None, k8s_version=None, kops
     if k8s_version is None:
         extract = "release/latest"
         k8s_deploy_url = "https://storage.googleapis.com/kubernetes-release/release/latest.txt"
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master"
     else:
         extract = expand("release/stable-{k8s_version}")
         k8s_deploy_url = expand("https://storage.googleapis.com/kubernetes-release/release/stable-{k8s_version}.txt") # pylint: disable=line-too-long
         # Hack to stop the autobumper getting confused
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18"
         e2e_image = e2e_image[:-4] + k8s_version
 
     kops_args = ""

--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -76,11 +76,11 @@ def build_tests(branch, k8s_version, ssh_user):
 
     if branch == 'master':
         extract = "release/latest-1.19"
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19"
     else:
         extract = expand("release/stable-{k8s_version}")
         # Hack to stop the autobumper getting confused
-        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18"
+        e2e_image = "gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18"
         e2e_image = e2e_image[:-4] + k8s_version
 
     tab = expand('kops-pipeline-updown-{branch}')

--- a/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-distros.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -66,7 +66,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -102,7 +102,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -138,7 +138,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -174,7 +174,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -210,7 +210,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -246,7 +246,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -282,7 +282,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -318,7 +318,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros
@@ -354,7 +354,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-distros

--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -28,7 +28,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
     testgrid-tab-name: kops-gce-stable
@@ -63,7 +63,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
     testgrid-tab-name: kops-gce-latest
@@ -97,7 +97,7 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
     testgrid-tab-name: kops-canary-gce-stable
@@ -127,7 +127,7 @@ periodics:
 #       - --provider=gce
 #       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
 #       - --timeout=120m
-#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+#       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 #   annotations:
 #     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
 #     testgrid-tab-name: kops-gce-ha

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -33,7 +33,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -76,7 +76,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -119,7 +119,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -162,7 +162,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -205,7 +205,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -248,7 +248,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -291,7 +291,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -334,7 +334,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -377,7 +377,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -420,7 +420,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -463,7 +463,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -506,7 +506,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -549,7 +549,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -592,7 +592,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -635,7 +635,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -678,7 +678,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -721,7 +721,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -764,7 +764,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -807,7 +807,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -850,7 +850,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -893,7 +893,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -936,7 +936,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -979,7 +979,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1022,7 +1022,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1065,7 +1065,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1108,7 +1108,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1151,7 +1151,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1194,7 +1194,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1237,7 +1237,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -1280,7 +1280,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -1323,7 +1323,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1366,7 +1366,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1409,7 +1409,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1452,7 +1452,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1495,7 +1495,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1538,7 +1538,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1581,7 +1581,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -1624,7 +1624,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -1667,7 +1667,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1710,7 +1710,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -1753,7 +1753,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1796,7 +1796,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -1839,7 +1839,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1882,7 +1882,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -1925,7 +1925,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -1968,7 +1968,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -2011,7 +2011,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2054,7 +2054,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2097,7 +2097,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2140,7 +2140,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2183,7 +2183,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2226,7 +2226,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2269,7 +2269,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -2312,7 +2312,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -2355,7 +2355,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2398,7 +2398,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2441,7 +2441,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2484,7 +2484,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2527,7 +2527,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2570,7 +2570,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2613,7 +2613,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -2656,7 +2656,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -2699,7 +2699,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2742,7 +2742,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -2785,7 +2785,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2828,7 +2828,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -2871,7 +2871,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2914,7 +2914,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -2957,7 +2957,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3000,7 +3000,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3043,7 +3043,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3086,7 +3086,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3129,7 +3129,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3172,7 +3172,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3215,7 +3215,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3258,7 +3258,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3301,7 +3301,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3344,7 +3344,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3387,7 +3387,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3430,7 +3430,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3473,7 +3473,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3516,7 +3516,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3559,7 +3559,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3602,7 +3602,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3645,7 +3645,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3688,7 +3688,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -3731,7 +3731,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3774,7 +3774,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -3817,7 +3817,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3860,7 +3860,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -3903,7 +3903,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3946,7 +3946,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -3989,7 +3989,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4032,7 +4032,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4075,7 +4075,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4118,7 +4118,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4161,7 +4161,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4204,7 +4204,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4247,7 +4247,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -4290,7 +4290,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -4333,7 +4333,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4376,7 +4376,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4419,7 +4419,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4462,7 +4462,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4505,7 +4505,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4548,7 +4548,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4591,7 +4591,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -4634,7 +4634,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -4677,7 +4677,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4720,7 +4720,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -4763,7 +4763,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4806,7 +4806,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -4849,7 +4849,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4892,7 +4892,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -4935,7 +4935,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -4978,7 +4978,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -5021,7 +5021,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5064,7 +5064,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5107,7 +5107,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5150,7 +5150,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5193,7 +5193,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5236,7 +5236,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5279,7 +5279,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -5322,7 +5322,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -5365,7 +5365,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5408,7 +5408,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5451,7 +5451,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5494,7 +5494,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5537,7 +5537,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5580,7 +5580,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5623,7 +5623,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -5666,7 +5666,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -5709,7 +5709,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5752,7 +5752,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -5795,7 +5795,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5838,7 +5838,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -5881,7 +5881,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5924,7 +5924,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -5967,7 +5967,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6010,7 +6010,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6053,7 +6053,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6096,7 +6096,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6139,7 +6139,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6182,7 +6182,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6225,7 +6225,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6268,7 +6268,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6311,7 +6311,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6354,7 +6354,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6397,7 +6397,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6440,7 +6440,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6483,7 +6483,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6526,7 +6526,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6569,7 +6569,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6612,7 +6612,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6655,7 +6655,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6698,7 +6698,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -6741,7 +6741,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6784,7 +6784,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -6827,7 +6827,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6870,7 +6870,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -6913,7 +6913,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6956,7 +6956,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -6999,7 +6999,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7042,7 +7042,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7085,7 +7085,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7128,7 +7128,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7171,7 +7171,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7214,7 +7214,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7257,7 +7257,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -7300,7 +7300,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -7343,7 +7343,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7386,7 +7386,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7429,7 +7429,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7472,7 +7472,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7515,7 +7515,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7558,7 +7558,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7601,7 +7601,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -7644,7 +7644,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -7687,7 +7687,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7730,7 +7730,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -7773,7 +7773,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7816,7 +7816,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -7859,7 +7859,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7902,7 +7902,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -7945,7 +7945,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -7988,7 +7988,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -8031,7 +8031,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8074,7 +8074,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8117,7 +8117,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8160,7 +8160,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8203,7 +8203,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8246,7 +8246,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8289,7 +8289,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -8332,7 +8332,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -8375,7 +8375,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8418,7 +8418,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8461,7 +8461,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8504,7 +8504,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8547,7 +8547,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8590,7 +8590,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8633,7 +8633,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -8676,7 +8676,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -8719,7 +8719,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8762,7 +8762,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -8805,7 +8805,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8848,7 +8848,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -8891,7 +8891,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8934,7 +8934,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -8977,7 +8977,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9020,7 +9020,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9063,7 +9063,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9106,7 +9106,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9149,7 +9149,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9192,7 +9192,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9235,7 +9235,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -9278,7 +9278,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -9321,7 +9321,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9364,7 +9364,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9407,7 +9407,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9450,7 +9450,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9493,7 +9493,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9536,7 +9536,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9579,7 +9579,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -9622,7 +9622,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -9665,7 +9665,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9708,7 +9708,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -9751,7 +9751,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9794,7 +9794,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -9837,7 +9837,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9880,7 +9880,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -9923,7 +9923,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -9966,7 +9966,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10009,7 +10009,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10052,7 +10052,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10095,7 +10095,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10138,7 +10138,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10181,7 +10181,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10224,7 +10224,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10267,7 +10267,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10310,7 +10310,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10353,7 +10353,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10396,7 +10396,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10439,7 +10439,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10482,7 +10482,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10525,7 +10525,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10568,7 +10568,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10611,7 +10611,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10654,7 +10654,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10697,7 +10697,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10740,7 +10740,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -10783,7 +10783,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10826,7 +10826,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -10869,7 +10869,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10912,7 +10912,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -10955,7 +10955,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -10998,7 +10998,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -11041,7 +11041,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11084,7 +11084,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11127,7 +11127,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11170,7 +11170,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11213,7 +11213,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11256,7 +11256,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11299,7 +11299,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -11342,7 +11342,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -11385,7 +11385,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11428,7 +11428,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11471,7 +11471,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11514,7 +11514,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11557,7 +11557,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11600,7 +11600,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11643,7 +11643,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -11686,7 +11686,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -11729,7 +11729,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11772,7 +11772,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -11815,7 +11815,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11858,7 +11858,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -11901,7 +11901,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11944,7 +11944,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -11987,7 +11987,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12030,7 +12030,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12073,7 +12073,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12116,7 +12116,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12159,7 +12159,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12202,7 +12202,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12245,7 +12245,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -12288,7 +12288,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -12331,7 +12331,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12374,7 +12374,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12417,7 +12417,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12460,7 +12460,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12503,7 +12503,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12546,7 +12546,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12589,7 +12589,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -12632,7 +12632,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -12675,7 +12675,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12718,7 +12718,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -12761,7 +12761,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12804,7 +12804,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -12847,7 +12847,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12890,7 +12890,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -12933,7 +12933,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -12976,7 +12976,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -13019,7 +13019,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13062,7 +13062,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13105,7 +13105,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13148,7 +13148,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13191,7 +13191,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13234,7 +13234,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13277,7 +13277,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -13320,7 +13320,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -13363,7 +13363,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13406,7 +13406,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13449,7 +13449,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13492,7 +13492,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13535,7 +13535,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13578,7 +13578,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13621,7 +13621,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -13664,7 +13664,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -13707,7 +13707,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13750,7 +13750,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -13793,7 +13793,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13836,7 +13836,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -13879,7 +13879,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13922,7 +13922,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -13965,7 +13965,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14008,7 +14008,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14051,7 +14051,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14094,7 +14094,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14137,7 +14137,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14180,7 +14180,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14223,7 +14223,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14266,7 +14266,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14309,7 +14309,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14352,7 +14352,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14395,7 +14395,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14438,7 +14438,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14481,7 +14481,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14524,7 +14524,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14567,7 +14567,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14610,7 +14610,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14653,7 +14653,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14696,7 +14696,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -14739,7 +14739,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14782,7 +14782,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -14825,7 +14825,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14868,7 +14868,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -14911,7 +14911,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14954,7 +14954,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -14997,7 +14997,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15040,7 +15040,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15083,7 +15083,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15126,7 +15126,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15169,7 +15169,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15212,7 +15212,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15255,7 +15255,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -15298,7 +15298,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -15341,7 +15341,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15384,7 +15384,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15427,7 +15427,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15470,7 +15470,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15513,7 +15513,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15556,7 +15556,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15599,7 +15599,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -15642,7 +15642,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -15685,7 +15685,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15728,7 +15728,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -15771,7 +15771,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15814,7 +15814,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -15857,7 +15857,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15900,7 +15900,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -15943,7 +15943,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -15986,7 +15986,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -16029,7 +16029,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16072,7 +16072,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16115,7 +16115,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16158,7 +16158,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16201,7 +16201,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16244,7 +16244,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16287,7 +16287,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -16330,7 +16330,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -16373,7 +16373,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16416,7 +16416,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16459,7 +16459,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16502,7 +16502,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16545,7 +16545,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16588,7 +16588,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16631,7 +16631,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -16674,7 +16674,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -16717,7 +16717,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16760,7 +16760,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -16803,7 +16803,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16846,7 +16846,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -16889,7 +16889,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16932,7 +16932,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           memory: 2Gi
@@ -16975,7 +16975,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -17018,7 +17018,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       resources:
         limits:
           memory: 2Gi
@@ -17061,7 +17061,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -17104,7 +17104,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       resources:
         limits:
           memory: 2Gi
@@ -17147,7 +17147,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi
@@ -17190,7 +17190,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       resources:
         limits:
           memory: 2Gi

--- a/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-misc.yaml
@@ -103,7 +103,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-arm64-latest
@@ -138,7 +138,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-arm64-ci
@@ -173,7 +173,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-arm64-conformance
@@ -208,7 +208,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-containerd
@@ -316,7 +316,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
@@ -386,7 +386,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[k8s.io\]\sNetworking.*\[Conformance\]
       - --timeout=45m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-misc
     testgrid-tab-name: kops-aws-updown

--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-amazon-vpc
@@ -65,7 +65,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-calico
@@ -100,7 +100,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-canal
@@ -135,7 +135,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|affinity.*clusterIP
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-cilium
@@ -170,7 +170,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-flannel
@@ -205,7 +205,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-kopeio
@@ -239,7 +239,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|load-balancer|hairpin|affinity\stimeout
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-kuberouter
@@ -274,7 +274,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-network-plugins
     testgrid-tab-name: kops-aws-cni-weave

--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -33,7 +33,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-latest
@@ -66,7 +66,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.19
@@ -99,7 +99,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.18
@@ -132,7 +132,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.17
@@ -165,7 +165,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.16
@@ -198,7 +198,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.15
@@ -231,7 +231,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.14
@@ -264,7 +264,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.13
@@ -297,7 +297,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.12
@@ -330,7 +330,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[Conformance\]|\[NodeConformance\] --ginkgo.skip=\[Slow\]|\[Serial\]|AdmissionWebhook|Aggregator|CustomResource|SchedulerPredicates|Lease|hostAliases|NodePort
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-versions
     testgrid-tab-name: kops-aws-k8s-1.11

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -16,7 +16,7 @@ periodics:
     preset-aws-credential: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - kubetest
@@ -66,7 +66,7 @@ periodics:
     preset-aws-credential: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -116,7 +116,7 @@ periodics:
     preset-aws-credential: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -166,7 +166,7 @@ periodics:
     preset-aws-credential: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -255,7 +255,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -277,7 +277,7 @@ presubmits:
     - release-1.16
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -298,7 +298,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -317,7 +317,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -338,7 +338,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -360,7 +360,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -379,7 +379,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -400,7 +400,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -423,7 +423,7 @@ presubmits:
     - release-1.16
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -447,7 +447,7 @@ presubmits:
     - release-1.16
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -472,7 +472,7 @@ presubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:
@@ -494,7 +494,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
       args:
       - --repo=k8s.io/kops
       - --repo=k8s.io/release
@@ -527,7 +527,7 @@ postsubmits:
     path_alias: k8s.io/kops
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - runner.sh
         args:

--- a/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kubernetes-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
+++ b/config/jobs/kubernetes/kubeadm/kubeadm-presubmits.yaml
@@ -9,7 +9,7 @@ presubmits:
     run_if_changed: '^kinder\/.*$'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./kinder/hack/verify-all.sh"
 
@@ -31,7 +31,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -53,7 +53,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - "./operator/hack/verify-all.sh"

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-ci.yaml
@@ -12,7 +12,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -39,7 +39,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -75,7 +75,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -113,7 +113,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -150,7 +150,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -187,7 +187,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -224,7 +224,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:
@@ -261,7 +261,7 @@ periodics:
     path_alias: k8s.io/node-problem-detector
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       env:
       - name: ZONE
         value: us-central1-a

--- a/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
+++ b/config/jobs/kubernetes/node-problem-detector/node-problem-detector-presubmits.yaml
@@ -11,7 +11,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -38,7 +38,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -72,7 +72,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -109,7 +109,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -145,7 +145,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -181,7 +181,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -217,7 +217,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -252,7 +252,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
         - name: ZONE
           value: us-central1-a

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -29,7 +29,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-release-cluster-up
         - --test_args=--ginkgo.focus=definitely-not-a-real-focus
         - --timeout=65m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-proto
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 - interval: 2h
@@ -72,7 +72,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-api-machinery-network-proxy
 
@@ -111,7 +111,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -150,7 +150,7 @@ presubmits:
         - --provider=gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"

--- a/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
+++ b/config/jobs/kubernetes/sig-apps/sig-apps-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/kubernetes-sigs/application=master
       - --upload=gs://kubernetes-jenkins/logs/
@@ -57,7 +57,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:TaintEviction\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 
   annotations:
@@ -81,7 +81,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-statefulset

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-config.yaml
@@ -7,7 +7,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -38,7 +38,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -69,7 +69,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -100,7 +100,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -131,7 +131,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/autoscaler=master
       - --root=/go/src
@@ -184,7 +184,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -209,7 +209,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -244,7 +244,7 @@ periodics:
       - --runtime-config=scheduling.k8s.io/v1alpha1=true
       - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-cluster-autoscaler
@@ -269,7 +269,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:CustomMetricsAutoscaling\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-autoscaling-hpa
@@ -295,7 +295,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:HPA\]
         --minStartupPods=8
       - --ginkgo-parallel=1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     # TODO: add to release blocking dashboards once run is successful

--- a/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-autoscaling/sig-autoscaling-presubmits.yaml
@@ -44,4 +44,4 @@ presubmits:
         - --runtime-config=scheduling.k8s.io/v1alpha1=true
         - --test_args=--ginkgo.focus=\[Feature:ClusterSizeAutoscalingScaleUp\]|\[Feature:ClusterSizeAutoscalingScaleDown\]|\[Feature:InitialResources\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=400m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master

--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -18,7 +18,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\].*\[Serial\]|\[sig-cli\].*\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -47,7 +47,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -75,7 +75,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-cli\] --ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   # kubectl skew tests
   annotations:
@@ -105,7 +105,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -139,7 +139,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -168,7 +168,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -207,7 +207,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -235,7 +235,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -262,7 +262,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-cli-master
@@ -290,7 +290,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -316,7 +316,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -344,7 +344,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -371,7 +371,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -398,7 +398,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\]|\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
@@ -424,7 +424,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=Kubectl.*\[Serial\] --ginkgo.skip=\[Deprecated\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: sig-release-job-config-errors

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
       preset-kubernetes-e2e-aws-eks-1-13: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         imagePullPolicy: Always
         args:
         - --root=/go/src

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -166,7 +166,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         command:
         - runner.sh
         - kubetest
@@ -219,7 +219,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -274,7 +274,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -331,7 +331,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -395,7 +395,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -448,7 +448,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -503,7 +503,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -557,7 +557,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -166,7 +166,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - runner.sh
         - kubetest
@@ -219,7 +219,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -274,7 +274,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -331,7 +331,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -395,7 +395,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -448,7 +448,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -503,7 +503,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -557,7 +557,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -64,7 +64,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -114,7 +114,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -166,7 +166,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         command:
         - runner.sh
         - kubetest
@@ -219,7 +219,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -274,7 +274,7 @@ periodics:
     path_alias: sigs.k8s.io/azuredisk-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -331,7 +331,7 @@ periodics:
     path_alias: sigs.k8s.io/azurefile-csi-driver
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -395,7 +395,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -448,7 +448,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -503,7 +503,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh
@@ -557,7 +557,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - ./scripts/ci-entrypoint.sh

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/sig-azure-config.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -69,7 +69,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -124,7 +124,7 @@ presubmits:
       path_alias: sigs.k8s.io/azuredisk-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -181,7 +181,7 @@ presubmits:
       path_alias: sigs.k8s.io/azurefile-csi-driver
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         - kubetest
@@ -234,7 +234,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest
@@ -291,7 +291,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - "runner.sh"
       - "./scripts/ci-entrypoint.sh"
@@ -336,7 +336,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - "runner.sh"
       - "./scripts/ci-entrypoint.sh"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -29,7 +29,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-misc.yaml
@@ -19,7 +19,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:HAMaster\] --minStartupPods=8
       - --timeout=220m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -55,7 +55,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -99,7 +99,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -152,7 +152,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -207,7 +207,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           resources:
             requests:
               memory: "6Gi"
@@ -263,7 +263,7 @@ presubmits:
             - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
             - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           resources:
             requests:
               memory: "6Gi"
@@ -295,7 +295,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -346,7 +346,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-alpha-features
         - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionHash|Audit|PodPreset|RunAsGroup|TTLAfterFinished|NodeLease|CSIStorageCapacity|GenericEphemeralVolume)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
         - --timeout=180m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -378,7 +378,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 2
@@ -424,7 +424,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           limits:
             cpu: 2
@@ -474,7 +474,7 @@ periodics:
           - --provider=gce
           - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
           - --timeout=50m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           limits:
             cpu: 2
@@ -513,7 +513,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|csi-hostpath-v0 --minStartupPods=8
       - --timeout=70m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-alpha-enabled-default
@@ -542,7 +542,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(ServiceAccountIssuerDiscovery|StorageVersionHash|Audit|PodPreset|RunAsGroup|TTLAfterFinished|NodeLease|CSIStorageCapacity|GenericEphemeralVolume)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance)\]|IPv6|csi-hostpath-v0 --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -580,7 +580,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 2
@@ -612,7 +612,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-flaky
@@ -638,7 +638,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-single-flake-attempt
@@ -664,7 +664,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -701,7 +701,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -738,7 +738,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         limits:
           cpu: 1
@@ -778,7 +778,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gce-multizone
@@ -808,7 +808,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-soak
     testgrid-tab-name: gce-gci
@@ -838,7 +838,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.15
@@ -868,7 +868,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.14
@@ -897,7 +897,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.13
@@ -926,7 +926,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1400m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: soak-gci-gce-1.12

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-presubmits.yaml
@@ -27,7 +27,7 @@ presubmits:
       preset-pull-gce-device-plugin-gpu: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gcp-gpu-upgrade-downgrade.yaml
@@ -24,7 +24,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -54,7 +54,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -84,7 +84,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -114,7 +114,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -144,7 +144,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -174,7 +174,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUMasterUpgrade\] --upgrade-target=ci/latest --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -205,7 +205,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce-upgrade
@@ -236,7 +236,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8 --ginkgo.skip=\[.+\]|Initializers|Dashboard
       - --timeout=150m
       - --upgrade_args=--ginkgo.focus=\[Feature:GPUClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-gpu-master-1.13-cluster-downgrade

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -42,4 +42,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/upgrade-gce.yaml
@@ -23,7 +23,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster
@@ -52,7 +52,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-parallel
@@ -81,7 +81,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new
@@ -111,7 +111,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-beta --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-cluster-new-parallel
@@ -139,7 +139,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master
@@ -168,7 +168,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-beta
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.14-upgrade-master-parallel
@@ -197,7 +197,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster
@@ -227,7 +227,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable2 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.13-1.12-downgrade-cluster-parallel
@@ -255,7 +255,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster
@@ -283,7 +283,7 @@ periodics:
       - --skew
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterUpgrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-cluster-new
@@ -311,7 +311,7 @@ periodics:
       - --test_args=--kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:MasterUpgrade\] --upgrade-target=ci/k8s-stable1
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.12-1.13-upgrade-master
@@ -341,7 +341,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Slow\]|\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=900m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster
@@ -372,7 +372,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --kubectl-path=../../../../kubernetes_skew/cluster/kubectl.sh --minStartupPods=8
       - --timeout=120m
       - --upgrade_args=--ginkgo.focus=\[Feature:ClusterDowngrade\] --upgrade-target=ci/k8s-stable1 --upgrade-image=gci
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce-upgrade
     testgrid-tab-name: gce-1.14-1.13-downgrade-cluster-parallel

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-addons.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-discovery.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-external-etcd.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-kustomize.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-patches.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -69,7 +69,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-upgrade.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder-x-on-y.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/kubeadm-kinder.yaml
@@ -28,7 +28,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -68,7 +68,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -108,7 +108,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -148,7 +148,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"
@@ -188,7 +188,7 @@ periodics:
     path_alias: k8s.io/kubeadm
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - "../kubeadm/kinder/ci/kinder-run.sh"

--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -20,7 +20,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce
@@ -46,7 +46,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
   annotations:
     testgrid-dashboards: google-gce

--- a/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml
@@ -15,7 +15,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       command:
       - runner.sh
       - kubetest
@@ -66,7 +66,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - runner.sh
       - kubetest
@@ -117,7 +117,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       command:
       - runner.sh
       - kubetest
@@ -168,7 +168,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -92,7 +92,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -114,7 +114,7 @@ postsubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --repo=k8s.io/ingress-gce=$(PULL_REFS)
         - --root=/go/src/
@@ -142,7 +142,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --timeout=340
       - --bare
@@ -173,7 +173,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --timeout=340
       - --bare
@@ -205,7 +205,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --timeout=340
       - --bare
@@ -233,7 +233,7 @@ periodics:
     preset-ingress-master-yaml: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --timeout=340
       - --bare

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -35,7 +35,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gci-gce-ipvs
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -84,7 +84,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GCEAlphaFeature\] --minStartupPods=8
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce, sig-network-gce
     testgrid-tab-name: gce-alpha-api
@@ -112,7 +112,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance
@@ -139,7 +139,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance
@@ -164,7 +164,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 6h
   name: ci-kubernetes-e2e-gce-coredns-performance-nodecache
@@ -190,7 +190,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-coredns-performance-nodecache
@@ -218,7 +218,7 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:PerformanceDNS\]
       - --timeout=60m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gce-kubedns-performance-nodecache
@@ -244,7 +244,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ingress
@@ -268,7 +268,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress
@@ -296,7 +296,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce
     testgrid-tab-name: gci-gce-ingress-manual-network
@@ -326,7 +326,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce, google-gci
     testgrid-tab-name: ip-alias
@@ -352,7 +352,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-num-failures-to-alert: '6'
     testgrid-alert-stale-results-hours: '24'
@@ -377,7 +377,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
@@ -401,7 +401,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
@@ -425,7 +425,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
@@ -450,7 +450,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
 
 - interval: 12h
   name: ci-kubernetes-e2e-gci-gce-basic-sctp
@@ -475,4 +475,4 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:SCTP\] --ginkgo.skip=\[Feature:NetworkPolicy\]
       - --timeout=300m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master

--- a/config/jobs/kubernetes/sig-node/containerd.yaml
+++ b/config/jobs/kubernetes/sig-node/containerd.yaml
@@ -45,7 +45,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/containerd/containerd=master
       - --repo=github.com/containerd/cri=master
@@ -63,7 +63,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/containerd/containerd=release/1.2
       - --repo=github.com/containerd/cri=release/1.2
@@ -82,7 +82,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/containerd/containerd=release/1.3
       - --repo=github.com/containerd/cri=release/1.3
@@ -121,7 +121,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci
@@ -181,7 +181,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-gci-1.3
@@ -212,7 +212,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: containerd-e2e-ubuntu
@@ -223,7 +223,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -253,7 +253,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -283,7 +283,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -343,7 +343,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes=release-1.16
@@ -394,7 +394,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --clean-start=true --minStartupPods=8
       - --timeout=1200m
       - --up=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: soak-gci-gce
@@ -404,7 +404,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -421,7 +421,7 @@ periodics:
     preset-service-account: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=github.com/containerd/cri=master
       - --root=/go/src
@@ -455,7 +455,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-device-plugin-gpu
@@ -487,7 +487,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-multizone
@@ -515,7 +515,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverMonitoring\]|\[Feature:StackdriverCustomMetrics\]|\[Feature:StackdriverMetadataAgent\]|\[Feature:StackdriverExternalMetrics\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-stackdriver
@@ -543,7 +543,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci
@@ -572,7 +572,7 @@ periodics:
       - --runtime-config=api/all=true
       - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandPersistentVolumes|VolumeSubpathEnvExpansion|RunAsGroup|NodeLease)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-alpha-features
@@ -599,7 +599,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Elasticsearch\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-es-logging
@@ -624,7 +624,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Flaky\] --ginkgo.skip=\[Feature:.+\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-flaky
@@ -652,7 +652,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-network-gce, sig-node-containerd
     testgrid-tab-name: e2e-gci-ingress
@@ -682,7 +682,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-ip-alias
@@ -709,7 +709,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-proto
@@ -734,7 +734,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Reboot\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-reboot
@@ -761,7 +761,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging
@@ -792,7 +792,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
       - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-sd-logging-k8s-resources
@@ -817,7 +817,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Serial\]|\[Disruptive\] --ginkgo.skip=\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=500m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-serial
@@ -843,7 +843,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=150m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-slow
@@ -867,7 +867,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:StatefulSet\] --minStartupPods=8
       - --timeout=90m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-gci-statefulset
@@ -895,7 +895,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: e2e-ubuntu
@@ -906,7 +906,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -936,7 +936,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -966,7 +966,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -996,7 +996,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1026,7 +1026,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1074,7 +1074,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-cos-e2e
@@ -1101,7 +1101,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: sig-node-containerd
     testgrid-tab-name: image-validation-ubuntu-e2e
@@ -1112,7 +1112,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1141,7 +1141,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --root=/go/src
       - --repo=k8s.io/kubernetes
@@ -1178,7 +1178,7 @@ periodics:
   spec:
     containers:
     - name: ci-cri-containerd-cri-validation-windows
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-node/node-docker.yaml
+++ b/config/jobs/kubernetes/sig-node/node-docker.yaml
@@ -6,7 +6,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -35,7 +35,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -64,7 +64,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200

--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -14,7 +14,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -47,7 +47,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -77,7 +77,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -108,7 +108,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -146,7 +146,7 @@ periodics:
     testgrid-tab-name: node-kubelet-features-master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -179,7 +179,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=90
@@ -209,7 +209,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=400
@@ -239,7 +239,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=320
@@ -269,7 +269,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=200
@@ -299,7 +299,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --timeout=240
@@ -330,7 +330,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240
@@ -361,7 +361,7 @@ periodics:
     preset-k8s-ssh: "true"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --timeout=240

--- a/config/jobs/kubernetes/sig-node/sig-node-config.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-config.yaml
@@ -24,7 +24,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-gce, sig-storage-kubernetes
     testgrid-tab-name: gce-containerd

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -15,7 +15,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -75,7 +75,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m     # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -91,7 +91,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - --job=$(JOB_NAME)
@@ -125,7 +125,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -163,7 +163,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -197,7 +197,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -231,7 +231,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           args:
             - --repo=k8s.io/kubernetes=$(PULL_REFS)
             - --repo=k8s.io/release
@@ -265,7 +265,7 @@ presubmits:
       preset-k8s-ssh: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - --env=KUBE_SSH_USER=core

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -55,7 +55,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         command:
         - infra/gcp/backup_tools/backup_test.sh
         env:
@@ -78,7 +78,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./test-e2e/cip/e2e-entrypoint-from-container.sh"
         env:
@@ -106,7 +106,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./test-e2e/cip-auditor/entrypoint-from-container.sh"
         env:
@@ -132,7 +132,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -25,7 +25,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -63,7 +63,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources: {}
 - annotations:
@@ -96,7 +96,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -133,7 +133,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -219,7 +219,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         requests:
@@ -280,7 +280,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources: {}
       securityContext:
@@ -323,7 +323,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources: {}
 - annotations:
@@ -384,7 +384,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -427,7 +427,7 @@ periodics:
         value: release-1.16
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       imagePullPolicy: Always
       name: ""
       resources:
@@ -481,7 +481,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.16.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources: {}
 - annotations:
@@ -516,7 +516,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -563,7 +563,7 @@ periodics:
         value: ipv6
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
       resources:
         limits:
@@ -602,7 +602,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -678,7 +678,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -720,7 +720,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -761,7 +761,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -806,7 +806,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources: {}
   - always_run: true
@@ -837,7 +837,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -878,7 +878,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -936,7 +936,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         name: ""
         resources:
           requests:
@@ -993,7 +993,7 @@ presubmits:
         - --test-cmd-args=--testoverrides=./testing/overrides/enable_oom_tracking.yaml
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -1070,7 +1070,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: main
         resources: {}
         securityContext:
@@ -1090,7 +1090,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: main
         resources: {}
   - always_run: true
@@ -1108,7 +1108,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -1155,7 +1155,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         name: ""
         resources:
           requests:
@@ -1202,7 +1202,7 @@ presubmits:
           value: release-1.16
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -31,7 +31,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -105,7 +105,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources: {}
 - annotations:
@@ -138,7 +138,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -175,7 +175,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -273,7 +273,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         requests:
@@ -341,7 +341,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources: {}
       securityContext:
@@ -384,7 +384,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources: {}
 - annotations:
@@ -445,7 +445,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -488,7 +488,7 @@ periodics:
         value: release-1.17
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       imagePullPolicy: Always
       name: ""
       resources:
@@ -540,7 +540,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.17.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources: {}
 - annotations:
@@ -575,7 +575,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -622,7 +622,7 @@ periodics:
         value: ipv6
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
       resources:
         limits:
@@ -661,7 +661,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -738,7 +738,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -780,7 +780,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -825,7 +825,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources: {}
   - always_run: true
@@ -865,7 +865,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -898,7 +898,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -939,7 +939,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -998,7 +998,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         name: ""
         resources:
           requests:
@@ -1064,7 +1064,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -1141,7 +1141,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: main
         resources: {}
         securityContext:
@@ -1161,7 +1161,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:
@@ -1183,7 +1183,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: main
         resources: {}
   - always_run: true
@@ -1210,7 +1210,7 @@ presubmits:
           value: release-1.17
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         imagePullPolicy: Always
         name: ""
         resources:
@@ -1253,7 +1253,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
         name: ""
         resources:
           requests:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -31,7 +31,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         limits:
@@ -106,7 +106,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
 - annotations:
@@ -139,7 +139,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         limits:
@@ -176,7 +176,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         limits:
@@ -273,7 +273,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
       securityContext:
@@ -341,7 +341,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         requests:
@@ -389,7 +389,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
 - annotations:
@@ -450,7 +450,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources:
         limits:
@@ -493,7 +493,7 @@ periodics:
         value: release-1.18
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       imagePullPolicy: Always
       name: ""
       resources:
@@ -545,7 +545,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
 - annotations:
@@ -588,7 +588,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
 - annotations:
@@ -723,7 +723,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -800,7 +800,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -839,7 +839,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -878,7 +878,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -925,7 +925,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -976,7 +976,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1021,7 +1021,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources: {}
   - always_run: true
@@ -1061,7 +1061,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1094,7 +1094,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1135,7 +1135,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1195,7 +1195,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1261,7 +1261,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1338,7 +1338,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: main
         resources: {}
         securityContext:
@@ -1358,7 +1358,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: ""
         resources:
           requests:
@@ -1418,7 +1418,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         name: main
         resources: {}
   - always_run: true
@@ -1445,7 +1445,7 @@ presubmits:
           value: release-1.18
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -26,7 +26,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources:
         limits:
@@ -65,7 +65,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources: {}
 - annotations:
@@ -98,7 +98,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources:
         limits:
@@ -135,7 +135,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources:
         limits:
@@ -227,7 +227,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=80m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources: {}
       securityContext:
@@ -291,7 +291,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources:
         requests:
@@ -339,7 +339,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources: {}
 - annotations:
@@ -400,7 +400,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources:
         limits:
@@ -443,7 +443,7 @@ periodics:
         value: release-1.19
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       imagePullPolicy: Always
       name: ""
       resources:
@@ -495,7 +495,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources: {}
 - annotations:
@@ -538,7 +538,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
       resources: {}
 - annotations:
@@ -673,7 +673,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -752,7 +752,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -791,7 +791,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -830,7 +830,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -877,7 +877,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -927,7 +927,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -972,7 +972,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources: {}
   - always_run: true
@@ -1012,7 +1012,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1045,7 +1045,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1086,7 +1086,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\]
           --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1140,7 +1140,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1201,7 +1201,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1278,7 +1278,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: main
         resources: {}
         securityContext:
@@ -1298,7 +1298,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: main
         resources: {}
   - always_run: true
@@ -1316,7 +1316,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: ""
         resources:
           requests:
@@ -1377,7 +1377,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         name: main
         resources: {}
   - always_run: true
@@ -1406,7 +1406,7 @@ presubmits:
           value: release-1.19
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-cleanup.yaml
@@ -8,7 +8,7 @@ periodics:
     testgrid-tab-name: snapshots-cleanup
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -13,7 +13,7 @@ periodics:
     testgrid-tab-name: storage
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -52,7 +52,7 @@ periodics:
     testgrid-tab-name: calico
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       env:
       - name: NETWORK_POLICY_PROVIDER
         value: "calico"
@@ -109,7 +109,7 @@ periodics:
     testgrid-tab-name: experimental-load
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master
@@ -162,7 +162,7 @@ periodics:
     testgrid-tab-name: experimental-load-containerd
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master
@@ -212,7 +212,7 @@ periodics:
     testgrid-tab-name: gce-cos-master-scalability-100-containerd-correctness
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --repo=k8s.io/kubernetes=master
           - --root=/go/src
@@ -251,7 +251,7 @@ periodics:
     testgrid-tab-name: gce-cos-master-scalability-100-nodekiller
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
           - --timeout=140
           - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -81,7 +81,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=430m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       env:
       - name: CL2_ENABLE_VIOLATIONS_FOR_API_CALL_PROMETHEUS
         value: "true"
@@ -143,7 +143,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 6
@@ -196,7 +196,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 6

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -13,7 +13,7 @@ periodics:
     testgrid-tab-name: node-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -53,7 +53,7 @@ periodics:
     testgrid-tab-name: node-containerd-throughput
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -98,7 +98,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -161,7 +161,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -220,7 +220,7 @@ periodics:
     testgrid-num-columns-recent: '3'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -282,7 +282,7 @@ periodics:
     testgrid-num-failures-to-alert: '1'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -330,7 +330,7 @@ periodics:
     testgrid-tab-name: kubemark-100-benchmark
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -357,7 +357,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -386,7 +386,7 @@ periodics:
     timeout: 1h55m
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - ./hack/jenkins/benchmark-dockerized.sh
       args:
@@ -423,7 +423,7 @@ periodics:
     testgrid-tab-name: kube-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
@@ -458,7 +458,7 @@ periodics:
     testgrid-tab-name: node-local-dns
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -52,7 +52,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -103,7 +103,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -149,7 +149,7 @@ presubmits:
         - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
         - --timeout=240m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -201,7 +201,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=540m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -224,7 +224,7 @@ presubmits:
       testgrid-create-test-group: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -292,7 +292,7 @@ presubmits:
       preset-e2e-scalability-presubmits: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -390,7 +390,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -444,7 +444,7 @@ presubmits:
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
             - --use-logexporter
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           resources:
             requests:
               memory: "6Gi"
@@ -505,7 +505,7 @@ presubmits:
             - --test-cmd-name=ClusterLoaderV2
             - --timeout=100m
             - --use-logexporter
-          image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+          image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           resources:
             requests:
               memory: "6Gi"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -35,7 +35,7 @@ periodics:
       - --test_args=--ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[DisabledForLargeClusters\] --minStartupPods=8 --node-schedulable-timeout=90m
       - --timeout=240m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 6
@@ -99,7 +99,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=1050m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 6
@@ -131,7 +131,7 @@ periodics:
     testgrid-num-failures-to-alert: '2'
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - --timeout=140
       - --repo=k8s.io/kubernetes=master

--- a/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml
@@ -45,7 +45,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -95,7 +95,7 @@ presubmits:
         # Bazel needs privileged mode in order to sandbox builds.
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -136,7 +136,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
         args:
@@ -195,7 +195,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-csi-serial
         - --test_args=--ginkgo.focus=CSI.*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\]|\[Feature:.+\]|\[Slow\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -237,7 +237,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -278,7 +278,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-iscsi-serial
         - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=120m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -315,7 +315,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-storage-disruptive
         - --test_args=--ginkgo.focus=\[sig-storage\].*\[Disruptive\] --ginkgo.skip=\[Flaky\] --minStartupPods=8
         - --timeout=240m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             memory: "6Gi"
@@ -345,7 +345,7 @@ periodics:
       - --ginkgo-parallel=30
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -370,7 +370,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Driver:.iscsi\].*(\[Serial\]|\[Disruptive\]) --ginkgo.skip=\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-num-columns-recent: '20'
 - interval: 24h
@@ -392,7 +392,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:VolumeSnapshotDataSource\] --ginkgo.skip=\[Disruptive\]|\[Flaky\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-num-columns-recent: '20'
     testgrid-num-failures-to-alert: '6'

--- a/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
+++ b/config/jobs/kubernetes/sig-storage/sig-storage-kops-config.yaml
@@ -30,7 +30,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.focus=\[sig-storage\].*\[Slow\] --ginkgo.skip=\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
   annotations:
     testgrid-num-columns-recent: '20'

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -72,7 +72,7 @@ postsubmits:
       preset-bazel-remote-cache-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--repo=k8s.io/$(REPO_NAME)=$(PULL_REFS)"
@@ -104,7 +104,7 @@ postsubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - bash
         args:
@@ -210,7 +210,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - bash
       args:

--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - "--job=$(JOB_NAME)"
         - "--root=/go/src"
@@ -63,7 +63,7 @@ presubmits:
       preset-kind-volume-mounts: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         env:
         # enable IPV6 in bootstrap image
         - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
@@ -112,7 +112,7 @@ periodics:
     preset-kind-volume-mounts: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--job=$(JOB_NAME)"
       - "--root=/go/src"

--- a/config/jobs/kubernetes/sig-testing/coverage.yaml
+++ b/config/jobs/kubernetes/sig-testing/coverage.yaml
@@ -23,7 +23,7 @@ periodics:
     timeout: 6h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - bash
@@ -84,7 +84,7 @@ periodics:
     timeout: 3h
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - bash
@@ -139,7 +139,7 @@ periodics:
     path_alias: k8s.io/test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       - bash

--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -20,7 +20,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - make
         - verify
@@ -45,7 +45,7 @@ presubmits:
       - name: main
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - make
         - verify

--- a/config/jobs/kubernetes/sig-testing/files-remake.yaml
+++ b/config/jobs/kubernetes/sig-testing/files-remake.yaml
@@ -20,7 +20,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -17,7 +17,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - runner.sh
         args:
@@ -50,7 +50,7 @@ periodics:
     description: "Ends up running: make test-cmd test-integration"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       command:
       - runner.sh
       args:

--- a/config/jobs/kubernetes/sig-testing/local-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/local-e2e.yaml
@@ -14,7 +14,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - --root=/go/src
         - "--job=$(JOB_NAME)"
@@ -54,7 +54,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       args:
       - "--timeout=140"
       - "--bare"

--- a/config/jobs/kubernetes/sig-testing/make-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/make-test.yaml
@@ -13,7 +13,7 @@ periodics:
       preset-service-account: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             - runner.sh
             - bash
@@ -40,7 +40,7 @@ periodics:
         path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
           command:
             - runner.sh
             - bash

--- a/config/jobs/kubernetes/sig-testing/typecheck.yaml
+++ b/config/jobs/kubernetes/sig-testing/typecheck.yaml
@@ -18,7 +18,7 @@ presubmits:
       - name: main
         command:
         - make
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         args:
         - verify
         env:

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -16,7 +16,7 @@ presubmits:
       preset-dind-enabled: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         imagePullPolicy: Always
         command:
         - runner.sh
@@ -62,7 +62,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       imagePullPolicy: Always
       command:
       - runner.sh

--- a/config/jobs/kubernetes/sig-windows/windows-gce.yaml
+++ b/config/jobs/kubernetes/sig-windows/windows-gce.yaml
@@ -88,7 +88,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -133,7 +133,7 @@ periodics:
         value: "win1909"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     fork-per-release: "true"
     fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}"
@@ -180,7 +180,7 @@ periodics:
         value: "prepull-head.yaml"
       - name: KUBE_FEATURE_GATES
         value: "WindowsGMSA=true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-master-alpha-features
@@ -225,7 +225,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce
     testgrid-tab-name: gce-windows-2019-serial
@@ -270,7 +270,7 @@ periodics:
         value: "win2019"
       - name: PREPULL_YAML
         value: "prepull-head.yaml"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   annotations:
     testgrid-dashboards: google-windows, sig-windows-gce, sig-windows-containerd, sig-node-containerd
     testgrid-tab-name: gce-windows-2019-containerd-master
@@ -318,7 +318,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
       resources: {}
   annotations:
@@ -352,7 +352,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "gcr.io/gke-release/pause-win:1.2.1"
@@ -406,7 +406,7 @@ periodics:
     - command:
       - runner.sh
       - /workspace/scenarios/kubernetes_e2e.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       env:
       - name: CL2_CONTAINER_IMAGE
         value: "mcr.microsoft.com/windows/servercore/iis"
@@ -489,7 +489,7 @@ presubmits:
           value: "win2019"
         - name: PREPULL_YAML
           value: "prepull-head.yaml"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
+++ b/config/jobs/kubernetes/system-validators/system-validators-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     decorate: true
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         command:
         - "./hack/verify-all.sh"
     annotations:

--- a/config/jobs/kubernetes/test-infra/janitors.yaml
+++ b/config/jobs/kubernetes/test-infra/janitors.yaml
@@ -40,7 +40,7 @@ periodics:
       - --config-path=config/prow/config.yaml
       - --job-config-path=config/jobs
       - --janitor-path=boskos/cmd/janitor/gcp_janitor.py
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
       resources:
         requests:
           cpu: 5
@@ -65,7 +65,7 @@ periodics:
       - --
       - --mode=pr
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
       resources:
         requests:
           cpu: 5
@@ -91,7 +91,7 @@ periodics:
       - --mode=scale
       - --ratelimit=5
       env:
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
       resources:
         requests:
           cpu: 5

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -50,7 +50,7 @@ presubmits:
       preset-service-account: "true"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-experimental
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-experimental
         command:
         - ./hack/verify-file-perms.sh
     annotations:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1066,7 +1066,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       command:
       - infra/gcp/backup_tools/backup.sh
       env:

--- a/releng/generate_tests.py
+++ b/releng/generate_tests.py
@@ -45,7 +45,7 @@ PROW_CONFIG_TEMPLATE = """
       containers:
       - args:
         env:
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
             cpu: 1000m

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -664,23 +664,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.19
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.19
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.18
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.18
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.17
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.17
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.16
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200801-95dd1ba-1.16
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Bumps jobs that use kubekins-e2e image to v20200802-ff98b58 to pick up
fix for fast builds source download URL.

xref https://github.com/kubernetes/test-infra/pull/18608

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @spiffxp @justaugustus @BenTheElder 