### PR TITLE
Add periodic conformance test run against cloud-provider-gcp using kubetest2

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -4,6 +4,7 @@ periodics:
   name: ci-cloud-provider-gcp-conformance-latest
   annotations:
     testgrid-tab-name: Conformance - Cloud Provider GCP - master
+    testgrid-dashboards: provider-gcp-periodics
     description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -11,6 +11,13 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16
+      resources:
+        limits:
+          cpu: 2000m
+          memory: 2G
+        requests:
+          cpu: 2000m
+          memory: 2G
       command:
       - wrapper.sh
       args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -1,0 +1,32 @@
+periodics:
+- interval: 3h
+  cluster: k8s-infra-prow-build
+  name: ci-cloud-provider-gcp-conformance-latest
+  annotations:
+    testgrid-tab-name: Conformance - Cloud Provider GCP - master
+    description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
+  labels:
+    preset-service-account: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16
+      command:
+      - wrapper.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      # TODO: Use published release tars for cloud-provider-gcp if/once they exist
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        git clone https://github.com/kubernetes/cloud-provider-gcp;
+        cd cloud-provider-gcp;
+        REPO_ROOT=$(git rev-parse --show-toplevel);
+        cd;
+        go get -u github.com/onsi/ginkgo/ginkgo;
+        export GO111MODULE=on;
+        go get sigs.k8s.io/kubetest2@latest;
+        go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --focus-regex='\[Conformance\]' --parallel=30

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -19,11 +19,11 @@ periodics:
     - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16
       resources:
         limits:
-          cpu: 2000m
-          memory: 2G
+          cpu: 4
+          memory: 14Gi
         requests:
-          cpu: 2000m
-          memory: 2G
+          cpu: 4
+          memory: 14Gi
       command:
       - wrapper.sh
       args:

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -2,12 +2,18 @@ periodics:
 - interval: 3h
   cluster: k8s-infra-prow-build
   name: ci-cloud-provider-gcp-conformance-latest
+  decorate: true
   annotations:
     testgrid-tab-name: Conformance - Cloud Provider GCP - master
     testgrid-dashboards: provider-gcp-periodics
     description: Runs conformance tests using kubetest2 against cloud-provider-gcp master on GCE
   labels:
     preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: cloud-provider-gcp
+    base_ref: master
+    path_alias: k8s.io/cloud-provider-gcp
   spec:
     containers:
     - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16
@@ -28,9 +34,7 @@ periodics:
         set -o nounset;
         set -o pipefail;
         set -o xtrace;
-        git clone https://github.com/kubernetes/cloud-provider-gcp;
-        cd cloud-provider-gcp;
-        REPO_ROOT=$(git rev-parse --show-toplevel);
+        REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
         cd;
         go get -u github.com/onsi/ginkgo/ginkgo;
         export GO111MODULE=on;

--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -29,4 +29,4 @@ periodics:
         go get sigs.k8s.io/kubetest2@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --focus-regex='\[Conformance\]' --parallel=30
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --focus-regex='\[Conformance\]'

--- a/config/testgrids/kubernetes/sig-cloud-provider/gcp/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/gcp/config.yaml
@@ -4,8 +4,10 @@ dashboard_groups:
     - provider-gcp-compute-persistent-disk-csi-driver
     - provider-gcp-presubmits
     - provider-gcp-filestore-csi-driver
+    - provider-gcp-periodics
 
 dashboards:
 - name: provider-gcp-compute-persistent-disk-csi-driver
 - name: provider-gcp-presubmits
 - name: provider-gcp-filestore-csi-driver
+- name: provider-gcp-periodics


### PR DESCRIPTION
Adds a new periodic job to run the conformance ginkgo suite against the [cloud-provider-gcp](https://github.com/kubernetes/cloud-provider-gcp) repository. Test job is based on
[ci-kubernetes-gce-conformance-latest](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml#L4), with the main difference being using the new [kubetest2](https://github.com/kubernetes-sigs/kubetest2) GCE deployer instead of kubetest. Because cloud-provider-gcp does not have published release tars, this job has to clone and build the cloud-provider-gcp repository. The job also does not include the forking and the alerting in the job it is based on because it needs to be validated in production prow before meaningful decisions can be made using it.

Additional note: due to https://github.com/kubernetes/test-infra/issues/18706, this job uses KRTE instead of kubekins-e2e as the test runner.

Tested in a GKE cluster using mkpj and mkpod.