### PR TITLE
Add sdnoverlay and sdnbridge testing to sig-windows testgrid

### DIFF
--- a/config/testgrids/kubernetes/sig-windows/OWNERS
+++ b/config/testgrids/kubernetes/sig-windows/OWNERS
@@ -1,0 +1,21 @@
+reviewers:
+- pjh
+- PatrickLang
+- michmike
+- benmoss
+- ddebroy
+- yliaog
+- marosset
+- chewong
+approvers:
+- pjh
+- PatrickLang
+- michmike
+- benmoss
+- ddebroy
+- yliaog
+- marosset
+- chewong
+
+labels:
+- sig/windows

--- a/config/testgrids/kubernetes/sig-windows/config.yaml
+++ b/config/testgrids/kubernetes/sig-windows/config.yaml
@@ -30,6 +30,18 @@ dashboards:
   - name: containerd-overlay-windows-master
     description: Runs Windows e2e tests on K8s clusters with Containerd and Flannel CNI in overlay network mode.
     test_group_name: ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
+  - name: containerd-windows-sac1909-sdnbridge
+    description: Runs Windows (SAC 1909) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in l2bridge network mode.
+    test_group_name: containerd-windows-sac1909-sdnbridge
+  - name: containerd-windows-sac1909-sdnoverlay
+    description: Runs Windows (SAC 1909) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in overlay network mode.
+    test_group_name: containerd-windows-sac1909-sdnoverlay
+  - name: containerd-windows-sac2004-sdnbridge
+    description: Runs Windows (SAC 2004) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in l2bridge network mode.
+    test_group_name: containerd-windows-sac2004-sdnbridge
+  - name: containerd-windows-sac2004-sdnoverlay
+    description: Runs Windows (SAC 2004) e2e tests on stable K8s clusters with Containerd and latest Flannel CNI in overlay network mode.
+    test_group_name: containerd-windows-sac2004-sdnoverlay
 
 test_groups:
 # Flannel CNI on Windows test groups
@@ -41,3 +53,11 @@ test_groups:
   gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnoverlay-ctrd-master-windows
 - name: ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
   gcs_prefix: k8s-ovn/ci-kubernetes-e2e-sdnbridge-ctrd-master-windows
+- name: containerd-windows-sac1909-sdnbridge
+  gcs_prefix: k8s-ovn/containerd-windows-sac1909-sdnbridge
+- name: containerd-windows-sac1909-sdnoverlay
+  gcs_prefix: k8s-ovn/containerd-windows-sac1909-sdnoverlay
+- name: containerd-windows-sac2004-sdnbridge
+  gcs_prefix: k8s-ovn/containerd-windows-sac2004-sdnbridge
+- name: containerd-windows-sac2004-sdnoverlay
+  gcs_prefix: k8s-ovn/containerd-windows-sac2004-sdnoverlay


### PR DESCRIPTION
Update the sig-windows testgrid config with the new prowjobs
that will test the latest `sdnbridge` and `sdnoverlay` CNI
plugins with stable K8s configured with Flannel networking.

The new prowjobs:
* will test the CNI plugins on the latest two Windows SAC
releases: `1909` and `2004`
* are already configured within the current prow environment used
for the other Windows e2e tests
* have some initial results published to the Google cloud storage bucket
* use the existing [e2e-win/k8s-e2e-runner](https://github.com/e2e-win/k8s-e2e-runner) with [cluster-api-provider-azure](https://github.com/kubernetes-sigs/cluster-api-provider-azure)
support for provisioning the testing infrastructure

Signed-off-by: Ionut Balutoiu <ibalutoiu@cloudbasesolutions.com>