### PR TITLE
Migrate periodic-kubernetes-bazel-test job variants to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -346,6 +346,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: bazel-test-1.16
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.16
@@ -364,8 +365,6 @@ periodics:
     - args:
       - test
       - --config=unit
-      - --config=remote
-      - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
       - //...
       - //hack:verify-all
       - --
@@ -377,10 +376,10 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
         requests:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -407,6 +407,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: bazel-test-1.17
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.17
@@ -425,8 +426,6 @@ periodics:
     - args:
       - test
       - --config=unit
-      - --config=remote
-      - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
       - //...
       - //hack:verify-all
       - --
@@ -438,10 +437,10 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
         requests:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -412,6 +412,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.18-blocking, google-unit
     testgrid-tab-name: bazel-test-1.18
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.18
@@ -430,8 +431,6 @@ periodics:
     - args:
       - test
       - --config=unit
-      - --config=remote
-      - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
       - //...
       - //hack:verify-all
       - --
@@ -443,10 +442,10 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
         requests:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -362,6 +362,7 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     testgrid-dashboards: sig-release-1.19-blocking, google-unit
     testgrid-tab-name: bazel-test-1.19
+  cluster: k8s-infra-prow-build
   decorate: true
   extra_refs:
   - base_ref: release-1.19
@@ -380,8 +381,6 @@ periodics:
     - args:
       - test
       - --config=unit
-      - --config=remote
-      - --remote_instance_name=projects/k8s-prow-builds/instances/default_instance
       - //...
       - //hack:verify-all
       - --
@@ -393,10 +392,10 @@ periodics:
       name: ""
       resources:
         limits:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
         requests:
-          cpu: 4
+          cpu: 7
           memory: "38Gi"
 - annotations:
     fork-per-release-generic-suffix: "true"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/test-infra/issues/18652

Adjust resources of the job variants based on the master job.

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>

/assign @spiffxp @BenTheElder 
cc @kubernetes/ci-signal 

/hold