### PR TITLE
GCS Kubernetes reporter: use a finalizer

### DIFF
--- a/config/prow/cluster/crier_rbac.yaml
+++ b/config/prow/cluster/crier_rbac.yaml
@@ -51,6 +51,12 @@ rules:
   verbs:
     - "get"
     - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
+++ b/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
@@ -13,8 +13,11 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 
@@ -29,6 +32,7 @@ go_test(
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This PR changes the GCS Kubernetes reporter to use a finalizer in order to ensure that it gets to the point of reporting and avoid situations where pods vanish, e.G. because plank deletes them.

After this PR, if a prowjob gets deleted while it has a running pod for which this reporter already added a finalizer, that pod will get stuck and manual intervention is required. We could work around this by making Sinker remove this finalizer for pods that do not have a corresponding prowjob.

Apart from the unit tests, I also deployed this manually and verified it works as expected.

Fixes https://github.com/kubernetes/test-infra/issues/18701

/cc hasheddan 

Sorry for taking this over, but after doing a different change I realized that this is actually pretty easy and it will be very useful.