### PR TITLE
Added presubmit prow job for kubernetes-sigs/multi-tenancy kubectl-mtb project

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/mtb-presubmit.yaml
@@ -1,0 +1,14 @@
+presubmits:
+    kubernetes-sigs/multi-tenancy:
+    - name: pull-mtb-test
+      annotations:
+        testgrid-dashboards: wg-multi-tenancy-mtb
+        testgrid-tab-name: presubmit-tests
+      decorate: true
+      path_alias: sigs.k8s.io/multi-tenancy
+      run_if_changed: "benchmarks/kubectl-mtb/.*"
+      spec:
+        containers:
+        - image: golang:1.13
+          command:
+          - ./benchmarks/kubectl-mtb/hack/ci-test.sh

--- a/config/testgrids/kubernetes/wg-multi-tenancy/config.yaml
+++ b/config/testgrids/kubernetes/wg-multi-tenancy/config.yaml
@@ -2,6 +2,8 @@ dashboard_groups:
 - name: wg-multi-tenancy
   dashboard_names:
     - wg-multi-tenancy-hnc
+    - wg-multi-tenancy-mtb
 
 dashboards:
 - name: wg-multi-tenancy-hnc
+- name: wg-multi-tenancy-mtb


### PR DESCRIPTION
This PR configures a Prow job to run our unit tests and check some conditions before, for kubectl-mtb project(https://github.com/kubernetes-sigs/multi-tenancy/tree/master/benchmarks/kubectl-mtb).

I tested this prow job locally with [Phaino](https://github.com/kubernetes/test-infra/tree/master/prow/cmd/phaino) and everything worked fine.