### PR TITLE
bugzilla: instrument event-local logging

### DIFF
--- a/prow/bugzilla/BUILD.bazel
+++ b/prow/bugzilla/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/bugzilla",
     deps = [
+        "//prow/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -44,15 +44,17 @@ var (
 
 func clientForUrl(url string) *client {
 	return &client{
-		logger:   logrus.WithField("testing", "true"),
-		endpoint: url,
-		client: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		logger: logrus.WithField("testing", "true"),
+		delegate: &delegate{
+			endpoint: url,
+			client: &http.Client{
+				Transport: &http.Transport{
+					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+				},
 			},
-		},
-		getAPIKey: func() []byte {
-			return []byte("api-key")
+			getAPIKey: func() []byte {
+				return []byte("api-key")
+			},
 		},
 	}
 }

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -257,6 +258,10 @@ func (c *Fake) GetRootForClone(bug *Bug) (*Bug, error) {
 func (c *Fake) SetRoundTripper(t http.RoundTripper) {
 	// Do nothing here
 }
+
+func (c *Fake) ForPlugin(plugin string) Client             { return c }
+func (c *Fake) ForSubcomponent(subcomponent string) Client { return c }
+func (c *Fake) WithFields(fields logrus.Fields) Client     { return c }
 
 // the Fake is a Client
 var _ Client = &Fake{}

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -14,6 +14,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//prow/bugzilla:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/githubeventserver:go_default_library",

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"k8s.io/test-infra/prow/bugzilla"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/githubeventserver"
@@ -105,8 +106,9 @@ func TestHook(t *testing.T) {
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
 	clientAgent := &plugins.ClientAgent{
-		GitHubClient: github.NewFakeClient(),
-		OwnersClient: repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
+		GitHubClient:   github.NewFakeClient(),
+		OwnersClient:   repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
+		BugzillaClient: &bugzilla.Fake{},
 	}
 	metrics := githubeventserver.NewMetrics()
 	var testcases = []struct {

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -862,7 +862,8 @@ func handleMerge(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 	for bug, state := range unmergedPrStates {
 		statements = append(statements, fmt.Sprintf("\n * %s is %s", link(bug), state))
 	}
-	unmergedMessage := fmt.Sprintf(`The following pull requests linked via external trackers have not merged:%s`, strings.Join(statements, "\n"))
+	unmergedMessage := fmt.Sprintf(`The following pull requests linked via external trackers have not merged:%s
+`, strings.Join(statements, "\n"))
 
 	outcomeMessage := func(action string) string {
 		return fmt.Sprintf(bugLink+" has %sbeen moved to the %s state.", e.bugId, bc.Endpoint(), e.bugId, action, options.StateAfterMerge)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1098,6 +1098,7 @@ Instructions for interacting with me using PR comments are available [here](http
 			},
 			expectedComment: `org/repo#1:@user: Some pull requests linked via external trackers have merged: [org/repo#1](https://github.com/org/repo/pull/1). The following pull requests linked via external trackers have not merged:
  * [org/repo#22](https://github.com/org/repo/pull/22) is open
+
 [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) has been moved to the MODIFIED state.
 
 <details>

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -177,7 +177,7 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 		GitClient:                 clientAgent.GitClient,
 		SlackClient:               clientAgent.SlackClient,
 		OwnersClient:              clientAgent.OwnersClient.WithFields(logger.Data).WithGitHubClient(gitHubClient),
-		BugzillaClient:            clientAgent.BugzillaClient,
+		BugzillaClient:            clientAgent.BugzillaClient.WithFields(logger.Data).ForPlugin(plugin),
 		Metrics:                   metrics,
 		Config:                    prowConfig,
 		PluginConfig:              pluginConfig,


### PR DESCRIPTION
Similar to how it's done for the GitHub client, the Bugzilla client now
exposes all of the event-specific data fields when logging, as well as
passing a specific and explicit user agent header.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 