### PR TITLE
Drop quotes in resources for pull-kubernetes-dependencies

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1105,11 +1105,11 @@ presubmits:
         name: main
         resources:
           limits:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
           requests:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1176,11 +1176,11 @@ presubmits:
         name: main
         resources:
           limits:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
           requests:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1373,11 +1373,11 @@ presubmits:
         name: main
         resources:
           limits:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
           requests:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1313,11 +1313,11 @@ presubmits:
         name: main
         resources:
           limits:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
           requests:
-            cpu: "2"
-            memory: "1.2Gi"
+            cpu: 2
+            memory: 1.2Gi
         securityContext:
           privileged: true
   - always_run: true


### PR DESCRIPTION
Drop quotes in resources limits and requests so config-forker don't have diffs when it forks job configs.

Ref: https://github.com/kubernetes/test-infra/pull/18645/files#r465271058

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @spiffxp 