### PR TITLE
[CAPZ] Add extra-ref to have test-infra repo in the coverage job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -309,6 +309,11 @@ presubmits:
     optional: true
     decorate: true
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    extra_refs:
+    - org: kubernetes
+      repo: test-infra
+      base_ref: master
+      path_alias: k8s.io/test-infra
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200813-1642133-1.18


### PR DESCRIPTION
Adding missing extra-ref to fetch the test-infra repo in order to use the gopherage tool

/kind bug

/assign @CecileRobertMichon 