### PR TITLE
Move ubuntu/containerd jobs to newer containerd v1.4.0-rc.0

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -195,7 +195,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-beta.2
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc91
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -463,7 +463,7 @@ periodics:
           - --check-leaked-resources
           - --extract=ci/latest-fast
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.3.5
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
Canary works! https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/93656/pull-kubernetes-e2e-gce-ubuntu-containerd-canary/1290723191336996865/

Signed-off-by: Davanum Srinivas <davanum@gmail.com>