### PR TITLE
pull-kubernetes-e2e-gce always_run: false

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -17,7 +17,7 @@ presets:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce
-    always_run: true
+    always_run: false
     skip_branches:
     - release-\d+\.\d+ # per-release image
     annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -779,7 +779,7 @@ presubmits:
         resources:
           requests:
             memory: 6Gi
-  - always_run: true
+  - always_run: false
     branches:
     - release-1.19
     labels:


### PR DESCRIPTION
to be replaced with `pull-kubernetes-e2e-gce-ubuntu-containerd`.

we can consider renaming the jobs in a followup, this way doesn't confuse the result history on running PRs

xref: https://github.com/kubernetes/test-infra/issues/18729