### PR TITLE
Use prow-controller-manager/plank v2

### DIFF
--- a/config/prow/cluster/BUILD.bazel
+++ b/config/prow/cluster/BUILD.bazel
@@ -55,6 +55,7 @@ release(
     component("needs-rebase", "deployment"),
     component("pipeline", "deployment", "rbac"),
     component("plank", "service", "deployment", "rbac"),
+    component("prow_controller_manager", "service", "deployment", "rbac"),
     component("prow-canary-k8s-io", "managedcertificate"),
     component("prow-k8s-io", "managedcertificate"),
     component("prow-kubernetes-io", "managedcertificate"),

--- a/config/prow/cluster/monitoring/prow_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/prow_servicemonitors.yaml
@@ -130,7 +130,7 @@ spec:
       - default
   selector:
     matchLabels:
-      app: plank
+      app: prow-controller-manager
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/config/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/config/prow/cluster/prow_controller_manager_deployment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2017 The Kubernetes Authors All rights reserved.
+# Copyright 2020 The Kubernetes Authors All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,40 +16,34 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   namespace: default
-  name: plank
+  name: prow-controller-manager
   labels:
-    app: plank
+    app: prow-controller-manager
 spec:
-  # Mutually exclusive with prow-controller-manager. Only one of them may have more than zero replicas.
-  # If this is re-enabled, the service monitor must be changed back to point to plank:
-  # https://github.com/kubernetes/test-infra/blob/a35145f8e7e00d72a69dc1e8be57b8cf09184a52/config/prow/cluster/monitoring/prow_servicemonitors.yaml#L133
-  replicas: 0 # Do not scale up.
-  strategy:
-    type: Recreate
+  # Mutually exclusive with plank. Only one of them may have more than zero replicas.
+  replicas: 1
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
-      app: plank
+      app: prow-controller-manager
   template:
     metadata:
       labels:
-        app: plank
+        app: prow-controller-manager
     spec:
-      serviceAccountName: plank
+      serviceAccountName: prow-controller-manager
       containers:
-      - name: plank
-        image: gcr.io/k8s-prow/plank:v20200820-86c379653b
+      - name: prow-controller-manager
+        image: gcr.io/k8s-prow/prow-controller-manager:v20200820-86c379653b
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false
+        - --enable-controller=plank
         - --job-config-path=/etc/job-config
         - --kubeconfig=/etc/kubeconfig/config
-        - --skip-report=true
         volumeMounts:
         - mountPath: /etc/kubeconfig
           name: kubeconfig
-          readOnly: true
-        - name: oauth
-          mountPath: /etc/github
           readOnly: true
         - name: config
           mountPath: /etc/config
@@ -62,9 +56,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: kubeconfig
-      - name: oauth
-        secret:
-          secretName: oauth-token
       - name: config
         configMap:
           name: config

--- a/config/prow/cluster/prow_controller_manager_rbac.yaml
+++ b/config/prow/cluster/prow_controller_manager_rbac.yaml
@@ -1,0 +1,98 @@
+# Copyright 2020 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  namespace: default
+  name: "prow-controller-manager"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: "prow-controller-manager"
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - create
+- apiGroups:
+  - prow.k8s.io
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - update
+  - list
+  - watch
+  - update
+  - patch
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "prow-controller-manager"
+rules:
+- apiGroups:
+   - ""
+  resources:
+  - pods
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+  - get
+  - patch
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: default
+  name: "prow-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "prow-controller-manager"
+subjects:
+- kind: ServiceAccount
+  name: "prow-controller-manager"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  namespace: test-pods
+  name: "prow-controller-manager"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "prow-controller-manager"
+subjects:
+- kind: ServiceAccount
+  name: "prow-controller-manager"
+  namespace: default

--- a/config/prow/cluster/prow_controller_manager_service.yaml
+++ b/config/prow/cluster/prow_controller_manager_service.yaml
@@ -1,0 +1,27 @@
+# Copyright 2020 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: prow-controller-manager
+  namespace: default
+  name: prow-controller-manager
+spec:
+  ports:
+    - name: metrics
+      port: 9090
+  selector:
+    app: prow-controller-manager


### PR DESCRIPTION
This PR changes the prow.k8s.io setup to stop using plank and instead use plank v2 in the prow controller manager.
Advantages:
* Eventbased rather than cronbased, hence reacting much faster to changes in prowjobs or pods
* Per-Prowjob retrying, meaning genuinely broken prowjobs will not be retried forever and transient errors will be retried much quicker
* Uses a cache for the build cluster rather than doing a LIST every 30 seconds, reducing the load on the build clusters api server

We use this in Openshift since the beginning of June (https://github.com/openshift/release/pull/9487), found some issues around cache staleness a day later (https://github.com/kubernetes/test-infra/pull/17860), found some more issues around cache staleness combined with the `max_concurrency` setting a month later in the beginning of July (https://github.com/kubernetes/test-infra/pull/18157) and haven't noticed any issues since.

If there are any other build cluster rbacs, they need to be updated to allow for watching.

Putting on hold because a human should watch the rollout. This can be rolled back easely by setting plank replicas back to 1 and prow-controller-manager replicas to 0.
/hold
/assign @fejta 