### PR TITLE
Fix service catalog job config

### DIFF
--- a/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/service-catalog/service-catalog-presubmits.yaml
@@ -202,7 +202,7 @@ presubmits:
             - runner.sh
           args:
             - make
-            - arch-image-ppc64le
+            - arch-image-s390x
           # docker-in-docker needs privileged mode
           securityContext:
             privileged: true


### PR DESCRIPTION
Fixed service catalog job config to build s390x images in the Prow job `pull-build-all-images-for-s390x`