### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.15

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,26 +1,26 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.15rc2
+    GO_VERSION: 1.15
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.28.1
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15rc2
+    GO_VERSION: 1.15
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   master:
     CONFIG: master
-    GO_VERSION: 1.15rc2
+    GO_VERSION: 1.15
     K8S_RELEASE: stable
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.15rc2
+    GO_VERSION: 1.15
     K8S_RELEASE: latest-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Tracking issue: https://github.com/kubernetes/release/issues/1421

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @BenTheElder @spiffxp 
cc: @kubernetes/release-engineering @liggitt @dims