### PR TITLE
Add job to test out k8s-infra-e2e-ingress-project

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -282,6 +282,42 @@ periodics:
     testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
     description: Uses kubetest to run e2e tests (+Feature:Ingress|NEG) against a cluster created with cluster/kube-up.sh
     testgrid-alert-stale-results-hours: '24'
+- interval: 30m
+  name: ci-kubernetes-e2e-gci-gce-ingress-canary
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  spec:
+    containers:
+    - args:
+      - --timeout=340
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
+      - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
+      - --extract=ci/latest-fast
+      - --gcp-node-image=gci
+      - --gcp-project=k8s-infra-e2e-ingress-project
+      - --gcp-zone=asia-southeast1-a
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
+      - --timeout=320m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
+      resources:
+        limits:
+          cpu: 1
+          memory: "3Gi"
+        requests:
+          cpu: 1
+          memory: "3Gi"
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: gci-gce-ingress
+    description: Duplicate of ci-kubernetes-e2e-gci-gce-ingress pinned to a k8s-infra project to verify quota
+    testgrid-alert-stale-results-hours: '24'
 - interval: 60m
   name: ci-kubernetes-e2e-gci-gce-ingress-manual-network
   labels:


### PR DESCRIPTION
Duplicate of ci-kubernetes-e2e-gci-gce-ingress

part of https://github.com/kubernetes/k8s.io/issues/1093
part of https://github.com/kubernetes/test-infra/issues/18651