### PR TITLE
Allow test-infra-oncall to bump images in wg-k8s-infra/trusted.

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/OWNERS
@@ -7,3 +7,4 @@ reviewers:
 - bartsmykla
 approvers:
 - wg-k8s-infra-oncall
+- test-infra-oncall


### PR DESCRIPTION
This is needed for test-infra-oncall to approve autobump PRs like this one: https://github.com/kubernetes/test-infra/pull/18932

/assign @spiffxp 
/woof