### PR TITLE
Disable PerformanceDNS test

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -87,7 +87,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv6|Example|Federation)\]|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
+        value: \[Feature:(Networking-IPv6|Example|Federation|PerformanceDNS)\]|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true
@@ -144,7 +144,7 @@ periodics:
       - name: FOCUS
         value: \[sig-network\]
       - name: SKIP
-        value: \[Feature:(Networking-IPv4|Example|Federation)\]|Internet.connection|upstream.nameserver|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
+        value: \[Feature:(Networking-IPv4|Example|Federation|PerformanceDNS)\]|Internet.connection|upstream.nameserver|LB.health.check|LoadBalancer|load.balancer|GCE|NetworkPolicy|SCTP|DualStack
       # we need privileged mode in order to do docker in docker
       securityContext:
         privileged: true


### PR DESCRIPTION
This test was very useful to understand several limits of Kubernetes using KIND
- etcd storage size, https://github.com/kubernetes/kubernetes/issues/94029
- controller manager QPS limit, https://kubernetes.slack.com/archives/C09QZTRH7/p1597992971004900

However, it is very disruptive and affects the other jobs, causing them to fail, so better to skip it