### PR TITLE
Implements 18592 QoS Guarantee for pull-kubernetes-files-remake

### DIFF
--- a/config/jobs/kubernetes/sig-testing/files-remake.yaml
+++ b/config/jobs/kubernetes/sig-testing/files-remake.yaml
@@ -27,3 +27,10 @@ presubmits:
         # Space separated list of the checks to run
         - name: WHAT
           value: generated-files-remake
+        resources:
+          limits:
+            cpu: 1500m
+            memory: 7Gi
+          requests:
+            cpu: 1500m
+            1memory: 7Gi


### PR DESCRIPTION
Adds matching limits and requests for cpu and memory : 1500m cpu, 7Gi mem

Part of #18530
cc @kubernetes/ci-signal