### PR TITLE
fix kind ipv6 network job regex

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -144,7 +144,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv4|Example|Federation|Experimental)\]|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
+        value: \[Feature:(Networking-IPv4|Example|Federation)\]|Internet.connection|upstream.nameserver|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
disable the IPv6 that require internet connectivity, they are going
to fail until the CI infra supports IPv6.

Also, fix the regex removing `Experimental` from the feature tag,
since it was never used there

xref: https://k8s-testgrid.appspot.com/sig-network-kind#sig-network-kind,%20IPv6,%20master

Fixes: https://github.com/kubernetes/kubernetes/issues/93527