### PR TITLE
Set memory limit for 5k correctness test to 48Gi

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -39,10 +39,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "64Gi"
+          memory: "48Gi"
         limits:
           cpu: 6
-          memory: "64Gi"
+          memory: "48Gi"
 
 # This is a sig-release-master-blocking job.
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)


### PR DESCRIPTION
Change memory limit for 5k correctness test

32Gi was not enough. 64Gi is too much.

Ref: kubernetes/kubernetes#93506

/sig scalability
/cc @wojtek-t 
/cc @jkaniuk 