### PR TITLE
Remove ProwMultipleContainerSupport annotation config requirement

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -1289,7 +1289,7 @@ func validateJobBase(v JobBase, jobType prowapi.ProwJobType, podNamespace string
 	if err := validateAgent(v, podNamespace); err != nil {
 		return err
 	}
-	if err := validatePodSpec(jobType, v.Spec, v.Annotations["ProwMultipleContainerSupport"] == "Yes, I know what I'm doing.", v.DecorationConfig != nil); err != nil {
+	if err := validatePodSpec(jobType, v.Spec, v.DecorationConfig != nil); err != nil {
 		return err
 	}
 	if err := ValidatePipelineRunSpec(jobType, v.ExtraRefs, v.PipelineRunSpec); err != nil {
@@ -1882,7 +1882,7 @@ func ValidatePipelineRunSpec(jobType prowapi.ProwJobType, extraRefs []prowapi.Re
 	return nil
 }
 
-func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, multipleContainerSupport bool, decorationEnabled bool) error {
+func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEnabled bool) error {
 	if spec == nil {
 		return nil
 	}
@@ -1896,10 +1896,6 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, multipleCont
 	if n := len(spec.Containers); n < 1 {
 		// We must return here to not cause an out of bounds panic in the remaining validation
 		return utilerrors.NewAggregate(append(errs, fmt.Errorf("pod spec must specify at least 1 container, found: %d", n)))
-	}
-
-	if n := len(spec.Containers); n > 1 && !multipleContainerSupport {
-		return utilerrors.NewAggregate(append(errs, fmt.Errorf("pod spec must specify exactly 1 container, found: %d", n)))
 	}
 
 	if n := len(spec.Containers); n > 1 && !decorationEnabled {

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -896,7 +896,7 @@ func TestValidatePodSpec(t *testing.T) {
 			} else if tc.spec != nil {
 				tc.spec(current)
 			}
-			switch err := validatePodSpec(jt, current, false, true); {
+			switch err := validatePodSpec(jt, current, true); {
 			case err == nil && !tc.pass:
 				t.Error("validation failed to raise an error")
 			case err != nil && tc.pass:
@@ -1191,9 +1191,6 @@ func TestValidateMultipleContainers(t *testing.T) {
 				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
 				Spec:          &goodSpec,
 				Namespace:     &ns,
-				Annotations: map[string]string{
-					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
-				},
 			},
 			pass: true,
 		},
@@ -1214,9 +1211,6 @@ func TestValidateMultipleContainers(t *testing.T) {
 					},
 				},
 				Namespace: &ns,
-				Annotations: map[string]string{
-					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
-				},
 			},
 		},
 		{
@@ -1236,20 +1230,6 @@ func TestValidateMultipleContainers(t *testing.T) {
 					},
 				},
 				Namespace: &ns,
-				Annotations: map[string]string{
-					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
-				},
-			},
-		},
-		{
-			name: "invalid: no ProwMultipleContainerSupport annotation",
-			base: JobBase{
-				Name:          "name",
-				Agent:         ka,
-				UtilityConfig: UtilityConfig{Decorate: &yes, DecorationConfig: &defCfg},
-				Spec:          &goodSpec,
-				Namespace:     &ns,
-				Annotations:   map[string]string{},
 			},
 		},
 		{
@@ -1259,9 +1239,6 @@ func TestValidateMultipleContainers(t *testing.T) {
 				Agent:     ka,
 				Spec:      &goodSpec,
 				Namespace: &ns,
-				Annotations: map[string]string{
-					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
-				},
 			},
 		},
 		{
@@ -1282,9 +1259,6 @@ func TestValidateMultipleContainers(t *testing.T) {
 						},
 					},
 				}, Namespace: &ns,
-				Annotations: map[string]string{
-					"ProwMultipleContainerSupport": "Yes, I know what I'm doing.",
-				},
 			},
 		},
 	}


### PR DESCRIPTION
removing the required annotation for multiple container prowjobs that was for testing.  