### PR TITLE
Use again fast builds for scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -22,7 +22,7 @@ periodics:
       - --cluster=gce-scale-cluster
       - --env=CONCURRENT_SERVICE_SYNCS=5
       - --env=HEAPSTER_MACHINE_TYPE=n1-standard-32
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-node-size=g1-small
@@ -75,7 +75,7 @@ periodics:
       # TODO(mborsz): Adjust or remove this change once we understand coredns
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
@@ -123,7 +123,7 @@ periodics:
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *
-    fork-per-release-replacements: "--extract=ci/latest -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
+    fork-per-release-replacements: "--extract=ci/latest-fast -> --extract=ci/latest-{{.Version}}, gce-100Nodes-master -> gce-100Nodes-{{.Version}}, --repo=k8s.io/perf-tests=master -> --repo=k8s.io/perf-tests=release-{{.Version}}"
     testgrid-dashboards: sig-release-master-blocking, sig-scalability-gce, google-gce, google-gci
     testgrid-tab-name: gce-cos-master-scalability-100
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com
@@ -143,7 +143,7 @@ periodics:
       # TODO(oxddr): remove once debugging is finished
       - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
-      - --extract=ci/latest
+      - --extract=ci/latest-fast
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project


### PR DESCRIPTION
Revert #18559 after kubernetes/kubernetes#93561 was fixed.

Fixes: https://github.com/kubernetes/test-infra/issues/18560

/cc @wojtek-t 
/sig scalability