### PR TITLE
Migrate release-blocking ingress jobs to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -1642,7 +1642,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.19
-      - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -1654,6 +1653,7 @@ periodics:
         limits:
           cpu: 1000m
           memory: 3Gi
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sbeta-ingress
     testgrid-dashboards: sig-release-1.19-blocking
@@ -1866,7 +1866,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.18
-      - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -1878,6 +1877,7 @@ periodics:
         limits:
           cpu: 1000m
           memory: 3Gi
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable1-ingress
     testgrid-dashboards: sig-release-1.18-blocking
@@ -2090,7 +2090,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.17
-      - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -2102,6 +2101,7 @@ periodics:
         limits:
           cpu: 1000m
           memory: 3Gi
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable2-ingress
     testgrid-dashboards: sig-release-1.17-blocking
@@ -2278,7 +2278,6 @@ periodics:
       - --gcp-zone=us-west1-b
       - --gcp-node-image=gci
       - --extract=ci/latest-1.16
-      - --gcp-project-type=ingress-project
       - --timeout=150m
       - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
       env:
@@ -2290,6 +2289,7 @@ periodics:
         limits:
           cpu: 1000m
           memory: 3Gi
+  cluster: k8s-infra-prow-build
   annotations:
     testgrid-tab-name: gce-cos-k8sstable3-ingress
     testgrid-dashboards: sig-release-1.16-blocking

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -248,6 +248,7 @@ periodics:
 
 - interval: 30m
   name: ci-kubernetes-e2e-gci-gce-ingress
+  cluster: k8s-infra-prow-build
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
@@ -263,7 +264,6 @@ periodics:
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest-fast
       - --gcp-node-image=gci
-      - --gcp-project-type=ingress-project
       - --gcp-zone=asia-southeast1-a
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
@@ -300,7 +300,6 @@ periodics:
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest-fast
       - --gcp-node-image=gci
-      - --gcp-project=k8s-infra-e2e-ingress-project
       - --gcp-zone=asia-southeast1-a
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1108,8 +1108,8 @@ func TestK8sInfraProwBuildJobsMustHavePodQOSGuaranteed(t *testing.T) {
 func TestK8sInfraProwBuildJobsMustNotExceedTotalCapacity(t *testing.T) {
 	// k8s-infra-prow-build pool1 is 3-zonal 6-30 n1-highmem-8's
 	maxLimit := coreapi.ResourceList{
-		coreapi.ResourceCPU:    resource.MustParse("288000m"), // 3 * 12 * 8 CPUs per n1-highmem-8
-		coreapi.ResourceMemory: resource.MustParse("1872Gi"),  // 3 * 12 * 52 Gi per n1-highmem-8
+		coreapi.ResourceCPU:    resource.MustParse("432"),    // 3 * 18 * 8 CPUs per n1-highmem-8
+		coreapi.ResourceMemory: resource.MustParse("2808Gi"), // 3 * 18 * 52 Gi per n1-highmem-8
 	}
 	resourceNames := []coreapi.ResourceName{
 		coreapi.ResourceCPU,

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -566,9 +566,9 @@ testSuites:
     cluster: k8s-infra-prow-build
   ingress:
     args:
-    - --gcp-project-type=ingress-project
     - --timeout=150m
     - --test_args=--ginkgo.focus=\[Feature:Ingress\] --minStartupPods=8
+    cluster: k8s-infra-prow-build
   reboot:
     args:
     - --timeout=180m


### PR DESCRIPTION
Based on https://testgrid.k8s.io/sig-testing-canaries#gci-gce-ingress it appears these jobs do just fine with the default set of quotas available in the GCP projects in the default gce-project pool

A followup change will remove the canary job once we have sufficient history/signal from the release-blocking jobs

Part of https://github.com/kubernetes/test-infra/issues/18651