### PR TITLE
Migrating e2e-gce-network-proxt-grpc job

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -123,6 +123,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-network-proxy
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
     always_run: false
+    cluster: k8s-infra-prow-build
     run_if_changed: '^(cluster/gce/manifests/konnectivity-server.yaml$|cluster/gce/addons/konnectivity-agent)'
     labels:
       preset-service-account: "true"


### PR DESCRIPTION
Migration of the job to the new cluster: `k8s-infra-prow-build` as a
result of https://github.com/kubernetes/test-infra/issues/18853

Signed-off-by: Bart Smykla <bsmykla@vmware.com>