### PR TITLE
Sync started.json with testgrid schema in Pod-Util

### DIFF
--- a/docs/tests/node-e2e-ci.md
+++ b/docs/tests/node-e2e-ci.md
@@ -51,7 +51,7 @@ For periodic jobs the expected GCS path is in the following form (see [gcs bucke
 gs://kubernetes-github-redhat/logs/${JOB_NAME}/${BUILD_NUMBER}/
 ```
 
-The `TestGrid` then expects the following content of each build:
+The [`TestGrid`](https://github.com/GoogleCloudPlatform/testgrid/blob/master/metadata/job.go) then expects the following content of each build:
 
 * started.json
 
@@ -63,8 +63,9 @@ The `TestGrid` then expects the following content of each build:
     "repos": {
       "k8s.io/kubernetes": "master"
     },
-    "version": "v1.10.0-alpha.0.684+51033c4dec6e00",
-    "repo-version": "v1.10.0-alpha.0.684+51033c4dec6e00"
+    "repo-commit": "51033c4dec6e00cbbb550fcc09940efc54e54f79",
+    "repo-version": "v1.10.0-alpha.0.684+51033c4dec6e00", *deprecated*
+    "job-version": "v1.10.0-alpha.0.684+51033c4dec6e00" *deprecated*
   }
   ```
 
@@ -74,7 +75,6 @@ The `TestGrid` then expects the following content of each build:
   ```json
   {
     "timestamp": 1511907565,
-    "version": "v1.10.0-alpha.0.684+51033c4dec6e00",
     "result": "SUCCESS",
     "passed": true,
     "job-version": "v1.10.0-alpha.0.684+51033c4dec6e00",
@@ -83,9 +83,9 @@ The `TestGrid` then expects the following content of each build:
       "repos": {
         "k8s.io/kubernetes": "master"
       },
-      "repo-commit": "51033c4dec6e00cbbb550fcc09940efc54e54f79",
-      "version": "v1.10.0-alpha.0.684+51033c4dec6e00",
-      "job-version": "v1.10.0-alpha.0.684+51033c4dec6e00"
+      "repo-commit": "51033c4dec6e00cbbb550fcc09940efc54e54f79",  *deprecated*
+      "revision": "v1.10.0-alpha.0.684+51033c4dec6e00", *deprecated*
+      "job-version": "v1.10.0-alpha.0.684+51033c4dec6e00" *deprecated*
     }
   }
   ```

--- a/prow/initupload/run.go
+++ b/prow/initupload/run.go
@@ -35,17 +35,22 @@ import (
 // specToStarted translate a jobspec into a started struct
 // optionally overwrite RepoVersion with provided cloneRecords
 func specToStarted(spec *downwardapi.JobSpec, cloneRecords []clone.Record) gcs.Started {
+	var version string
+
 	started := gcs.Started{
 		Timestamp: time.Now().Unix(),
 	}
 
 	if mainRefs := spec.MainRefs(); mainRefs != nil {
-		started.DeprecatedRepoVersion = shaForRefs(*mainRefs, cloneRecords)
+		version = shaForRefs(*mainRefs, cloneRecords)
 	}
 
-	if started.DeprecatedRepoVersion == "" {
-		started.DeprecatedRepoVersion = downwardapi.GetRevisionFromSpec(spec)
+	if version == "" {
+		version = downwardapi.GetRevisionFromSpec(spec)
 	}
+
+	started.DeprecatedRepoVersion = version
+	started.RepoCommit = version
 
 	// TODO(fejta): VM name
 

--- a/prow/initupload/run_test.go
+++ b/prow/initupload/run_test.go
@@ -52,6 +52,7 @@ func TestSpecToStarted(t *testing.T) {
 			expected: gcs.Started{
 				Pull:                  "123",
 				DeprecatedRepoVersion: "abcd1234",
+				RepoCommit:            "abcd1234",
 				Repos: map[string]string{
 					"kubernetes/test-infra": "master:deadbeef,123:abcd1234",
 				},
@@ -68,6 +69,7 @@ func TestSpecToStarted(t *testing.T) {
 			},
 			expected: gcs.Started{
 				DeprecatedRepoVersion: "master",
+				RepoCommit:            "master",
 				Repos: map[string]string{
 					"kubernetes/test-infra": "master",
 				},
@@ -92,6 +94,7 @@ func TestSpecToStarted(t *testing.T) {
 			},
 			expected: gcs.Started{
 				DeprecatedRepoVersion: "deadbeef",
+				RepoCommit:            "deadbeef",
 				Repos: map[string]string{
 					"kubernetes/test-infra": "master:deadbeef",
 					"kubernetes/release":    "v1.10",
@@ -124,6 +127,7 @@ func TestSpecToStarted(t *testing.T) {
 			}},
 			expected: gcs.Started{
 				DeprecatedRepoVersion: "aaaaaaaa",
+				RepoCommit:            "aaaaaaaa",
 				Repos: map[string]string{
 					"kubernetes/test-infra": "master",
 					"kubernetes/release":    "v1.10",
@@ -151,6 +155,7 @@ func TestSpecToStarted(t *testing.T) {
 			}},
 			expected: gcs.Started{
 				DeprecatedRepoVersion: "aaaaaaaa",
+				RepoCommit:            "aaaaaaaa",
 				Repos: map[string]string{
 					"kubernetes/release": "v1.10",
 				},


### PR DESCRIPTION
Add RepoCommit for standardization in pod util
Doc boyscout
This will enable Kettle to not need to fall back to the deprecated repo-version from metadata

/area Prow
#3412
