### PR TITLE
Enforce critical merge-blocking jobs pod qos guaranteed

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -1017,8 +1017,7 @@ func isKubernetesReleaseBlocking(job cfg.JobBase) bool {
 	return re.MatchString(dashboards)
 }
 
-// TODO: s/Should/Must and s/Logf/Errorf when all jobs pass
-func TestKubernetesMergeBlockingJobsShouldHavePodQOSGuaranteed(t *testing.T) {
+func TestKubernetesMergeBlockingJobsMustHavePodQOSGuaranteed(t *testing.T) {
 	repo := "kubernetes/kubernetes"
 	jobs := c.AllStaticPresubmits([]string{repo})
 	sort.Slice(jobs, func(i, j int) bool {
@@ -1032,7 +1031,7 @@ func TestKubernetesMergeBlockingJobsShouldHavePodQOSGuaranteed(t *testing.T) {
 		branches := job.Branches
 		errs := verifyPodQOSGuaranteed(job.Spec)
 		for _, err := range errs {
-			t.Logf("%v (%v): %v", job.Name, branches, err)
+			t.Errorf("%v (%v): %v", job.Name, branches, err)
 		}
 	}
 }


### PR DESCRIPTION
All critical merge-blocking jobs now have resource limits declared.  Switch test from logging to erroring.

Part of https://github.com/kubernetes/test-infra/issues/18530