### PR TITLE
Crier: Pass on logger onto reporters

### DIFF
--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
         "//prow/client/clientset/versioned/fake:go_default_library",
         "//prow/client/listers/prowjobs/v1:go_default_library",
         "//prow/kube:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/prow/crier/controller_test.go
+++ b/prow/crier/controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -49,7 +50,7 @@ type fakeReporter struct {
 	shouldReportFunc func(pj *prowv1.ProwJob) bool
 }
 
-func (f *fakeReporter) Report(pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
+func (f *fakeReporter) Report(_ *logrus.Entry, pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
 	f.reported = append(f.reported, pj.Spec.Job)
 	return []*prowv1.ProwJob{pj}, nil
 }
@@ -58,7 +59,7 @@ func (f *fakeReporter) GetName() string {
 	return reporterName
 }
 
-func (f *fakeReporter) ShouldReport(pj *prowv1.ProwJob) bool {
+func (f *fakeReporter) ShouldReport(_ *logrus.Entry, pj *prowv1.ProwJob) bool {
 	return f.shouldReportFunc(pj)
 }
 

--- a/prow/crier/reporters/gcs/BUILD.bazel
+++ b/prow/crier/reporters/gcs/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
         "//prow/crier/reporters/gcs/internal/testutil:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/prow/crier/reporters/gcs/internal/util/util.go
+++ b/prow/crier/reporters/gcs/internal/util/util.go
@@ -53,8 +53,8 @@ func (sa StorageAuthor) NewWriter(ctx context.Context, bucket, path string, over
 }
 
 func WriteContent(ctx context.Context, logger *logrus.Entry, author Author, bucket, path string, overwrite bool, content []byte) error {
-	log := logger.WithFields(logrus.Fields{"bucket": bucket, "path": path})
-	log.Debugf("Uploading to %s/%s; overwrite: %v", bucket, path, overwrite)
+	log := logger.WithFields(logrus.Fields{"bucket": bucket, "path": path, "overwrite": overwrite})
+	log.Debug("Uploading")
 	w, err := author.NewWriter(ctx, bucket, path, overwrite)
 	if err != nil {
 		return err

--- a/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
+++ b/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/crier/reporters/gcs/internal/testutil:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",

--- a/prow/crier/reporters/gcs/kubernetes/reporter_test.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -110,7 +111,7 @@ func TestShouldReport(t *testing.T) {
 			}
 
 			kgr := internalNew(testutil.Fca{}.Config, nil, nil, 1.0, false)
-			shouldReport := kgr.ShouldReport(pj)
+			shouldReport := kgr.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if shouldReport != tc.shouldReport {
 				t.Errorf("Expected ShouldReport() to return %v, but got %v", tc.shouldReport, shouldReport)
 			}
@@ -326,7 +327,7 @@ func TestReportPodInfo(t *testing.T) {
 			}
 			author := &testutil.TestAuthor{}
 			reporter := internalNew(fca.Config, author, rg, 1.0, tc.dryRun)
-			err := reporter.report(pj)
+			err := reporter.report(logrus.NewEntry(logrus.StandardLogger()), pj)
 
 			if tc.expectErr {
 				if err == nil {

--- a/prow/crier/reporters/gcs/reporter.go
+++ b/prow/crier/reporters/gcs/reporter.go
@@ -39,30 +39,29 @@ const reporterName = "gcsreporter"
 type gcsReporter struct {
 	cfg    config.Getter
 	dryRun bool
-	logger *logrus.Entry
 	author util.Author
 }
 
-func (gr *gcsReporter) Report(pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
+func (gr *gcsReporter) Report(log *logrus.Entry, pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second) // TODO: pass through a global context?
 	defer cancel()
 
 	_, _, err := util.GetJobDestination(gr.cfg, pj)
 	if err != nil {
-		gr.logger.Infof("Not uploading %q (%s#%s) because we couldn't find a destination: %v", pj.Name, pj.Spec.Job, pj.Status.BuildID, err)
+		log.WithError(err).Info("Not uploading prowjob because we couldn't find a destination")
 		return []*prowv1.ProwJob{pj}, nil
 	}
-	stateErr := gr.reportJobState(ctx, pj)
-	prowjobErr := gr.reportProwjob(ctx, pj)
+	stateErr := gr.reportJobState(ctx, log, pj)
+	prowjobErr := gr.reportProwjob(ctx, log, pj)
 
 	return []*prowv1.ProwJob{pj}, utilerrors.NewAggregate([]error{stateErr, prowjobErr})
 }
 
-func (gr *gcsReporter) reportJobState(ctx context.Context, pj *prowv1.ProwJob) error {
-	startedErr := gr.reportStartedJob(ctx, pj)
+func (gr *gcsReporter) reportJobState(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) error {
+	startedErr := gr.reportStartedJob(ctx, log, pj)
 	var finishedErr error
 	if pj.Complete() {
-		finishedErr = gr.reportFinishedJob(ctx, pj)
+		finishedErr = gr.reportFinishedJob(ctx, log, pj)
 	}
 	return utilerrors.NewAggregate([]error{startedErr, finishedErr})
 }
@@ -70,7 +69,7 @@ func (gr *gcsReporter) reportJobState(ctx context.Context, pj *prowv1.ProwJob) e
 // reportStartedJob uploads a started.json for the job. This will almost certainly
 // happen before the pod itself gets to upload one, at which point the pod will
 // upload its own. If for some reason one already exists, it will not be overwritten.
-func (gr *gcsReporter) reportStartedJob(ctx context.Context, pj *prowv1.ProwJob) error {
+func (gr *gcsReporter) reportStartedJob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) error {
 	s := metadata.Started{
 		Timestamp: pj.Status.StartTime.Unix(),
 		Metadata:  metadata.Metadata{"uploader": "crier"},
@@ -85,15 +84,15 @@ func (gr *gcsReporter) reportStartedJob(ctx context.Context, pj *prowv1.ProwJob)
 		return fmt.Errorf("failed to get job destination: %v", err)
 	}
 
-	gr.logger.Debugf("Would upload started.json to %q/%q", bucketName, dir)
 	if gr.dryRun {
+		log.WithFields(logrus.Fields{"bucketName": bucketName, "dir": dir}).Debug("Would upload started.json")
 		return nil
 	}
-	return util.WriteContent(ctx, gr.logger, gr.author, bucketName, path.Join(dir, prowv1.StartedStatusFile), false, output)
+	return util.WriteContent(ctx, log, gr.author, bucketName, path.Join(dir, prowv1.StartedStatusFile), false, output)
 }
 
 // reportFinishedJob uploads a finished.json for the job, iff one did not already exist.
-func (gr *gcsReporter) reportFinishedJob(ctx context.Context, pj *prowv1.ProwJob) error {
+func (gr *gcsReporter) reportFinishedJob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) error {
 	if !pj.Complete() {
 		return errors.New("cannot report finished.json for incomplete job")
 	}
@@ -115,14 +114,14 @@ func (gr *gcsReporter) reportFinishedJob(ctx context.Context, pj *prowv1.ProwJob
 		return fmt.Errorf("failed to get job destination: %v", err)
 	}
 
-	gr.logger.Debugf("Would upload finished.json info to %q/%q", bucketName, dir)
 	if gr.dryRun {
+		log.WithFields(logrus.Fields{"bucketName": bucketName, "dir": dir}).Debug("Would upload finished.json")
 		return nil
 	}
-	return util.WriteContent(ctx, gr.logger, gr.author, bucketName, path.Join(dir, prowv1.FinishedStatusFile), false, output)
+	return util.WriteContent(ctx, log, gr.author, bucketName, path.Join(dir, prowv1.FinishedStatusFile), false, output)
 }
 
-func (gr *gcsReporter) reportProwjob(ctx context.Context, pj *prowv1.ProwJob) error {
+func (gr *gcsReporter) reportProwjob(ctx context.Context, log *logrus.Entry, pj *prowv1.ProwJob) error {
 	// Unconditionally dump the prowjob to GCS, on all job updates.
 	output, err := json.MarshalIndent(pj, "", "\t")
 	if err != nil {
@@ -134,18 +133,18 @@ func (gr *gcsReporter) reportProwjob(ctx context.Context, pj *prowv1.ProwJob) er
 		return fmt.Errorf("failed to get job destination: %v", err)
 	}
 
-	gr.logger.Debugf("Would upload pod info to %q/%q", bucketName, dir)
 	if gr.dryRun {
+		log.WithFields(logrus.Fields{"bucketName": bucketName, "dir": dir}).Debug("Would upload pod info")
 		return nil
 	}
-	return util.WriteContent(ctx, gr.logger, gr.author, bucketName, path.Join(dir, "prowjob.json"), true, output)
+	return util.WriteContent(ctx, log, gr.author, bucketName, path.Join(dir, "prowjob.json"), true, output)
 }
 
 func (gr *gcsReporter) GetName() string {
 	return reporterName
 }
 
-func (gr *gcsReporter) ShouldReport(pj *prowv1.ProwJob) bool {
+func (gr *gcsReporter) ShouldReport(_ *logrus.Entry, pj *prowv1.ProwJob) bool {
 	// We can only report jobs once they have a build ID. By denying responsibility
 	// for it until it has one, crier will not mark us as having handled it until
 	// it is possible for us to handle it, ensuring that we get a chance to see it.
@@ -160,7 +159,6 @@ func newWithAuthor(cfg config.Getter, author util.Author, dryRun bool) *gcsRepor
 	return &gcsReporter{
 		cfg:    cfg,
 		dryRun: dryRun,
-		logger: logrus.WithField("component", reporterName),
 		author: author,
 	}
 }

--- a/prow/crier/reporters/gcs/reporter_test.go
+++ b/prow/crier/reporters/gcs/reporter_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/testgrid/metadata"
 	"github.com/google/go-cmp/cmp"
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -108,7 +109,7 @@ func TestReportJobFinished(t *testing.T) {
 				},
 			}
 
-			err := reporter.reportFinishedJob(ctx, pj)
+			err := reporter.reportFinishedJob(ctx, logrus.NewEntry(logrus.StandardLogger()), pj)
 			if tc.expectErr {
 				if err == nil {
 					t.Fatalf("Expected an error, but didn't get one.")
@@ -185,7 +186,7 @@ func TestReportJobStarted(t *testing.T) {
 				},
 			}
 
-			err := reporter.reportStartedJob(ctx, pj)
+			err := reporter.reportStartedJob(ctx, logrus.NewEntry(logrus.StandardLogger()), pj)
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -248,7 +249,7 @@ func TestReportProwJob(t *testing.T) {
 		},
 	}
 
-	if err := reporter.reportProwjob(ctx, pj); err != nil {
+	if err := reporter.reportProwjob(ctx, logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
 		t.Fatalf("Unexpected error calling reportProwjob: %v", err)
 	}
 
@@ -301,7 +302,7 @@ func TestShouldReport(t *testing.T) {
 				},
 			}
 			gr := newWithAuthor(testutil.Fca{}.Config, nil, false)
-			result := gr.ShouldReport(pj)
+			result := gr.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if result != tc.shouldReport {
 				t.Errorf("Got ShouldReport() returned %v, but expected %v", result, tc.shouldReport)
 			}

--- a/prow/crier/reporters/gerrit/BUILD.bazel
+++ b/prow/crier/reporters/gerrit/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//prow/client/listers/prowjobs/v1:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/kube:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -1065,7 +1066,7 @@ func TestReport(t *testing.T) {
 			fl := &fakeLister{pjs: allpj}
 			reporter := &Client{gc: fgc, lister: fl}
 
-			shouldReport := reporter.ShouldReport(tc.pj)
+			shouldReport := reporter.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), tc.pj)
 			if shouldReport != tc.expectReport {
 				t.Errorf("shouldReport: %v, expectReport: %v", shouldReport, tc.expectReport)
 			}
@@ -1074,7 +1075,7 @@ func TestReport(t *testing.T) {
 				return
 			}
 
-			reportedJobs, err := reporter.Report(tc.pj)
+			reportedJobs, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), tc.pj)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -117,7 +117,7 @@ func (c *Client) GetName() string {
 }
 
 // ShouldReport returns if this prowjob should be reported by the github reporter
-func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
+func (c *Client) ShouldReport(_ *logrus.Entry, pj *v1.ProwJob) bool {
 
 	switch {
 	case pj.Labels[client.GerritReportLabel] != "":
@@ -132,7 +132,7 @@ func (c *Client) ShouldReport(pj *v1.ProwJob) bool {
 }
 
 // Report will report via reportlib
-func (c *Client) Report(pj *v1.ProwJob) ([]*v1.ProwJob, error) {
+func (c *Client) Report(_ *logrus.Entry, pj *v1.ProwJob) ([]*v1.ProwJob, error) {
 
 	// The github comment create/update/delete done for presubmits
 	// needs pr-level locking to avoid racing when reporting multiple

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -95,7 +96,7 @@ func TestShouldReport(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			c := NewReporter(nil, nil, tc.reportAgent)
-			if r := c.ShouldReport(&tc.pj); r == tc.report {
+			if r := c.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), &tc.pj); r == tc.report {
 				return
 			}
 			if tc.report {
@@ -145,13 +146,13 @@ func TestPresumitReportingLocks(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		if _, err := reporter.Report(pj); err != nil {
+		if _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
 			t.Errorf("error reporting: %v", err)
 		}
 		wg.Done()
 	}()
 	go func() {
-		if _, err := reporter.Report(pj); err != nil {
+		if _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
 			t.Errorf("error reporting: %v", err)
 		}
 		wg.Done()
@@ -219,7 +220,7 @@ func TestReport(t *testing.T) {
 			}
 
 			errMsg := ""
-			_, err := c.Report(pj)
+			_, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if err != nil {
 				errMsg = err.Error()
 			}

--- a/prow/crier/reporters/pubsub/BUILD.bazel
+++ b/prow/crier/reporters/pubsub/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )
@@ -28,6 +29,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/io/providers:go_default_library",
         "//prow/spyglass/api:go_default_library",
+        "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",
     ],
 )

--- a/prow/crier/reporters/pubsub/reporter.go
+++ b/prow/crier/reporters/pubsub/reporter.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/pubsub"
+	"github.com/sirupsen/logrus"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
@@ -85,14 +86,14 @@ func findLabels(pj *prowapi.ProwJob, labels ...string) map[string]string {
 }
 
 // ShouldReport tells if a prowjob should be reported by this reporter
-func (c *Client) ShouldReport(pj *prowapi.ProwJob) bool {
+func (c *Client) ShouldReport(_ *logrus.Entry, pj *prowapi.ProwJob) bool {
 	pubSubMap := findLabels(pj, PubSubProjectLabel, PubSubTopicLabel)
 	return pubSubMap[PubSubProjectLabel] != "" && pubSubMap[PubSubTopicLabel] != ""
 }
 
 // Report takes a prowjob, and generate a pubsub ReportMessage and publish to specific Pub/Sub topic
 // based on Pub/Sub related labels if they exist in this prowjob
-func (c *Client) Report(pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error) {
+func (c *Client) Report(_ *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error) {
 	message := c.generateMessageFromPJ(pj)
 
 	ctx := context.Background()

--- a/prow/crier/reporters/pubsub/reporter_test.go
+++ b/prow/crier/reporters/pubsub/reporter_test.go
@@ -21,6 +21,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -429,7 +430,7 @@ func TestShouldReport(t *testing.T) {
 	c := NewReporter(fakeConfigAgent.Config)
 
 	for _, tc := range testcases {
-		r := c.ShouldReport(tc.pj)
+		r := c.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), tc.pj)
 
 		if r != tc.expectedResult {
 			t.Errorf("Unexpected result from test: %s.\nExpected: %v\nGot: %v",

--- a/prow/crier/reporters/slack/BUILD.bazel
+++ b/prow/crier/reporters/slack/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
-        "//prow/pjutil:go_default_library",
         "//prow/slack:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/prow/crier/reporters/slack/reporter_test.go
+++ b/prow/crier/reporters/slack/reporter_test.go
@@ -200,10 +200,9 @@ func TestShouldReport(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reporter := &slackReporter{
 				config: cfgGetter,
-				logger: logrus.NewEntry(&logrus.Logger{}),
 			}
 
-			if result := reporter.ShouldReport(tc.pj); result != tc.expected {
+			if result := reporter.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), tc.pj); result != tc.expected {
 				t.Errorf("expected result to be %t but was %t", tc.expected, result)
 			}
 		})
@@ -227,17 +226,16 @@ func TestReloadsConfig(t *testing.T) {
 
 	reporter := &slackReporter{
 		config: cfgGetter,
-		logger: logrus.NewEntry(&logrus.Logger{}),
 	}
 
-	if shouldReport := reporter.ShouldReport(pj); shouldReport {
+	if shouldReport := reporter.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), pj); shouldReport {
 		t.Error("Did expect shouldReport to be false")
 	}
 
 	cfg.JobStatesToReport = []v1.ProwJobState{v1.FailureState}
 	cfg.JobTypesToReport = []v1.ProwJobType{v1.PostsubmitJob}
 
-	if shouldReport := reporter.ShouldReport(pj); !shouldReport {
+	if shouldReport := reporter.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), pj); !shouldReport {
 		t.Error("Did expect shouldReport to be true after config change")
 	}
 }
@@ -460,7 +458,6 @@ func TestShouldReportDefaultsToExtraRefs(t *testing.T) {
 		},
 	}
 	sr := slackReporter{
-		logger: logrus.NewEntry(logrus.New()),
 		config: func(r *v1.Refs) config.SlackReporter {
 			if r.Org == "org" {
 				return config.SlackReporter{
@@ -472,7 +469,7 @@ func TestShouldReportDefaultsToExtraRefs(t *testing.T) {
 		},
 	}
 
-	if !sr.ShouldReport(job) {
+	if !sr.ShouldReport(logrus.NewEntry(logrus.StandardLogger()), job) {
 		t.Fatal("expected job to report but did not")
 	}
 }
@@ -502,7 +499,6 @@ func TestReportDefaultsToExtraRefs(t *testing.T) {
 		},
 	}
 	sr := slackReporter{
-		logger: logrus.NewEntry(logrus.New()),
 		config: func(r *v1.Refs) config.SlackReporter {
 			if r.Org == "org" {
 				return config.SlackReporter{
@@ -517,7 +513,7 @@ func TestReportDefaultsToExtraRefs(t *testing.T) {
 		client: &fakeSlackClient{},
 	}
 
-	if _, err := sr.Report(job); err != nil {
+	if _, err := sr.Report(logrus.NewEntry(logrus.StandardLogger()), job); err != nil {
 		t.Fatalf("reporting failed: %v", err)
 	}
 	if sr.client.(*fakeSlackClient).messages["emercengy"] != "there you go" {

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -93,8 +93,8 @@ type messageInterface interface {
 }
 
 type reportClient interface {
-	Report(pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error)
-	ShouldReport(pj *prowapi.ProwJob) bool
+	Report(log *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error)
+	ShouldReport(log *logrus.Entry, pj *prowapi.ProwJob) bool
 }
 
 type pubSubMessage struct {
@@ -163,8 +163,8 @@ func (s *Subscriber) handlePeriodicJob(l *logrus.Entry, msg messageInterface, su
 	reportProwJobFailure := func(pj *prowapi.ProwJob, err error) {
 		pj.Status.State = prowapi.ErrorState
 		pj.Status.Description = err.Error()
-		if s.Reporter.ShouldReport(&prowJob) {
-			if _, err := s.Reporter.Report(&prowJob); err != nil {
+		if s.Reporter.ShouldReport(l, &prowJob) {
+			if _, err := s.Reporter.Report(l, &prowJob); err != nil {
 				l.Warningf("failed to report status. %v", err)
 			}
 		}

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -101,12 +101,12 @@ type fakeReporter struct {
 	reported bool
 }
 
-func (r *fakeReporter) Report(pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error) {
+func (r *fakeReporter) Report(_ *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error) {
 	r.reported = true
 	return nil, nil
 }
 
-func (r *fakeReporter) ShouldReport(pj *prowapi.ProwJob) bool {
+func (r *fakeReporter) ShouldReport(_ *logrus.Entry, pj *prowapi.ProwJob) bool {
 	return pj.Annotations[reporter.PubSubProjectLabel] != "" && pj.Annotations[reporter.PubSubTopicLabel] != ""
 }
 


### PR DESCRIPTION
Today, all the crier reporters have their own logger that may or may not
have certain fields which makes them extremely hard to debug.

This PR changes the reporter interface to include a logger and makes the
reporters use that.