### PR TITLE
Print output of push build call

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -142,7 +142,8 @@ def main(args):
         check('make', 'quick-release')
     else:
         check('make', 'release')
-    check(args.push_build_script, *push_build_args)
+    output = check_output(args.push_build_script, *push_build_args)
+    print >>sys.stderr, 'Push build result: ', output
 
 if __name__ == '__main__':
     PARSER = argparse.ArgumentParser(


### PR DESCRIPTION
Prints the output of push build when called as a subprocess in
kubernetes_build.py scenario.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I _think_ this will print the output --> `check_output` runs command and returns output

/cc @justaugustus 