### PR TITLE
Bump pull-kubernetes-verify memory limits to accomodate for govet test

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1267,11 +1267,13 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
           requests:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1275,12 +1275,14 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
           requests:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1514,11 +1514,13 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
           requests:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1482,11 +1482,13 @@ presubmits:
         imagePullPolicy: Always
         name: ""
         resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
           requests:
             cpu: "7"
-            memory: 10Gi
+            memory: 12Gi
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -38,12 +38,14 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
           limits:
             cpu: 7
-            memory: 10Gi
+            memory: 12Gi
           requests:
             cpu: 7
-            memory: 10Gi
+            memory: 12Gi
 periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
We are currently passing the entire kubernetes source tree to govet in
the pull-kubernetes-verify presubmits. New memory limits cause the jobs
to fail due to OOM errors on verify.govet. This bumps the limits
slightly higher until the issue with the tests is addressed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Limits introduced in https://github.com/kubernetes/test-infra/pull/18610
xref https://github.com/kubernetes/kubernetes/issues/93822

/cc @liggitt @spiffxp @kubernetes/ci-signal 