### PR TITLE
Migrate release-blocking gpu jobs to k8s-infra

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -11,6 +11,7 @@ presets:
 
 periodics:
 - name: ci-kubernetes-e2e-gce-device-plugin-gpu
+  cluster: k8s-infra-prow-build
   cron: "30 1-23/2 * * *"
   labels:
     preset-service-account: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -42,6 +42,7 @@ periodics:
     testgrid-dashboards: sig-release-1.16-blocking, google-gce
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.16
+  cluster: k8s-infra-prow-build
   cron: 0 8-23/24 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -84,6 +84,7 @@ periodics:
     testgrid-dashboards: sig-release-1.17-blocking, google-gce
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.17
+  cluster: k8s-infra-prow-build
   cron: 0 8-23/12 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -84,6 +84,7 @@ periodics:
     testgrid-dashboards: sig-release-1.18-blocking, google-gce
     testgrid-num-failures-to-alert: "12"
     testgrid-tab-name: gce-device-plugin-gpu-1.18
+  cluster: k8s-infra-prow-build
   cron: 0 3-23/6 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -43,6 +43,7 @@ periodics:
     testgrid-dashboards: sig-release-1.19-blocking, google-gce
     testgrid-num-failures-to-alert: "6"
     testgrid-tab-name: gce-device-plugin-gpu-1.19
+  cluster: k8s-infra-prow-build
   cron: 0 0-23/2 * * *
   labels:
     preset-ci-gce-device-plugin-gpu: "true"

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -619,13 +619,6 @@ testSuites:
     - --timeout=40m
     - --test_args=--ginkgo.focus=\[Feature:NoSNAT\] --minStartupPods=8
     - --ginkgo-parallel=1
-  gpu:
-    args:
-    - --gcp-project-type=gpu-project
-    - --timeout=180m
-    - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
-    - --env=NVIDIA_DRIVER_INSTALLER_DAEMONSET=https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/master/nvidia-driver-installer/ubuntu/daemonset-preloaded.yaml
-    - --gke-create-command=container clusters create --accelerator=type=nvidia-tesla-k80,count=2
 
 # The following settings are used by node e2e tests.
 


### PR DESCRIPTION
Now that gpu-project has been setup over there via https://github.com/kubernetes/k8s.io/issues/1095

Part of https://github.com/kubernetes/test-infra/issues/18650