### PR TITLE
jobs/k8s/sig-testing: move kind-ga-only-parallel to k8s-infra cluster

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubernetes-kind-presubmits.yaml
@@ -301,3 +301,4 @@ presubmits:
       testgrid-alert-stale-results-hours: '24'
       testgrid-create-test-group: 'true'
       testgrid-dashboards: sig-testing-kind
+    cluster: k8s-infra-prow-build


### PR DESCRIPTION
> Make sure any release-branch variants are also updated

seems this job is not run on release-*.

```
skip_branches:
    - release-\d+\.\d+ # per-release settings
```

xref https://github.com/kubernetes/test-infra/issues/18850
