### PR TITLE
Lower pull-kubernetes-integration cpu limit to 6

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1175,11 +1175,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
           requests:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
         securityContext:
           privileged: true
   - always_run: false

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1222,11 +1222,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
           requests:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1424,11 +1424,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
           requests:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1389,11 +1389,11 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
           requests:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
         securityContext:
           privileged: true
   - always_run: true

--- a/config/jobs/kubernetes/sig-testing/integration.yaml
+++ b/config/jobs/kubernetes/sig-testing/integration.yaml
@@ -28,11 +28,11 @@ presubmits:
           privileged: true
         resources:
           limits:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
           requests:
-            cpu: 7
-            memory: "15Gi"
+            cpu: 6
+            memory: 15Gi
 periodics:
 - interval: 1h
   cluster: k8s-infra-prow-build


### PR DESCRIPTION
This matches the CPU limit for the CI variants, which run more,
and take a roughly equivalent amount of time

Part of https://github.com/kubernetes/test-infra/issues/18811