### PR TITLE
add CI checks for prow bot in kube-state-metrics

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -248,6 +248,17 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        kube-state-metrics:
+          required_status_checks:
+            contexts:
+            - ci/benchmark-tests
+            - ci/build-kube-state-metrics
+            - ci/e2e-tests
+            - ci/go-lint
+            - ci/unit-tests
+            - ci/validate-docs
+            - ci/validate-go-modules
+            - ci/validate-manifests
         kube-scheduler:
           restrictions:
             users: []


### PR DESCRIPTION
Hello 👋 

We have added some new Github Action CI checks in kube-state-metrics to improve the CI processes. We would need prow bot to be aware of these checks as it is currently merging PRs regardless of the status check outcomes.

cc @lilic @brancz 