### PR TITLE
Use multi os hyperv aks-engine package

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -515,7 +515,7 @@ periodics:
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-ce5c82940-marosset-hyperv.tar.gz
+      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-97ae5a54f-hyperv-amd64.tar.gz
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
@@ -569,7 +569,7 @@ periodics:
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-ce5c82940-marosset-hyperv.tar.gz
+      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-97ae5a54f-hyperv-amd64.tar.gz
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)

--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-sac.yaml
@@ -312,7 +312,7 @@ periodics:
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-ce5c82940-marosset-hyperv.tar.gz
+      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-97ae5a54f-hyperv-amd64.tar.gz
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)
@@ -367,7 +367,7 @@ periodics:
       - --aksengine-admin-username=azureuser
       - --aksengine-admin-password=AdminPassw0rd
       - --aksengine-creds=$(AZURE_CREDENTIALS)
-      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-ce5c82940-marosset-hyperv.tar.gz
+      - --aksengine-download-url=https://k8swin.blob.core.windows.net/k8s-windows/aks-engine-97ae5a54f-hyperv-amd64.tar.gz
       - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
       - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
       - --aksengine-winZipBuildScript=$(WIN_BUILD)


### PR DESCRIPTION
The current aks-engine package used for hyperv does not support server 2004 and the testgrid job is failing: https://testgrid.k8s.io/sig-windows-containerd#aks-engine-azure-windows-2004-master-containerd-hyperv

This unblocks the test failure with a ask-engine package that enables multiple OS based on https://github.com/Azure/aks-engine/pull/3688 until we are able to get merge and get a new aks-engine release.

/cc @chewong @marosset @adelina-t 

/sig windows