### PR TITLE
Add resources for pull-kubernetes-dependencies (non relase-branch)

### DIFF
--- a/config/jobs/kubernetes/sig-testing/dependencies.yaml
+++ b/config/jobs/kubernetes/sig-testing/dependencies.yaml
@@ -31,6 +31,13 @@ presubmits:
         # Space separated list of the checks to run
         - name: WHAT
           value: "external-dependencies-version vendor vendor-licenses"
+        resources:
+          limits:
+            cpu: 2
+            memory: 1.2Gi
+          requests:
+            cpu: 2
+            memory: 1.2Gi
   - name: pull-kubernetes-dependencies-canary
     path_alias: "k8s.io/kubernetes"
     decorate: true
@@ -56,5 +63,12 @@ presubmits:
         # Space separated list of the checks to run
         - name: WHAT
           value: "external-dependencies-version vendor vendor-licenses"
+        resources:
+          limits:
+            cpu: 2
+            memory: 1.2Gi
+          requests:
+            cpu: 2
+            memory: 1.2Gi
     annotations:
       testgrid-create-test-group: 'true'


### PR DESCRIPTION
We got the release-branch variants, but not the copy of the job
that ignores release branches. I went ahead and added the limits
to the canary job while I was here

Part of https://github.com/kubernetes/test-infra/issues/18587
Followup to https://github.com/kubernetes/test-infra/pull/18645