### PR TITLE
Azure: Use VM size Standard_F2 to prevent quota issues when scaling out too many nodes

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -387,7 +387,7 @@ periodics:
       - --aksengine-creds=$(AZURE_CREDENTIALS)
       - --aksengine-orchestratorRelease=1.18
       - --aksengine-mastervmsize=Standard_DS2_v2
-      - --aksengine-agentvmsize=Standard_D4s_v3
+      - --aksengine-agentvmsize=Standard_F2
       - --aksengine-ccm
       - --aksengine-cnm
       - --aksengine-deploy-custom-k8s


### PR DESCRIPTION
The multi-pool autoscaling test needs to scale the cluster to more than 500 nodes, which may cause the unexpected quota problems.

/area provider/azure
/kind failing-test