### PR TITLE
Move gpu canary job to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -51,6 +51,7 @@ periodics:
           cpu: 1
           memory: 3Gi
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu-canary
+  cluster: k8s-infra-prow-build
   cron: "30 1-23/2 * * *"
   labels:
     preset-service-account: "true"


### PR DESCRIPTION
It's still running in k8s-prow-builds.  That would explain why it
keeps failing as unable to use k8s-infra-e2e-gpu-project

ref: https://github.com/kubernetes/k8s.io/issues/1095