### PR TITLE
releng: Phased reopen w/ k/k@master v1.20 milestone restriction

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -520,9 +520,30 @@ tide:
     - needs-sig
   - repos:
     - kubernetes/kubernetes
-    milestone: v1.19
+    milestone: v1.20
     includedBranches:
     - master
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-kind
+    - needs-rebase
+    - needs-sig
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.19
+    includedBranches:
     - release-1.19
     labels:
     - lgtm


### PR DESCRIPTION
Here we enable a v1.20 milestone restriction to kubernetes/kubernetes@master to facilitate a phased reopen for Kubernetes v1.20 development.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold for [proposal consensus](https://docs.google.com/document/d/1yI7o7R2bOB7QtkHUFMHMb5XObiJmzIAnJPuxhdAX-CA/edit?usp=sharing)
/assign @spiffxp @BenTheElder 
cc: @liggitt @kubernetes/sig-release-leads @kubernetes/sig-architecture-leads 