### PR TITLE
Add CAPI job to verify external links

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -81,6 +81,25 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-verify
+  - name: pull-cluster-api-verify-external-links
+    optional: true
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    skip_branches:
+    - gh-pages
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200802-ff98b58-1.18
+        command:
+        - "runner.sh"
+        - "make"
+        - "verify-book-links"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: pr-verify-external-links
   - name: pull-cluster-api-test
     decorate: true
     path_alias: sigs.k8s.io/cluster-api


### PR DESCRIPTION
The other part of https://github.com/kubernetes-sigs/cluster-api/pull/3474. With that PR we won't be doing link verification in `make verify`, so adding this as an optional additional PR presubmit.

@vincepri @fabriziopandini