### PR TITLE
Plank: Remove kubernetes reporter finalizer when re-creating evicted pods

### DIFF
--- a/config/prow/cluster/plank_rbac.yaml
+++ b/config/prow/cluster/plank_rbac.yaml
@@ -36,6 +36,7 @@ rules:
       - create
       - delete
       - list
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -776,6 +776,7 @@ rules:
     verbs:
       - delete
       - list
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -1199,6 +1200,12 @@ rules:
   verbs:
     - "get"
     - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -1082,6 +1082,7 @@ rules:
       - list
       - watch
       - create
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -776,6 +776,7 @@ rules:
     verbs:
       - delete
       - list
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -1199,6 +1200,12 @@ rules:
   verbs:
     - "get"
     - "list"
+- apiGroups:
+    - ""
+  resources:
+    - "pods"
+  verbs:
+    - "patch"
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -1082,6 +1082,7 @@ rules:
       - list
       - watch
       - create
+      - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/plank/BUILD.bazel
+++ b/prow/plank/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config:go_default_library",
+        "//prow/crier/reporters/gcs/kubernetes/api:go_default_library",
         "//prow/kube:go_default_library",
         "//prow/pjutil:go_default_library",
         "//prow/pod-utils/decorate:go_default_library",
@@ -65,6 +66,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_apimachinery//pkg/util/clock:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",


### PR DESCRIPTION
Otherwise we deadlock on evicted pods.