### PR TITLE
image-pushing: add config for nfd

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-nfd.yaml
+++ b/config/jobs/image-pushing/k8s-staging-nfd.yaml
@@ -1,0 +1,31 @@
+postsubmits:
+  # This is the github repo we'll build from. This block needs to be repeated
+  # for each repo.
+  kubernetes-sigs/node-feature-discovery:
+    # The name should be changed to match the repo name above
+    - name: post-node-feature-discovery-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # This is the name of some testgrid dashboard to report to.
+        # If this is the first one for your sig, you may need to create one
+        testgrid-dashboards: sig-node-node-feature-discovery
+      decorate: true
+      # this causes the job to only run on the master branch. Remove it if your
+      # job makes sense on every branch (unless it's setting a `latest` tag it
+      # probably does).
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200806-ee9d917
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-nfd
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-nfd-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -9,6 +9,7 @@ dashboard_groups:
     - sig-node-cri
     - sig-node-arm64
     - sig-node-docker
+    - sig-node-node-feature-discovery
     - sig-node-node-problem-detector
     - sig-node-seccomp-operator
 
@@ -111,6 +112,8 @@ dashboards:
     - name: ee19.03-node-ubuntu16.04-k8s1.14
       test_group_name: ee19.03-ubuntu16.04-k8s1.14.x-conformance
       description: k8s1.14.x node conformance test results for ee-19.03 on ubuntu16.04
+
+- name: sig-node-node-feature-discovery
 
 - name: sig-node-node-problem-detector
 


### PR DESCRIPTION
Introduce new config for pushing node-feature-discovery container images
to it's gcr staging repository. Also, add a testgrid for nfd.