### PR TITLE
Small fix to multicontainer job: change bash to sh

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -34,7 +34,7 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: benchmark-demo
     description: Demoing JUnit golang benchmark results.
-- interval: 10m
+- interval: 1h
   name: ci-test-infra-multiple-container-test
   decorate: true
   spec:

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -45,13 +45,13 @@ periodics:
       args: ["I am first"]
     - name: test-2
       image: alpine
-      command: ["/bin/bash"]
+      command: ["/bin/sh"]
       args:
       - -c
       - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
     - name: test-3
       image: alpine
-      command: ["/bin/bash"]
+      command: ["/bin/sh"]
       args:
       - -c
       - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -43,18 +43,30 @@ periodics:
       image: alpine
       command: ["/bin/echo"]
       args: ["I am first"]
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
     - name: test-2
       image: alpine
       command: ["/bin/sh"]
       args:
       - -c
       - "sleep 60 && echo I && sleep 60 && echo am && sleep 60 && echo second"
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
     - name: test-3
       image: alpine
       command: ["/bin/sh"]
       args:
       - -c
       - "sleep 120 && echo I && sleep 120 && echo am && sleep 120 && echo third"
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
   annotations:
     testgrid-alert-email: anthonytong@google.com
     testgrid-dashboards: sig-testing-canaries

--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -46,6 +46,9 @@ periodics:
       resources:
         requests:
           memory: "128Mi"
+          cpu: "250m"
+        limits:
+          memory: "256Mi"
           cpu: "500m"
     - name: test-2
       image: alpine
@@ -56,6 +59,9 @@ periodics:
       resources:
         requests:
           memory: "128Mi"
+          cpu: "250m"
+        limits:
+          memory: "256Mi"
           cpu: "500m"
     - name: test-3
       image: alpine
@@ -66,6 +72,9 @@ periodics:
       resources:
         requests:
           memory: "128Mi"
+          cpu: "250m"
+        limits:
+          memory: "256Mi"
           cpu: "500m"
   annotations:
     testgrid-alert-email: anthonytong@google.com


### PR DESCRIPTION
Using /bin/sh instead of /bin/bash for job since alpine image does not have bash.