### PR TITLE
image-builder: set Azure CI to always run

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -3,7 +3,7 @@ presubmits:
   - name: pull-azure-all
     labels:
       preset-azure-cred: "true"
-    always_run: false
+    always_run: true
     optional: true
     decorate: true
     decoration_config:


### PR DESCRIPTION
Now that https://github.com/kubernetes-sigs/image-builder/pull/313 has merged, set the presubmit job to always run. Note that it is still optional, will change the job to required as a second step once we have good confidence in the job and it has been running on PRs without issue.

/assign @codenrhoden @detiber 