### PR TITLE
Recommend number of janitor replicas to use

### DIFF
--- a/config/prow/cluster/boskos-janitor.yaml
+++ b/config/prow/cluster/boskos-janitor.yaml
@@ -6,7 +6,7 @@ metadata:
     app: boskos-janitor
   namespace: test-pods
 spec:
-  replicas: 4  # 4 distributed janitor instances for gke
+  replicas: 4  # 4 distributed janitor instances for gke; recommend min 2, 1 for each 30 projects
   selector:
     matchLabels:
       app: boskos-janitor


### PR DESCRIPTION
When I first setup boskos I was very confused on how to set this
number. Knative had a ratio of 1:6 for a long time, which is a little
ridiculous.

/assign ixdy
/cc ixdy