### PR TITLE
Implements #18584 sets pull-kubernetes-bazel-test pod to Guaranteed QoS

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -57,6 +57,13 @@ presubmits:
         - --
         - -//build/...
         - -//vendor/...
+      resources:
+        limits:
+          cpu: 4
+          memory: "38Gi"
+        requests:
+          cpu: 4
+          memory: "38Gi"
 postsubmits:
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build


### PR DESCRIPTION
Adds matching limits and requests for cpu and memory : 4 cpu, 38Gi
Part of #18530
cc @kubernetes/ci-signal