### PR TITLE
refresh some owners

### DIFF
--- a/gopherage/OWNERS
+++ b/gopherage/OWNERS
@@ -1,13 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- Katharine
+- amwat
 - spiffxp
 - BenTheElder
+- MushuEE
 approvers:
-- Katharine
+- amwat
 - spiffxp
 - BenTheElder
+emeritus_approvers:
+- Katharine
 
 labels:
 - area/gopherage

--- a/greenhouse/OWNERS
+++ b/greenhouse/OWNERS
@@ -2,11 +2,14 @@
 
 reviewers:
 - amwat
+- spiffxp
 - BenTheElder
-- ixdy
+- MushuEE
 approvers:
 - amwat
+- spiffxp
 - BenTheElder
+emeritus_approvers:
 - ixdy
 
 labels:

--- a/images/bootstrap/OWNERS
+++ b/images/bootstrap/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- amwat
+- spiffxp
+- BenTheElder
+- MushuEE
+approvers:
+- amwat
+- spiffxp
+- BenTheElder

--- a/images/builder/OWNERS
+++ b/images/builder/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- test-infra-oncall
+approvers:
+- test-infra-oncall

--- a/images/krte/OWNERS
+++ b/images/krte/OWNERS
@@ -4,6 +4,7 @@ reviewers:
 - amwat
 - spiffxp
 - BenTheElder
+- MushuEE
 approvers:
 - amwat
 - spiffxp

--- a/images/kubekins-e2e/OWNERS
+++ b/images/kubekins-e2e/OWNERS
@@ -5,6 +5,7 @@ reviewers:
 - justaugustus
 - spiffxp
 - BenTheElder
+- MushuEE
 approvers:
 - amwat
 - justaugustus

--- a/kettle/OWNERS
+++ b/kettle/OWNERS
@@ -1,12 +1,17 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- Katharine
 - spiffxp
 - MushuEE
+- amwat
+- BenTheElder
 approvers:
-- Katharine
 - spiffxp
+- MushuEE
+- amwat
+- BenTheElder
+emeritus_approvers:
+- Katharine
 
 labels:
 - area/kettle

--- a/scenarios/OWNERS
+++ b/scenarios/OWNERS
@@ -1,10 +1,15 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- cjwagner
-- fejta
-- krzyzacy
+- amwat
+- BenTheElder
+- MushuEE
+- spiffxp
 approvers:
+- amwat
+- BenTheElder
+- spiffxp
+emeritus_approvers:
 - cjwagner
 - fejta
 - krzyzacy


### PR DESCRIPTION
signing up my team for more reviews / approves for things we work on after discussing with them, and cleaning up some stale entries

- @spiffxp and I are current root approvers, and none of these are no_parent_owners type things...
- @amwat is an emeritus root approver
- @MushuEE is neither, only signing up for reviews, except for kettle, which he's been reviewing / working on, bumping up to approver

- @cjwagner reached out about scenarios/ specifically, it's deprecated but needs nominal maintainership until kubernetes no longer depends on it. shifting the load on that to kubernetes engprod, following the points above

- @Katharine and @ixdy are working on other things, rotating them to emeritus for any files I touched along the way

/cc @amwat @spiffxp @MushuEE @cjwagner @Katharine @ixdy 