### PR TITLE
Increase benchmark-junit demo period from 20m to 24h.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-canaries.yaml
@@ -12,7 +12,7 @@ periodics:
     testgrid-tab-name: echo-test
     description: temporarily echoing things.
 - name: ci-test-infra-benchmark-demo
-  interval: 20m
+  interval: 24h
   decorate: true
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
ref: https://github.com/kubernetes/test-infra/issues/18480#issuecomment-682961944

The current frequency is excessive.