### PR TITLE
Fix typo in resource requests for files-remake

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1362,7 +1362,7 @@ presubmits:
             memory: 7Gi
           requests:
             cpu: 1500m
-            1memory: 7Gi
+            memory: 7Gi
   - always_run: true
     branches:
     - release-1.19

--- a/config/jobs/kubernetes/sig-testing/files-remake.yaml
+++ b/config/jobs/kubernetes/sig-testing/files-remake.yaml
@@ -33,4 +33,4 @@ presubmits:
             memory: 7Gi
           requests:
             cpu: 1500m
-            1memory: 7Gi
+            memory: 7Gi


### PR DESCRIPTION
The task fails when 1memory is used instead of memory.