### PR TITLE
[CAPZ] Add PR test coverage optional presubmit

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -304,3 +304,31 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pr-apidiff
+  - name: pull-cluster-api-provider-azure-coverage
+    always_run: true
+    optional: true
+    decorate: true
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200813-1642133-1.18
+        command:
+        - runner.sh
+        - bash
+        args:
+        - -c
+        - |
+          result=0
+          ./scripts/ci-test-coverage.sh || result=$?
+          cd ../test-infra/gopherage
+          GO111MODULE=on go build .
+          find ${ARTIFACTS} -type f -iname 'junit*.xml' -exec rm {} \;
+          ./gopherage filter --exclude-path="zz_generated,generated\.pb\.go"  "${ARTIFACTS}/combined-coverage.out" > "${ARTIFACTS}/filtered.cov" || result=$?
+          ./gopherage junit --threshold 0.05 "${ARTIFACTS}/filtered.cov" > "${ARTIFACTS}/junit_coverage.xml" || result=$?
+          exit $result
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: pr-coverage
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io


### PR DESCRIPTION
Add an optional presubmit that generates the test coverage for PR. this is optional for now maybe we enable that for all PRs and add in the periodic as well.
similar to this: https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-testing/coverage.yaml#L129

- Fixes: https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/692

/hold until this gets merged: https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/883


Note: There is a way to test this?

/assign @CecileRobertMichon 