### PR TITLE
remove mention of StartupProbe feature flag as it is being GA'd

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -281,7 +281,7 @@ periodics:
       - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
-      - --node-test-args=--feature-gates=StartupProbe=true --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
+      - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
       - --node-tests=true
       - --provider=gce
       - --test_args=--nodes=1 --focus="\[Serial\].*\[NodeAlphaFeature:.+\]"


### PR DESCRIPTION
As the StartupProve being GA'd this feature flag needs to be removed.  See PR: https://github.com/kubernetes/kubernetes/pull/94160

This tab was broken for a while as this tab was querying `[NodeAlphaFeature:..]` tests. And this was removed from the test definition for a while now as feature was moved to the beta. 

So this PR can be merged right away. There is very little point in making test show up in this tab again or add this feature flag to the `node-kubelet-serial` tab to make tests work again. Presumably this flag will be removed in master next week.