### PR TITLE
Revert "bugzilla: instrument event-local logging"

### DIFF
--- a/prow/bugzilla/BUILD.bazel
+++ b/prow/bugzilla/BUILD.bazel
@@ -32,7 +32,6 @@ go_library(
     ],
     importpath = "k8s.io/test-infra/prow/bugzilla",
     deps = [
-        "//prow/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",

--- a/prow/bugzilla/client.go
+++ b/prow/bugzilla/client.go
@@ -32,8 +32,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-
-	"k8s.io/test-infra/prow/version"
 )
 
 const (
@@ -85,23 +83,15 @@ type Client interface {
 	GetRootForClone(bug *Bug) (*Bug, error)
 	// SetRoundTripper sets a custom implementation of RoundTripper as the Transport for http.Client
 	SetRoundTripper(t http.RoundTripper)
-
-	// ForPlugin and ForSubcomponent allow for the logger used in the client
-	// to be created in a more specific manner when spawning parallel workers
-	ForPlugin(plugin string) Client
-	ForSubcomponent(subcomponent string) Client
-	WithFields(fields logrus.Fields) Client
 }
 
 // NewClient returns a bugzilla client.
 func NewClient(getAPIKey func() []byte, endpoint string) Client {
 	return &client{
-		logger: logrus.WithField("client", "bugzilla"),
-		delegate: &delegate{
-			client:    &http.Client{},
-			endpoint:  endpoint,
-			getAPIKey: getAPIKey,
-		},
+		logger:    logrus.WithField("client", "bugzilla"),
+		client:    &http.Client{},
+		endpoint:  endpoint,
+		getAPIKey: getAPIKey,
 	}
 }
 
@@ -147,53 +137,8 @@ func (bd *bugDetailsCache) list() []Bug {
 	return result
 }
 
-// client interacts with the Bugzilla api.
 type client struct {
-	// If logger is non-nil, log all method calls with it.
-	logger *logrus.Entry
-	// identifier is used to add more identification to the user-agent header
-	identifier string
-	*delegate
-}
-
-// ForPlugin clones the client, keeping the underlying delegate the same but adding
-// a plugin identifier and log field
-func (c *client) ForPlugin(plugin string) Client {
-	return c.forKeyValue("plugin", plugin)
-}
-
-// ForSubcomponent clones the client, keeping the underlying delegate the same but adding
-// an identifier and log field
-func (c *client) ForSubcomponent(subcomponent string) Client {
-	return c.forKeyValue("subcomponent", subcomponent)
-}
-
-func (c *client) forKeyValue(key, value string) Client {
-	return &client{
-		identifier: value,
-		logger:     c.logger.WithField(key, value),
-		delegate:   c.delegate,
-	}
-}
-
-func (c *client) userAgent() string {
-	if c.identifier != "" {
-		return version.UserAgentWithIdentifier(c.identifier)
-	}
-	return version.UserAgent()
-}
-
-// WithFields clones the client, keeping the underlying delegate the same but adding
-// fields to the logging context
-func (c *client) WithFields(fields logrus.Fields) Client {
-	return &client{
-		logger:   c.logger.WithFields(fields),
-		delegate: c.delegate,
-	}
-}
-
-// delegate actually does the work to talk to Bugzilla
-type delegate struct {
+	logger    *logrus.Entry
 	client    *http.Client
 	endpoint  string
 	getAPIKey func() []byte
@@ -670,9 +615,6 @@ func (c *client) request(req *http.Request, logger *logrus.Entry) ([]byte, error
 		values := req.URL.Query()
 		values.Add("api_key", string(apiKey))
 		req.URL.RawQuery = values.Encode()
-	}
-	if userAgent := c.userAgent(); userAgent != "" {
-		req.Header.Add("User-Agent", userAgent)
 	}
 	start := time.Now()
 	resp, err := c.client.Do(req)

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -44,17 +44,15 @@ var (
 
 func clientForUrl(url string) *client {
 	return &client{
-		logger: logrus.WithField("testing", "true"),
-		delegate: &delegate{
-			endpoint: url,
-			client: &http.Client{
-				Transport: &http.Transport{
-					TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-				},
+		logger:   logrus.WithField("testing", "true"),
+		endpoint: url,
+		client: &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			},
-			getAPIKey: func() []byte {
-				return []byte("api-key")
-			},
+		},
+		getAPIKey: func() []byte {
+			return []byte("api-key")
 		},
 	}
 }

--- a/prow/bugzilla/fake.go
+++ b/prow/bugzilla/fake.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -258,10 +257,6 @@ func (c *Fake) GetRootForClone(bug *Bug) (*Bug, error) {
 func (c *Fake) SetRoundTripper(t http.RoundTripper) {
 	// Do nothing here
 }
-
-func (c *Fake) ForPlugin(plugin string) Client             { return c }
-func (c *Fake) ForSubcomponent(subcomponent string) Client { return c }
-func (c *Fake) WithFields(fields logrus.Fields) Client     { return c }
 
 // the Fake is a Client
 var _ Client = &Fake{}

--- a/prow/hook/BUILD.bazel
+++ b/prow/hook/BUILD.bazel
@@ -14,7 +14,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//prow/bugzilla:go_default_library",
         "//prow/config:go_default_library",
         "//prow/github:go_default_library",
         "//prow/githubeventserver:go_default_library",

--- a/prow/hook/hook_test.go
+++ b/prow/hook/hook_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/test-infra/prow/bugzilla"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/githubeventserver"
@@ -106,9 +105,8 @@ func TestHook(t *testing.T) {
 	pa.Set(&plugins.Configuration{Plugins: map[string][]string{"foo/bar": {"baz"}}})
 	ca := &config.Agent{}
 	clientAgent := &plugins.ClientAgent{
-		GitHubClient:   github.NewFakeClient(),
-		OwnersClient:   repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
-		BugzillaClient: &bugzilla.Fake{},
+		GitHubClient: github.NewFakeClient(),
+		OwnersClient: repoowners.NewClient(nil, nil, func(org, repo string) bool { return false }, func(org, repo string) bool { return false }, func() config.OwnersDirBlacklist { return config.OwnersDirBlacklist{} }),
 	}
 	metrics := githubeventserver.NewMetrics()
 	var testcases = []struct {

--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -862,8 +862,7 @@ func handleMerge(e event, gc githubClient, bc bugzilla.Client, options plugins.B
 	for bug, state := range unmergedPrStates {
 		statements = append(statements, fmt.Sprintf("\n * %s is %s", link(bug), state))
 	}
-	unmergedMessage := fmt.Sprintf(`The following pull requests linked via external trackers have not merged:%s
-`, strings.Join(statements, "\n"))
+	unmergedMessage := fmt.Sprintf(`The following pull requests linked via external trackers have not merged:%s`, strings.Join(statements, "\n"))
 
 	outcomeMessage := func(action string) string {
 		return fmt.Sprintf(bugLink+" has %sbeen moved to the %s state.", e.bugId, bc.Endpoint(), e.bugId, action, options.StateAfterMerge)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1098,7 +1098,6 @@ Instructions for interacting with me using PR comments are available [here](http
 			},
 			expectedComment: `org/repo#1:@user: Some pull requests linked via external trackers have merged: [org/repo#1](https://github.com/org/repo/pull/1). The following pull requests linked via external trackers have not merged:
  * [org/repo#22](https://github.com/org/repo/pull/22) is open
-
 [Bugzilla bug 123](www.bugzilla/show_bug.cgi?id=123) has been moved to the MODIFIED state.
 
 <details>

--- a/prow/plugins/plugins.go
+++ b/prow/plugins/plugins.go
@@ -177,7 +177,7 @@ func NewAgent(configAgent *config.Agent, pluginConfigAgent *ConfigAgent, clientA
 		GitClient:                 clientAgent.GitClient,
 		SlackClient:               clientAgent.SlackClient,
 		OwnersClient:              clientAgent.OwnersClient.WithFields(logger.Data).WithGitHubClient(gitHubClient),
-		BugzillaClient:            clientAgent.BugzillaClient.WithFields(logger.Data).ForPlugin(plugin),
+		BugzillaClient:            clientAgent.BugzillaClient,
 		Metrics:                   metrics,
 		Config:                    prowConfig,
 		PluginConfig:              pluginConfig,


### PR DESCRIPTION
This reverts commit 64eaf7405870676e0b3d4b2959dc397561370e73. (https://github.com/kubernetes/test-infra/pull/18907)

Slack thread with context: https://kubernetes.slack.com/archives/C7J9RP96G/p1597942416001000

Segfault trace:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x98 pc=0x17ab5b7]
goroutine 130 [running]:
k8s.io/test-infra/prow/plugins.NewAgent(0xc0004e7540, 0xc001f79480, 0xc001694700, 0xc00000e7e8, 0xc001666000, 0xc0006b6a10, 0x3, 0x0, 0x0, 0x0, ...)
	prow/plugins/plugins.go:180 +0x267
k8s.io/test-infra/prow/hook.(*Server).handleStatusEvent.func1(0xc001695ab0, 0xc00000e870, 0xc000776fc0, 0xc0006b6a10, 0x3, 0x1e8d5d0)
	prow/hook/events.go:384 +0xd8
created by k8s.io/test-infra/prow/hook.(*Server).handleStatusEvent
	prow/hook/events.go:382 +0x681
```

/assign @stevekuznetsov @alvaroaleman @michelle192837 