### PR TITLE
fix: use latest runc in ci-kubernetes-e2e-ubuntu-gce-containerd

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -292,7 +292,7 @@ presubmits:
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc91
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -353,7 +353,7 @@ presubmits:
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
             - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
-            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc91
+            - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
             - --env=CONTAINER_RUNTIME_TEST_HANDLER=true
@@ -569,7 +569,7 @@ periodics:
           - --extract=ci/latest-fast
           - --env=KUBE_CONTAINER_RUNTIME=containerd
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
-          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc10
+          - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true
           - --env=CONTAINER_RUNTIME_TEST_HANDLER=true


### PR DESCRIPTION
runc v1.0.0-rc92 would retry writing to cgroup files on EINTR error

Signed-off-by: knight42 <anonymousknight96@gmail.com>

Fixes https://github.com/kubernetes/kubernetes/issues/94159

xref: https://github.com/kubernetes/kubernetes/issues/94159#issuecomment-678471572
> @liggitt From https://golang.org/doc/go1.14#runtime:
>
>> Goroutines are now asynchronously preemptible. As a result, loops without function calls no longer potentially deadlock the scheduler or significantly delay garbage collection. This is supported on all platforms except windows/arm, darwin/arm, js/wasm, and plan9/*.
>
>> A consequence of the implementation of preemption is that on Unix systems, including Linux and macOS systems, programs built with Go 1.14 will receive more signals than programs built with earlier releases. This means that programs that use packages like syscall or golang.org/x/sys/unix will see more slow system calls fail with EINTR errors. Those programs will have to handle those errors in some way, most likely looping to try the system call again. For more information about this see man 7 signal for Linux systems or similar documentation for other systems.
>
> this appears to have been fixed in opencontainers/runc@f34eb2c which is included in v1.0.0-rc91+

As @liggitt suggests, we'd better use the latest runc in job `ci-kubernetes-e2e-ubuntu-gce-containerd`.

It is worth noting that we are still using runc v1.0.0-rc10 in 1.18 and 1.19 branch:
* https://github.com/kubernetes/test-infra/blob/18ae41703918b53db754c3e6aa0b7fd9172ab093/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml#L986
* https://github.com/kubernetes/test-infra/blob/18ae41703918b53db754c3e6aa0b7fd9172ab093/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml#L938

I am not sure whether we should update the runc version in these jobs too.