### PR TITLE
Kops - use custom GCS state store for all kops commands

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -62,7 +62,7 @@ var (
 	// kops specific flags.
 	kopsPath         = flag.String("kops", "", "(kops only) Path to the kops binary. kops will be downloaded from kops-base-url if not set.")
 	kopsCluster      = flag.String("kops-cluster", "", "(kops only) Deprecated. Cluster name for kops; if not set defaults to --cluster.")
-	kopsState        = flag.String("kops-state", "", "(kops only) s3:// path to kops state store. Must be set.")
+	kopsState        = flag.String("kops-state", "", "(kops only) s3:// path to kops state store. Must be set for the AWS provider.")
 	kopsSSHUser      = flag.String("kops-ssh-user", os.Getenv("USER"), "(kops only) Username for SSH connections to nodes.")
 	kopsSSHKey       = flag.String("kops-ssh-key", "", "(kops only) Path to ssh key-pair for each node (defaults '~/.ssh/kube_aws_rsa' if unset.)")
 	kopsSSHPublicKey = flag.String("kops-ssh-public-key", "", "(kops only) Path to ssh public key for each node (defaults to --kops-ssh-key value with .pub suffix if unset.)")
@@ -206,9 +206,15 @@ func newKops(provider, gcpProject, cluster string) (*kops, error) {
 	if cluster == "" {
 		return nil, fmt.Errorf("--cluster or --kops-cluster must be set to a valid cluster name for kops deployment")
 	}
-	if *kopsState == "" {
-		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployment")
+	if *kopsState == "" && provider != "gce" {
+		return nil, fmt.Errorf("--kops-state must be set to a valid S3 path for kops deployments on AWS")
+	} else if provider == "gce" {
+		kopsState, err = setupGCEStateStore(gcpProject)
+		if err != nil {
+			return nil, err
+		}
 	}
+
 	if *kopsPriorityPath != "" {
 		if err := util.InsertPath(*kopsPriorityPath); err != nil {
 			return nil, err
@@ -445,13 +451,8 @@ func (k kops) Up() error {
 		createArgs = append(createArgs, "--project", k.gcpProject)
 	}
 	if k.isGoogleCloud() {
-		stateBucket, err := k.setupGCEStateStore(k.gcpProject)
-		if err != nil {
-			return err
-		}
 		featureFlags = append(featureFlags, "AlphaAllowGCE")
 		createArgs = append(createArgs, "--cloud", "gce")
-		createArgs = append(createArgs, "--state", fmt.Sprintf("gs://%s", stateBucket))
 	} else {
 		// append cloud type to allow for use of new regions without updates
 		createArgs = append(createArgs, "--cloud", "aws")
@@ -716,7 +717,19 @@ func (k kops) Down() error {
 		// This is expected if the cluster doesn't exist.
 		return nil
 	}
-	return control.FinishRunning(exec.Command(k.path, "delete", "cluster", k.cluster, "--yes"))
+	control.FinishRunning(exec.Command(k.path, "delete", "cluster", k.cluster, "--yes"))
+	if kopsState != nil {
+		ctx := context.Background()
+		client, err := storage.NewClient(ctx)
+		if err != nil {
+			return fmt.Errorf("error building storage API client: %v", err)
+		}
+		bkt := client.Bucket(*kopsState)
+		if err := bkt.Delete(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (k kops) GetClusterCreated(gcpProject string) (time.Time, error) {
@@ -865,19 +878,20 @@ func parseKubeconfig(kubeconfigPath string) (*kubeconfig, error) {
 }
 
 // setupGCEStateStore is used to create a 1-off state bucket in the active GCP project
-func (k kops) setupGCEStateStore(projectId string) (string, error) {
+func setupGCEStateStore(projectId string) (*string, error) {
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
 	if err != nil {
-		return "", fmt.Errorf("error building storage API client: %v", err)
+		return nil, fmt.Errorf("error building storage API client: %v", err)
 	}
 	name := gceBucketName(projectId)
 	bkt := client.Bucket(name)
 	if err := bkt.Create(ctx, projectId, nil); err != nil {
-		return "", err
+		return nil, err
 	}
 	log.Printf("Created new GCS bucket for state store: %s\n.", name)
-	return name, nil
+	store := fmt.Sprintf("gs://%s", name)
+	return &store, nil
 }
 
 // gceBucketName generates a name for GCE state store bucket


### PR DESCRIPTION
A followup to https://github.com/kubernetes/test-infra/pull/18870

Previously we were only using this newly created bucket for `kops create cluster` which caused the other commands to fail.
Now the bucket is used for all commands. This also deletes the bucket during teardown.

Fixes https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-gce-latest/1299281299755765761