### PR TITLE
WIP: kops staging build: Build tagged builds not as CI

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-kops.yaml
+++ b/config/jobs/image-pushing/k8s-staging-kops.yaml
@@ -10,9 +10,6 @@ postsubmits:
       branches:
         - ^master$
         - ^release-.*
-        # Build tags also
-        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         serviceAccountName: gcb-builder
         containers:
@@ -26,3 +23,30 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --with-git-dir
               - .
+
+    - name: kops-postsubmit-push-to-staging-tagged
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # this is the name of some testgrid dashboard to report to.
+        testgrid-dashboards: sig-cluster-lifecycle-kops, kops-misc
+      decorate: true
+      branches:
+        # Build tagged versions
+        # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200824-5d057db
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
+              - --project=k8s-staging-kops
+              - --scratch-bucket=gs://k8s-staging-kops-gcb
+              - --env-passthrough=PULL_BASE_REF,TAGGED_BUILD
+              - --with-git-dir
+              - .
+            env:
+            - name: TAGGED_BUILD
+              value: "1" # Use the git tag as the version & image tag


### PR DESCRIPTION
Continuous builds have a tag that includes the git sha; for tagged
builds we only want to use the tag.