### PR TITLE
image-builder: change Azure presubmit to run if capi directory has changed

### DIFF
--- a/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/image-builder/image-builder-presubmits.yaml
@@ -3,12 +3,11 @@ presubmits:
   - name: pull-azure-all
     labels:
       preset-azure-cred: "true"
-    always_run: true
-    optional: true
     decorate: true
+    run_if_changed: 'images/capi/.*'
     decoration_config:
       timeout: 1h
-    max_concurrency: 12
+    max_concurrency: 5
     path_alias: sigs.k8s.io/image-builder
     spec:
       containers:


### PR DESCRIPTION
Now that we've collected data over the past few days of the job running in optional mode, and after discussing at office hours, change the job to no longer be optional and run if anything in capi has changed. Also adjusts the max concurrency to 12.

/assign @codenrhoden @moshloop @detiber 