### PR TITLE
Guaranteed Pod QOS: pull-kubernetes-e2e-gce-network-proxy-grpc

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -157,6 +157,10 @@ presubmits:
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-master
         resources:
           requests:
-            memory: "6Gi"
+            cpu: 4
+            memory: 12Gi
+          limits:
+            cpu: 4
+            memory: 12Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy

--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -158,9 +158,9 @@ presubmits:
         resources:
           requests:
             cpu: 4
-            memory: 12Gi
+            memory: 14Gi
           limits:
             cpu: 4
-            memory: 12Gi
+            memory: 14Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy


### PR DESCRIPTION
CPU and memory resource limits, and matching resource requests to change pull-kubernetes-e2e-gce-network-proxy-grpc job as Guaranteed Pod QOS

Fixes #18677

@kubernetes/ci-signal
@spiffxp 