### PR TITLE
Fix nil map assignment that was causing panics

### DIFF
--- a/triage/summarize/summarize.go
+++ b/triage/summarize/summarize.go
@@ -94,7 +94,7 @@ func summarize(flags summarizeFlags) {
 	data := render(builds, clustered)
 
 	// Load the owners from the file, if given
-	var owners map[string][]string = nil
+	var owners map[string][]string
 	if flags.owners != "" {
 		owners, err = loadOwners(flags.owners)
 		if err != nil {
@@ -125,6 +125,10 @@ func summarize(flags summarizeFlags) {
 			}
 		}
 
+		// If owners is nil, initialize it
+		if owners == nil {
+			owners = make(map[string][]string)
+		}
 		if _, ok := owners["testing"]; !ok {
 			owners["testing"] = make([]string, 0)
 		}


### PR DESCRIPTION
ref: #18726 

Fix issue introduced in #18731 that caused panics when not passing anything to triage's `owners` flag (see, for example, https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-test-infra-triage-go/1292771712537989124).
A test to check for this issue has been added to #18490.