### PR TITLE
describe node-kubelet orphans job

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -231,6 +231,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-orphans
+    description: "Contains all uncategorized tests, these are tests which are not marked with a [Node] tag. All node tests should be marked with [NodeFeature] or [NodeSpecialFeature] or [NodeAlphaFeature] or [NodeConformance] classification. Also skipped are [Flaky], [Benchmark], [Legacy]."
 
 - name: ci-kubernetes-node-kubelet-serial
   interval: 4h30m


### PR DESCRIPTION
See 3815dfe478695d58c82e84c4e8097ca29ee58df7 in k/k#64130 for classification PR.

Node-exclusive tags described in:
https://docs.google.com/document/d/1BdNVUGtYO6NDx10x_fueRh_DLT-SVdlPC_SsXjYCHOE/edit#

It's not clear what this job is for without looking back about 2 years in history. This is my attempt at adding context. 

We should make a goal of our node test/ci to classify these jobs and get rid of this bucket that is a miscellaneous grab bag.
/cc @vpickard @SergeyKanzhelev

