### PR TITLE
Update plank dashboard to filter and group by more things

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/plank.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/plank.jsonnet
@@ -2,6 +2,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
+local template = grafana.template;
 
 local legendConfig = {
         legend+: {
@@ -18,36 +19,134 @@ dashboard.new(
         time_from='now-1h',
         schemaVersion=18,
       )
+.addTemplate(
+  template.new(
+    'cluster',
+    'prometheus',
+    'label_values(prowjobs{job="plank"}, cluster)',
+    label='cluster',
+    allValues='.*',
+    includeAll=true,
+    refresh='time',
+  )
+)
+.addTemplate(
+  template.new(
+    'org',
+    'prometheus',
+    'label_values(prowjobs{job="plank"}, org)',
+    label='org',
+    allValues='.*',
+    includeAll=true,
+    refresh='time',
+  )
+)
+.addTemplate(
+  template.new(
+    'repo',
+    'prometheus',
+    'label_values(prowjobs{job="plank"}, repo)',
+    label='repo',
+    allValues='.*',
+    includeAll=true,
+    refresh='time',
+  )
+)
+.addTemplate(
+  template.custom(
+    'state',
+    'all,aborted,error,failure,pending,success,triggered',
+    'all',
+    label='state',
+    includeAll=true,
+    allValues='.*',
+  )
+)
+.addTemplate(
+  template.custom(
+    'type',
+    'all,batch,periodic,presubmit,postsubmit',
+    'all',
+    label='type',
+    includeAll=true,
+    allValues='.*',
+  )
+)
+.addTemplate(
+  template.custom(
+    'group_by_1',
+    'cluster,org,repo,state,type',
+    'type',
+    label='group_by_1',
+    allValues='.*',
+  )
+)
+.addTemplate(
+  template.custom(
+    'group_by_2',
+    'cluster,org,repo,state,type',
+    'state',
+    label='group_by_2',
+    allValues='.*',
+  )
+)
+.addTemplate(
+  template.custom(
+    'group_by_3',
+    'cluster,org,repo,state,type',
+    'cluster',
+    label='group_by_3',
+    allValues='.*',
+  )
+)
 .addPanel(
     (graphPanel.new(
-        'number of Prow jobs by type',
-        description='sum(prowjobs{job="plank"}) by (type)',
+        'number of Prow jobs by ${group_by_1}',
+        description='sum(prowjobs{...}) by (${group_by_1})',
         datasource='prometheus',
         legend_alignAsTable=true,
         legend_rightSide=true,
         
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(prowjobs{job="plank"}) by (type)',
-        legendFormat='{{type}}',
+        'sum(prowjobs{job="plank",cluster=~"${cluster}",org=~"${org}",repo=~"${repo}",state=~"${state}",type=~"${type}"}) by (${group_by_1})',
+        legendFormat='{{${group_by_1}}}',
     )), gridPos={
     h: 9,
     w: 24,
     x: 0,
-    y: 0,
+    y: 9,
   })
 .addPanel(
     (graphPanel.new(
-        'number of Prow jobs by state',
-        description='sum(prowjobs{job="plank"}) by (state)',
+        'number of Prow jobs by ${group_by_2}',
+        description='sum(prowjobs{...}) by (${group_by_2})',
         datasource='prometheus',
         legend_alignAsTable=true,
         legend_rightSide=true,
         
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(prowjobs{job="plank"}) by (state)',
-        legendFormat='{{state}}',
+        'sum(prowjobs{job="plank",cluster=~"${cluster}",org=~"${org}",repo=~"${repo}",state=~"${state}",type=~"${type}"}) by (${group_by_2})',
+        legendFormat='{{${group_by_2}}}',
+    )), gridPos={
+    h: 9,
+    w: 24,
+    x: 0,
+    y: 9,
+  })
+.addPanel(
+    (graphPanel.new(
+        'number of Prow jobs by ${group_by_3}',
+        description='sum(prowjobs{...}) by (${group_by_3})',
+        datasource='prometheus',
+        legend_alignAsTable=true,
+        legend_rightSide=true,
+        
+    ) + legendConfig)
+    .addTarget(prometheus.target(
+        'sum(prowjobs{job="plank",cluster=~"${cluster}",org=~"${org}",repo=~"${repo}",state=~"${state}",type=~"${type}"}) by (${group_by_3})',
+        legendFormat='{{${group_by_3}}}',
     )), gridPos={
     h: 9,
     w: 24,


### PR DESCRIPTION
Allow someone to filter and group by:
- cluster
- org
- repo
- state
- type

Add a third graph panel, and change each graph panel to group by
user-selectable labels

I intially had a graph panel for each of these, but:
- it's a lot of clutter
- it appeared to be timing out prometheus at the 90d range

It turns out each template re-queries prometheus (serially) anytime the
dashboard's time-range changes, and only after templates are refreshed do
queries fired off for the dashboard's panels in parallel. This is necessary
because the `label_values` prometheus query is time-range dependent.

To mitigate this I changed the "type" and "state" templates to use a hardcoded
list of values, since I think it unlikely we're going to add new prowjob types
or states.

This required https://github.com/kubernetes/test-infra/pull/19004 to
merge first so I could use `template.custom`