### PR TITLE
Kops - update gce-latest e2e job to use latest-experimental kubekins image

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-gce.yaml
@@ -65,7 +65,8 @@ periodics:
       - --provider=gce
       - --timeout=140m
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Firewall|Dashboard|Services.*functioning.*NodePort
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200825-523865b-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+      imagePullPolicy: Always
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-kops-gce, kops-gce
     testgrid-tab-name: kops-gce-latest


### PR DESCRIPTION
hoping to get some signal from https://github.com/kubernetes/test-infra/pull/18870 before office hours tomorrow.

This job has been failing for a long time, hoping to get it green soon.