### PR TITLE
fix update_summaries.sh missing slash, move num_workers setting to job config

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -36,6 +36,9 @@ periodics:
       env:
       - name: GOOGLE_APPLICATION_CREDENTIALS
         value: /etc/service-account/service-account.json
+      # Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1) corresponding to test-infra-periodics.yaml
+      - name: NUM_WORKERS
+        value: "7"
       command:
       - "timeout"
       args:
@@ -45,8 +48,9 @@ periodics:
       - name: service
         mountPath: /etc/service-account
         readOnly: true
+      # When changing CPUs, also change NUM_WORKERS above
       resources:
-        requests:  # When changing CPUs, also change num_workers flag in triage/update_summaries.sh
+        requests:
           cpu: 4
           memory: 40Gi
         limits:

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -68,14 +68,11 @@ gzip -df triage_tests/*.gz
 
 mkdir -p slices
 
-# --num-workers: Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1) corresponding to test-infra-periodics.yaml
-# TODO: enable passing this flag via $@ instead so we don't have to keep the image
-# in sync with the infra
 /triage \
   --builds triage_builds.json \
   --output failure_data.json \
   --output_slices slices/failure_data_PREFIX.json \
-  --num_workers 7 \
+  ${NUM_WORKERS:+"--num_workers=${NUM_WORKERS}"} \
   triage_tests/*.json
 
 gsutil_cp() {

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -68,11 +68,14 @@ gzip -df triage_tests/*.gz
 
 mkdir -p slices
 
+# --num-workers: Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1) corresponding to test-infra-periodics.yaml
+# TODO: enable passing this flag via $@ instead so we don't have to keep the image
+# in sync with the infra
 /triage \
   --builds triage_builds.json \
   --output failure_data.json \
   --output_slices slices/failure_data_PREFIX.json \
-  --num_workers 7  # Go incorrectly determines the number of CPUs in a pod, set manually to (2*CPUs-1) corresponding to test-infra-periodics.yaml
+  --num_workers 7 \
   triage_tests/*.json
 
 gsutil_cp() {


### PR DESCRIPTION
fixes: https://github.com/kubernetes/test-infra/pull/18984/files#r476656811
also move --num_workers value out into the job config so we can keep it in sync properly