### PR TITLE
Remove job filtering from triage query, should be in kettle

### DIFF
--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -42,8 +42,7 @@ bq --headless --format=json query --max_rows 1000000 \
   from
     [k8s-gubernator:build.all]
   where
-    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
-    and job != 'ci-kubernetes-coverage-unit'" \
+    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY')) \
   > triage_builds.json
 
 bq query --allow_large_results --headless --max_rows 0 --replace --destination_table k8s-gubernator:temp.triage \
@@ -56,8 +55,7 @@ bq query --allow_large_results --headless --max_rows 0 --replace --destination_t
     [k8s-gubernator:build.all]
   where
     test.failed
-    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))
-    and job != 'ci-kubernetes-coverage-unit'"
+    and timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))"
 gsutil rm gs://k8s-gubernator/triage_tests/shard_*.json.gz || true
 bq extract --compression GZIP --destination_format NEWLINE_DELIMITED_JSON 'k8s-gubernator:temp.triage' gs://k8s-gubernator/triage_tests/shard_*.json.gz
 mkdir -p triage_tests

--- a/triage/update_summaries.sh
+++ b/triage/update_summaries.sh
@@ -42,7 +42,7 @@ bq --headless --format=json query --max_rows 1000000 \
   from
     [k8s-gubernator:build.all]
   where
-    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY')) \
+    timestamp_to_sec(started) > TIMESTAMP_TO_SEC(DATE_ADD(CURRENT_DATE(), -14, 'DAY'))" \
   > triage_builds.json
 
 bq query --allow_large_results --headless --max_rows 0 --replace --destination_table k8s-gubernator:temp.triage \


### PR DESCRIPTION
Reverting #18325 and replacing with #19038

/hold need to update kettle and verify that the change is working prior to merging. 

/cc @michaelkolber 