### PR TITLE
releng: milestone applier for 1.20

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -321,19 +321,19 @@ slack:
 
 milestone_applier:
   kubernetes/enhancements:
-    master: v1.19
+    master: v1.20
   kubernetes/kubernetes:
-    master: v1.19
+    master: v1.20
     release-1.19: v1.19
     release-1.18: v1.18
     release-1.17: v1.17
     release-1.16: v1.16
   kubernetes/release:
-    master: v1.19
+    master: v1.20
   kubernetes/sig-release:
-    master: v1.19
+    master: v1.20
   kubernetes/test-infra:
-    master: v1.19
+    master: v1.20
   kubernetes/kops:
     master: v1.19
     release-1.18: v1.18


### PR DESCRIPTION
- Update milestone_applier config to v1.20 for release repos
  - kubernetes/kubernetes
  - kubernetes/release
  - kubernetes/sig-release
  - kubernetes/enhancements
  - kubernetes/test-infra

/hold till 1.19.0 is out
/milestone v1.19
/sig release
/area release-eng
cc: @kubernetes/release-engineering @kubernetes/release-team @onlydole  @cblecker @justaugustus 