### PR TITLE
Migrate pull-kubernetes-e2e-gce to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -18,6 +18,7 @@ presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce
     always_run: false
+    cluster: k8s-infra-prow-build
     skip_branches:
     - release-\d+\.\d+ # per-release image
     annotations:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -749,6 +749,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.16
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -768,6 +768,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.17
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -830,6 +830,7 @@ presubmits:
   - always_run: true
     branches:
     - release-1.18
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -782,6 +782,7 @@ presubmits:
   - always_run: false
     branches:
     - release-1.19
+    cluster: k8s-infra-prow-build
     labels:
       preset-bazel-remote-cache-enabled: "true"
       preset-bazel-scratch-dir: "true"


### PR DESCRIPTION
Even though 1.19 and the main branch variants are no longer
merge blocking, let's go ahead and move them all at once

Part of https://github.com/kubernetes/test-infra/issues/18852