### PR TITLE
Update interval to 12h for sig-cli periodic e2e tests.

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -1,5 +1,5 @@
 periodics:
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-gci-serial-sig-cli
   labels:
     preset-service-account: "true"
@@ -25,7 +25,7 @@ periodics:
     testgrid-tab-name: gce-serial
     testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
     description: kubectl gce serial e2e tests for master branch
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gci-gce-sig-cli
   labels:
     preset-service-account: "true"
@@ -54,7 +54,7 @@ periodics:
     testgrid-tab-name: gce
     testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
     description: kubectl gce e2e tests for master branch
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-kops-aws-sig-cli
   labels:
     preset-service-account: "true"
@@ -82,7 +82,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: aws
     testgrid-alert-email: kubernetes-sig-cli-oncall@gmail.com
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -117,7 +117,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gce-1.14-1.13-gci-kubectl-skew
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-beta-stable1-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -144,7 +144,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gce-1.14-1.13-gci-kubectl-skew-serial
-- interval: 1h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew
   cluster: k8s-infra-prow-build
   labels:
@@ -185,7 +185,7 @@ periodics:
     testgrid-num-columns-recent: "3"
     testgrid-num-failures-to-alert: "2"
     testgrid-alert-stale-results-hours: "24"
-- interval: 1h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -213,7 +213,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-latest-kubectl-stable1-gce-serial
     description: stable1 serial tests run against a master gce cluster using a stable1 kubectl binary
-- interval: 1h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -241,7 +241,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce
     description: stable1 e2e tests run against a stable1 gce cluster using a master kubectl binary
-- interval: 1h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-new-master-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"
@@ -268,7 +268,7 @@ periodics:
     testgrid-dashboards: sig-cli-master
     testgrid-tab-name: skew-cluster-stable1-kubectl-latest-gce-serial
     description: stable1 serial tests run against a stable1 gce cluster using a master kubectl binary
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew
   labels:
     preset-service-account: "true"
@@ -295,7 +295,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-job-config-errors
     testgrid-tab-name: gce-1.13-1.14-gci-kubectl-skew
-- interval: 2h
+- interval: 12h
   name: ci-kubernetes-e2e-gce-stable1-beta-gci-kubectl-skew-serial
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
Per the [discussion in the 7/15/2020 SIG-CLI meeting](https://docs.google.com/document/d/1r0YElcXt6G5mOWxwZiXgGu_X6he3F--wKwg-9UBc29I/edit?pli=1#heading=h.himo1st0tqyy), the interval should be changed from 1h or 2h to 12h. This is a more reasonable frequency that still allows failures to be actionable if there is a failure.

/cc @soltysh 
/cc @justaugustus 