### PR TITLE
update job template for windows tests

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -185,7 +185,7 @@ presubmits:
         - --aksengine-location=westus2
         - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
         - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
-        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/windows-testing/master/job-templates/kubernetes_in_tree_volume_plugins.json
+        - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/test/bats/tests/azure/job_templates/kubernetes_windows.json
         - --aksengine-download-url=https://github.com/Azure/aks-engine/releases/download/v0.54.0/aks-engine-v0.54.0-linux-amd64.tar.gz
         # Specific test args
         - --test-secrets-store-csi-driver


### PR DESCRIPTION
Updates the job template to a new URL for the manifest host in `secrets-store-csi-driver`.

Dependent on https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/276

/hold