### PR TITLE
config/jobs/helm/charts: remove inactive members from OWNERS

### DIFF
--- a/config/jobs/helm/charts/OWNERS
+++ b/config/jobs/helm/charts/OWNERS
@@ -5,10 +5,10 @@ reviewers:
 - mattfarina
 - prydonius
 - unguiculus
-- viglesiasce
 approvers:
 - foxish
 - mattfarina
 - prydonius
 - unguiculus
+emeritus_approvers:
 - viglesiasce


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves viglesiasce to
the emeritus_approvers section.

/assign @mattfarina 