### PR TITLE
remove node-kubelet-serial-alpha as it doesn't contain any tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -263,36 +263,6 @@ periodics:
     testgrid-dashboards: sig-node-kubelet
     testgrid-tab-name: node-kubelet-serial
 
-- name: ci-kubernetes-node-kubelet-serial-alpha
-  interval: 3h30m
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200903-fd282bc-master
-      args:
-      - --repo=k8s.io/kubernetes=master
-      - --timeout=200
-      - --root=/go/src
-      - --scenario=kubernetes_e2e
-      - --
-      - --deployment=node
-      - --gcp-project-type=node-e2e-project
-      - --gcp-zone=us-west1-b
-      - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial.yaml
-      - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
-      - --node-tests=true
-      - --provider=gce
-      - --test_args=--nodes=1 --focus="\[Serial\].*\[NodeAlphaFeature:.+\]"
-      - --timeout=180m
-      env:
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-node-kubelet
-    testgrid-tab-name: node-kubelet-serial-alpha
-
 - name: ci-kubernetes-node-kubelet-serial-cpu-manager
   interval: 4h
   labels:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -208,13 +208,6 @@ test_groups:
     - target_config: Tests name
     - target_config: Context
     name_format: '%s [%s]'
-- name: ci-kubernetes-node-kubelet-serial-alpha
-  gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-alpha
-  test_name_config:
-    name_elements:
-    - target_config: Tests name
-    - target_config: Context
-    name_format: '%s [%s]'
 - name: ci-kubernetes-node-kubelet-serial-topology-manager
   gcs_prefix: kubernetes-jenkins/logs/ci-kubernetes-node-kubelet-serial-topology-manager
   test_name_config:


### PR DESCRIPTION
See some thoughts on it here: https://github.com/kubernetes/test-infra/issues/18972

This tab has no tests to run.

/sig node
/kind cleanup