### PR TITLE
delete fake deck_deployment file

### DIFF
--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -1,3 +1,0 @@
-# fake deck_deployment file to help autobump.sh
-# TODO(fejta): delete this file June 2020
-image: v20200501-e6124e633


### PR DESCRIPTION
doing the TODO:
> \# fake deck_deployment file to help autobump.sh
> \# TODO(fejta): delete this file June 2020

xref: https://github.com/kubernetes/test-infra/issues/11782