### PR TITLE
azure: add preset label for azure jobs that need anonymous pull

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -100,7 +100,8 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200806-da6d139-1.18
@@ -110,6 +111,8 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Cluster API E2E tests"
+          - name: LOCAL_ONLY
+            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -727,6 +727,32 @@ presets:
   - name: azure-ssh
     mountPath: /etc/azure-ssh
     readOnly: true
+- labels:
+    preset-azure-anonymous-pull: "true"
+  env:
+    - name: REGISTRY
+      value: capzci.azurecr.io
+- labels:
+    preset-azure-cred-only: "true"
+  env:
+    - name: AZURE_CREDENTIALS
+      value: /etc/azure-cred/credentials
+    - name: AZURE_SSH_PUBLIC_KEY_FILE
+      value: /etc/azure-ssh/azure-ssh-pub
+  volumes:
+    - name: azure-cred
+      secret:
+        secretName: azure-cred
+    - name: azure-ssh
+      secret:
+        secretName: azure-ssh
+  volumeMounts:
+    - name: azure-cred
+      mountPath: /etc/azure-cred
+      readOnly: true
+    - name: azure-ssh
+      mountPath: /etc/azure-ssh
+      readOnly: true
 # storage / caching presets
 - labels:
     preset-bazel-scratch-dir: "true"


### PR DESCRIPTION
Create a new preset label derived from `preset-azure-cred` which contains a registry with anonymous pull access enabled. This will be used initially in the Cluster API Provider Azure jobs.

/cc @chewong @CecileRobertMichon 