### PR TITLE
Logrusutil: Don't reuse the standard logger

### DIFF
--- a/prow/logrusutil/logrusutil.go
+++ b/prow/logrusutil/logrusutil.go
@@ -101,7 +101,7 @@ const censored = "CENSORED"
 
 var (
 	censoredBytes = []byte(censored)
-	standardLog   = logrus.NewEntry(logrus.StandardLogger())
+	standardLog   = logrus.NewEntry(logrus.New())
 )
 
 // Censor replaces sensitive parts of the content with a placeholder.

--- a/prow/logrusutil/logrusutil_test.go
+++ b/prow/logrusutil/logrusutil_test.go
@@ -127,3 +127,12 @@ func TestCensoringFormatterWithCornerCases(t *testing.T) {
 		})
 	}
 }
+
+func TestCensoringFormatterDoesntDeadLockWhenUsedWithStandardLogger(t *testing.T) {
+	// The whitespace makes the censoring fornmatter emit a warning. If it uses the same global
+	// logger, that results in a deadlock.
+	logrus.SetFormatter(NewCensoringFormatter(logrus.StandardLogger().Formatter, func() sets.String {
+		return sets.NewString(" untrimmed")
+	}))
+	logrus.Info("test")
+}


### PR DESCRIPTION
Logrus internally does locking, if the formatter is used for the
standard logger but itself also uses the standard logger, it can
deadlock.
