### PR TITLE
Fix autobumper Prow job and build an image for it for other usages

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -876,13 +876,13 @@ periodics:
     base_ref: master
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/bazelbuild:v20200720-57a7724-test-infra
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200819-491a5ae-master
       command:
-      - bazel
-      - run
-      - //experiment/autobumper
-      - --
+      - runner.sh
       args:
+      - go
+      - run
+      - experiment/autobumper/main.go
       - --github-login=k8s-ci-robot
       - --github-token=/etc/github-token/oauth
       - --git-name=Kubernetes Prow Robot

--- a/experiment/autobumper/BUILD.bazel
+++ b/experiment/autobumper/BUILD.bazel
@@ -1,4 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//prow:def.bzl", "prow_image")
+
+NAME = "autobumper"
 
 go_library(
     name = "go_default_library",
@@ -31,5 +34,14 @@ filegroup(
         "//experiment/autobumper/bumper:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+prow_image(
+    name = "image",
+    base = "@git-base//image",
+    component = NAME,
+    directory = "/",
+    files = [":autobumper"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
It looks `bazel run` does not work with relative path in the repo, so switch to `go run` for the autobumper Prow job.

Also build an image for it so that it can be used by other projects in the future.

/cc @cjwagner 