### PR TITLE
critical jobs Guaranteed Pod QOS: periodic-kubernetes-bazel-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -325,7 +325,13 @@ periodics:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.16
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "12Gi"
+        requests:
+          cpu: 4
+          memory: "12Gi"
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -386,7 +386,13 @@ periodics:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.17
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "12Gi"
+        requests:
+          cpu: 4
+          memory: "12Gi"
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -391,7 +391,13 @@ periodics:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "12Gi"
+        requests:
+          cpu: 4
+          memory: "12Gi"
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.18-blocking, google-unit

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -341,7 +341,13 @@ periodics:
       - bash
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.19
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "12Gi"
+        requests:
+          cpu: 4
+          memory: "12Gi"
 - annotations:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.19-blocking, google-unit

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -224,6 +224,13 @@ periodics:
             --release=//build/release-tars \
             --gcs=gs://kubernetes-release-dev/ci-periodic \
             --version-suffix=-bazel
+      resources:
+        limits:
+          cpu: 4
+          memory: "12Gi"
+        requests:
+          cpu: 4
+          memory: "12Gi"
   rerun_auth_config:
     github_team_ids:
       - 2241179 # release-managers


### PR DESCRIPTION
Adding basic resource request and limit for
periodic-kubernetes-bazel-build, which is in the
sig-release-master-blocking dashboard.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/cc @kubernetes/ci-signal

Fixes: #18581 