### PR TITLE
Rename default git user for clonerefs to `clonerefs`

### DIFF
--- a/prow/clonerefs/options.go
+++ b/prow/clonerefs/options.go
@@ -109,9 +109,9 @@ const (
 	// in when run.
 	JSONConfigEnvVar = "CLONEREFS_OPTIONS"
 	// DefaultGitUserName is the default name used in git config
-	DefaultGitUserName = "ci-robot"
+	DefaultGitUserName = "clonerefs"
 	// DefaultGitUserEmail is the default email used in git config
-	DefaultGitUserEmail = "ci-robot@k8s.io"
+	DefaultGitUserEmail = "clonerefs@k8s.io"
 )
 
 // ConfigVar exposes the environment variable used

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -90,7 +90,7 @@ spec:
     - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
-      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/.gitcookies"}'
+      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"clonerefs","git_user_email":"clonerefs@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/.gitcookies"}'
     image: clonerefs:tag
     name: clonerefs
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -90,7 +90,7 @@ spec:
     - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
-      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/yummy"}'
+      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"clonerefs","git_user_email":"clonerefs@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"cookie_path":"/secrets/cookiefile/yummy"}'
     image: clonerefs:tag
     name: clonerefs
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -88,7 +88,7 @@ spec:
     - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
-      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"host_fingerprints":["hello","world"]}'
+      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"clonerefs","git_user_email":"clonerefs@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"host_fingerprints":["hello","world"]}'
     image: clonerefs:tag
     name: clonerefs
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -88,7 +88,7 @@ spec:
     - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
-      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"]}'
+      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"clonerefs","git_user_email":"clonerefs@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"]}'
     image: clonerefs:tag
     name: clonerefs
     resources: {}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -141,7 +141,7 @@ spec:
     - /clonerefs
     env:
     - name: CLONEREFS_OPTIONS
-      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"ci-robot","git_user_email":"ci-robot@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},{"org":"extra-org","repo":"extra-repo"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"cookie_path":"/secrets/cookiefile/yummy"}'
+      value: '{"src_root":"/home/prow/go","log":"/logs/clone.json","git_user_name":"clonerefs","git_user_email":"clonerefs@k8s.io","refs":[{"org":"org-name","repo":"repo-name","base_ref":"base-ref","base_sha":"base-sha","pulls":[{"number":1,"author":"author-name","sha":"pull-sha"}],"path_alias":"somewhere/else"},{"org":"extra-org","repo":"extra-repo"}],"key_files":["/secrets/ssh/ssh-1","/secrets/ssh/ssh-2"],"cookie_path":"/secrets/cookiefile/yummy"}'
     image: clonerefs:tag
     name: clonerefs
     resources: {}


### PR DESCRIPTION
This helps identifying commits created by this user, the generic
`ci-robot` we currently use makes this hard.

This change will break scripts that expect to find a commit authored by
the old name.
