### PR TITLE
Test using kubetest2 uses go get instead of build from source

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml
@@ -34,11 +34,6 @@ presubmits:
       testgrid-dashboards: provider-gcp-presubmits
       description: End to end cluster creation test using kubetest2 based on kubernetes/cloud-provider-gcp.
       testgrid-num-columns-recent: '30'
-    extra_refs:
-    - org: kubernetes-sigs
-      repo: kubetest2
-      base_ref: master
-      path_alias: k8s.io/kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
@@ -52,7 +47,9 @@ presubmits:
           set -o pipefail;
           set -o xtrace;
           REPO_ROOT=$(git rev-parse --show-toplevel);
-          cd "${REPO_ROOT}/../kubetest2" || exit 1;
-          make install;
-          make install-deployer-gce;
+          cd;
+          export GO111MODULE=on;
+          go get sigs.k8s.io/kubetest2@latest;
+          go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+          go get sigs.k8s.io/kubetest2/kubetest2-tester-exec@latest;
           kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=exec -- kubectl get all --all-namespaces --kubeconfig="${ARTIFACTS}/kubetest2-kubeconfig";


### PR DESCRIPTION
Stops test runners from needing kubetest2's build dependencies. Overall more robust. Tested on a GKE cluster with mkpj and mkpod.

Solves a test problem occuring in https://github.com/kubernetes/cloud-provider-gcp/pull/160. Addresses https://github.com/kubernetes/cloud-provider-gcp/issues/161.