### PR TITLE
critical jobs Guaranteed Pod QOS: pull-kubernetes-cross

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -19,8 +19,11 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 7300m
+            memory: "41Gi"
           requests:
-            cpu: 7
+            cpu: 7300m
             memory: "41Gi"
     annotations:
       testgrid-create-test-group: 'true'


### PR DESCRIPTION
Adding basic resource request and limit for pull-kubernetes-cross
which we can see in the presubmits-kubernetes-nonblocking
dashboards.

 - Fixes: https://github.com/kubernetes/test-infra/issues/18586

/cc @kubernetes/ci-signal