### PR TITLE
Update Slack merge warning config to use the new fields

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -205,19 +205,19 @@ slack:
     - kubernetes/org
     channels:
     - sig-contribex
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
   - repos:
     - kubernetes/enhancements
     channels:
     - enhancements
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
   - repos:
     - kubernetes/utils
     channels:
     - sig-architecture
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
   - repos:
     - kubernetes/api
@@ -234,16 +234,16 @@ slack:
     - kubernetes/sample-controller
     channels:
     - sig-api-machinery
-    whitelist:
+    exempt_users:
     - k8s-publishing-bot
   - repos:
     - kubernetes/kubernetes
     channels:
     - kubernetes-dev
-    whitelist:
+    exempt_users:
     - k8s-ci-robot # future home of tide
     - k8s-release-robot # anago
-    branch_whitelist:
+    exempt_branches:
         release-1.16:
             - cpanato # Branch Manager
             - dougm # Patch Release Team
@@ -294,21 +294,21 @@ slack:
     - kubernetes/test-infra
     channels:
     - testing-ops
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
   - repos:
     - kubernetes/sig-release
     channels:
     - sig-release
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
   - repos:
     - kubernetes/release
     channels:
     - sig-release
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
-    branch_whitelist:
+    exempt_branches:
         prototype:
             - justaugustus # k8s-infra prototype Branch Manager
             - tpepper # k8s-infra prototype Branch Manager
@@ -316,7 +316,7 @@ slack:
     - kubernetes/k8s.io
     channels:
     - wg-k8s-infra
-    whitelist:
+    exempt_users:
     - k8s-ci-robot
 
 milestone_applier:


### PR DESCRIPTION
ref: #18801 for switching prow Slack merge warning config to the new fields (continuity of #18946).

/kind cleanup
/area prow