### PR TITLE
Add resources to pull-kubernetes-typecheck (release branches)

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1133,7 +1133,13 @@ presubmits:
           value: typecheck
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200807-c10eea0-1.16
         name: main
-        resources: {}
+        resources:
+          limits:
+            cpu: 5
+            memory: 36Gi
+          requests:
+            cpu: 5
+            memory: 36Gi
   - always_run: true
     branches:
     - release-1.16

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1230,7 +1230,13 @@ presubmits:
           value: typecheck
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200807-c10eea0-1.17
         name: main
-        resources: {}
+        resources:
+          limits:
+            cpu: 5
+            memory: 36Gi
+          requests:
+            cpu: 5
+            memory: 36Gi
   - always_run: true
     branches:
     - release-1.17

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1469,7 +1469,13 @@ presubmits:
           value: typecheck typecheck-providerless
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200807-c10eea0-1.18
         name: main
-        resources: {}
+        resources:
+          limits:
+            cpu: 5
+            memory: 36Gi
+          requests:
+            cpu: 5
+            memory: 36Gi
   - always_run: true
     branches:
     - release-1.18

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1428,7 +1428,13 @@ presubmits:
           value: typecheck typecheck-providerless typecheck-dockerless
         image: gcr.io/k8s-testimages/kubekins-e2e:v20200807-c10eea0-1.19
         name: main
-        resources: {}
+        resources:
+          limits:
+            cpu: 5
+            memory: 36Gi
+          requests:
+            cpu: 5
+            memory: 36Gi
   - always_run: true
     branches:
     - release-1.19


### PR DESCRIPTION
We added them to the non-release branch variant, but missed the
release-branch jobs

Part of https://github.com/kubernetes/test-infra/issues/18596
Followup to https://github.com/kubernetes/test-infra/pull/18648