### PR TITLE
add NFS CSI driver sanity test

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-nfs/OWNERS
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+- andyzhangx
+- msau42
+approvers:
+- andyzhangx
+- msau42

--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
@@ -1,0 +1,26 @@
+presubmits:
+  kubernetes-csi/csi-driver-nfs:
+  - name: pull-csi-driver-nfs-sanity
+    decorate: true
+    always_run: true
+    path_alias: sigs.k8s.io/csi-driver-nfs
+    branches:
+    - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200811-4afd9ba-master
+        command:
+        - runner.sh
+        args:
+        - make
+        - sanity-test
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-storage-csi-other
+      testgrid-tab-name: pull-csi-driver-nfs-sanity
+      description: "Run sanity tests for NFS CSI driver."
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
/assign @msau42

after this PR(https://github.com/kubernetes-csi/csi-driver-nfs/pull/49) merged, we could run sanity test in CI.