### PR TITLE
add jobs to deploy k8s-infra prow-build resources

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -66,3 +66,51 @@ postsubmits:
         args:
         - -c
         - "cd dns && make dry-run-local"
+  - name: post-k8sio-deploy-prow-build-resources
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    max_concurrency: 1
+    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources/"
+    branches:
+    - ^master$
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+    spec:
+      serviceAccountName: prow-deployer
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200205-602500d
+        command:
+        - bash
+        args:
+        - -c
+        - |
+          gcloud container clusters get-credentials prow-build --project=k8s-infra-prow-build --region=us-central1
+          kubectl --context=gke_k8s-infra-prow-build_us-central1_prow-build \
+            apply -f ./infra/gcp/clusters/projects/k8s-infra-prow-build/prow-build/resources
+  - name: post-k8sio-deploy-prow-build-trusted-resources
+    cluster: k8s-infra-prow-build-trusted
+    decorate: true
+    max_concurrency: 1
+    run_if_changed: "^infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources/"
+    branches:
+    - ^master$
+    annotations:
+      testgrid-create-test-group: 'true'
+      testgrid-dashboards: wg-k8s-infra-k8sio
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io
+      testgrid-num-failures-to-alert: '1'
+    spec:
+      serviceAccountName: prow-deployer
+      containers:
+      - image: gcr.io/k8s-testimages/gcloud-in-go:v20200205-602500d
+        command:
+        - bash
+        args:
+        - -c
+        - |
+          gcloud container clusters get-credentials prow-build-trusted --project=k8s-infra-prow-build-trusted --region=us-central1
+          kubectl --context=gke_k8s-infra-prow-build-trusted_us-central1_prow-build-trusted \
+            apply -f ./infra/gcp/clusters/projects/k8s-infra-prow-build-trusted/prow-build-trusted/resources


### PR DESCRIPTION
One job for each cluster, but both jobs run in the k8s-infra trusted cluster, which is the only cluster that has the prow-deployer service account

part of https://github.com/kubernetes/k8s.io/issues/845