### PR TITLE
Added a mirror of the k/k pull-kubernetes-e2e-gce using kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -95,7 +95,6 @@ presubmits:
           set -o xtrace;
           REPO_ROOT=$PWD;
           cd;
-          go get -u github.com/onsi/ginkgo/ginkgo;
           export GO111MODULE=on;
           go get sigs.k8s.io/kubetest2@latest;
           go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -70,6 +70,9 @@ presubmits:
       timeout: 80m # hard cap, based on original pre-kubetest2 job but moved to a prow-level timeout
     labels:
       preset-service-account: "true"
+    annotations:
+      testgrid-dashboards: presubmits-kubernetes-nonblocking
+      testgrid-tab-name: pull-kubernetes-e2e-gce-kubetest2
     spec:
       containers:
       - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -63,6 +63,56 @@ presubmits:
           limits:
             cpu: 4
             memory: 14Gi
+  - name: pull-kubernetes-e2e-gce-kubetest2
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 80m # hard cap, based on original pre-kubetest2 job but moved to a prow-level timeout
+    labels:
+      preset-service-account: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/krte:v20200806-28035c4-1.16
+        resources:
+          requests:
+            cpu: 4
+            memory: 14Gi
+          limits:
+            cpu: 4
+            memory: 14Gi
+        command:
+        - wrapper.sh
+        args:
+        - "/bin/bash"
+        - "-c"
+        # TODO: Use the e2e.test package built during the "build" step instead of downloading
+        # TODO: Investigate the need of --create-custom-network and debug issues
+        # Please note that the semicolon after the \ is necessary due to how
+        # parsing works out when embedding a bash script in a string like this
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          REPO_ROOT=$PWD;
+          cd;
+          go get -u github.com/onsi/ginkgo/ginkgo;
+          export GO111MODULE=on;
+          go get sigs.k8s.io/kubetest2@latest;
+          go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+          go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+          kubetest2 gce -v 2 \;
+          --repo-root $REPO_ROOT \;
+          --legacy-mode \;
+          --build \;
+          --up \;
+          --down \;
+          --enable-cache-mutation-detector \;
+          --runtime-config=batch/v2alpha1=true \;
+          --enable-pod-security-policy \;
+          --test=ginkgo \;
+          -- \;
+          --skip-regex='\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]' \;
+          --parallel=30
 
   - name: pull-kubernetes-e2e-gce-canary
     always_run: false


### PR DESCRIPTION
This is the first (test) iteration of the job using kubetest2 intended to replace the current merge-blocking job pull-kubernetes-e2e-gce.

The new job does not pass the `--create-custom-network` flag to kubetest2 because of errors encountered during testing related to `kube-up.sh`'s handling of the associated environment variable.

Tested using mkpj and mkpod, deploying to a GKE cluster.

/cc @amwat 
Do you want to hold this for the Ginkgo tester extracting its binary?