### PR TITLE
move tests to arguments

### DIFF
--- a/triage/summarize/summarize.go
+++ b/triage/summarize/summarize.go
@@ -54,11 +54,9 @@ func parseFlags() summarizeFlags {
 	flag.StringVar(&flags.outputSlices, "output_slices", "", "path to slices output (must include PREFIX in template)")
 	flag.IntVar(&flags.numWorkers, "num_workers", 2*runtime.NumCPU()-1, "number of worker goroutines to spawn for parallelized functions") // This has shown to be a sensible number of workers
 
-	// The tests flag can contain multiple arguments, so we'll split it by space
-	tempTests := flag.String("tests", "", "path to tests.json files from BigQuery")
-
 	flag.Parse()
-	flags.tests = strings.Split(*tempTests, " ")
+	// list of tests files comes from arguments
+	flags.tests = flag.Args()
 
 	// Do some checks on the flags
 	if !(strings.Contains(flags.outputSlices, "PREFIX")) {

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -70,10 +70,10 @@ mkdir -p slices
 
 /triage \
   --builds triage_builds.json \
-  --tests triage_tests/*.json \
   --output failure_data.json \
   --output_slices slices/failure_data_PREFIX.json \
   --num_workers 7  # Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1) corresponding to test-infra-periodics.yaml
+  triage_tests/*.json
 
 gsutil_cp() {
   gsutil -h 'Cache-Control: no-store, must-revalidate' -m cp -Z -a public-read "$@"


### PR DESCRIPTION
We were passing a glob to a flag, in shell this expands to N arguments when there are N matching files so we wind up with (hand converted

`'/triage' '--builds' 'triage_builds.json' '--tests' 'triage_tests/shard_000000000000.json' 'triage_tests/shard_000000000001.json' 'triage_tests/shard_000000000002.json' '--output failure_data.json' '--output_slices slices/failure_data_PREFIX.json' '--num_workers' '7'`

Note particularly: `'--tests' 'triage_tests/shard_000000000000.json' 'triage_tests/shard_000000000001.json' 'triage_tests/shard_000000000002.json'`

Because there's an argument without a flag, go's flag package stops parsing flags, so we fail to set the flags that come after it.

I moved this to the binaries' arguments instead since it's the only repeated flag, and go native flags don't offer repeated flags so we were space splitting.

Another option would be to use a different flag parser and craft the bash to pass `--tests $file` once per file.