### PR TITLE
Pin test version to v1.18.0 for ci-cloud-provider-gcp-conformance

### DIFF
--- a/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
+++ b/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-periodics.yaml
@@ -40,4 +40,4 @@ periodics:
         go get sigs.k8s.io/kubetest2@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-gce@latest;
         go get sigs.k8s.io/kubetest2/kubetest2-tester-ginkgo@latest;
-        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --focus-regex='\[Conformance\]'
+        kubetest2 gce -v 2 --repo-root $REPO_ROOT --build --up --down --test=ginkgo -- --test-package-version=v1.18.0 --focus-regex='\[Conformance\]'


### PR DESCRIPTION
ref: https://github.com/kubernetes/kubernetes/issues/94051

/cc @liggitt @BenTheElder 