### PR TITLE
Add extra-version-markers support to kubernetes_build.py

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -42,7 +42,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-master
+      - --extra-version-markers=k8s-master
       - --registry=gcr.io/kubernetes-ci-images
       # docker-in-docker needs privileged mode
       securityContext:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -168,7 +168,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable3
+      - --extra-version-markers=k8s-stable3
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -210,7 +210,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable2
+      - --extra-version-markers=k8s-stable2
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -214,7 +214,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-stable1
+      - --extra-version-markers=k8s-stable1
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
       name: ""

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -172,7 +172,7 @@ periodics:
       - --scenario=kubernetes_build
       - --
       - --allow-dup
-      - --extra-publish-file=k8s-beta
+      - --extra-version-markers=k8s-beta
       - --registry=gcr.io/kubernetes-ci-images
       image: gcr.io/k8s-testimages/bootstrap:v20200801-23e4b0e
       name: ""

--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -124,6 +124,8 @@ def main(args):
         push_build_args.append('--docker-registry=%s' % args.registry)
     if args.extra_publish_file:
         push_build_args.append('--extra-publish-file=%s' % args.extra_publish_file)
+    if args.extra_version_markers:
+        push_build_args.append('--extra-version-markers=%s' % args.extra_version_markers)
     if args.fast:
         push_build_args.append('--fast')
     if args.allow_dup:
@@ -162,6 +164,8 @@ if __name__ == '__main__':
         '--registry', help='Push images to the specified docker registry')
     PARSER.add_argument(
         '--extra-publish-file', help='Additional version file uploads to')
+    PARSER.add_argument(
+        '--extra-version-markers', help='Additional version file uploads to')
     PARSER.add_argument(
         '--fast', action='store_true', help='Specifies a fast build')
     PARSER.add_argument(


### PR DESCRIPTION
Add the ability to specify --extra-version-markers when pushing a build,
which is replacing the deprecated --extra-publish-file arg.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to https://github.com/kubernetes/release/pull/1385. Will follow with migrating build jobs to `--extra-version-markers`. Motivation is https://github.com/kubernetes/kubernetes/issues/93694#issuecomment-669209941. Should also fix `push-build` to still honor `--extra-publish-file`.

/hold for explicit approval from @justaugustus 

/cc @justaugustus @kubernetes/release-engineering 