### PR TITLE
Change spyglass error to be info level log in the case of no artifacts

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -966,7 +966,7 @@ func renderSpyglass(ctx context.Context, sg *spyglass.Spyglass, cfg config.Gette
 		return "", fmt.Errorf("error listing artifacts: %v", err)
 	}
 	if len(artifactNames) == 0 {
-		return "", fmt.Errorf("found no artifacts for %s", src)
+		log.Infof("found no artifacts for %s", src)
 	}
 
 	regexCache := cfg().Deck.Spyglass.RegexCache


### PR DESCRIPTION
This is a fix for issue https://github.com/kubernetes/test-infra/issues/18910