### PR TITLE
Centralize the create-build-cluster.sh script and make merge_kubeconfig_secret.py handle secret keys intelligently.

### DIFF
--- a/gencred/README.md
+++ b/gencred/README.md
@@ -143,10 +143,13 @@ users:
 If you store kubeconfig files in kubernetes secrets to allow pods to access other kubernetes clusters (like many of Prow's components require) consider using [`merge_kubeconfig_secret.py`](/gencred/merge_kubeconfig_secret.py) to merge the kubeconfig produced by `gencred` into the secret.
 
 ```shell
-# Generate a kubeconfig.yaml as described and shown above, then run something like:
-./merge_kubeconfig_secret.py --src-key=config-old --dest-key=config-new kubeconfig.yaml
-# Update references (e.g. `--kubeconfig` flags) to point to config-new instead of config-old.
+# Generate a kubeconfig.yaml as described and shown above.
+./merge_kubeconfig_secret.py --auto --context=my-kube-context kubeconfig.yaml
+# Note: The first time the script is used you may be prompted to rerun it with --src-key specified.
+# Finish by updating references (e.g. `--kubeconfig` flags in Prow deployment files) to point to the updated secret key. The script will indicate which key was updated in its output.
 ```
+
+The script exposes optional flags to override the secret namespace, name, keys, and pruning behavior. Run `./merge_kubeconfig_secret.py --help` to view all options.
 
 ### Library
 

--- a/gencred/merge_kubeconfig_secret.py
+++ b/gencred/merge_kubeconfig_secret.py
@@ -28,9 +28,13 @@ precedence to the secret."""
 
 import argparse
 import os
+import re
 import subprocess
 import sys
 import tempfile
+import time
+
+reAutoKey = re.compile('^config-(\\d{8})$')
 
 def call(cmd, **kwargs):
     print('>>> %s' % cmd)
@@ -47,11 +51,31 @@ def call(cmd, **kwargs):
 
 def main(args):
     print(args)
+    validateArgs(args)
+    if args.auto:
+        # We need to determine the dest key automatically.
+        args.dest_key = time.strftime('config-%Y%m%d')
+        if not args.src_key:
+            # Also try to automatically determine the src key.
+            cmd = 'kubectl --context="%s" get secret --namespace "%s" "%s" -o go-template="{{range \\$key, \\$content := .data}}{{\\$key}};{{end}}"' % (args.context, args.namespace, args.name) #pylint: disable=line-too-long
+            keys = call(cmd).stdout.rstrip(";").split(";")
+            matches = [key for key in keys if reAutoKey.match(key)]
+            matches.sort(reverse=True)
+            if len(matches) == 0:
+                raise ValueError('The %s/%s secret does not contain any keys matching the "config-20200730" format. Please try again with --src-key set to the most recent key. Existing keys: %s' % (args.namespace, args.name, keys)) #pylint: disable=line-too-long
+
+            args.src_key = matches[0]
+        # Only enable pruning if we won't overwrite the source key.
+        # This ensures that a second update on the same day will still have a
+        # key to roll back to if needed.
+        args.prune = args.src_key != args.dest_key
+        print('Automatic mode: --src-key=%s  --dest-key=%s' % (args.src_key, args.dest_key))
+
     with tempfile.TemporaryDirectory() as tmpdir:
         orig = '%s/original' % (tmpdir)
         merged = '%s/merged' % (tmpdir)
         # Copy the current secret contents into a temp file.
-        cmd = 'kubectl get secret --namespace "%s" "%s" -o go-template="{{index .data \\"%s\\"}}" | base64 -d > %s' % (args.namespace, args.name, args.src_key, orig) #pylint: disable=line-too-long
+        cmd = 'kubectl --context="%s" get secret --namespace "%s" "%s" -o go-template="{{index .data \\"%s\\"}}" | base64 -d > %s' % (args.context, args.namespace, args.name, args.src_key, orig) #pylint: disable=line-too-long
         call(cmd)
 
         # Merge the existing and new kubeconfigs into another temp file.
@@ -68,19 +92,34 @@ def main(args):
             srcflag = ''
             if args.src_key != args.dest_key:
                 srcflag = '--from-file="%s=%s"' % (args.src_key, orig)
-            call('kubectl create secret generic --namespace "%s" "%s" --from-file="%s=%s" %s --dry-run -oyaml | kubectl replace -f -' % (args.namespace, args.name, args.dest_key, merged, srcflag)) #pylint: disable=line-too-long
+            call('kubectl --context="%s" create secret generic --namespace "%s" "%s" --from-file="%s=%s" %s --dry-run -oyaml | kubectl replace -f -' % (args.context, args.namespace, args.name, args.dest_key, merged, srcflag)) #pylint: disable=line-too-long
         else:
             content = ''
             with open(merged, 'r') as mergedFile:
                 yamlPad = '    '
                 content = yamlPad + mergedFile.read()
                 content = content.replace('\n', '\n' + yamlPad)
-            call('kubectl patch --namespace "%s" "secret/%s" --patch "stringData:\n  %s: |\n%s\n"' % (args.namespace, args.name, args.dest_key, content)) #pylint: disable=line-too-long
+            call('kubectl --context="%s" patch --namespace "%s" "secret/%s" --patch "stringData:\n  %s: |\n%s\n"' % (args.context, args.namespace, args.name, args.dest_key, content)) #pylint: disable=line-too-long
 
-        print('Successfully updated secret %s/%s.' % (args.namespace, args.name))
+        print('Successfully updated secret "%s/%s". The new kubeconfig is under the key "%s".' % (args.namespace, args.name, args.dest_key)) #pylint: disable=line-too-long
+        print('Don\'t forget to update any deployments or podspecs that use the secret to reference the updated key!') #pylint: disable=line-too-long
+
+def validateArgs(args):
+    if args.auto:
+        if args.dest_key:
+            raise ValueError("--dest-key must be omitted when --auto is used.")
+    else:
+        if not args.src_key or not args.dest_key:
+            raise ValueError("--src-key and --dest-key are required unless --auto is used.")
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Merges the provided kubeconfig file into a kubeconfig file living in a kubernetes secret in order to add new cluster contexts to the secret. Requires kubectl and base64.') #pylint: disable=line-too-long
+    parser.add_argument(
+        '--context',
+        help='The kubectl context of the cluster containing the secret.',
+        required=True,
+    )
     parser.add_argument(
         '--name',
         help='The name of the k8s secret containing the kubeconfig file to add to.',
@@ -94,12 +133,10 @@ if __name__ == '__main__':
     parser.add_argument(
         '--src-key',
         help='The key of the source kubeconfig file in the k8s secret.',
-        required=True,
     )
     parser.add_argument(
         '--dest-key',
         help='The destination key of the merged kubeconfig file in the k8s secret.',
-        required=True,
     )
     parser.add_argument(
         'kubeconfig_to_merge',
@@ -108,7 +145,12 @@ if __name__ == '__main__':
     parser.add_argument(
         '--prune',
         action='store_true',
-        help='Remove all secret keys besides the source and dest. This should be used periodically to delete old kubeconfigs and keep the secret size under control.' #pylint: disable=line-too-long
-        )
+        help='Remove all secret keys besides the source and dest. This should be used periodically to delete old kubeconfigs and keep the secret size under control.', #pylint: disable=line-too-long
+    )
+    parser.add_argument(
+        '--auto',
+        action='store_true',
+        help='Automatically determine --dest-key and optionally --src-key assuming keys are of the form "config-20200730". Pruning is enabled.', #pylint: disable=line-too-long
+    )
 
     main(parser.parse_args())

--- a/prow/create-build-cluster.sh
+++ b/prow/create-build-cluster.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# This script is used to create a new build cluster for use with oss-prow. The cluster will have a 
+# single pd-ssd nodepool that will have autoupgrade and autorepair enabled.
+#
+# Usage: populate the parameters by setting them below or specifying environment variables then run
+# the script and follow the prompts. You'll be prompted to share some credentials and commands
+# with the current oncall.
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+TEAM="${TEAM:-}"
+PROJECT="${PROJECT:-oss-prow-build-${TEAM}}"
+ZONE="${ZONE:-us-west1-b}"
+CLUSTER="${CLUSTER:-${PROJECT}}"
+
+# Only needed for creating cluster
+MACHINE="${MACHINE:-n1-highmem-8}"
+NODECOUNT="${NODECOUNT:-15}"
+DISKSIZE="${DISKSIZE:-100GB}"
+
+# Only needed for creating project
+FOLDER_ID="${FOLDER_ID:-0123}"
+BILLING_ACCOUNT_ID="${BILLING_ACCOUNT_ID:-0123}"  # Find the billing account ID in the cloud console.
+
+# Specific to Prow instance VV
+GCSBUCKET="${GCSBUCKET:-oss-prow}"
+
+# Overriding output
+OUT_FILE="${OUT_FILE:-build-cluster-kubeconfig.yaml}"
+
+function main() {
+  parseArgs "$@"
+  prompt "Create project" createProject
+  prompt "Create cluster" createCluster
+  prompt "Create a SA and secret for uploading results to GCS" createUploadSASecret
+  prompt "Generate kubeconfig credentials for Prow" gencreds
+  echo "All done!"
+}
+# Prep and check args.
+function parseArgs() {
+  for var in TEAM PROJECT ZONE CLUSTER MACHINE NODECOUNT DISKSIZE FOLDER_ID BILLING_ACCOUNT_ID; do
+    if [[ -z "${!var}" ]]; then
+      echo "Must specify ${var} environment variable (or specify a default in the script)."
+      exit 2
+    fi
+    echo "${var}=${!var}"
+  done
+}
+function prompt() {
+  local msg="$1" cmd="$2"
+  echo
+  read -r -n1 -p "$msg ? [y/n] "
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    "$cmd"
+  else
+    echo "Skipping and continuing to next step..."
+  fi
+}
+function pause() {
+  read -n 1 -s -r
+}
+
+authed=""
+function getClusterCreds() {
+  if [[ -z "${authed}" ]]; then
+    gcloud container clusters get-credentials --project="${PROJECT}" --zone="${ZONE}" "${CLUSTER}"
+    authed="true"
+  fi
+}
+function createProject() {
+  # Create project, configure billing, enable GKE, add IAM rule for oncall team.
+  echo "Creating project '${PROJECT}' (this may take a few minutes)..."
+  gcloud projects create "${PROJECT}" --name="${PROJECT}" --folder="${FOLDER_ID}"
+  gcloud beta billing projects link "${PROJECT}" --billing-account="${BILLING_ACCOUNT_ID}"
+  gcloud services enable "container.googleapis.com" --project="${PROJECT}"
+  gcloud projects add-iam-policy-binding "${PROJECT}" --member="group:mdb.cloud-kubernetes-engprod-oncall@google.com" --role="roles/owner"
+}
+function createCluster() {
+  echo "Creating cluster '${CLUSTER}' (this may take a few minutes)..."
+  echo "If this fails due to insufficient project quota, request more at https://console.cloud.google.com/iam-admin/quotas?project=${PROJECT}"
+  echo
+  gcloud container clusters create "${CLUSTER}" --project="${PROJECT}" --zone="${ZONE}" --machine-type="${MACHINE}" --num-nodes="${NODECOUNT}" --disk-size="${DISKSIZE}" --disk-type="pd-ssd" --enable-autoupgrade --enable-autorepair
+  getClusterCreds
+  kubectl create namespace "test-pods"
+}
+function createUploadSASecret() {
+  getClusterCreds
+  local sa="prow-pod-utils"
+  local saFull="${sa}@${PROJECT}.iam.gserviceaccount.com"
+  # Create a service account for uploading to GCS.
+  gcloud beta iam service-accounts create "${sa}" --project="${PROJECT}" --description="SA for Prow's pod utilities to use to upload job results to GCS." --display-name="Prow Pod Utilities"
+  # Generate private key and attach to the service account.
+  gcloud iam service-accounts keys create "sa-key.json" --project="${PROJECT}" --iam-account="${saFull}"
+  kubectl create secret generic "service-account" -n "test-pods" --from-file="service-account.json=sa-key.json"
+  echo
+  echo "Please ask the test-infra oncall (https://go.k8s.io/oncall) to run the following:"
+  echo "  gsutil acl ch -u \"${saFull}:O\" \"gs://${GCSBUCKET}\""
+  echo
+  echo "Press any key to aknowledge (this doesn't need to be completed to continue this script, but it needs to be done before uploading will work)..."
+  pause
+}
+
+origdir="$( pwd -P )"
+tempdir="$( mktemp -d )"
+# generate a JWT kubeconfig file that we can merge into prow's kubeconfig secret so that Prow can schedule pods
+function gencreds() {
+  getClusterCreds
+  local clusterAlias="build-${TEAM}"
+  local outfile="${OUT_FILE}"
+  # TODO: Make gencred build without bazel so we can use something like the following:
+  # GO111MODULE=on go run k8s.io/test-infra/gencred --serviceaccount --name "${clusterAlias}"
+  cd "${tempdir}"
+  git clone https://github.com/kubernetes/test-infra --depth=1
+  cd test-infra
+  bazel run //gencred -- --context="$(kubectl config current-context)" --name "${clusterAlias}" > "${origdir}/${outfile}"
+  cd "${origdir}"
+  echo
+  echo "Supply the file '${outfile}' to the current oncall for them to add to Prow's kubeconfig secret via:"
+  echo "  ./merge_kubeconfig_secret.py --secret-key=oss-config ${outfile}"
+  echo "ProwJobs that intend to use this cluster should specify 'cluster: ${clusterAlias}'" # TODO: color this
+  echo
+  echo "Press any key to acknowledge (this doesn't need to be completed to continue this script, but it needs to be done before Prow can schedule jobs to your cluster)..."
+  pause
+}
+function cleanup() {
+  returnCode="$?"
+  rm -f "sa-key.json" || true
+  rm -rf "${tempdir}" || true
+  exit "${returnCode}"
+}
+trap cleanup EXIT
+main "$@"
+cleanup


### PR DESCRIPTION
I recommend reviewing by commit as the second commit just copies [`create-build-cluster.sh`](https://github.com/GoogleCloudPlatform/oss-test-infra/blob/master/prow/create-build-cluster.sh) from GoogleCloudPlatform/oss-test-infra. This script is generally useful for any Prow instance so I'd like to upstream it and centralize it like `pj-on-kind.sh`.

The changes to `merge_kubeconfig_secret.py` have two effects:
- A required `--context` flag was added so that users must explicitly identify the cluster they wish to update.
- An `--auto` mode was added to automatically determine the `--dest-key` and `--src-key` values assuming that keys are formatted like `config-20200730`. This will make it simpler for oncall to update the secret and promote a consistent key formatting pattern that makes roll backs easy.

Addresses https://github.com/GoogleCloudPlatform/oss-test-infra/issues/400

/assign @chaodaiG @michelle192837 @alvaroaleman 