### PR TITLE
Set azure loadbanacer sku to basic when enabling public IP address in agentpool

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -464,6 +464,9 @@ periodics:
         value: /etc/ssh-key-secret/ssh-private # Requires preset-k8s-ssh label
       - name: KUBE_SSH_USER
         value: azureuser
+      - name: K8S_AZURE_LOADBALANCE_SKU
+        value: "basic"
+
   annotations:
     testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-periodic
     testgrid-tab-name: cloud-provider-azure-serial


### PR DESCRIPTION
Since aks-engine enable the check that the lb must be basic when enabling public IP address in agentpool since v0.53.0, we should set an env to prevent test failure in https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/cloud-provider-azure-serial/1291895438504366081.

/area provider/azure
/kind bug