### PR TITLE
GKE: Disable shielded nodes if using custom image

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -336,6 +336,8 @@ func (g *gkeDeployer) Up() error {
 		// gcloud enables node auto-upgrade by default, which doesn't work with CUSTOM image.
 		// We disable auto-upgrade explicitly here.
 		args = append(args, "--no-enable-autoupgrade")
+		// Custom images are not supported with shielded nodes (which is enaled by default) in GKE.
+		args = append(args, "--no-enable-shielded-nodes")
 	}
 	if g.subnetwork != "" {
 		args = append(args, "--subnetwork="+g.subnetwork)


### PR DESCRIPTION
In 1.18+ Shielded Nodes are enabled by default in GKE. However, custom images are not supported with shielded nodes. This disables the feature when using custom image type.

In this case, the cluster will not come up successfully, and the kubelet will just fail to connect to the apiserver.