### PR TITLE
Revert "Revert kubeflow branch protection config."

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -410,6 +410,14 @@ branch-protection:
           required_status_checks:
             contexts:
             - continuous-integration/travis-ci
+    kubeflow:
+      protect: true
+      required_status_checks:
+        contexts:
+        - cla/google
+      exclude:
+      - "^revert-" # don't protect revert branches
+      - "^dependabot/" # don't protect branches created by dependabot
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
Reverts kubernetes/test-infra#18415
Fixes https://github.com/kubeflow/internal-acls/pull/308

We reverted in https://github.com/kubernetes/test-infra/pull/18415, because k8s-ci-bot didn't have enough permissions to kubeflow org. I've now added required permissions. Therefore, reverting the PR back.