### PR TITLE
Make network-proxy presubmit optional

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -123,6 +123,7 @@ presubmits:
       testgrid-dashboards: sig-api-machinery-network-proxy
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
     always_run: false
+    optional: true
     cluster: k8s-infra-prow-build
     run_if_changed: '^(cluster/gce/manifests/konnectivity-server.yaml$|cluster/gce/addons/konnectivity-agent)'
     labels:

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -68,9 +68,6 @@ dashboards:
   - name: pull-kubernetes-dependencies
     test_group_name: pull-kubernetes-dependencies
     base_options: width=10
-  - name: pull-kubernetes-e2e-gce-network-proxy-grpc
-    test_group_name: pull-kubernetes-e2e-gce-network-proxy-grpc
-    base_options: width=10
   - name: pull-kubernetes-e2e-gce-network-proxy-http-connect
     test_group_name: pull-kubernetes-e2e-gce-network-proxy-http-connect
     base_options: width=10
@@ -82,6 +79,9 @@ dashboards:
     base_options: width=10
 - name: presubmits-kubernetes-nonblocking
   dashboard_tab:
+  - name: pull-kubernetes-e2e-gce-network-proxy-grpc
+    test_group_name: pull-kubernetes-e2e-gce-network-proxy-grpc
+    base_options: width=10
   - name: pull-kubernetes-e2e-gce-rbe
     test_group_name: pull-kubernetes-e2e-gce-rbe
     base_options: width=10


### PR DESCRIPTION
The job is [solidly failing](https://testgrid.k8s.io/presubmits-kubernetes-blocking#pull-kubernetes-e2e-gce-network-proxy-grpc) and blocking merges (e.g. https://github.com/kubernetes/kubernetes/pull/93095)

It looks like work on the job is in progress (https://github.com/kubernetes/kubernetes/pull/94127), but it should not be blocking.

cc @BenTheElder 
cc @bartsmykla 