### PR TITLE
Add podman label to the kind project

### DIFF
--- a/label_sync/labels.md
+++ b/label_sync/labels.md
@@ -10,6 +10,7 @@
 - [Labels that apply to all repos, only for PRs](#labels-that-apply-to-all-repos-only-for-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/cluster-api-provider-azure, for both issues and PRs](#labels-that-apply-to-kubernetes-sigscluster-api-provider-azure-for-both-issues-and-prs)
+- [Labels that apply to kubernetes-sigs/kind, for both issues and PRs](#labels-that-apply-to-kubernetes-sigskind-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/krew, for both issues and PRs](#labels-that-apply-to-kubernetes-sigskrew-for-both-issues-and-prs)
 - [Labels that apply to kubernetes-sigs/service-apis, only for issues](#labels-that-apply-to-kubernetes-sigsservice-apis-only-for-issues)
 - [Labels that apply to kubernetes/community, for both issues and PRs](#labels-that-apply-to-kubernetescommunity-for-both-issues-and-prs)
@@ -193,6 +194,13 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="kind/proposal" href="#kind/proposal">`kind/proposal`</a> | Issues or PRs related to proposals.| anyone |  [label](https://git.k8s.io/test-infra/prow/plugins/label) |
+
+## Labels that apply to kubernetes-sigs/kind, for both issues and PRs
+
+| Name | Description | Added By | Prow Plugin |
+| ---- | ----------- | -------- | --- |
+| <a id="area/provider/docker" href="#area/provider/docker">`area/provider/docker`</a> | Issues or PRs related to docker| humans | |
+| <a id="area/provider/podman" href="#area/provider/podman">`area/provider/podman`</a> | Issues or PRs related to podman| humans | |
 
 ## Labels that apply to kubernetes-sigs/krew, for both issues and PRs
 

--- a/label_sync/labels.yaml
+++ b/label_sync/labels.yaml
@@ -1543,3 +1543,15 @@ repos:
         name: kind/user-story
         target: issues
         addedBy: humans
+  kubernetes-sigs/kind:
+    labels:
+      - color: 19abff
+        description: Issues or PRs related to docker
+        name: area/provider/docker
+        target: both
+        addedBy: humans
+      - color: 970fff
+        description: Issues or PRs related to podman
+        name: area/provider/podman
+        target: both
+        addedBy: humans


### PR DESCRIPTION
KIND currently has 2 providers, docker as default and podman as experimental.

We add a label for podman provider In order to differentiate issues and PRs

Fixes: https://github.com/kubernetes-sigs/kind/issues/1765