### PR TITLE
Configure Guaranteed QoS pod for ci-kubernetes-e2e-gci-gce-ingress

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -269,6 +269,13 @@ periodics:
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
       - --timeout=320m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
+      resources:
+        limits:
+          cpu: "1"
+          memory: "3Gi"
+        requests:
+          cpu: "1"
+          memory: "3Gi"
   annotations:
     testgrid-dashboards: sig-release-master-blocking, google-gce, sig-network-gce
     testgrid-tab-name: gci-gce-ingress


### PR DESCRIPTION
Add limits and requests resources as suggested by @spiffxp.

Ref: https://github.com/kubernetes/test-infra/issues/18580
Part of: https://github.com/kubernetes/test-infra/issues/18530

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @BenTheElder @spiffxp 
cc @kubernetes/ci-signal 