### PR TITLE
K8SGCSReporter: Fix handling of aborted jobs

### DIFF
--- a/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
+++ b/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 


### PR DESCRIPTION
Currently, the k8s gcs reporter will attempt to add a finalizer to aborted jobs that are not complete. These jobs appear when trigger cancels jobs, for example because a PR got merged. If this happens, Plank will delete the pod asynchronously.

This PR fixes that to:
* Not add a finalizer to aborted jobs
* Defer handling of aborted jobs until they are completed by plugging through a RequeueAfter

Fixes https://github.com/kubernetes/test-infra/issues/19014