### PR TITLE
cloud-provider-gcp conformance periodic does not download ginkgo

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -36,7 +36,6 @@ periodics:
         set -o xtrace;
         REPO_ROOT=$GOPATH/src/k8s.io/cloud-provider-gcp;
         cd;
-        go get -u github.com/onsi/ginkgo/ginkgo;
         export GO111MODULE=on;
         go get sigs.k8s.io/kubetest2@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;


### PR DESCRIPTION
Recent updates to the kubetest2 ginkgo tester make this unnecessary. See https://github.com/kubernetes-sigs/kubetest2/pull/30