### PR TITLE
releng: Migrate go-runner image postsubmit to k/release

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -1,31 +1,4 @@
 postsubmits:
-  kubernetes/kubernetes:
-    - name: post-kubernetes-push-image-go-runner
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
-      decorate: true
-      run_if_changed: '^build\/go-runner\/'
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200813-af45e55
-            command:
-              - /run.sh
-            args:
-              - --project=k8s-staging-build-image
-              - --scratch-bucket=gs://k8s-staging-build-image-gcb
-              - --build-dir=.
-              - build/go-runner
-            env:
-              - name: LOG_TO_STDOUT
-                value: "y"
-      rerun_auth_config:
-        github_team_ids:
-          - 2241179 # release-managers
   kubernetes/release:
     - name: post-release-push-image-debian-base
       cluster: k8s-infra-prow-build-trusted
@@ -105,6 +78,32 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
               - --build-dir=.
               - images/build/debian-iptables
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
+    - name: post-release-push-image-go-runner
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+      decorate: true
+      run_if_changed: '^images\/build\/go-runner\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200813-af45e55
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-build-image
+              - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --build-dir=.
+              - images/build/go-runner
             env:
               - name: LOG_TO_STDOUT
                 value: "y"


### PR DESCRIPTION
Companion PR to https://github.com/kubernetes/release/pull/1498.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @spiffxp @BenTheElder 
cc: @kubernetes/release-engineering 