### PR TITLE
Revert "Update prow to v20200820-859d15fc43, and other images as nece…

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -316,7 +316,7 @@ presubmits:
       path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200819-491a5ae-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200813-1642133-1.18
         command:
         - runner.sh
         - bash

--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -9,7 +9,7 @@ periodics:
     testgrid-tab-name: api-review-help
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -55,7 +55,7 @@ periodics:
     testgrid-tab-name: cla
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -95,7 +95,7 @@ periodics:
     testgrid-tab-name: close
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -136,7 +136,7 @@ periodics:
     description: Automatically /retest for approved PRs that failed retesting
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -192,7 +192,7 @@ periodics:
     testgrid-tab-name: rotten
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -236,7 +236,7 @@ periodics:
     testgrid-tab-name: stale
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:
@@ -281,7 +281,7 @@ periodics:
     description: Creates github issues based on data from various 'IssueSource's.
   spec:
     containers:
-    - image: gcr.io/k8s-prow/issue-creator:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/issue-creator:v20200818-222ac18931
       command:
       - /app/robots/issue-creator/app.binary
       args:
@@ -310,7 +310,7 @@ periodics:
     testgrid-tab-name: enhancements-unfreeze
   spec:
     containers:
-    - image: gcr.io/k8s-prow/commenter:v20200820-859d15fc43
+    - image: gcr.io/k8s-prow/commenter:v20200818-222ac18931
       command:
       - /app/robots/commenter/app.binary
       args:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -78,7 +78,7 @@ presubmits:
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'
     spec:
       containers:
-      - image: gcr.io/k8s-prow/checkconfig:v20200820-859d15fc43
+      - image: gcr.io/k8s-prow/checkconfig:v20200818-222ac18931
         command:
         - /checkconfig
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -116,7 +116,7 @@ postsubmits:
     - master
     spec:
       containers:
-      - image: gcr.io/k8s-prow/hmac:v20200820-859d15fc43
+      - image: gcr.io/k8s-prow/hmac:v20200818-222ac18931
         command:
         - /hmac
         args:
@@ -951,7 +951,7 @@ periodics:
   spec:
     containers:
     - name: branchprotector
-      image: gcr.io/k8s-prow/branchprotector:v20200820-859d15fc43
+      image: gcr.io/k8s-prow/branchprotector:v20200818-222ac18931
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -985,7 +985,7 @@ periodics:
   spec:
     containers:
     - name: label-sync
-      image: gcr.io/k8s-prow/label_sync:v20200820-859d15fc43
+      image: gcr.io/k8s-prow/label_sync:v20200818-222ac18931
       command:
       - /app/label_sync/app.binary
       args:

--- a/config/prow/cluster/crier_deployment.yaml
+++ b/config/prow/cluster/crier_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/crier:v20200818-222ac18931
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/deck_deployment.yaml
+++ b/config/prow/cluster/deck_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/deck:v20200818-222ac18931
         imagePullPolicy: Always
         ports:
           - name: http

--- a/config/prow/cluster/ghproxy.yaml
+++ b/config/prow/cluster/ghproxy.yaml
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/ghproxy:v20200818-222ac18931
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/config/prow/cluster/grandmatriarch.yaml
+++ b/config/prow/cluster/grandmatriarch.yaml
@@ -56,6 +56,6 @@ spec:
       serviceAccountName: grandmatriarch
       containers:
       - name: bakery
-        image: gcr.io/k8s-prow/grandmatriarch:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/grandmatriarch:v20200818-222ac18931
         args:
         - http-cookiefile

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -38,7 +38,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/hook:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/horologium_deployment.yaml
+++ b/config/prow/cluster/horologium_deployment.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/horologium:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config

--- a/config/prow/cluster/needs-rebase_deployment.yaml
+++ b/config/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/needs-rebase:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/pipeline_deployment.yaml
+++ b/config/prow/cluster/pipeline_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: prow-pipeline
       containers:
       - name: pipeline
-        image: gcr.io/k8s-prow/pipeline:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/pipeline:v20200818-222ac18931
         args:
         - --all-contexts
         - --config=/etc/prow-config/config.yaml

--- a/config/prow/cluster/plank_deployment.yaml
+++ b/config/prow/cluster/plank_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: plank
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/plank:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/config/prow/cluster/sinker_deployment.yaml
+++ b/config/prow/cluster/sinker_deployment.yaml
@@ -23,7 +23,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/sinker:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/sinker:v20200818-222ac18931
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -99,10 +99,10 @@ data:
             path_strategy: explicit
           gcs_credentials_secret: gcs-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20200820-859d15fc43
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20200820-859d15fc43
-            initupload: gcr.io/k8s-prow/initupload:v20200820-859d15fc43
-            sidecar: gcr.io/k8s-prow/sidecar:v20200820-859d15fc43
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20200818-222ac18931
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20200818-222ac18931
+            initupload: gcr.io/k8s-prow/initupload:v20200818-222ac18931
+            sidecar: gcr.io/k8s-prow/sidecar:v20200818-222ac18931
 
     tide:
       queries:
@@ -240,7 +240,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/hook:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -322,7 +322,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/sinker:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         volumeMounts:
@@ -360,7 +360,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/deck:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -450,7 +450,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/horologium:v20200818-222ac18931
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -485,7 +485,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/tide:v20200818-222ac18931
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -584,7 +584,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/status-reconciler:v20200818-222ac18931
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -950,7 +950,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/ghproxy:v20200818-222ac18931
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -1012,7 +1012,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --enable-controller=plank
-        image: gcr.io/k8s-prow/prow-controller-manager:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/prow-controller-manager:v20200818-222ac18931
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1131,7 +1131,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/crier:v20200818-222ac18931
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -98,10 +98,10 @@ data:
             path_strategy: explicit
           s3_credentials_secret: s3-credentials
           utility_images:
-            clonerefs: gcr.io/k8s-prow/clonerefs:v20200820-859d15fc43
-            entrypoint: gcr.io/k8s-prow/entrypoint:v20200820-859d15fc43
-            initupload: gcr.io/k8s-prow/initupload:v20200820-859d15fc43
-            sidecar: gcr.io/k8s-prow/sidecar:v20200820-859d15fc43
+            clonerefs: gcr.io/k8s-prow/clonerefs:v20200818-222ac18931
+            entrypoint: gcr.io/k8s-prow/entrypoint:v20200818-222ac18931
+            initupload: gcr.io/k8s-prow/initupload:v20200818-222ac18931
+            sidecar: gcr.io/k8s-prow/sidecar:v20200818-222ac18931
 
     tide:
       queries:
@@ -239,7 +239,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/hook:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - --dry-run=false
@@ -321,7 +321,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/sinker:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         volumeMounts:
@@ -359,7 +359,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/deck:v20200818-222ac18931
         args:
         - --config-path=/etc/config/config.yaml
         - --plugin-config=/etc/plugins/plugins.yaml
@@ -450,7 +450,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/horologium:v20200818-222ac18931
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -485,7 +485,7 @@ spec:
       serviceAccountName: "tide"
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/tide:v20200818-222ac18931
         args:
         - --dry-run=false
         - --config-path=/etc/config/config.yaml
@@ -584,7 +584,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/status-reconciler:v20200818-222ac18931
         args:
         - --dry-run=false
         - --continue-on-error=true
@@ -950,7 +950,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/ghproxy:v20200818-222ac18931
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99
@@ -1012,7 +1012,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --enable-controller=plank
-        image: gcr.io/k8s-prow/prow-controller-manager:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/prow-controller-manager:v20200818-222ac18931
         volumeMounts:
         - name: github-token
           mountPath: /etc/github
@@ -1131,7 +1131,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/crier:v20200818-222ac18931
         args:
         - --blob-storage-workers=10
         - --config-path=/etc/config/config.yaml

--- a/config/prow/cluster/statusreconciler_deployment.yaml
+++ b/config/prow/cluster/statusreconciler_deployment.yaml
@@ -33,7 +33,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/status-reconciler:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - --dry-run=false

--- a/config/prow/cluster/tide_deployment.yaml
+++ b/config/prow/cluster/tide_deployment.yaml
@@ -34,7 +34,7 @@ spec:
       serviceAccountName: tide
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/tide:v20200818-222ac18931
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/config/prow/cluster/tot_deployment.yaml
+++ b/config/prow/cluster/tot_deployment.yaml
@@ -65,7 +65,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/tot:v20200818-222ac18931
         imagePullPolicy: Always
         args:
         - -storage=/store/tot.json

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       timeout: 2h
       grace_period: 15m
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200820-859d15fc43"
-        initupload: "gcr.io/k8s-prow/initupload:v20200820-859d15fc43"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200820-859d15fc43"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20200820-859d15fc43"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20200818-222ac18931"
+        initupload: "gcr.io/k8s-prow/initupload:v20200818-222ac18931"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20200818-222ac18931"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20200818-222ac18931"
       gcs_configuration:
         bucket: "kubernetes-jenkins"
         path_strategy: "legacy"

--- a/config/prow/experimental/controller_manager.yaml
+++ b/config/prow/experimental/controller_manager.yaml
@@ -22,7 +22,7 @@ spec:
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
         - --dry-run=false
-        image: gcr.io/k8s-prow/prow-controller-manager:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/prow-controller-manager:v20200818-222ac18931
         volumeMounts:
         - name: config
           mountPath: /etc/config

--- a/label_sync/cluster/label_sync_cron_job.yaml
+++ b/label_sync/cluster/label_sync_cron_job.yaml
@@ -28,7 +28,7 @@ spec:
         spec:
           containers:
             - name: label-sync
-              image: gcr.io/k8s-prow/label_sync:v20200820-859d15fc43
+              image: gcr.io/k8s-prow/label_sync:v20200818-222ac18931
               args:
               - --config=/etc/config/labels.yaml
               - --confirm=true

--- a/label_sync/cluster/label_sync_job.yaml
+++ b/label_sync/cluster/label_sync_job.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never  # https://github.com/kubernetes/kubernetes/issues/54870
       containers:
       - name: label-sync
-        image: gcr.io/k8s-prow/label_sync:v20200820-859d15fc43
+        image: gcr.io/k8s-prow/label_sync:v20200818-222ac18931
         args:
         - --config=/etc/config/labels.yaml
         - --confirm=true


### PR DESCRIPTION
…ssary."

This reverts commit 2408739ed02ae76d2995a8f4937556ccc7446b62.

`hook` is crashlooping due to failing readiness and liveness probes.