### PR TITLE
cloud-provider-vsphere: move abrarshivani to emeritus_approvers

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
+++ b/config/jobs/kubernetes/cloud-provider-vsphere/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- abrarshivani
 - baludontu
 - divyenpatel
 - imkin
@@ -12,7 +11,6 @@ reviewers:
 - akutz
 - yastij
 approvers:
-- abrarshivani
 - baludontu
 - divyenpatel
 - imkin
@@ -22,6 +20,8 @@ approvers:
 - figo
 - akutz
 - yastij
+emeritus_approvers:
+- abrarshivani
 labels:
 - sig/cloud-provider
 - area/provider/vmware


### PR DESCRIPTION
Ref: kubernetes/org#2076

As a part of cleaning up inactive members (who haven't been active since
beginning of 2019) from OWNERS files, this commit moves abrarshivani to
emeritus_approvers section.

cc @abrarshivani @mrbobbytables 

/kind cleanup
/assign @yastij 