### PR TITLE
Migrate pull-kubernetes-e2e-gce-ubuntu-containerd to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -218,6 +218,7 @@ presubmits:
             memory: "6Gi"
 
   - name: pull-kubernetes-e2e-gce-ubuntu-containerd
+    cluster: k8s-infra-prow-build
     always_run: true
     skip_branches:
       - release-\d+\.\d+ # per-release image
@@ -277,6 +278,7 @@ presubmits:
               memory: "14Gi"
 
   - name: pull-kubernetes-e2e-gce-ubuntu-containerd-canary
+    cluster: k8s-infra-prow-build
     always_run: false
     skip_report: false
     skip_branches:
@@ -329,8 +331,12 @@ presubmits:
             - --timeout=80m # thinking about making this longer? don't! 80m is a hard cap, and should get down to no more than 60m.
           image: gcr.io/k8s-testimages/kubekins-e2e:v20200811-4afd9ba-master
           resources:
+            limits:
+              cpu: 4
+              memory: "14Gi"
             requests:
-              memory: "6Gi"
+              cpu: 4
+              memory: "14Gi"
 
   - name: pull-kubernetes-e2e-gce-rbe
     always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -959,6 +959,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.18
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -911,6 +911,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.19
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"


### PR DESCRIPTION
I migrated the canary version (manually triggered) while I'm here

This was introduced during v1.18 so there aren't earlier release-branch jobs to migrate

ref: https://github.com/kubernetes/test-infra/issues/18813

FYI @kubernetes/ci-signal
/cc @hasheddan @BenTheElder