### PR TITLE
Use different field names for Slack merge warning config

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -116,7 +116,8 @@ state and no claims of backwards compatibility are made for any external API.
 Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
-
+ 
+ - *August 22, 2020* The `whitelist` and `branch_whitelist` fields in Slack merge warning are deprecated in favor of the new `exempt_users` and `exempt_branches` fields.
  - *July 17, 2020* Slack reporter will no longer report all states of a Prow job if it has `Channel`
    specified on the Prow job config. Instead, it will report the `job_states_to_report` configured in
    the Prow job or in the Prow core config if the former does not exist.  

--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -509,10 +509,14 @@ type MergeWarning struct {
 	Repos []string `json:"repos,omitempty"`
 	// List of channels on which a event is published.
 	Channels []string `json:"channels,omitempty"`
-	// A slack event is published if the user is not part of the WhiteList.
+	// Deprecated: Use ExemptUsers instead.
 	WhiteList []string `json:"whitelist,omitempty"`
-	// A slack event is published if the user is not on the branch whitelist
+	// A slack event is published if the user is not part of the ExemptUsers.
+	ExemptUsers []string `json:"exempt_users,omitempty"`
+	// Deprecated: Use ExemptBranches instead.
 	BranchWhiteList map[string][]string `json:"branch_whitelist,omitempty"`
+	// A slack event is published if the user is not on the exempt branches.
+	ExemptBranches map[string][]string `json:"exempt_branches,omitempty"`
 }
 
 // Welcome is config for the welcome plugin.
@@ -1076,6 +1080,34 @@ func validateTrigger(triggers []Trigger) error {
 	return nil
 }
 
+var (
+	warnSlackMergeWarningWhiteList       time.Time
+	warnSlackMergeWarningBranchWhiteList time.Time
+)
+
+func validateSlack(slack Slack) error {
+	for i := range slack.MergeWarnings {
+		if len(slack.MergeWarnings[i].WhiteList) > 0 {
+			if len(slack.MergeWarnings[i].ExemptUsers) > 0 {
+				return errors.New("invalid Slack merge warning configuration: both whitelist (deprecated) and exempt_users are set.")
+			}
+
+			warnDeprecated(&warnSlackMergeWarningWhiteList, 5*time.Minute, "whitelist field in Slack merge warning is deprecated and has been renamed to exempt_users. Please update your configuration.")
+			slack.MergeWarnings[i].ExemptUsers = slack.MergeWarnings[i].WhiteList
+		}
+
+		if len(slack.MergeWarnings[i].BranchWhiteList) > 0 {
+			if len(slack.MergeWarnings[i].ExemptBranches) > 0 {
+				return errors.New("invalid Slack merge warning configuration: both branch_whitelist (deprecated) and exempt_branches are set.")
+			}
+
+			warnDeprecated(&warnSlackMergeWarningBranchWhiteList, 5*time.Minute, "branch_whitelist field in Slack merge warning is deprecated and has been renamed to exempt_branches. Please update your configuration.")
+			slack.MergeWarnings[i].ExemptBranches = slack.MergeWarnings[i].BranchWhiteList
+		}
+	}
+	return nil
+}
+
 func compileRegexpsAndDurations(pc *Configuration) error {
 	cRe, err := regexp.Compile(pc.SigMention.Regexp)
 	if err != nil {
@@ -1147,6 +1179,9 @@ func (c *Configuration) Validate() error {
 		return err
 	}
 	if err := validateTrigger(c.Triggers); err != nil {
+		return err
+	}
+	if err := validateSlack(c.Slack); err != nil {
 		return err
 	}
 

--- a/prow/plugins/slackevents/slackevents_test.go
+++ b/prow/plugins/slackevents/slackevents_test.go
@@ -85,14 +85,14 @@ func TestPush(t *testing.T) {
 	pushEvManual.Sender.Login = "tester"
 	pushEvManual.Ref = "refs/heads/master"
 
-	pushEvManualBranchWhiteListed := pushEv
-	pushEvManualBranchWhiteListed.Pusher.Name = "Warren Teened"
-	pushEvManualBranchWhiteListed.Pusher.Email = "wteened@users.noreply.github.com"
-	pushEvManualBranchWhiteListed.Sender.Login = "WTeened"
-	pushEvManualBranchWhiteListed.Ref = "refs/heads/warrens-branch"
+	pushEvManualBranchExempted := pushEv
+	pushEvManualBranchExempted.Pusher.Name = "Warren Teened"
+	pushEvManualBranchExempted.Pusher.Email = "wteened@users.noreply.github.com"
+	pushEvManualBranchExempted.Sender.Login = "WTeened"
+	pushEvManualBranchExempted.Ref = "refs/heads/warrens-branch"
 
-	pushEvManualNotBranchWhiteListed := pushEvManualBranchWhiteListed
-	pushEvManualNotBranchWhiteListed.Ref = "refs/heads/master"
+	pushEvManualNotBranchExempted := pushEvManualBranchExempted
+	pushEvManualNotBranchExempted.Ref = "refs/heads/master"
 
 	pushEvManualCreated := pushEvManual
 	pushEvManualCreated.Created = true
@@ -147,22 +147,22 @@ func TestPush(t *testing.T) {
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If PR merged by a user not in the whitelist but in THIS branch whitelist, we should NOT send a message to sig-contribex and kubernetes-dev.",
-			pushReq:          pushEvManualBranchWhiteListed,
+			name:             "If PR merged by a user not in the exemption list but in THIS branch exemption list, we should NOT send a message to sig-contribex and kubernetes-dev.",
+			pushReq:          pushEvManualBranchExempted,
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If PR merged by a user not in the whitelist, in a branch whitelist, but not THIS branch whitelist, we should send a message to sig-contribex and kubernetes-dev.",
-			pushReq:          pushEvManualBranchWhiteListed,
+			name:             "If PR merged by a user not in the exemption list, in a branch exemption list, but not THIS branch exemption list, we should send a message to sig-contribex and kubernetes-dev.",
+			pushReq:          pushEvManualBranchExempted,
 			expectedMessages: noMessages,
 		},
 		{
-			name:             "If a branch is created by a non-whitelisted user, we send message to sig-contribex and kubernetes-dev with branch created message.",
+			name:             "If a branch is created by a non-exempted user, we send message to sig-contribex and kubernetes-dev with branch created message.",
 			pushReq:          pushEvManualCreated,
 			expectedMessages: createdWarningMessages,
 		},
 		{
-			name:             "If a branch is deleted by a non-whitelisted user, we send message to sig-contribex and kubernetes-dev with branch deleted message.",
+			name:             "If a branch is deleted by a non-exempted user, we send message to sig-contribex and kubernetes-dev with branch deleted message.",
 			pushReq:          pushEvManualDeleted,
 			expectedMessages: deletedWarningMessages,
 		},
@@ -172,10 +172,10 @@ func TestPush(t *testing.T) {
 		SlackConfig: plugins.Slack{
 			MergeWarnings: []plugins.MergeWarning{
 				{
-					Repos:     []string{"kubernetes/kubernetes"},
-					Channels:  []string{"kubernetes-dev", "sig-contribex"},
-					WhiteList: []string{"k8s-merge-robot"},
-					BranchWhiteList: map[string][]string{
+					Repos:       []string{"kubernetes/kubernetes"},
+					Channels:    []string{"kubernetes-dev", "sig-contribex"},
+					ExemptUsers: []string{"k8s-merge-robot"},
+					ExemptBranches: map[string][]string{
 						"warrens-branch": {"wteened"},
 					},
 				},
@@ -342,10 +342,10 @@ func TestHelpProvider(t *testing.T) {
 					MentionChannels: []string{"chan1", "chan2"},
 					MergeWarnings: []plugins.MergeWarning{
 						{
-							Repos:     []string{"org2/repo"},
-							Channels:  []string{"chan1", "chan2"},
-							WhiteList: []string{"k8s-merge-robot"},
-							BranchWhiteList: map[string][]string{
+							Repos:       []string{"org2/repo"},
+							Channels:    []string{"chan1", "chan2"},
+							ExemptUsers: []string{"k8s-merge-robot"},
+							ExemptBranches: map[string][]string{
 								"warrens-branch": {"wteened"},
 							},
 						},


### PR DESCRIPTION
Part of #18801

/kind cleanup
/area prow
/cc @spiffxp @BenTheElder 