### PR TITLE
Raise ci-kubernetes-build-fast timeout to 40min

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -76,7 +76,7 @@ periodics:
       - --repo=k8s.io/kubernetes
       - --repo=k8s.io/release
       - --root=/go/src
-      - --timeout=30
+      - --timeout=40
       - --scenario=kubernetes_build
       - --
       - --allow-dup


### PR DESCRIPTION
Looking at recent history it is not uncommon for it to timeout
N times in a row when it's actually building release artifacts.

Since this has been happening before we put resource limits in
place, I'm inclined to say the timeout is too tight. Let's raise
it to 40min before we consider throwing more cpu at it

ref: https://github.com/kubernetes/test-infra/issues/18578#issuecomment-668815626

/cc @ZhiFeng1993 @hasheddan
FYI @kubernetes/release-engineering