### PR TITLE
Migrate pull-kubernetes-e2e-kind to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1202,6 +1202,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
     name: pull-kubernetes-e2e-kind
+    cluster: k8s-infra-prow-build
     optional: true
     path_alias: k8s.io/kubernetes
     spec:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1307,6 +1307,7 @@ presubmits:
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
     name: pull-kubernetes-e2e-kind
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1443,6 +1443,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1409,6 +1409,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     name: pull-kubernetes-e2e-kind
+    cluster: k8s-infra-prow-build
     path_alias: k8s.io/kubernetes
     spec:
       containers:

--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-kind
+    cluster: k8s-infra-prow-build
     optional: false
     always_run: true
     decorate: true


### PR DESCRIPTION
Migrate pull-kubernetes-e2e-kind to give more visibility to the community
about resources consumption.

Ref: https://github.com/kubernetes/test-infra/issues/18812

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @spiffxp @BenTheElder @hasheddan 