### PR TITLE
Extend kettle unit testing for build object

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -86,7 +86,7 @@ class Build:
         self.repos = None
         self.metadata = None
         self.elapsed = None
-        self.path_to_job_and_number()
+        self.populate_path_to_job_and_number()
 
     @classmethod
     def generate(cls, path, tests, started, finished, metadata, repos):
@@ -97,7 +97,7 @@ class Build:
         build.set_elapsed()
         return build
 
-    def path_to_job_and_number(self):
+    def populate_path_to_job_and_number(self):
         assert not self.path.endswith('/')
         for bucket, meta in BUCKETS.items():
             if self.path.startswith(bucket):

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -103,11 +103,11 @@ class Build:
             if self.path.startswith(bucket):
                 prefix = meta['prefix']
                 break
+
+            if self.path.startswith('gs://kubernetes-jenkins/pr-logs'):
+                prefix = 'pr:'
             else:
-                if self.path.startswith('gs://kubernetes-jenkins/pr-logs'):
-                    prefix = 'pr:'
-                else:
-                    raise ValueError('unknown build path')
+                raise ValueError('unknown build path')
         build = os.path.basename(self.path)
         job = prefix + os.path.basename(os.path.dirname(self.path))
         self.job = job

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -34,6 +34,30 @@ import model
 
 SECONDS_PER_DAY = 86400
 
+def buckets_yaml():
+    import ruamel.yaml as yaml  # pylint: disable=import-outside-toplevel
+    with open(os.path.dirname(os.path.abspath(__file__))+'/buckets.yaml') as fp:
+        return yaml.safe_load(fp)
+
+# pypy compatibility hack
+def python_buckets_yaml(python='python3'):
+    return json.loads(subprocess.check_output(
+        [python, '-c',
+         'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'
+         ],
+        cwd=os.path.dirname(os.path.abspath(__file__))).decode("utf-8"))
+
+for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
+    try:
+        BUCKETS = attempt()
+        break
+    except (ImportError, OSError):
+        traceback.print_exc()
+else:
+    # pylint: disable=misplaced-bare-raise
+    # This is safe because the only way we get here is by faling all attempts
+    raise
+
 class Build:
     """
     Represent Metadata and Details of a build. Leveraging the information in
@@ -49,9 +73,6 @@ class Build:
         self.test = tests
         self.tests_run = len(tests)
         self.tests_failed = sum(t.get('failed', 0) for t in tests)
-        job, number = path_to_job_and_number(path)
-        self.job = job
-        self.number = number if number else None
         #From Started.json
         self.started = None
         self.executor = None
@@ -65,6 +86,7 @@ class Build:
         self.repos = None
         self.metadata = None
         self.elapsed = None
+        self.path_to_job_and_number()
 
     @classmethod
     def generate(cls, path, tests, started, finished, metadata, repos):
@@ -74,6 +96,25 @@ class Build:
         build.populate_meta(metadata, repos)
         build.set_elapsed()
         return build
+
+    def path_to_job_and_number(self):
+        assert not self.path.endswith('/')
+        for bucket, meta in BUCKETS.items():
+            if self.path.startswith(bucket):
+                prefix = meta['prefix']
+                break
+            else:
+                if self.path.startswith('gs://kubernetes-jenkins/pr-logs'):
+                    prefix = 'pr:'
+                else:
+                    raise ValueError('unknown build path')
+        build = os.path.basename(self.path)
+        job = prefix + os.path.basename(os.path.dirname(self.path))
+        self.job = job
+        try:
+            self.number = int(build)
+        except ValueError:
+            self.number = None
 
     def as_dict(self):
         return {k: v for k, v in self.__dict__.items() if v is not None}
@@ -151,51 +192,6 @@ def parse_junit(xml):
                 yield make_result(name, time, failure_text)
     else:
         logging.error('unable to find failures, unexpected tag %s', tree.tag)
-
-
-def buckets_yaml():
-    import ruamel.yaml as yaml  # pylint: disable=import-outside-toplevel
-    with open(os.path.dirname(os.path.abspath(__file__))+'/buckets.yaml') as fp:
-        return yaml.safe_load(fp)
-
-# pypy compatibility hack
-def python_buckets_yaml(python='python3'):
-    return json.loads(subprocess.check_output(
-        [python, '-c',
-         'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'
-         ],
-        cwd=os.path.dirname(os.path.abspath(__file__))).decode("utf-8"))
-
-for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
-    try:
-        BUCKETS = attempt()
-        break
-    except (ImportError, OSError):
-        traceback.print_exc()
-else:
-    # pylint: disable=misplaced-bare-raise
-    # This is safe because the only way we get here is by faling all attempts
-    raise
-
-
-def path_to_job_and_number(path):
-    assert not path.endswith('/')
-    for bucket, meta in BUCKETS.items():
-        if path.startswith(bucket):
-            prefix = meta['prefix']
-            break
-    else:
-        if path.startswith('gs://kubernetes-jenkins/pr-logs'):
-            prefix = 'pr:'
-        else:
-            raise ValueError('unknown build path')
-    build = os.path.basename(path)
-    job = prefix + os.path.basename(os.path.dirname(path))
-    try:
-        return job, int(build)
-    except ValueError:
-        return job, None
-
 
 def row_for_build(path, started, finished, results):
     """

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -46,26 +46,28 @@ class BuildObjectTests(unittest.TestCase):
         ),
         (
             "Base_Build",
-            make_json.Build("gs://kubernetes-jenkins/pr-logs/path",[]),
+            make_json.Build("gs://kubernetes-jenkins/pr-logs/path", []),
             {"path":"gs://kubernetes-jenkins/pr-logs/path",
-            "test":[],
-            "tests_run":0,
-            "tests_failed":0,
-            "job":"pr:pr-logs",
+             "test": [],
+             "tests_run": 0,
+             "tests_failed": 0,
+             "job":"pr: pr-logs",
             },
         ),
         (
             "Tests_populate",
-            make_json.Build("gs://kubernetes-jenkins/pr-logs/path", [{'name': 'Test1', 'failed': True}]),
+            make_json.Build(
+                "gs://kubernetes-jenkins/pr-logs/path",
+                [{'name': 'Test1', 'failed': True}],
+            ),
             {"path":"gs://kubernetes-jenkins/pr-logs/path",
-            "test":[{'name': 'Test1', 'failed': True}],
-            "tests_run":1,
-            "tests_failed":1,
-            "job":"pr:pr-logs",
+             "test": [{'name': 'Test1', 'failed': True}],
+             "tests_run": 1,
+             "tests_failed": 1,
+             "job": "pr:pr-logs",
             },
         ),
-    ]
-    )
+    ])
     def test_as_dict(self, _, build, expected):
         self.assertEqual(build.as_dict(), expected)
 

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -51,7 +51,7 @@ class BuildObjectTests(unittest.TestCase):
              "test": [],
              "tests_run": 0,
              "tests_failed": 0,
-             "job":"pr: pr-logs",
+             "job": "pr:pr-logs",
             },
         ),
         (

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -37,6 +37,38 @@ class ValidateBuckets(unittest.TestCase):
             self.assertEqual(prefix[-1], ':', "bucket %s prefix should be %s:" % (name, prefix))
 
 
+class BuildObjectTests(unittest.TestCase):
+    @parameterized.expand([
+        (
+            "Empty_Build",
+            make_json.Build.__new__(make_json.Build),
+            {},
+        ),
+        (
+            "Base_Build",
+            make_json.Build("gs://kubernetes-jenkins/pr-logs/path",[]),
+            {"path":"gs://kubernetes-jenkins/pr-logs/path",
+            "test":[],
+            "tests_run":0,
+            "tests_failed":0,
+            "job":"pr:pr-logs",
+            },
+        ),
+        (
+            "Tests_populate",
+            make_json.Build("gs://kubernetes-jenkins/pr-logs/path", [{'name': 'Test1', 'failed': True}]),
+            {"path":"gs://kubernetes-jenkins/pr-logs/path",
+            "test":[{'name': 'Test1', 'failed': True}],
+            "tests_run":1,
+            "tests_failed":1,
+            "job":"pr:pr-logs",
+            },
+        ),
+    ]
+    )
+    def test_as_dict(self, _, build, expected):
+        self.assertEqual(build.as_dict(), expected)
+
 class GenerateBuilds(unittest.TestCase):
     @parameterized.expand([
         (
@@ -294,7 +326,8 @@ class MakeJsonTest(unittest.TestCase):
 
     def test_path_to_job_and_number(self):
         def expect(path, job, number):
-            self.assertEqual(make_json.path_to_job_and_number(path), (job, number))
+            build = make_json.Build(path, [])
+            self.assertEqual((build.job, build.number), (job, number))
 
         expect('gs://kubernetes-jenkins/logs/some-build/123', 'some-build', 123)
         expect('gs://kubernetes-jenkins/logs/some-build/123asdf', 'some-build', None)
@@ -302,6 +335,7 @@ class MakeJsonTest(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             expect('gs://unknown-bucket/foo/123', None, None)
+            expect('gs://unknown-bucket/foo/123/', None, None)
 
     def test_row_for_build(self):
         def expect(path, start, finish, results, **kwargs):


### PR DESCRIPTION
I also reorg some of the methods to be more visible in setup and to make more sense with the flow of the Build object

I will extend unit tests for more methods in other PRs. Don't want to have super massive reviews with all the other things in our pipeline