### PR TITLE
Try to catch gubernator-breaking job changes at presubmit time

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -25,7 +25,7 @@ presubmits:
   - name: pull-test-infra-gubernator
     branches:
     - master
-    run_if_changed: 'gubernator|config/prow/config.yaml' # TODO(fejta): |config/jobs/.+\.yaml
+    run_if_changed: 'gubernator|config/prow/config.yaml|config/jobs/.+\.yaml'
     decorate: true
     labels:
       preset-service-account: "true"

--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -19,4 +19,3 @@ set -o pipefail
 
 cd "$(git rev-parse --show-toplevel)"
 find hack -name 'verify-*.sh' -not -name "$(basename "$0")" \( -print -exec '{}' ';' -o -quit \)
-./guberantor/verify_config.sh


### PR DESCRIPTION
Another attempt at fixing https://github.com/kubernetes/test-infra/issues/18770

The previous attempt at triggering the relevant tests via `bazel test //hack/...` (https://github.com/kubernetes/test-infra/pull/18448) didn't work because:
- the script was mispelled...
- ...actually bazel doesn't invoke verify-all.sh
- ...actually gubernator isn't in bazel's view of the world at all

Rather than tackle that last problem, let's just trigger the job that ends up failing more often

I won't be able to verify this as part of this PR, so look for a dummy PR to verify this post-merge