### PR TITLE
chore(gce-ubuntu): switch to containerd v1.4.0

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -352,7 +352,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0-rc.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
Signed-off-by: knight42 <anonymousknight96@gmail.com>

Use containerd v1.4.0 in job `pull-kubernetes-e2e-gce-ubuntu-containerd-canary`.

/cc @dims 