### PR TITLE
releng(kubekins, krte): Update Golang versions

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,44 +1,44 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.15rc1
+    GO_VERSION: 1.15rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15rc1
+    GO_VERSION: 1.15rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   master:
     CONFIG: master
-    GO_VERSION: 1.15rc1
+    GO_VERSION: 1.15rc2
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.15rc1
+    GO_VERSION: 1.15rc2
     K8S_RELEASE: latest-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.18':
     CONFIG: '1.18'
-    GO_VERSION: 1.13.14
+    GO_VERSION: 1.13.15
     K8S_RELEASE: stable-1.18
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.17':
     CONFIG: '1.17'
-    GO_VERSION: 1.13.14
+    GO_VERSION: 1.13.15
     K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.16':
     CONFIG: '1.16'
-    GO_VERSION: 1.13.14
+    GO_VERSION: 1.13.15
     K8S_RELEASE: stable-1.16
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Golang version // variant(s):
- go1.15rc2 // master, 1.19, experimental, go-canary
- go1.13.15 // 1.18, 1.17, 1.16

Tracking issues: https://github.com/kubernetes/release/issues/1421, https://github.com/kubernetes/release/issues/1474

Signed-off-by: Stephen Augustus <saugustus@vmware.com>
