### PR TITLE
Add kube-up/down and dump logs dependencies to KRTE

### DIFF
--- a/images/krte/Dockerfile
+++ b/images/krte/Dockerfile
@@ -66,6 +66,7 @@ RUN echo "Installing Packages ..." \
             kmod \
             lsb-release \
             mercurial \
+            openssh-client \
             pkg-config \
             procps \
             python \
@@ -93,6 +94,8 @@ RUN echo "Installing Packages ..." \
             --path-update=false \
             --usage-reporting=false \
         && gcloud components install kubectl \
+        && gcloud components install alpha \
+        && gcloud components install beta \
     && echo "Installing Docker ..." \
         && curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | apt-key add - \
         && add-apt-repository \


### PR DESCRIPTION
The recently-released GCE deployer for kubetest2 will be run in KRTE containers in CI. KRTE is currently missing a couple of necessary dependencies:

The deployer calls out to `kube-up.sh`, which needs `gcloud` alpha and beta components.

The deployer also uses a log dumping script which relies on `gcloud compute ssh` and `scp`. This adds a necessary SSH client.