### PR TITLE
Increase memory limit for 5k correctness test to 64Gi

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -39,10 +39,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "32Gi"
+          memory: "64Gi"
         limits:
           cpu: 6
-          memory: "32Gi"
+          memory: "64Gi"
 
 # This is a sig-release-master-blocking job.
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)


### PR DESCRIPTION
Increase memory limit for 5k correctness test

[32Gi](https://github.com/kubernetes/test-infra/pull/18496) was not enough.

Fix: https://github.com/kubernetes/kubernetes/issues/93506

/sig scalability
/cc wojtekt-t