### PR TITLE
Use relative paths when fetching triage results

### DIFF
--- a/triage/interactive.js
+++ b/triage/interactive.js
@@ -304,6 +304,11 @@ function getData() {
   }
 
   var url = '/k8s-gubernator/triage/'
+  if (document.location.host == 'storage.googleapis.com' && document.location.pathname.endsWith('index.html')) {
+    // Use the bucket name where available
+    var pathname = document.location.pathname;
+    url = pathname.substring(0, pathname.lastIndexOf('/')+1);
+  }
   var date = document.getElementById('date');
   if (date && date.value) {
     url += 'history/' + date.value.replace(/-/g, '') + '.json';


### PR DESCRIPTION
ref: #18726

Uses the bucket name when we're confident we can determine it

/cc BenTheElder spiffxp