### PR TITLE
spyglass: buildlog: allow hiding the raw log link

### DIFF
--- a/prow/spyglass/lenses/buildlog/lens.go
+++ b/prow/spyglass/lenses/buildlog/lens.go
@@ -44,6 +44,12 @@ const (
 
 type config struct {
 	HighlightRegexes []string `json:"highlight_regexes"`
+	HideRawLog       bool     `json:"hide_raw_log,omitempty"`
+}
+
+type parsedConfig struct {
+	highlightRegex *regexp.Regexp
+	showRawLog     bool
 }
 
 var _ api.Lens = Lens{}
@@ -62,7 +68,8 @@ func (lens Lens) Config() lenses.LensConfig {
 
 // Header executes the "header" section of the template.
 func (lens Lens) Header(artifacts []api.Artifact, resourceDir string, config json.RawMessage) string {
-	return executeTemplate(resourceDir, "header", BuildLogsView{})
+	conf := getConfig(config)
+	return executeTemplate(resourceDir, "header", BuildLogsView{ShowRawLog: conf.showRawLog})
 }
 
 // defaultErrRE matches keywords and glog error messages.
@@ -121,43 +128,48 @@ type LogArtifactView struct {
 
 // BuildLogsView holds each log file view
 type BuildLogsView struct {
-	LogViews           []LogArtifactView
-	RawGetAllRequests  map[string]string
-	RawGetMoreRequests map[string]string
+	LogViews   []LogArtifactView
+	ShowRawLog bool
 }
 
-func getHighlightRegex(rawConfig json.RawMessage) *regexp.Regexp {
+func getConfig(rawConfig json.RawMessage) parsedConfig {
+	conf := parsedConfig{
+		highlightRegex: defaultErrRE,
+		showRawLog:     true,
+	}
+
 	// No config at all is fine.
 	if len(rawConfig) == 0 {
-		return defaultErrRE
+		return conf
 	}
 
 	var c config
 	if err := json.Unmarshal(rawConfig, &c); err != nil {
 		logrus.WithError(err).Error("Failed to decode buildlog config")
-		return defaultErrRE
+		return conf
 	}
+	conf.showRawLog = !c.HideRawLog
 	if len(c.HighlightRegexes) == 0 {
-		return defaultErrRE
+		return conf
 	}
 
 	re, err := regexp.Compile(strings.Join(c.HighlightRegexes, "|"))
 	if err != nil {
 		logrus.WithError(err).Warnf("Couldn't compile %q", c.HighlightRegexes)
-		return defaultErrRE
+		return conf
 	}
-	return re
+	conf.highlightRegex = re
+	return conf
 }
 
 // Body returns the <body> content for a build log (or multiple build logs)
 func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string, rawConfig json.RawMessage) string {
 	buildLogsView := BuildLogsView{
-		LogViews:           []LogArtifactView{},
-		RawGetAllRequests:  make(map[string]string),
-		RawGetMoreRequests: make(map[string]string),
+		LogViews: []LogArtifactView{},
 	}
 
-	highlightRe := getHighlightRegex(rawConfig)
+	conf := getConfig(rawConfig)
+	buildLogsView.ShowRawLog = conf.showRawLog
 	// Read log artifacts and construct template structs
 	for _, a := range artifacts {
 		av := LogArtifactView{
@@ -169,7 +181,7 @@ func (lens Lens) Body(artifacts []api.Artifact, resourceDir string, data string,
 			logrus.WithError(err).Info("Error reading log.")
 			continue
 		}
-		av.LineGroups = groupLines(highlightLines(lines, 0, av.ArtifactName, highlightRe))
+		av.LineGroups = groupLines(highlightLines(lines, 0, av.ArtifactName, conf.highlightRegex))
 		av.ViewAll = true
 		buildLogsView.LogViews = append(buildLogsView.LogViews, av)
 	}
@@ -199,7 +211,8 @@ func (lens Lens) Callback(artifacts []api.Artifact, resourceDir string, data str
 		return fmt.Sprintf("failed to retrieve log lines: %v", err)
 	}
 
-	logLines := highlightLines(lines, request.StartLine, request.Artifact, getHighlightRegex(rawConfig))
+	conf := getConfig(rawConfig)
+	logLines := highlightLines(lines, request.StartLine, request.Artifact, conf.highlightRegex)
 	return executeTemplate(resourceDir, "line group", logLines)
 }
 

--- a/prow/spyglass/lenses/buildlog/template.html
+++ b/prow/spyglass/lenses/buildlog/template.html
@@ -7,7 +7,7 @@
 {{range $log := .LogViews}}
   <div>
     <button class="show-all-button" data-artifact="{{$log.ArtifactName}}">Show all hidden lines</button>
-    <a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>
+    {{if .ShowRawLog}}<a href="{{$log.ArtifactLink}}" style="padding-left:15px;">Raw {{$log.ArtifactName}}<i class="material-icons" style="font-size: 1em; vertical-align: middle; padding-left: 3px;">open_in_new</i></a>{{end}}
     <div class="loglines" id="{{$log.ArtifactName}}-content" style="font-family: monospace; margin-top: 15px;">
       {{range $g := $log.LineGroups}}
         {{if $g.Skip}}


### PR DESCRIPTION
There's nothing more annoying that getting a raw GCS txt link from a
user instead of the full Spyglass page.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 