### PR TITLE
Add standard go build params to Triage image

### DIFF
--- a/triage/Dockerfile
+++ b/triage/Dockerfile
@@ -22,7 +22,12 @@ COPY . /test-infra/
 
 # Build Triage
 RUN cd /test-infra/triage/ && \
-    env GOOS=linux go build -v -o triage ./main.go
+    env GOOS=linux \
+        CGO_ENABLED=0 \
+        GO111MODULE=on \
+        GOPROXY=https://proxy.golang.org \
+        GOSUMDB=sum.golang.org \
+        go build -v -o triage ./main.go
 # Get the Google Cloud SDK
 RUN curl -o installer https://sdk.cloud.google.com && \
     bash installer --disable-prompts --install-dir=/ && \


### PR DESCRIPTION
ref: #18726

The previous fix worked on my local Docker instance, but did not work when deployed. I'm adding some parameters now that will hopefully work (and which work on my local instance). These are the standard parameters that seem to be used throughout test-infra when building Go binaries.

If this doesn't work, the switch to klog will have to be temporarily rolled back.

/cc BenTheElder spiffxp MushuEE