### PR TITLE
Update kettle pypy source as bitbucket no longer hosts

### DIFF
--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
 
 RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.24.0 influxdb ruamel.yaml==0.16
 
-RUN curl -fsSL https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.6-7.1.1-beta-linux_x86_64-portable.tar.bz2 | tar xj -C opt  && \
+RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.0-linux64.tar.bz2 | tar xj -C opt  && \
     ln -s /opt/pypy*/bin/pypy /usr/bin
 
 RUN curl -o installer https://sdk.cloud.google.com && \

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
 
 RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.24.0 influxdb ruamel.yaml==0.16
 
-RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.0-linux64.tar.bz2 | tar xj -C opt  && \
+RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 | tar xj -C opt  && \
     ln -s /opt/pypy*/bin/pypy /usr/bin
 
 RUN curl -o installer https://sdk.cloud.google.com && \


### PR DESCRIPTION
Updating the pypy version and source as BB has removed hosting

@clarketm It looks like https://github.com/squeaky-pl/portable-pypy version 7.3.0+ can just use pypy from source because the portable parts were added upstream. So I bumped the version here and changed the source. 

#18966 

/area kettle