### PR TITLE
Introduce layeredsets to reflect OWNERS hierarchy

### DIFF
--- a/prow/BUILD.bazel
+++ b/prow/BUILD.bazel
@@ -141,6 +141,7 @@ filegroup(
         "//prow/pipeline/informers/externalversions:all-srcs",
         "//prow/pipeline/listers/pipeline/v1alpha1:all-srcs",
         "//prow/pjutil:all-srcs",
+        "//prow/pkg/layeredsets:all-srcs",
         "//prow/plank:all-srcs",
         "//prow/pluginhelp:all-srcs",
         "//prow/plugins:all-srcs",

--- a/prow/pkg/layeredsets/BUILD.bazel
+++ b/prow/pkg/layeredsets/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["string.go"],
+    importpath = "k8s.io/test-infra/prow/pkg/layeredsets",
+    visibility = ["//visibility:public"],
+    deps = ["@io_k8s_apimachinery//pkg/util/sets:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/prow/pkg/layeredsets/string.go
+++ b/prow/pkg/layeredsets/string.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package layeredsets
+
+import (
+	"math/rand"
+	"sort"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// String is a layered set implemented as a slice of sets.String.
+type String []sets.String
+
+// NewString creates a String from a list of values.
+func NewString(items ...string) String {
+	ss := String{}
+	ss.Insert(0, items...)
+	return ss
+}
+
+// NewStringFromSlices creates a String from a list of sets.
+func NewStringFromSlices(items ...[]string) String {
+	ss := String{}
+	for i, s := range items {
+		ss.Insert(i, s...)
+	}
+	return ss
+}
+
+// Insert adds items to the set.
+func (s *String) Insert(layerID int, items ...string) {
+	for len(*s) < layerID+1 {
+		*s = append(*s, sets.NewString())
+	}
+	for _, item := range items {
+		if !s.Has(item) {
+			(*s)[layerID].Insert(item)
+		}
+	}
+}
+
+// Delete removes all items from the set.
+func (s String) Delete(items ...string) {
+	for _, layer := range s {
+		layer.Delete(items...)
+	}
+}
+
+// Has returns true if and only if item is contained in the set.
+func (s String) Has(item string) bool {
+	for _, layer := range s {
+		if layer.Has(item) {
+			return true
+		}
+	}
+	return false
+}
+
+// Difference returns a set of objects that are not in s2
+func (s String) Difference(s2 sets.String) String {
+	result := NewString()
+	for layerID, layer := range s {
+		for _, key := range layer.List() {
+			if !s2.Has(key) {
+				result.Insert(layerID, key)
+			}
+		}
+	}
+	return result
+}
+
+// Union returns a new set which includes items in either s1 or s2.
+func (s String) Union(s2 String) String {
+	result := NewString()
+	for layerID, layer := range s {
+		result.Insert(layerID, layer.List()...)
+	}
+	for layerID, layer := range s2 {
+		result.Insert(layerID, layer.List()...)
+	}
+	return result
+}
+
+// PopRandom randomly selects an element and pops it.
+func (s String) PopRandom() string {
+	for _, layer := range s {
+		if layer.Len() > 0 {
+			list := layer.List()
+			sort.Strings(list)
+			sel := list[rand.Intn(len(list))]
+			s.Delete(sel)
+			return sel
+		}
+	}
+	return ""
+}
+
+// Equal returns true if and only if s1 is equal (as a set) to s2.
+func (s String) Equal(s2 String) bool {
+	if s.Len() != s2.Len() {
+		return false
+	}
+	for layerID, layer := range s {
+		if !s2[layerID].Equal(layer) {
+			return false
+		}
+	}
+	return true
+}
+
+// List returns the contents as a sorted string slice, respecting layers.
+func (s String) List() []string {
+	var res []string
+	for _, layer := range s {
+		res = append(res, layer.List()...)
+	}
+	return res
+}
+
+// UnsortedList returns the slice with contents in random order, respecting layers.
+func (s String) UnsortedList() []string {
+	var res []string
+	for _, layer := range s {
+		res = append(res, layer.UnsortedList()...)
+	}
+	return res
+}
+
+// Set converts the multiset into a regular sets.String for compatibility.
+func (s String) Set() sets.String {
+	ss := sets.String{}
+	return ss.Insert(s.List()...)
+}
+
+// Len returns the size of the set.
+func (s String) Len() int {
+	var i int
+	for _, layer := range s {
+		i += layer.Len()
+	}
+	return i
+}

--- a/prow/plugins/approve/BUILD.bazel
+++ b/prow/plugins/approve/BUILD.bazel
@@ -29,6 +29,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/approve/approvers:go_default_library",
         "//prow/repoowners:go_default_library",

--- a/prow/plugins/approve/approve_test.go
+++ b/prow/plugins/approve/approve_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/plugins/approve/approvers"
 	"k8s.io/test-infra/prow/repoowners"
@@ -127,12 +128,13 @@ func newFakeGitHubClient(hasLabel, humanApproved bool, files []string, comments 
 }
 
 type fakeRepo struct {
-	approvers, leafApprovers map[string]sets.String
-	approverOwners           map[string]string
-	dirBlacklist             []*regexp.Regexp
+	approvers      map[string]layeredsets.String
+	leafApprovers  map[string]sets.String
+	approverOwners map[string]string
+	dirBlacklist   []*regexp.Regexp
 }
 
-func (fr fakeRepo) Approvers(path string) sets.String {
+func (fr fakeRepo) Approvers(path string) layeredsets.String {
 	return fr.approvers[path]
 }
 func (fr fakeRepo) LeafApprovers(path string) sets.String {
@@ -1046,10 +1048,10 @@ Approvers can cancel approval by writing ` + "`/approve cancel`" + ` in a commen
 	}
 
 	fr := fakeRepo{
-		approvers: map[string]sets.String{
-			"a":   sets.NewString("alice"),
-			"a/b": sets.NewString("alice", "bob"),
-			"c":   sets.NewString("cblecker", "cjwagner"),
+		approvers: map[string]layeredsets.String{
+			"a":   layeredsets.NewString("alice"),
+			"a/b": layeredsets.NewString("alice", "bob"),
+			"c":   layeredsets.NewString("cblecker", "cjwagner"),
 		},
 		leafApprovers: map[string]sets.String{
 			"a":   sets.NewString("alice"),
@@ -1201,8 +1203,8 @@ func (fro fakeRepoOwners) LeafReviewers(path string) sets.String {
 	return sets.NewString()
 }
 
-func (fro fakeRepoOwners) Reviewers(path string) sets.String {
-	return sets.NewString()
+func (fro fakeRepoOwners) Reviewers(path string) layeredsets.String {
+	return layeredsets.NewString()
 }
 
 func (fro fakeRepoOwners) RequiredReviewers(path string) sets.String {

--- a/prow/plugins/approve/approvers/BUILD.bazel
+++ b/prow/plugins/approve/approvers/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/test-infra/prow/plugins/approve/approvers",
     visibility = ["//visibility:public"],
     deps = [
+        "//prow/pkg/layeredsets:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
@@ -19,6 +20,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//prow/pkg/layeredsets:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],

--- a/prow/plugins/approve/approvers/owners.go
+++ b/prow/plugins/approve/approvers/owners.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 )
 
 const (
@@ -40,7 +41,7 @@ const (
 
 // Repo allows querying and interacting with OWNERS information in a repo.
 type Repo interface {
-	Approvers(path string) sets.String
+	Approvers(path string) layeredsets.String
 	LeafApprovers(path string) sets.String
 	FindApproverOwnersForFile(file string) string
 	IsNoParentOwners(path string) bool
@@ -65,7 +66,7 @@ func (o Owners) GetApprovers() map[string]sets.String {
 	ownersToApprovers := map[string]sets.String{}
 
 	for fn := range o.GetOwnersSet() {
-		ownersToApprovers[fn] = o.repo.Approvers(fn)
+		ownersToApprovers[fn] = o.repo.Approvers(fn).Set()
 	}
 
 	return ownersToApprovers

--- a/prow/plugins/blunderbuss/BUILD.bazel
+++ b/prow/plugins/blunderbuss/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/plugins/assign:go_default_library",
@@ -39,6 +40,7 @@ go_test(
     deps = [
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/repoowners"
 )
@@ -105,15 +106,15 @@ func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoown
 
 type fakeOwnersClient struct {
 	owners            map[string]string
-	approvers         map[string]sets.String
+	approvers         map[string]layeredsets.String
 	leafApprovers     map[string]sets.String
-	reviewers         map[string]sets.String
+	reviewers         map[string]layeredsets.String
 	requiredReviewers map[string]sets.String
 	leafReviewers     map[string]sets.String
 	dirBlacklist      []*regexp.Regexp
 }
 
-func (foc *fakeOwnersClient) Approvers(path string) sets.String {
+func (foc *fakeOwnersClient) Approvers(path string) layeredsets.String {
 	return foc.approvers[path]
 }
 
@@ -125,7 +126,7 @@ func (foc *fakeOwnersClient) FindApproverOwnersForFile(path string) string {
 	return foc.owners[path]
 }
 
-func (foc *fakeOwnersClient) Reviewers(path string) sets.String {
+func (foc *fakeOwnersClient) Reviewers(path string) layeredsets.String {
 	return foc.reviewers[path]
 }
 
@@ -197,14 +198,14 @@ var (
 		"e.go":  "5",
 		"ee.go": "5",
 	}
-	reviewers = map[string]sets.String{
-		"a.go": sets.NewString("al"),
-		"b.go": sets.NewString("al"),
-		"c.go": sets.NewString("charles", "ben"),
+	reviewers = map[string]layeredsets.String{
+		"a.go": layeredsets.NewString("al"),
+		"b.go": layeredsets.NewString("al"),
+		"c.go": layeredsets.NewStringFromSlices([]string{"charles"}, []string{"ben"}), // ben is top level, charles is lower
 
-		"e.go":  sets.NewString("erick", "evan"),
-		"ee.go": sets.NewString("erick", "evan"),
-		"f.go":  sets.NewString("author", "non-author"),
+		"e.go":  layeredsets.NewString("erick", "evan"),
+		"ee.go": layeredsets.NewString("erick", "evan"),
+		"f.go":  layeredsets.NewString("author", "non-author"),
 	}
 	requiredReviewers = map[string]sets.String{
 		"a.go": sets.NewString("ben"),
@@ -230,16 +231,22 @@ var (
 		alternateExpectedRequested []string
 	}{
 		{
-			name:              "one file, 3 leaf reviewers, 1 parent, request 3",
+			name:              "one file, 3 leaf reviewers, 1 parent reviewer, 1 top level reviewer, request 3",
 			filesChanged:      []string{"c.go"},
 			reviewerCount:     3,
 			expectedRequested: []string{"cole", "carl", "chad"},
 		},
 		{
-			name:              "one file, 3 leaf reviewers, 1 parent reviewer, request 4",
+			name:              "one file, 3 leaf reviewers, 1 parent reviewer, 1 top level reviewer, request 4",
 			filesChanged:      []string{"c.go"},
 			reviewerCount:     4,
 			expectedRequested: []string{"cole", "carl", "chad", "charles"},
+		},
+		{
+			name:              "one file, 3 leaf reviewers, 1 parent reviewer, 1 top level reviewer, request 5",
+			filesChanged:      []string{"c.go"},
+			reviewerCount:     5,
+			expectedRequested: []string{"cole", "carl", "chad", "charles", "ben"}, // last resort we take the top level reviewer
 		},
 		{
 			name:              "two files, 2 leaf reviewers, 1 common parent, request 2",
@@ -399,15 +406,15 @@ func TestHandleWithoutExcludeApproversMixed(t *testing.T) {
 				"f.go":  "6",
 				"g.go":  "7",
 			},
-			approvers: map[string]sets.String{
-				"a.go": sets.NewString("al"),
-				"b.go": sets.NewString("jeff"),
-				"c.go": sets.NewString("jeff"),
+			approvers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("al"),
+				"b.go": layeredsets.NewString("jeff"),
+				"c.go": layeredsets.NewString("jeff"),
 
-				"e.go":  sets.NewString(),
-				"ee.go": sets.NewString("larry"),
-				"f.go":  sets.NewString("approver1"),
-				"g.go":  sets.NewString("Approver1"),
+				"e.go":  layeredsets.NewString(),
+				"ee.go": layeredsets.NewString("larry"),
+				"f.go":  layeredsets.NewString("approver1"),
+				"g.go":  layeredsets.NewString("Approver1"),
 			},
 			leafApprovers: map[string]sets.String{
 				"a.go": sets.NewString("alice"),
@@ -419,13 +426,13 @@ func TestHandleWithoutExcludeApproversMixed(t *testing.T) {
 				"f.go":  sets.NewString("leafApprover1", "leafApprover2"),
 				"g.go":  sets.NewString("leafApprover1", "leafApprover2"),
 			},
-			reviewers: map[string]sets.String{
-				"a.go": sets.NewString("al"),
-				"b.go": sets.NewString(),
-				"c.go": sets.NewString("charles"),
+			reviewers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("al"),
+				"b.go": layeredsets.NewString(),
+				"c.go": layeredsets.NewString("charles"),
 
-				"e.go":  sets.NewString("erick", "evan"),
-				"ee.go": sets.NewString("erick", "evan"),
+				"e.go":  layeredsets.NewString("erick", "evan"),
+				"ee.go": layeredsets.NewString("erick", "evan"),
 			},
 			leafReviewers: map[string]sets.String{
 				"a.go":  sets.NewString("alice"),
@@ -753,20 +760,20 @@ func TestPopActiveReviewer(t *testing.T) {
 				"bb.go": "3",
 				"c.go":  "4",
 			},
-			approvers: map[string]sets.String{
-				"a.go": sets.NewString("alice"),
-				"b.go": sets.NewString("brad"),
-				"c.go": sets.NewString("busy-user"),
+			approvers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("alice"),
+				"b.go": layeredsets.NewString("brad"),
+				"c.go": layeredsets.NewString("busy-user"),
 			},
 			leafApprovers: map[string]sets.String{
 				"a.go": sets.NewString("alice"),
 				"b.go": sets.NewString("brad"),
 				"c.go": sets.NewString("busy-user"),
 			},
-			reviewers: map[string]sets.String{
-				"a.go": sets.NewString("alice"),
-				"b.go": sets.NewString("brad"),
-				"c.go": sets.NewString("busy-user"),
+			reviewers: map[string]layeredsets.String{
+				"a.go": layeredsets.NewString("alice"),
+				"b.go": layeredsets.NewString("brad"),
+				"c.go": layeredsets.NewString("busy-user"),
 			},
 			leafReviewers: map[string]sets.String{
 				"a.go": sets.NewString("alice"),

--- a/prow/plugins/blunderbuss/blunderbuss_test.go
+++ b/prow/plugins/blunderbuss/blunderbuss_test.go
@@ -200,7 +200,7 @@ var (
 	reviewers = map[string]sets.String{
 		"a.go": sets.NewString("al"),
 		"b.go": sets.NewString("al"),
-		"c.go": sets.NewString("charles"),
+		"c.go": sets.NewString("charles", "ben"),
 
 		"e.go":  sets.NewString("erick", "evan"),
 		"ee.go": sets.NewString("erick", "evan"),

--- a/prow/plugins/lgtm/BUILD.bazel
+++ b/prow/plugins/lgtm/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
@@ -31,11 +32,11 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
     ],
 )
 

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -23,11 +23,11 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/repoowners"
@@ -491,8 +491,8 @@ func getChangedFiles(gc githubClient, org, repo string, number int) ([]string, e
 
 // loadReviewers returns all reviewers and approvers from all OWNERS files that
 // cover the provided filenames.
-func loadReviewers(ro repoowners.RepoOwner, filenames []string) sets.String {
-	reviewers := sets.String{}
+func loadReviewers(ro repoowners.RepoOwner, filenames []string) layeredsets.String {
+	reviewers := layeredsets.String{}
 	for _, filename := range filenames {
 		reviewers = reviewers.Union(ro.Approvers(filename)).Union(ro.Reviewers(filename))
 	}

--- a/prow/plugins/override/BUILD.bazel
+++ b/prow/plugins/override/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -31,6 +31,7 @@ import (
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/repoowners"
 )
@@ -60,8 +61,8 @@ func (foc *fakeOwnersClient) TopLevelApprovers() sets.String {
 	return foc.topLevelApprovers
 }
 
-func (foc *fakeOwnersClient) Approvers(path string) sets.String {
-	return sets.String{}
+func (foc *fakeOwnersClient) Approvers(path string) layeredsets.String {
+	return layeredsets.String{}
 }
 
 func (foc *fakeOwnersClient) LeafApprovers(path string) sets.String {
@@ -72,8 +73,8 @@ func (foc *fakeOwnersClient) FindApproverOwnersForFile(path string) string {
 	return ""
 }
 
-func (foc *fakeOwnersClient) Reviewers(path string) sets.String {
-	return sets.String{}
+func (foc *fakeOwnersClient) Reviewers(path string) layeredsets.String {
+	return layeredsets.String{}
 }
 
 func (foc *fakeOwnersClient) RequiredReviewers(path string) sets.String {

--- a/prow/plugins/verify-owners/BUILD.bazel
+++ b/prow/plugins/verify-owners/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "//prow/plugins:go_default_library",
         "//prow/repoowners:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/plugins/verify-owners/verify-owners_test.go
+++ b/prow/plugins/verify-owners/verify-owners_test.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/github/fakegithub"
 	"k8s.io/test-infra/prow/labels"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 	"k8s.io/test-infra/prow/plugins"
 	"k8s.io/test-infra/prow/repoowners"
 )
@@ -203,15 +204,15 @@ func (froc fakeRepoownersClient) LoadRepoOwners(org, repo, base string) (repoown
 
 type fakeOwnersClient struct {
 	owners            map[string]string
-	approvers         map[string]sets.String
+	approvers         map[string]layeredsets.String
 	leafApprovers     map[string]sets.String
-	reviewers         map[string]sets.String
+	reviewers         map[string]layeredsets.String
 	requiredReviewers map[string]sets.String
 	leafReviewers     map[string]sets.String
 	dirBlacklist      []*regexp.Regexp
 }
 
-func (foc *fakeOwnersClient) Approvers(path string) sets.String {
+func (foc *fakeOwnersClient) Approvers(path string) layeredsets.String {
 	return foc.approvers[path]
 }
 
@@ -223,7 +224,7 @@ func (foc *fakeOwnersClient) FindApproverOwnersForFile(path string) string {
 	return foc.owners[path]
 }
 
-func (foc *fakeOwnersClient) Reviewers(path string) sets.String {
+func (foc *fakeOwnersClient) Reviewers(path string) layeredsets.String {
 	return foc.reviewers[path]
 }
 

--- a/prow/repoowners/BUILD.bazel
+++ b/prow/repoowners/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
+        "//prow/pkg/layeredsets:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/repoowners/repoowners.go
+++ b/prow/repoowners/repoowners.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/github"
+	"k8s.io/test-infra/prow/pkg/layeredsets"
 
 	prowConf "k8s.io/test-infra/prow/config"
 )
@@ -216,9 +217,9 @@ type RepoOwner interface {
 	FindLabelsForFile(path string) sets.String
 	IsNoParentOwners(path string) bool
 	LeafApprovers(path string) sets.String
-	Approvers(path string) sets.String
+	Approvers(path string) layeredsets.String
 	LeafReviewers(path string) sets.String
-	Reviewers(path string) sets.String
+	Reviewers(path string) layeredsets.String
 	RequiredReviewers(path string) sets.String
 	ParseSimpleConfig(path string) (SimpleConfig, error)
 	ParseFullConfig(path string) (FullConfig, error)
@@ -776,7 +777,7 @@ func (o *RepoOwners) FindReviewersOwnersForFile(path string) string {
 // FindLabelsForFile returns a set of labels which should be applied to PRs
 // modifying files under the given path.
 func (o *RepoOwners) FindLabelsForFile(path string) sets.String {
-	return o.entriesForFile(path, o.labels, false)
+	return o.entriesForFile(path, o.labels, false).Set()
 }
 
 // IsNoParentOwners checks if an OWNERS file path refers to an OWNERS file with NoParentOwners enabled.
@@ -789,7 +790,7 @@ func (o *RepoOwners) IsNoParentOwners(path string) bool {
 // and not directory as the final directory will be discounted if enableMDYAML is true
 // leafOnly indicates whether only the OWNERS deepest in the tree (closest to the file)
 // should be returned or if all OWNERS in filepath should be returned
-func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.Regexp]sets.String, leafOnly bool) sets.String {
+func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.Regexp]sets.String, leafOnly bool) layeredsets.String {
 	d := path
 	if !o.enableMDYAML || !strings.HasSuffix(path, ".md") {
 		// if path is a directory, this will remove the leaf directory, and returns "." for topmost dir
@@ -797,7 +798,8 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 		d = canonicalize(path)
 	}
 
-	out := sets.NewString()
+	out := layeredsets.NewString()
+	var layerID int
 	for {
 		relative, err := filepath.Rel(d, path)
 		if err != nil {
@@ -806,7 +808,7 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 		}
 		for re, s := range people[d] {
 			if re == nil || re.MatchString(relative) {
-				out.Insert(s.List()...)
+				out.Insert(layerID, s.List()...)
 			}
 		}
 		if leafOnly && out.Len() > 0 {
@@ -820,6 +822,7 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 		}
 		d = filepath.Dir(d)
 		d = canonicalize(d)
+		layerID++
 	}
 	return out
 }
@@ -828,14 +831,14 @@ func (o *RepoOwners) entriesForFile(path string, people map[string]map[*regexp.R
 // requested file. If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will only return user2 for the path pkg/util/sets/file.go
 func (o *RepoOwners) LeafApprovers(path string) sets.String {
-	return o.entriesForFile(path, o.approvers, true)
+	return o.entriesForFile(path, o.approvers, true).Set()
 }
 
 // Approvers returns ALL of the users who are approvers for the
 // requested file (including approvers in parent dirs' OWNERS).
 // If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will return both user1 and user2 for the path pkg/util/sets/file.go
-func (o *RepoOwners) Approvers(path string) sets.String {
+func (o *RepoOwners) Approvers(path string) layeredsets.String {
 	return o.entriesForFile(path, o.approvers, false)
 }
 
@@ -843,14 +846,14 @@ func (o *RepoOwners) Approvers(path string) sets.String {
 // requested file. If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will only return user2 for the path pkg/util/sets/file.go
 func (o *RepoOwners) LeafReviewers(path string) sets.String {
-	return o.entriesForFile(path, o.reviewers, true)
+	return o.entriesForFile(path, o.reviewers, true).Set()
 }
 
 // Reviewers returns ALL of the users who are reviewers for the
 // requested file (including reviewers in parent dirs' OWNERS).
 // If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will return both user1 and user2 for the path pkg/util/sets/file.go
-func (o *RepoOwners) Reviewers(path string) sets.String {
+func (o *RepoOwners) Reviewers(path string) layeredsets.String {
 	return o.entriesForFile(path, o.reviewers, false)
 }
 
@@ -859,9 +862,9 @@ func (o *RepoOwners) Reviewers(path string) sets.String {
 // If pkg/OWNERS has user1 and pkg/util/OWNERS has user2 this
 // will return both user1 and user2 for the path pkg/util/sets/file.go
 func (o *RepoOwners) RequiredReviewers(path string) sets.String {
-	return o.entriesForFile(path, o.requiredReviewers, false)
+	return o.entriesForFile(path, o.requiredReviewers, false).Set()
 }
 
 func (o *RepoOwners) TopLevelApprovers() sets.String {
-	return o.entriesForFile(".", o.approvers, false)
+	return o.entriesForFile(".", o.approvers, true).Set()
 }

--- a/prow/repoowners/repoowners_test.go
+++ b/prow/repoowners/repoowners_test.go
@@ -1067,7 +1067,7 @@ func TestGetApprovers(t *testing.T) {
 	}
 	for testNum, test := range tests {
 		foundLeafApprovers := ro.LeafApprovers(test.filePath)
-		foundApprovers := ro.Approvers(test.filePath)
+		foundApprovers := ro.Approvers(test.filePath).Set()
 		foundOwnersPath := ro.FindApproverOwnersForFile(test.filePath)
 		if !foundLeafApprovers.Equal(test.expectedLeafOwners) {
 			t.Errorf("The Leaf Approvers Found Do Not Match Expected For Test %d: %s", testNum, test.name)


### PR DESCRIPTION
relates to #16793
A multiset is a slice of sets used to keep the hierarchy of owners files when computing approvers/reviewers
I have kept the API similar to sets for readability.
We could eventually move the implementation to apimachinery in the future if that makes sense...