### PR TITLE
critical jobs Guaranteed Pod QOS: periodic-kubernetes-bazel-test

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -359,7 +359,13 @@ periodics:
       - ../test-infra/hack/bazel.sh
       image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -420,7 +420,13 @@ periodics:
       - ../test-infra/hack/bazel.sh
       image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 24h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -425,7 +425,13 @@ periodics:
       - ../test-infra/hack/bazel.sh
       image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -375,7 +375,13 @@ periodics:
       - ../test-infra/hack/bazel.sh
       image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
       name: ""
-      resources: {}
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -303,7 +303,13 @@ periodics:
       - --
       - -//build/...
       - -//vendor/...
-
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 - name: periodic-kubernetes-bazel-test-canary
   cluster: k8s-infra-prow-build
   annotations:


### PR DESCRIPTION
Adding basic resource request and limit for periodic-kubernetes-bazel-test,
which is in the sig-release-master-blocking dashboard.

Signed-off-by: Tim Pepper <tpepper@vmware.com>

/cc @kubernetes/ci-signal

Fixes: #18582 