### PR TITLE
Change job to test streaming logs from multiple containers

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -34,38 +34,29 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: benchmark-demo
     description: Demoing JUnit golang benchmark results.
-- interval: 1h
-  name: ci-test-infra-larger-multiple-container-test
+- interval: 10m
+  name: ci-test-infra-multiple-container-test
   decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-    path_alias: k8s.io/test-infra
-  labels:
-    preset-bazel-scratch-dir: "true"
   spec:
     containers:
-    - name: benchmark-junit-container
-      image: gcr.io/k8s-testimages/benchmarkjunit:latest
-      command:
-      - /benchmarkjunit
+    - name: test-1
+      image: alpine
+      command: ["/bin/echo"]
+      args: ["I am first"]
+    - name: test-2
+      image: alpine
+      command: ["/bin/bash"]
       args:
-      - --log-file=$(ARTIFACTS)/benchmark-log.txt
-      - --output=$(ARTIFACTS)/junit_benchmarks.xml
-      - --pass-on-error
-      - ./experiment/dummybenchmarks/...
-    - name: bazel-test-container
-      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20200713-e9b3d9d-test-infra
-      command:
-      - hack/bazel.sh
+      - -c
+      - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
+    - name: test-3
+      image: alpine
+      command: ["/bin/bash"]
       args:
-      - test
-      - --config=ci
-      - --nobuild_tests_only
-      - //...
+      - -c
+      - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"
   annotations:
     testgrid-alert-email: anthonytong@google.com
     testgrid-dashboards: sig-testing-canaries
-    testgrid-tab-name: larger-multiple-container-test
-    description: combination of test-infra-bazel and ci-test-infra-benchmark-demo to test more complicated multi container behavior
+    testgrid-tab-name: multiple-container-test
+    description: echo at different times from three different containers


### PR DESCRIPTION
Job runs a series of echo commands at different times from 3 different containers.
This job is mainly to test spyglass's functionality for streaming multiple build logs for jobs with multiple containers.