### PR TITLE
sig-scalability: add scheduler 100-node kubemark test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -117,6 +117,64 @@ periodics:
       - --kubemark
       - --kubemark-nodes=100
       - --provider=gce
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=100
+      - --test-cmd-args=--prometheus-scrape-node-exporter=true
+      - --test-cmd-args=--provider=kubemark
+      - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testconfig=testing/density/config.yaml
+      - --test-cmd-args=--testconfig=testing/load/config.yaml
+      - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_load_throughput.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=240m
+      - --use-logexporter
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+
+- name: ci-kubernetes-kubemark-100-gce-scheduler
+  tags:
+  - "perfDashPrefix: kubemark-100Nodes-scheduler"
+  - "perfDashJobType: performance"
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    testgrid-tab-name: kubemark-100-scheduler
+    testgrid-num-failures-to-alert: '1'
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200824-5d057db-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
+      - --timeout=260
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-100
+      - --extract=ci/latest
+      - --gcp-master-size=n1-standard-2
+      - --gcp-node-image=gci
+      - --gcp-node-size=n1-standard-4
+      - --gcp-nodes=4
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=100
+      - --provider=gce
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --test=false
       - --test_args=--ginkgo.focus=xxxx
@@ -128,13 +186,10 @@ periodics:
       - --env=CL2_ENABLE_DNS_PROGRAMMING=true
       - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me
       - --test-cmd-args=--report-dir=/workspace/_artifacts
-      - --test-cmd-args=--testconfig=testing/density/config.yaml
-      - --test-cmd-args=--testconfig=testing/load/config.yaml
-      - --test-cmd-args=--testconfig=testing/access-tokens/config.yaml
+      - --test-cmd-args=--testsuite=testing/density/scheduler-suite.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_prometheus_api_responsiveness.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
-      - --test-cmd-args=--testoverrides=./testing/overrides/kubemark_load_throughput.yaml
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=240m
       - --use-logexporter


### PR DESCRIPTION
/sig scalability
/sig scheduling
/cc @mm4tt 

This PR adds the 100-node kubemark test. Once this has been running for a few days, I'll verify that everything looks correct and then create another PR for 500 and 5000 nodes.

@mm4tt I've taken a few decisions I've taken in this PR that I'd like your opinion on:

1. Using the name "ci-kubernetes-kubemark-100-gce-scheduler".
1. Using a separate tab under the sig-scalability-kubemark dashboard called "kubemark-100-scheduler".
1. Running the test every 24 hours. We discussed a way less frequent schedule for the new 5000 node tests (IIRC every other day), but I feel that the 100 node tests are quick. The 100-node density test ("ci-kubernetes-kubemark-100-gce"), which is what this PR is based on, runs every 3 hours.