### PR TITLE
Plank: Allow startup even when there are defunct kubeconfigs

### DIFF
--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -129,7 +129,7 @@ func main() {
 
 	buildClusterClients, err := o.kubernetes.BuildClusterUncachedRuntimeClients(o.dryRun)
 	if err != nil {
-		logrus.WithError(err).Fatal("Error creating build cluster clients.")
+		logrus.WithError(err).Warning("Error creating build cluster clients.")
 	}
 
 	c, err := plank.NewController(mgr.GetClient(), buildClusterClients, nil, cfg, o.totURL, o.selector)

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -155,7 +155,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		logrus.WithError(err).Fatal("Failed to construct build cluster managers")
+		logrus.WithError(err).Warning("Failed to construct build cluster managers")
 	}
 
 	for _, buildManager := range buildManagers {


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/18866
Fixes #19084 
/assign @michelle192837 