### PR TITLE
Cherrypicker: Fix output

### DIFF
--- a/prow/external-plugins/cherrypicker/server.go
+++ b/prow/external-plugins/cherrypicker/server.go
@@ -434,7 +434,7 @@ func (s *Server) handle(logger *logrus.Entry, requestor string, comment *github.
 
 	// Apply the patch.
 	if err := r.Am(localPath); err != nil {
-		resp := fmt.Sprintf("#%d failed to apply on top of branch %q:\n```%v\n```", num, targetBranch, err)
+		resp := fmt.Sprintf("#%d failed to apply on top of branch %q:\n```\n%v\n```", num, targetBranch, err)
 		logger.Info(resp)
 		err := s.createComment(org, repo, num, comment, resp)
 

--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -387,11 +387,14 @@ func (r *Repo) Am(path string) error {
 		r.logger.WithError(abortErr).Warningf("Aborting patch apply failed with output: %s", string(b))
 	}
 	applyMsg := "The copy of the patch that failed is found in: .git/rebase-apply/patch"
+	msg := ""
 	if strings.Contains(output, applyMsg) {
 		i := strings.Index(output, applyMsg)
-		err = fmt.Errorf("%s", output[:i])
+		msg = string(output[:i])
+	} else {
+		msg = string(output)
 	}
-	return err
+	return errors.New(msg)
 }
 
 // Push pushes over https to the provided owner/repo#branch using a password


### PR DESCRIPTION
So far, we apparently relied on two things in the `git` command that do not seem to be true anymore:
* Its messages have a leading `\n`
* If it fails to apply, the message ends with `The copy of the patch that failed is found in: .git/rebase-apply/patch`

Fixes https://github.com/kubernetes/test-infra/issues/18679

Sample occurences e.G. in
* https://github.com/openshift/openshift-docs/pull/24588#issuecomment-672104813
* https://github.com/istio/istio/issues/26168#issue-673654271

log output for the openshift failure:
```
{"args":["/usr/bin/git","checkout","-b","cherry-pick-24588-to-enterprise-4.5"],"client":"git","dir":"/tmp/git272213939","level":"debug","msg":"Constructed git command","time":"2020-08-11T17:10:28Z"}
{"client":"git","level":"info","msg":"Applying /tmp/openshift_openshift-docs_24588_enterprise-4.5.patch.","time":"2020-08-11T17:10:28Z"}
{"args":["/usr/bin/git","am","--3way","/tmp/openshift_openshift-docs_24588_enterprise-4.5.patch"],"client":"git","dir":"/tmp/git272213939","level":"debug","msg":"Constructed git command","time":"2020-08-11T17:10:28Z"}
{"client":"git","error":"exit status 128","level":"info","msg":"Patch apply failed with output: Applying: RHV and OSP install code blocks\nUsing index info to reconstruct a base tree...\nM\tmodules/installation-osp-verifying-external-network.adoc\nFalling back to patching base and 3-way merge...\nAuto-merging modules/installation-osp-verifying-external-network.adoc\nCONFLICT (content): Merge conflict in modules/installation-osp-verifying-external-network.adoc\nerror: Failed to merge in the changes.\nhint: Use 'git am --show-current-patch=diff' to see the failed patch\nPatch failed at 0001 RHV and OSP install code blocks\nWhen you have resolved this problem, run \"git am --continue\".\nIf you prefer to skip this patch, run \"git am --skip\" instead.\nTo restore the original branch and stop patching, run \"git am --abort\".\n","time":"2020-08-11T17:10:28Z"}
{"args":["/usr/bin/git","am","--abort"],"client":"git","dir":"/tmp/git272213939","level":"debug","msg":"Constructed git command","time":"2020-08-11T17:10:28Z"}
{"event-GUID":"83a01b80-dbf5-11ea-85cd-08c37341326a","event-type":"issue_comment","level":"info","msg":"#24588 failed to apply on top of branch \"enterprise-4.5\":\n```exit status 128\n```","org":"openshift","pr":24588,"repo":"openshift-docs","requestor":"kalexand-rh","target_branch":"enterprise-4.5","time":"2020-08-11T17:10:28Z"}
{"client":"github","level":"info","msg":"CreateComment(openshift, openshift-docs, 24588, @kalexand-rh: #24588 failed to apply on top of branch \"enterprise-4.5\":\n```exit status 128\n```\n\n\u003cdetails\u003e\n\nIn response to [this](https://github.com/openshift/openshift-docs/pull/24588#issuecomment-672104645):\n\n\u003e/cherrypick enterprise-4.5\n\n\nInstructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.\n\u003c/details\u003e)","time":"2020-08-11T17:10:28Z"}
{"client":"git","level":"info","msg":"Checkout enterprise-4.6.","time":"2020-08-11T17:10:29Z"}
```

/assign @stevekuznetsov 