### PR TITLE
create new Prow cron job to update the vulnerability dashboard

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1086,7 +1086,7 @@ periodics:
 - interval: 24h
   cluster: test-infra-trusted
   max_concurrency: 1
-  name: k8sio-vuln-dashboard-cron
+  name: ci-k8sio-vuln-dashboard-update
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1083,3 +1083,26 @@ periodics:
     testgrid-dashboards: sig-release-releng-blocking
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
     testgrid-num-failures-to-alert: '1'
+- interval: 24h
+  cluster: test-infra-trusted
+  max_concurrency: 1
+  name: k8sio-vuln-dashboard-cron
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: master
+  spec:
+    serviceAccountName: k8s-infra-gcr-vuln-dashboard
+    containers:
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+      command:
+      - dashboard
+      args:
+        - -dashboard-file-path=/home/prow/go/src/github.com/kubernetes-sigs/k8s-container-image-promoter/dashboard/
+        - -vuln-target-project=k8s-artifacts-prod
+        - -dashboard-bucket=gs://k8s-artifacts-prod-vuln-dashboard
+  annotations:
+    testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1103,6 +1103,6 @@ periodics:
         - -vuln-target-project=k8s-artifacts-prod
         - -dashboard-bucket=gs://k8s-artifacts-prod-vuln-dashboard
   annotations:
-    testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
+    testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
     testgrid-num-failures-to-alert: '1'


### PR DESCRIPTION
Created a new Prow cron job ("k8s-vuln-dashboard-cron") to run once every 24 hours to update the vulnerability dashboard. The vulnerability dashboard is described in more detail [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/253). 

This Prow job will update the contents of the vulnerability dashboard by reading in vulnerability occurrences from the Container Analysis Service and writing to a json stored in GCS.