### PR TITLE
Sinker: Fix log to contain cluster name and not cluster index

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -142,10 +142,9 @@ func main() {
 		logrus.WithError(err).Fatal("Error creating build cluster clients.")
 	}
 
-	var podClients []podInterface
-	for _, client := range buildClusterClients {
-		// sinker doesn't care about build cluster aliases
-		podClients = append(podClients, client)
+	podClients := map[string]podInterface{}
+	for cluster, client := range buildClusterClients {
+		podClients[cluster] = client
 	}
 
 	c := controller{
@@ -175,7 +174,7 @@ type controller struct {
 	cancel        context.CancelFunc
 	logger        *logrus.Entry
 	prowJobClient ctrlruntimeclient.Client
-	podClients    []podInterface
+	podClients    map[string]podInterface
 	config        config.Getter
 	runOnce       bool
 }

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -22,6 +22,7 @@ import (
 	"flag"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -688,9 +689,9 @@ func TestClean(t *testing.T) {
 
 	fpjc := fakectrlruntimeclient.NewFakeClient(prowJobs...)
 	fkc := []*corev1fake.Clientset{corev1fake.NewSimpleClientset(pods...), corev1fake.NewSimpleClientset(podsTrusted...)}
-	fpc := []podInterface{unreachableCluster{}}
-	for _, fakeClient := range fkc {
-		fpc = append(fpc, &finalizerFreeDeleteEnforcingClient{t: t, PodInterface: fakeClient.CoreV1().Pods("ns")})
+	fpc := map[string]podInterface{"unreachable": unreachableCluster{}}
+	for idx, fakeClient := range fkc {
+		fpc[strconv.Itoa(idx)] = &finalizerFreeDeleteEnforcingClient{t: t, PodInterface: fakeClient.CoreV1().Pods("ns")}
 	}
 	// Run
 	c := controller{


### PR DESCRIPTION
Currently, we see something like

```
{"cluster":5,"component":"sinker","file":"prow/cmd/sinker/main.go:474","func":"main.(*controller).deletePod","level":"info","msg":"Deleted old completed pod.","pod":"89982bef-e878-11ea-aed8-0a580a820a13","reason":"aged","severity":"info","time":"2020-08-27T21:19:41Z"}
```

which is head to reason about at best.