### PR TITLE
Migrate pull-kubernetes-node-e2e to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -9,6 +9,7 @@ presubmits:
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
     always_run: true
+    cluster: k8s-infra-prow-build
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -26,7 +27,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - -- # end bootstrap args, scenario args below
         - --deployment=node
-        - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -837,6 +837,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.16
+    cluster: k8s-infra-prow-build
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -854,7 +855,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -898,6 +898,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.17
+    cluster: k8s-infra-prow-build
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -915,7 +916,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1099,6 +1099,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.18
+    cluster: k8s-infra-prow-build
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1116,7 +1117,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1050,6 +1050,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.19
+    cluster: k8s-infra-prow-build
     labels:
       preset-k8s-ssh: "true"
       preset-service-account: "true"
@@ -1067,7 +1068,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project=k8s-jkns-pr-node-e2e
         - --gcp-zone=us-west1-b
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true


### PR DESCRIPTION
Drop the use of k8s-jkns-pr-node-e2e, which means the jobs will
instead use the gce-project pool from boskos, which is the same
pool used by the ci equivalent of this job.

Part of https://github.com/kubernetes/test-infra/issues/18851