### PR TITLE
trigger: avoid double-triggering on `/ok-to-test

### DIFF
--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -135,7 +135,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 			if err != nil {
 				return err
 			}
-			if author == botName {
+			if pr.Sender.Login == botName {
 				c.Logger.Debug("Label added by the bot, skipping.")
 				return nil
 			}


### PR DESCRIPTION
When someone comments `/lgtm`, triggers reacts to that comment by 1)
adding the label 2) triggering the tests. Adding the label causes
another event to happen, which the logic attempts to skip by checking
that the event was caused by the bot, but it incorrectly used the author
(of the PR) for this comparison, not the `sender` field, which is the
[account that caused the event to happen](https://developer.github.com/webhooks/event-payloads/#webhook-payload-object-common-properties).

This PR fixes the comparison to use the event `sender` field.

Proof: I OK'd a PR here: https://github.com/kubernetes/test-infra/pull/18908#issuecomment-680744760 which caused
 
![ok-to-test](https://user-images.githubusercontent.com/712614/91285440-82422780-e78d-11ea-8852-fcb40cc3994e.png)
