### PR TITLE
Revert "Fix seccomp-operator bucket name"

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -14,7 +14,7 @@ postsubmits:
               - /run.sh
             args:
               - --project=k8s-infra-staging-seccomp-operator
-              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator
+              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator-gcb
               - .
             env:
               - name: LOG_TO_STDOUT

--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -13,8 +13,8 @@ postsubmits:
             command:
               - /run.sh
             args:
-              - --project=k8s-infra-staging-seccomp-operator
-              - --scratch-bucket=gs://k8s-infra-staging-seccomp-operator-gcb
+              - --project=k8s-staging-seccomp-operator
+              - --scratch-bucket=gs://k8s-staging-seccomp-operator-gcb
               - .
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
Reverts kubernetes/test-infra#18541
Fixes https://github.com/kubernetes-sigs/seccomp-operator/issues/64

This change was made thinking we were targeting the wrong bucket. It appears the the correct bucket to use here is the one with the `-gcb` postfix.

/hold to determine this is the correct fix

/cc @saschagrunert @dims 