### PR TITLE
[gcsweb] Add the ability to use an OAuth token to access private buckets

### DIFF
--- a/gcsweb/README.md
+++ b/gcsweb/README.md
@@ -1,7 +1,9 @@
 # gcsweb
 
-gcsweb is a web frontend to Google Cloud Storage that uses the public,
-no-login-required API. Obviously this means it can only browse public buckets.
+gcsweb is a web frontend to Google Cloud Storage that uses the GCS API.
+
+To access private buckets, the user has to specify a valid OAuth token with 
+the `--oauth-token-file` flag.
 
 You can build a docker image of it by running the following command:
 

--- a/gcsweb/cmd/gcsweb/BUILD.bazel
+++ b/gcsweb/cmd/gcsweb/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     deps = [
         "//gcsweb/pkg/version:go_default_library",
+        "//prow/logrusutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/gcsweb/cmd/gcsweb/BUILD.bazel
+++ b/gcsweb/cmd/gcsweb/BUILD.bazel
@@ -41,7 +41,10 @@ go_library(
     name = "go_default_library",
     srcs = ["gcsweb.go"],
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
-    deps = ["//gcsweb/pkg/version:go_default_library"],
+    deps = [
+        "//gcsweb/pkg/version:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
+    ],
 )
 
 filegroup(

--- a/gcsweb/cmd/gcsweb/BUILD.bazel
+++ b/gcsweb/cmd/gcsweb/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
     importpath = "k8s.io/test-infra/gcsweb/cmd/gcsweb",
     deps = [
         "//gcsweb/pkg/version:go_default_library",
+        "//prow/config/secret:go_default_library",
         "//prow/logrusutil:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],


### PR DESCRIPTION
Currently, the `gcsweb` tool can access only public buckets. In order to give the ability to access also private buckets, GCS already supports using OAuth token in the API calls. ref https://cloud.google.com/storage/docs/authentication 

With this change, the user will be able to provide the OAuth token in a file using the flag `--oauth-token-file`. Then all the API calls will use the `"Authorization: Bearer OAUTH2_TOKEN"` header as well.

This PR:

- Refactor option flags
- Improving the logging
- Include the OAuth token file support

/cc @stevekuznetsov @alvaroaleman 

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>