### PR TITLE
Update kettle tests to mirror Prow started.json

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -82,7 +82,7 @@ class Build:
         if started:
             self.started = int(started['timestamp'])
             self.executor = started.get('node')
-            self.repo_commit = started.get('repo-commit')
+            self.repo_commit = started.get('repo-commit', started.get('repo-version'))
             self.repos = json.dumps(started.get('repos')) if started.get('repos') else None
 
     def populate_finish(self, finished):

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -82,7 +82,7 @@ class Build:
         if started:
             self.started = int(started['timestamp'])
             self.executor = started.get('node')
-            self.repo_commit = started.get('repo-commit', started.get('repo-version'))
+            self.repo_commit = started.get('repo-commit')
             self.repos = json.dumps(started.get('repos')) if started.get('repos') else None
 
     def populate_finish(self, finished):

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -79,6 +79,7 @@ class GenerateBuilds(unittest.TestCase):
                 "timestamp":1595284709,
                 "repos":{"kubernetes/kubernetes":"master"},
                 "repo-version":"5a529aa3a0dd3a050c5302329681e871ef6c162e",
+                "repo-commit":"5a529aa3a0dd3a050c5302329681e871ef6c162e",
             },
             {
                 "timestamp":1595286616,
@@ -112,6 +113,7 @@ class GenerateBuilds(unittest.TestCase):
                 "pull":"93264",
                 "repos":{"kubernetes/kubernetes":"master:5feab0"},
                 "repo-version":"30f64c5b1fc57a3beb1476f9beb29280166954d1",
+                "repo-commit":"30f64c5b1fc57a3beb1476f9beb29280166954d1",
             },
             {
                 "timestamp":1595279434,


### PR DESCRIPTION
Decorated jobs now have repo-commit added and are standard with bootstrap