### PR TITLE
Adds preset-windows-repo-list to master-windows-containerd job

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -319,6 +319,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:


### PR DESCRIPTION
Adds a label that is missing from the containerd job. It contains the necessary image-repo-list env var.