### PR TITLE
Removed dry-run from post-k8sio-dns-update prow job

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -65,7 +65,7 @@ postsubmits:
         - bash
         args:
         - -c
-        - "cd dns && make dry-run-local"
+        - "cd dns && make push-local"
   - name: post-k8sio-deploy-prow-build-resources
     cluster: k8s-infra-prow-build-trusted
     decorate: true


### PR DESCRIPTION
This job was being run in dry-run mode to test if everything works as
expected and after few months I'm confident it is, so we can switch it's
mode to push the changes.

Here is the Makefile which this image is using:
https://github.com/kubernetes/k8s.io/blob/07a2f07b78fa498a83b31eac3ed022d2cc278687/dns/Makefile

/cc @spiffxp @cblecker 