### PR TITLE
Cleanup starter-*.yaml

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -301,6 +301,7 @@ spec:
     app: hook
   ports:
   - port: 8888
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -426,6 +427,7 @@ spec:
   ports:
   - port: 80
     targetPort: 8080
+  type: NodePort
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -531,6 +533,7 @@ spec:
   ports:
   - port: 80
     targetPort: 8888
+  type: NodePort
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -89,7 +89,7 @@ data:
         "*": https://prow.<< your-domain.com >>/view/gcs
       report_templates:
         '*': >-
-            [Full PR test history](https://prow..<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
+            [Full PR test history](https://prow.<< your-domain.com >>/pr-history?org={{.Spec.Refs.Org}}&repo={{.Spec.Refs.Repo}}&pr={{with index .Spec.Refs.Pulls 0}}{{.Number}}{{end}}).
             [Your PR dashboard](https://prow.<< your-domain.com >>/pr?query=is:pr+state:open+author:{{with
             index .Spec.Refs.Pulls 0}}{{.Author}}{{end}}).
       default_decoration_configs:
@@ -543,7 +543,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
 spec:
   backend:
-    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#prow_backend)
+    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
     serviceName: deck
     servicePort: 80
   rules:

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -543,7 +543,7 @@ metadata:
     cert-manager.io/cluster-issuer: letsencrypt-staging
 spec:
   backend:
-    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#prow_backend)
+    # specify the default backend for `ingress-gce` (https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#default_backend)
     serviceName: deck
     servicePort: 80
   rules:

--- a/prow/getting_started_deploy.md
+++ b/prow/getting_started_deploy.md
@@ -146,7 +146,7 @@ kubectl create secret generic github-token --from-file=token=/path/to/oauth/secr
 
 There are two sample manifests to get you started:
 * [`starter-s3.yaml`](/config/prow/cluster/starter-s3.yaml) sets up a minio as blob storage for logs and is particularly well suited to quickly get something working
-* [`starter-gcs.yaml`](/config/prow/cluster/starter-gcs.yaml) uses GCS as blob storage and requires additional configuration to set up the bucket and ServiceAccounts. See [this](# Configure a GCS bucket) for details.
+* [`starter-gcs.yaml`](/config/prow/cluster/starter-gcs.yaml) uses GCS as blob storage and requires additional configuration to set up the bucket and ServiceAccounts. See [this](#Configure a GCS bucket) for details.
 
 Regardless of which object storage you choose, the below adjustments are always needed:
 


### PR DESCRIPTION
- Minor formatting and syntax cleanup for `starter-*.yaml` and corresponding docs
- Ensure `type: NodePort` is set for services accessed through GKE loadbalancer (ref: [GKE Ingress for HTTP(S) Load Balancing](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#multiple_backend_services)).