### PR TITLE
Migrate pull-kubernetes-e2e-kind-ipv6 to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -39,10 +39,10 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 7400m
+            cpu: 4
             memory: 9000Mi
           requests:
-            cpu: 7400m
+            cpu: 4
             memory: 9000Mi
     annotations:
       testgrid-num-failures-to-alert: '10'
@@ -52,6 +52,7 @@ presubmits:
 
 
   - name: pull-kubernetes-e2e-kind-canary
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false # manual for testing new configurations
     decorate: true
@@ -89,15 +90,19 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            memory: "9000Mi"
-            cpu: 7400m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
 
   - name: pull-kubernetes-e2e-kind-ipv6
+    cluster: k8s-infra-prow-build
     optional: false
     always_run: true
     skip_report: false
@@ -141,19 +146,19 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
 
   - name: pull-kubernetes-e2e-kind-ipv6-canary
+    cluster: k8s-infra-prow-build
     optional: true
     always_run: false # manual for testing new configurations
     decorate: true
@@ -197,13 +202,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'
@@ -241,13 +245,12 @@ presubmits:
         securityContext:
           privileged: true
         resources:
+          limits:
+            cpu: 4
+            memory: 9Gi
           requests:
-            # TODO(BenTheElder): adjust these everywhere
-            # these are both a bit below peak usage during build
-            # this is mostly for building kubernetes
-            memory: "9000Mi"
-            # during the tests more like 3-20m is used
-            cpu: 2000m
+            cpu: 4
+            memory: 9Gi
     annotations:
       testgrid-num-failures-to-alert: '10'
       testgrid-alert-stale-results-hours: '24'


### PR DESCRIPTION
I'm also dropping its cpu down from 7400m to 4

The 7400m was an attempt to reserve an entire node on k8s-prow since
other jobs weren't declaring their resource usage up front. Since we're
moving to k8s-infra-prow-build which requires resource limits, I expect
this to be less of a problem.

I've also noticed that pull-kuberentes-conformance-kind-ga-only-parallel
has been running with `cpu: 4` pretty happily. The bulk of the CPU usage
is for building kubernetes.

The ci- variants of these jobs use 7300m CPU, I'm inclined to bump them
down once we see how these behave

ref: https://github.com/kubernetes/test-infra/issues/18812

/cc @BenTheElder