### PR TITLE
Create a parallel triage instance in Go for testing

### DIFF
--- a/triage/Dockerfile-go
+++ b/triage/Dockerfile-go
@@ -1,0 +1,50 @@
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This Dockerfile uses multi-stage builds. The first stage builds Triage and gathers the Google
+# Cloud SDK, and the resulting files are then used in the second stage.
+
+# Stage 1
+FROM golang:1.13 AS build
+
+COPY . /test-infra/
+
+# Build Triage
+RUN cd /test-infra/triage/ && \
+    go build -v -o triage ./main.go
+# Get the Google Cloud SDK
+RUN curl -o installer https://sdk.cloud.google.com && \
+    bash installer --disable-prompts --install-dir=/ && \
+    rm installer
+
+
+# Stage 2
+FROM alpine:3.12.0
+
+# Copy over the files we want from the previous stage
+COPY --from=build /test-infra/triage/triage /
+COPY --from=build /google-cloud-sdk/ /google-cloud-sdk/
+
+# Copy the shell script that orchestrates everything
+COPY triage/update_summaries-go.sh /
+
+# Link the binaries
+RUN ln -s /google-cloud-sdk/bin/* /bin/
+
+# Google Cloud SDK requires python 2.7.9+ (https://cloud.google.com/python/setup#installing_the_cloud_sdk).
+# update_summaries.sh requires bash.
+RUN apk add --no-cache python2 bash
+
+# Point GOOGLE_APPLICATION_CREDENTIALS at a serviceaccount.json with the necessary permissions.
+ENTRYPOINT ["timeout", "10800", "/update_summaries-go.sh"]

--- a/triage/cloudbuild.yaml
+++ b/triage/cloudbuild.yaml
@@ -1,11 +1,20 @@
 steps:
+# Build Python triage
   - name: gcr.io/cloud-builders/docker
     args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/triage:$_GIT_TAG', '.' ]
     dir: triage/
   - name: gcr.io/cloud-builders/docker
     args: [ 'tag', 'gcr.io/$PROJECT_ID/triage:$_GIT_TAG', 'gcr.io/$PROJECT_ID/triage:latest']
+# Build Go triage
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/triage:go-$_GIT_TAG', '-f', 'triage/Dockerfile-go', '.' ]
+    dir: /
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/triage:go-$_GIT_TAG', 'gcr.io/$PROJECT_ID/triage:go-latest']
 substitutions:
   _GIT_TAG: '12345'
 images:
   - 'gcr.io/$PROJECT_ID/triage:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/triage:latest'
+  - 'gcr.io/$PROJECT_ID/triage:go-$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/triage:go-latest'

--- a/triage/update_summaries-go.sh
+++ b/triage/update_summaries-go.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -exu
+cd $(dirname $0)
+
+start=$(date +%s)
+
+if [[ -e ${GOOGLE_APPLICATION_CREDENTIALS-} ]]; then
+  gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+fi
+
+gcloud config set project k8s-gubernator
+bq show <<< $'\n'
+
+date
+
+bq --headless --format=json query --max_rows 1000000 \
+  "select
+    path,
+    timestamp_to_sec(started) started,
+    elapsed,
+    tests_run,
+    tests_failed,
+    result,
+    executor,
+    job,
+    number
+  from
+    [k8s-gubernator:build.all]
+  where
+    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
+    and job != 'ci-kubernetes-coverage-unit'" \
+  > triage_builds.json
+
+bq query --allow_large_results --headless --max_rows 0 --replace --destination_table k8s-gubernator:temp.triagego \
+  "select
+    timestamp_to_sec(started) started,
+    path build,
+    test.name name,
+    test.failure_text failure_text
+  from
+    [k8s-gubernator:build.all]
+  where
+    test.failed
+    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
+    and job != 'ci-kubernetes-coverage-unit'"
+gsutil rm gs://k8s-gubernator/triage_tests-go/shard_*.json.gz || true
+bq extract --compression GZIP --destination_format NEWLINE_DELIMITED_JSON 'k8s-gubernator:temp.triagego' gs://k8s-gubernator/triage_tests-go/shard_*.json.gz
+mkdir -p triage_tests
+gsutil cp -r gs://k8s-gubernator/triage_tests-go/* triage_tests/
+gzip -df triage_tests/*.gz
+
+# gsutil cp gs://k8s-gubernator/triage/failure_data.json failure_data_previous.json
+
+mkdir -p slices
+
+/triage \
+  --builds triage_builds.json \
+  --previous triage_tests/*.json \
+  --output failure_data.json \
+  --output_slices slices/failure_data_PREFIX.json
+
+gsutil_cp() {
+  gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"
+}
+
+gsutil_cp failure_data.json gs://k8s-gubernator/triage-go/
+gsutil_cp slices/*.json gs://k8s-gubernator/triage-go/slices/
+gsutil_cp failure_data.json "gs://k8s-gubernator/triage-go/history/$(date -u +%Y%m%d).json"
+
+stop=$(date +%s)
+elapsed=$(( ${stop} - ${start} ))
+echo "Finished in $(( ${elapsed} / 60))m$(( ${elapsed} % 60))s"


### PR DESCRIPTION
This PR will temporarily add some `-go` files so that the Go version of Triage can be tested side-by-side with the Python version. Eventually, they will replace the Python versions.

In addition, this will update some other files necessary to get the instance up and running.