### PR TITLE
Add presets to the 1.16-1.18 releases jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.16-windows.yaml
@@ -12,6 +12,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -69,6 +70,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -124,6 +126,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:
@@ -178,6 +181,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.17-windows.yaml
@@ -12,6 +12,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -69,6 +70,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -124,6 +126,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:
@@ -177,6 +180,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:

--- a/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/release-1.18-windows.yaml
@@ -12,6 +12,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -70,6 +71,7 @@ presubmits:
       preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
+      preset-windows-repo-list: "true"
       preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
     extra_refs:
@@ -126,6 +128,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:
@@ -179,6 +182,7 @@ periodics:
     preset-service-account: "true"
     preset-azure-cred: "true"
     preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
   extra_refs:


### PR DESCRIPTION
The job https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-aks-engine-azure-1-18-windows/1291035664158035968 

Failed due to changes in the labels for the image repo https://github.com/kubernetes/test-infra/pull/18639 and https://github.com/kubernetes/test-infra/pull/18538

```
2020/08/05 16:46:00 process.go:153: Running: kubectl --match-server-version=false get nodes -oyaml
2020/08/05 16:46:01 process.go:155: Step 'kubectl --match-server-version=false get nodes -oyaml' finished in 825.123569ms
2020/08/05 16:46:01 aksengine.go:1257: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION not set. Using default test image repos.
2020/08/05 16:46:01 aksengine.go:1257: KUBE_TEST_REPO_LIST_DOWNLOAD_LOCATION not set. Using default test image repos.
2020/08/05 16:46:01 process.go:153: Running: kubectl get nodes --no-headers
2020/08/05 16:46:01 process.go:155: Step 'kubectl get nodes --no-headers' finished in 461.668135ms
2020/08/05 16:46:01 e2e.go:474: Cluster nodes:
2751k8s000              Ready   agent    21m   v1.18.7-rc.0.34+c6cb4f0949d4b9
2751k8s001              Ready   agent    21m   v1.18.7-rc.0.34+c6cb4f0949d4b9
2751k8s010              Ready   agent    21m   v1.18.7-rc.0.34+c6cb4f0949d4b9
k8s-master-27517424-0   Ready   master   21m   v1.18.7-rc.0.34+c6cb4f0949d4b9
```

This adds the label to all of the 1.16-1.18 releases jobs


/sig windows
/assing @chewong  @claudiubelu 