### PR TITLE
Adding Job with multiple more complicated test containers

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -53,3 +53,40 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: multiple-container-test
     description: echo from two different containers
+- interval: 1h
+  name: ci-test-infra-larger-multiple-container-test
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+    path_alias: k8s.io/test-infra
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+  spec:
+    containers:
+    - name: benchmark-junit-container
+      image: gcr.io/k8s-testimages/benchmarkjunit:latest
+      command:
+      - /benchmarkjunit
+      args:
+      - --log-file=$(ARTIFACTS)/benchmark-log.txt
+      - --output=$(ARTIFACTS)/junit_benchmarks.xml
+      - --pass-on-error
+      - ./experiment/dummybenchmarks/...
+    - name: bazel-test-container
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200713-e9b3d9d-test-infra
+      command:
+      - hack/bazel.sh
+      args:
+      - test
+      - --config=ci
+      - --nobuild_tests_only
+      - //...
+  annotations:
+    testgrid-alert-email: anthonytong@google.com
+    ProwMultipleContainerSupport: Yes, I know what I'm doing.
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: larger-multiple-container-test
+    description: combination of test-infra-bazel and ci-test-infra-benchmark-demo to test more complicated multi container behavior

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -49,7 +49,6 @@ periodics:
       args: ["I am the second container"]
   annotations:
     testgrid-alert-email: anthonytong@google.com
-    ProwMultipleContainerSupport: Yes, I know what I'm doing.
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: multiple-container-test
     description: echo from two different containers
@@ -62,7 +61,6 @@ periodics:
     base_ref: master
     path_alias: k8s.io/test-infra
   labels:
-    preset-service-account: "true"
     preset-bazel-scratch-dir: "true"
   spec:
     containers:
@@ -86,7 +84,6 @@ periodics:
       - //...
   annotations:
     testgrid-alert-email: anthonytong@google.com
-    ProwMultipleContainerSupport: Yes, I know what I'm doing.
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: larger-multiple-container-test
     description: combination of test-infra-bazel and ci-test-infra-benchmark-demo to test more complicated multi container behavior

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -34,24 +34,6 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: benchmark-demo
     description: Demoing JUnit golang benchmark results.
-- interval: 10m
-  name: ci-test-infra-multiple-container-test
-  decorate: true
-  spec:
-    containers:
-    - name: test-1
-      image: alpine
-      command: ["/bin/echo"]
-      args: ["I am the first container"]
-    - name: test-2
-      image: alpine
-      command: ["/bin/echo"]
-      args: ["I am the second container"]
-  annotations:
-    testgrid-alert-email: anthonytong@google.com
-    testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: multiple-container-test
-    description: echo from two different containers
 - interval: 1h
   name: ci-test-infra-larger-multiple-container-test
   decorate: true


### PR DESCRIPTION
Job is a combination of ci-test-infra-bazel and ci-test-infra-benchmark-demo to test more complicated multi container behavior.