### PR TITLE
code of conduct committee update

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -165,10 +165,10 @@ aliases:
     - phenixblue
   committee-code-of-conduct:
     - AevaOnline
-    - Bradamant3
-    - carolynvs
-    - jdumars
+    - celestehorgan
+    - karenhchu
     - tashimi
+    - tpepper
   committee-product-security:
     - cjcullen
     - joelsmith


### PR DESCRIPTION
Rotating out our emeriti members and adding the 2020 elected members.

Signed-off-by: Tim Pepper <tpepper@vmware.com>