### PR TITLE
Add resources for pull-kubernetes-bazel-test (release branches)

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1085,7 +1085,13 @@ presubmits:
         - ../test-infra/hack/bazel.sh
         image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
-        resources: {}
+        resources:
+          limits:
+            cpu: 4
+            memory: 38Gi
+          requests:
+            cpu: 4
+            memory: 38Gi
   - always_run: true
     branches:
     - release-1.16

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1156,7 +1156,13 @@ presubmits:
         - ../test-infra/hack/bazel.sh
         image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
-        resources: {}
+        resources:
+          limits:
+            cpu: 4
+            memory: 38Gi
+          requests:
+            cpu: 4
+            memory: 38Gi
   - always_run: true
     branches:
     - release-1.17

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1357,7 +1357,13 @@ presubmits:
         - ../test-infra/hack/bazel.sh
         image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
-        resources: {}
+        resources:
+          limits:
+            cpu: 4
+            memory: 38Gi
+          requests:
+            cpu: 4
+            memory: 38Gi
   - always_run: true
     branches:
     - release-1.18

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1297,7 +1297,13 @@ presubmits:
         - ../test-infra/hack/bazel.sh
         image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         name: ""
-        resources: {}
+        resources:
+          limits:
+            cpu: 4
+            memory: 38Gi
+          requests:
+            cpu: 4
+            memory: 38Gi
   - always_run: true
     branches:
     - release-1.19

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -57,13 +57,13 @@ presubmits:
         - --
         - -//build/...
         - -//vendor/...
-      resources:
-        limits:
-          cpu: 4
-          memory: "38Gi"
-        requests:
-          cpu: 4
-          memory: "38Gi"
+        resources:
+          limits:
+            cpu: 4
+            memory: 38Gi
+          requests:
+            cpu: 4
+            memory: 38Gi
 postsubmits:
   kubernetes/kubernetes:
   - name: ci-kubernetes-bazel-build


### PR DESCRIPTION
~We added the limits for the non-release-branch variant~ (EDIT: haha, just kidding! your friend, YAML indentation), but not the release branches

Part of https://github.com/kubernetes/test-infra/issues/18584
Followup to https://github.com/kubernetes/test-infra/pull/18670