### PR TITLE
Create a copy of ci-kubernetes-gce-conformance-latest with kubetest2

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -37,3 +37,55 @@ periodics:
         requests:
           cpu: 1
           memory: 3Gi
+- interval: 3h
+  cluster: k8s-infra-prow-build
+  name: ci-kubernetes-gce-conformance-latest-kubetest2
+  annotations:
+    testgrid-dashboards: conformance-all, conformance-gce
+    testgrid-tab-name: Conformance - GCE - master - kubetest2
+    description: Runs conformance tests using kubetest2 against kubernetes master on GCE
+  labels:
+    preset-service-account: "true"
+  decorate: true
+  decoration_config:
+    timeout: 220m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200809-b9b3222-1.16
+      resources:
+        limits:
+          cpu: 4
+          memory: 14Gi
+        requests:
+          cpu: 4
+          memory: 14Gi
+      command:
+      - wrapper.sh
+      args:
+      - "/bin/bash"
+      - "-c"
+      # TODO: Use published release tars for k/k
+      - set -o errexit;
+        set -o nounset;
+        set -o pipefail;
+        set -o xtrace;
+        REPO_ROOT=$GOPATH/src/k8s.io/kubernetes;
+        cd;
+        export GO111MODULE=on;
+        go get sigs.k8s.io/kubetest2@latest;
+        go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
+        go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
+        kubetest2 gce -v 2 \;
+          --repo-root $REPO_ROOT \;
+          --legacy-mode \;
+          --build \;
+          --up \;
+          --down \;
+          --test=ginkgo \;
+          -- \;
+          --focus-regex='\[Conformance\]'


### PR DESCRIPTION
Tested with `mkpj.sh` and `mkpod` deployed to a GKE cluster.