### PR TITLE
Correct intervals for periodic-kubernetes-bazel-test jobs

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -247,7 +247,7 @@ periodics:
     testgrid-dashboards: sig-testing-canaries
     testgrid-tab-name: bazel-test
     description: runs bazel test //... //hack:verify-all -//build/... -//vendor/... (using RBE)
-  interval: 5m
+  interval: 1h
   decorate: true
   labels:
     preset-service-account: "true"
@@ -287,7 +287,7 @@ periodics:
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: bazel-test-master
     description: runs bazel test //... //hack:verify-all -//build/... -//vendor/...
-  interval: 1h
+  interval: 5m
   cluster: k8s-infra-prow-build
   decorate: true
   labels:


### PR DESCRIPTION
The canary and main jobs were swapped, but their intervals were not.
The main job should be running more frequently than the canary

This addresses https://github.com/kubernetes/test-infra/issues/18652#issuecomment-670970119

Followup to https://github.com/kubernetes/test-infra/pull/18613
Part of https://github.com/kubernetes/test-infra/issues/18652