### PR TITLE
use gh workflow YAML compliant names for prow checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -251,14 +251,14 @@ branch-protection:
         kube-state-metrics:
           required_status_checks:
             contexts:
-            - ci/benchmark-tests
-            - ci/build-kube-state-metrics
-            - ci/e2e-tests
-            - ci/go-lint
-            - ci/unit-tests
-            - ci/validate-docs
-            - ci/validate-go-modules
-            - ci/validate-manifests
+            - ci-benchmark-tests
+            - ci-build-kube-state-metrics
+            - ci-e2e-tests
+            - ci-go-lint
+            - ci-unit-tests
+            - ci-validate-docs
+            - ci-validate-go-modules
+            - ci-validate-manifests
         kube-scheduler:
           restrictions:
             users: []


### PR DESCRIPTION
Just realised that we need to use the `job` yaml object name as the check over here and the value of the `job` object's field `name`.
