### PR TITLE
Plank: Mark jobs whose pod is deleted as done

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -415,9 +415,11 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 				}
 				break
 			}
-			// Pod is running. Do nothing.
-			c.incrementNumPendingJobs(pj.Spec.Job)
-			return nil
+			if pod.DeletionTimestamp == nil {
+				// Pod is running. Do nothing.
+				c.incrementNumPendingJobs(pj.Spec.Job)
+				return nil
+			}
 		case corev1.PodRunning:
 			maxPodRunning := c.config().Plank.PodRunningTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
@@ -435,11 +437,22 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 				return fmt.Errorf("failed to delete pod %s/%s in cluster %s: %w", pod.Namespace, pod.Name, pj.ClusterAlias(), err)
 			}
 		default:
-			// other states, ignore
-			c.incrementNumPendingJobs(pj.Spec.Job)
-			return nil
+			if pod.DeletionTimestamp == nil {
+				// other states, ignore
+				c.incrementNumPendingJobs(pj.Spec.Job)
+				return nil
+			}
 		}
 	}
+
+	// If a pod gets deleted unexpectedly, it might be in any phase and will stick around until
+	// we complete the job if the kubernetes reporter is used, because it sets a finalizer.
+	if !pj.Complete() && pod.DeletionTimestamp != nil {
+		pj.SetComplete()
+		pj.Status.State = prowapi.ErrorState
+		pj.Status.Description = "Pod got deleteted unexpectedly"
+	}
+
 	var err error
 	pj.Status.URL, err = pjutil.JobURL(c.config().Plank, pj, c.log)
 	if err != nil {

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1413,6 +1413,63 @@ func TestSyncPendingJob(t *testing.T) {
 			ExpectedState:   prowapi.PendingState,
 			ExpectedNumPods: 1,
 		},
+		{
+			Name: "Pod deleted in pending phase, job marked as errored",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "deleted-pod-in-pending-marks-job-as-errored",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "deleted-pod-in-pending-marks-job-as-errored",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "deleted-pod-in-pending-marks-job-as-errored",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Second)},
+						DeletionTimestamp: func() *metav1.Time { n := metav1.Now(); return &n }(),
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodPending,
+					},
+				},
+			},
+			ExpectedState:    prowapi.ErrorState,
+			ExpectedComplete: true,
+			ExpectedNumPods:  1,
+		},
+		{
+			Name: "Pod deleted in unset phase, job marked as errored",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-deleted-in-unset-phase",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "pod-deleted-in-unset-phase",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod-deleted-in-unset-phase",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Second)},
+						DeletionTimestamp: func() *metav1.Time { n := metav1.Now(); return &n }(),
+					},
+				},
+			},
+			ExpectedState:    prowapi.ErrorState,
+			ExpectedComplete: true,
+			ExpectedNumPods:  1,
+		},
 	}
 
 	// Copy the tests for PlankV2

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -368,7 +368,9 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 				break
 			}
 			// Pod is running. Do nothing.
-			return nil
+			if pod.DeletionTimestamp == nil {
+				return nil
+			}
 		case corev1.PodRunning:
 			maxPodRunning := r.config().Plank.PodRunningTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
@@ -385,9 +387,19 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 				return fmt.Errorf("failed to delete pod %s/%s in cluster %s: %w", pod.Namespace, pod.Name, pj.ClusterAlias(), err)
 			}
 		default:
-			// other states, ignore
-			return nil
+			if pod.DeletionTimestamp == nil {
+				// other states, ignore
+				return nil
+			}
 		}
+	}
+
+	// If a pod gets deleted unexpectedly, it might be in any phase and will stick around until
+	// we complete the job if the kubernetes reporter is used, because it sets a finalizer.
+	if !pj.Complete() && pod != nil && pod.DeletionTimestamp != nil {
+		pj.SetComplete()
+		pj.Status.State = prowv1.ErrorState
+		pj.Status.Description = "Pod got deleteted unexpectedly"
 	}
 
 	pj.Status.URL, err = pjutil.JobURL(r.config().Plank, *pj, r.log)


### PR DESCRIPTION
Currently its possible that a pod gets deleted, hangs around because of the kubernetes reporter finalizer but the job is not marked as completed, resulting in the pod staying around and the job getting stuck.

This PR changes Plank to mark jobs for which the pod got deleted but still exists as errored.

A sample pod manifest for this can be found here: https://gist.github.com/alvaroaleman/1864aa808958a2cb1cdab4aed869466f