### PR TITLE
don't write docker pull to stdout

### DIFF
--- a/config/mkpj.sh
+++ b/config/mkpj.sh
@@ -32,5 +32,5 @@ root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
 config="${root}/config/prow/config.yaml"
 job_config_path="${root}/config/jobs"
 
-docker pull gcr.io/k8s-prow/mkpj || true
+docker pull gcr.io/k8s-prow/mkpj 1>&2 || true
 docker run -i --rm -v "${root}:${root}:z" gcr.io/k8s-prow/mkpj "--config-path=${config}" "--job-config-path=${job_config_path}" "$@"


### PR DESCRIPTION
honestly I didn't expect to need this ...

```
$ docker pull gcr.io/k8s-prow/mkpj 2>/dev/null
Using default tag: latest
latest: Pulling from k8s-prow/mkpj
Digest: sha256:17ab21f25e725f5d4a011e7f429716f7548092ed54420d155fa92165fd63e66d
Status: Image is up to date for gcr.io/k8s-prow/mkpj:latest
gcr.io/k8s-prow/mkpj:latest
```