### PR TITLE
cluster-api-provider-aws: Cleanup jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -26,6 +26,8 @@ periodics:
         value: "boskos.test-pods.svc.cluster.local"
       - name: AWS_REGION
         value: "us-west-2"
+      - name: NEW_E2E_FLOW
+        value: "1"
       securityContext:
         privileged: true
       resources:
@@ -37,51 +39,11 @@ periodics:
     testgrid-tab-name: periodic-e2e-v1alpha3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-provider-aws-e2e-new-v1alpha3
-  decorate: true
-  decoration_config:
-    timeout: 5h
-  interval: 6h
-  labels:
-    preset-dind-enabled: "true"
-    preset-kind-volume-mounts: "true"
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  extra_refs:
-    - org: kubernetes-sigs
-      repo: cluster-api-provider-aws
-      base_ref: master
-      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-  spec:
-    containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-master
-        command:
-          - "runner.sh"
-          - "./scripts/ci-e2e.sh"
-        env:
-          - name: BOSKOS_HOST
-            value: "boskos.test-pods.svc.cluster.local"
-          - name: AWS_REGION
-            value: "us-west-2"
-          - name: NEW_E2E_FLOW
-            value: "1"
-        securityContext:
-          privileged: true
-        resources:
-          requests:
-            cpu: 1
-            memory: "4Gi"
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-    testgrid-tab-name: periodic-e2e-new-v1alpha3
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    testgrid-num-failures-to-alert: "2"
 - name: periodic-cluster-api-provider-aws-e2e-v1alpha2
   decorate: true
   decoration_config:
     timeout: 5h
-  interval: 6h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -136,7 +98,7 @@ periodics:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-1.18
         command:
           - "runner.sh"
-          - "./scripts/ci-e2e-conformance.sh"
+          - "./scripts/ci-conformance.sh"
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"
@@ -157,7 +119,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  interval: 4h
+  interval: 48h
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
@@ -191,7 +153,7 @@ periodics:
     testgrid-tab-name: periodic-e2e-conformance-v1alpha2
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: ci-cluster-api-provider-aws-make-conformance-v1alpha2-k8s-ci-artifacts
+- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha2-with-k8s-ci-artifacts
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -204,7 +166,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  interval: 4h
+  interval: 48h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-aws
@@ -247,7 +209,7 @@ periodics:
     testgrid-tab-name: capa-conformance-v1alpha2-k8s-master
     testgrid-num-columns-recent: '20'
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-- name: ci-cluster-api-provider-aws-make-conformance-v1alpha3-k8s-ci-artifacts
+- name: periodic-cluster-api-provider-aws-e2e-conformance-v1alpha3-with-k8s-ci-artifacts
   max_concurrency: 1
   labels:
     preset-dind-enabled: "true"
@@ -282,10 +244,11 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
           - name: AWS_REGION
             value: "us-west-2"
+          - name: E2E_ARGS
+            value: "-kubetest.use-ci-artifacts"
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
-          - "--use-ci-artifacts"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -23,40 +23,6 @@ postsubmits:
                 value: "boskos.test-pods.svc.cluster.local"
               - name: AWS_REGION
                 value: "us-west-2"
-            securityContext:
-              privileged: true
-            resources:
-              requests:
-                cpu: 1
-                memory: "4Gi"
-      annotations:
-        testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-        testgrid-tab-name: ci-e2e
-        testgrid-num-columns-recent: '20'
-        testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
-    - name: ci-cluster-api-provider-aws-e2e-new
-      path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-      decorate: true
-      decoration_config:
-        timeout: 5h
-      max_concurrency: 1
-      labels:
-        preset-dind-enabled: "true"
-        preset-kind-volume-mounts: "true"
-        preset-service-account: "true"
-        preset-aws-ssh: "true"
-        preset-aws-credential: "true"
-      spec:
-        containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-master
-            command:
-              - "runner.sh"
-              - "./scripts/ci-e2e.sh"
-            env:
-              - name: BOSKOS_HOST
-                value: "boskos.test-pods.svc.cluster.local"
-              - name: AWS_REGION
-                value: "us-west-2"
               - name: NEW_E2E_FLOW
                 value: "1"
             securityContext:
@@ -67,7 +33,7 @@ postsubmits:
                 memory: "4Gi"
       annotations:
         testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-        testgrid-tab-name: ci-e2e-new
+        testgrid-tab-name: ci-e2e
         testgrid-num-columns-recent: '20'
         testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     - name: ci-cluster-api-provider-aws-e2e-conformance
@@ -87,7 +53,7 @@ postsubmits:
           - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-1.18
             command:
               - "runner.sh"
-              - "./scripts/ci-e2e-conformance.sh"
+              - "./scripts/ci-conformance.sh"
             env:
               - name: BOSKOS_HOST
                 value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -60,8 +60,8 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: verify
-  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
-  - name: pull-cluster-api-provider-aws-make-conformance
+  # conformance test
+  - name: pull-cluster-api-provider-aws-e2e-conformance
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -92,7 +92,6 @@ presubmits:
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
-            - "--use-ci-artifacts"
           env:
             - name: BOSKOS_HOST
               value: "boskos.test-pods.svc.cluster.local"
@@ -108,6 +107,44 @@ presubmits:
               memory: "9000Mi"
               # during the tests more like 3-20m is used
               cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
+      testgrid-tab-name: pr-conformance
+      testgrid-num-columns-recent: '20'
+  # conformance test against kubernetes master branch with `kind` + cluster-api-provider-aws
+  - name: pull-cluster-api-provider-aws-e2e-conformance-with-ci-artifacts
+    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
+    always_run: false
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 4h
+    max_concurrency: 1
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-1.18
+          command:
+            - "runner.sh"
+            - "./scripts/ci-conformance.sh"
+          env:
+            - name: BOSKOS_HOST
+              value: "boskos.test-pods.svc.cluster.local"
+            - name: AWS_REGION
+              value: "us-west-2"
+            - name: E2E_ARGS
+              value: "-kubetest.use-ci-artifacts"
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 1
+              memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
       testgrid-tab-name: pr-conformance-k8s-master
@@ -137,41 +174,6 @@ presubmits:
               value: "boskos.test-pods.svc.cluster.local"
             - name: AWS_REGION
               value: "us-west-2"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 1
-              memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e
-      testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-new
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 5h
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-master
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: AWS_REGION
-              value: "us-west-2"
             - name: NEW_E2E_FLOW
               value: "1"
           securityContext:
@@ -182,40 +184,5 @@ presubmits:
               memory: "4Gi"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e-new
-      testgrid-num-columns-recent: '20'
-  - name: pull-cluster-api-provider-aws-e2e-conformance
-    path_alias: "sigs.k8s.io/cluster-api-provider-aws"
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 4h
-    max_concurrency: 1
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-service-account: "true"
-      preset-aws-ssh: "true"
-      preset-aws-credential: "true"
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-1.18
-          command:
-            - "runner.sh"
-            - "./scripts/ci-e2e-conformance.sh"
-          env:
-            - name: BOSKOS_HOST
-              value: "boskos.test-pods.svc.cluster.local"
-            - name: AWS_REGION
-              value: "us-west-2"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 1
-              memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
-      testgrid-tab-name: pr-e2e-conformance
+      testgrid-tab-name: pr-e2e
       testgrid-num-columns-recent: '20'


### PR DESCRIPTION
Starting clean up of jobs, moving to new e2e flow where needed.
Moving v1alpha2 periodics to every 48h as no longer in development.

/assign @ncdc 