### PR TITLE
make pull-kubernetes-e2e-kind-ipv6 required

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -94,7 +94,7 @@ presubmits:
       testgrid-create-test-group: 'true'
 
   - name: pull-kubernetes-e2e-kind-ipv6
-    optional: true
+    optional: false
     always_run: true
     skip_report: false
     decorate: true

--- a/config/testgrids/config.yaml
+++ b/config/testgrids/config.yaml
@@ -327,6 +327,11 @@ dashboards:
     base_options: width=10
     alert_options:
       alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
+  - name: pull-kubernetes-e2e-kind-ipv6
+    test_group_name: pull-kubernetes-e2e-kind-ipv6
+    base_options: width=10
+    alert_options:
+      alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
   - name: pull-kubernetes-bazel-build
     test_group_name: pull-kubernetes-bazel-build
     base_options: width=10
@@ -378,11 +383,6 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-ipv6-canary
     test_group_name: pull-kubernetes-e2e-kind-ipv6-canary
     base_options: width=10
-  - name: pull-kubernetes-e2e-kind-ipv6
-    test_group_name: pull-kubernetes-e2e-kind-ipv6
-    base_options: width=10
-    alert_options:
-      alert_mail_to_addresses: bentheelder+alerts@google.com, antonio.ojea.garcia@gmail.com
   - name: pull-kubernetes-e2e-kind-dual-canary
     test_group_name: pull-kubernetes-e2e-kind-dual-canary
     base_options: width=10


### PR DESCRIPTION
This job has comparable stability to the other e2e presubmits, we've made significant strides by removing problematic tests for now (in line with the ipv4 job) and making some fixes to the networking stack.

Right now is our opportunity to make it required before the PR floodgates open and we regress on IPv6 again.

https://prow.k8s.io/?job=pull-kubernetes-e2e-kind
> Success rate over time: 3h: 80%, 12h: 79%, 48h: 64%

https://prow.k8s.io/?job=pull-kubernetes-e2e-kind-ipv6
> Success rate over time: 3h: 67%, 12h: 74%, 48h: 68%

https://prow.k8s.io/?job=pull-kubernetes-e2e-gce
> Success rate over time: 3h: 75%, 12h: 70%, 48h: 68%

(NOTE: 3h rate is meaningless this time of night, but you can see the 12h / 48h are actually comparable to e2e-gce)

This job also takes only ~1/2 the time of GCE, and can be done with less resources*

We already run it by default on all PRs, and it is currently reporting to PRs.