### PR TITLE
Fix image for periodic-kubernetes-bazel-build-canary

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -214,7 +214,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-master
       imagePullPolicy: Always
       command:
       - bash


### PR DESCRIPTION
I suspect the gcloud command isn't required (or can be replaced
with an appropriate service account) but for now just copy the
non-canary job

Part of https://github.com/kubernetes/test-infra/issues/18653
/cc @BenTheElder @ameukam