### PR TITLE
Crier github reporter: Avoid lock contention issues

### DIFF
--- a/prow/crier/BUILD.bazel
+++ b/prow/crier/BUILD.bazel
@@ -47,11 +47,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//prow/apis/prowjobs/v1:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )

--- a/prow/crier/reporters/gcs/BUILD.bazel
+++ b/prow/crier/reporters/gcs/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "@com_github_googlecloudplatform_testgrid//metadata:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
+++ b/prow/crier/reporters/gcs/kubernetes/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/gcs/kubernetes/reporter.go
+++ b/prow/crier/reporters/gcs/kubernetes/reporter.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
@@ -92,8 +93,8 @@ func (rg k8sResourceGetter) GetEvents(cluster, namespace string, pod *v1.Pod) ([
 	return events.Items, nil
 }
 
-func (gr *gcsK8sReporter) Report(log *logrus.Entry, pj *prowv1.ProwJob) ([]*prowv1.ProwJob, error) {
-	return []*prowv1.ProwJob{pj}, gr.report(log, pj)
+func (gr *gcsK8sReporter) Report(log *logrus.Entry, pj *prowv1.ProwJob) ([]*prowv1.ProwJob, *reconcile.Result, error) {
+	return []*prowv1.ProwJob{pj}, nil, gr.report(log, pj)
 }
 
 func (gr *gcsK8sReporter) report(log *logrus.Entry, pj *prowv1.ProwJob) error {

--- a/prow/crier/reporters/gerrit/BUILD.bazel
+++ b/prow/crier/reporters/gerrit/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//prow/kube:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/gerrit/reporter_test.go
+++ b/prow/crier/reporters/gerrit/reporter_test.go
@@ -1057,7 +1057,7 @@ func TestReport(t *testing.T) {
 				return
 			}
 
-			reportedJobs, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), tc.pj)
+			reportedJobs, _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), tc.pj)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//prow/github/report:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 
@@ -38,7 +39,10 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//prow/gerrit/client:go_default_library",
         "//prow/github/report:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -54,34 +55,36 @@ type simplePull struct {
 
 type shardedLock struct {
 	mapLock *sync.Mutex
-	locks   map[simplePull]*sync.Mutex
+	locks   map[simplePull]*semaphore.Weighted
 }
 
-func (s *shardedLock) getLock(key simplePull) *sync.Mutex {
+func (s *shardedLock) getLock(key simplePull) *semaphore.Weighted {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()
 	if _, exists := s.locks[key]; !exists {
-		s.locks[key] = &sync.Mutex{}
+		s.locks[key] = semaphore.NewWeighted(1)
 	}
 	return s.locks[key]
 }
 
 // cleanup deletes all locks by acquiring first
-// the mapLock and then each individual lock before
-// deleting it. The individual lock must be acquired
-// because otherwise it may be held, we delete it from
-// the map, it gets recreated and acquired and two
-// routines report in parallel for the same job.
-// Note that while this function is running, no new
-// presubmit reporting can happen, as we hold the mapLock.
+// the mapLock and then the individual lock via TryAcquire.
+// The latter is required, otherwise the lock might be held,
+// deleted by us and then recreated, resulting in two routines
+// having it in parallel.
+// Because running this function requires acquiring the mapLock,
+// no new presubmit reporting can happen. To minimize lock contention,
+// we use TryAcquire and skip locks we didn't acquire.
 func (s *shardedLock) cleanup() {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()
 
 	for key, lock := range s.locks {
-		lock.Lock()
+		if !lock.TryAcquire(1) {
+			continue
+		}
 		delete(s.locks, key)
-		lock.Unlock()
+		lock.Release(1)
 	}
 }
 
@@ -105,7 +108,7 @@ func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJ
 		reportAgent: reportAgent,
 		prLocks: &shardedLock{
 			mapLock: &sync.Mutex{},
-			locks:   map[simplePull]*sync.Mutex{},
+			locks:   map[simplePull]*semaphore.Weighted{},
 		},
 	}
 	c.prLocks.runCleanup()
@@ -144,8 +147,11 @@ func (c *Client) Report(_ *logrus.Entry, pj *v1.ProwJob) ([]*v1.ProwJob, *reconc
 			return nil, nil, fmt.Errorf("failed to get lockkey for job: %v", err)
 		}
 		lock := c.prLocks.getLock(*key)
-		lock.Lock()
-		defer lock.Unlock()
+		// Don't block a worker waiting for the lock, they are limited.
+		if !lock.TryAcquire(1) {
+			return nil, &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
+		}
+		defer lock.Release(1)
 	}
 
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -20,11 +20,15 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -33,15 +37,15 @@ import (
 func TestShouldReport(t *testing.T) {
 	var testcases = []struct {
 		name        string
-		pj          v1.ProwJob
+		pj          prowv1.ProwJob
 		report      bool
-		reportAgent v1.ProwJobAgent
+		reportAgent prowv1.ProwJobAgent
 	}{
 		{
 			name: "should not report periodic job",
-			pj: v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PeriodicJob,
+			pj: prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.PeriodicJob,
 					Report: true,
 				},
 			},
@@ -49,9 +53,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should report postsubmit job",
-			pj: v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PostsubmitJob,
+			pj: prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.PostsubmitJob,
 					Report: true,
 				},
 			},
@@ -59,9 +63,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should not report batch job",
-			pj: v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.BatchJob,
+			pj: prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.BatchJob,
 					Report: true,
 				},
 			},
@@ -69,9 +73,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should report presubmit job",
-			pj: v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PresubmitJob,
+			pj: prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.PresubmitJob,
 					Report: true,
 				},
 			},
@@ -79,14 +83,14 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "github should not report gerrit jobs",
-			pj: v1.ProwJob{
+			pj: prowv1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						client.GerritReportLabel: "plus-one-this-gerrit-label-please",
 					},
 				},
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PresubmitJob,
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.PresubmitJob,
 					Report: true,
 				},
 			},
@@ -119,26 +123,26 @@ func TestPresumitReportingLocks(t *testing.T) {
 			return &config.Config{
 				ProwConfig: config.ProwConfig{
 					GitHubReporter: config.GitHubReporter{
-						JobTypesToReport: []v1.ProwJobType{v1.PresubmitJob},
+						JobTypesToReport: []prowv1.ProwJobType{prowv1.PresubmitJob},
 					},
 				},
 			}
 		},
-		v1.ProwJobAgent(""),
+		prowv1.ProwJobAgent(""),
 	)
 
-	pj := &v1.ProwJob{
-		Spec: v1.ProwJobSpec{
-			Refs: &v1.Refs{
+	pj := &prowv1.ProwJob{
+		Spec: prowv1.ProwJobSpec{
+			Refs: &prowv1.Refs{
 				Org:   "org",
 				Repo:  "repo",
-				Pulls: []v1.Pull{{Number: 1}},
+				Pulls: []prowv1.Pull{{Number: 1}},
 			},
-			Type:   v1.PresubmitJob,
+			Type:   prowv1.PresubmitJob,
 			Report: true,
 		},
-		Status: v1.ProwJobStatus{
-			State:          v1.ErrorState,
+		Status: prowv1.ProwJobStatus{
+			State:          prowv1.ErrorState,
 			CompletionTime: &metav1.Time{},
 		},
 	}
@@ -163,9 +167,9 @@ func TestPresumitReportingLocks(t *testing.T) {
 
 func TestShardedLockCleanup(t *testing.T) {
 	t.Parallel()
-	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*sync.Mutex{}}
+	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{}}
 	key := simplePull{"org", "repo", 1}
-	sl.locks[key] = &sync.Mutex{}
+	sl.locks[key] = semaphore.NewWeighted(1)
 	sl.cleanup()
 	if _, exists := sl.locks[key]; exists {
 		t.Error("lock didn't get cleaned up")
@@ -176,12 +180,17 @@ func TestShardedLockCleanup(t *testing.T) {
 func TestReport(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name          string
-		githubError   error
-		expectedError string
+		name                  string
+		jobType               prowv1.ProwJobType
+		locks                 *shardedLock
+		githubError           error
+		expectedError         string
+		expectReport          bool
+		expectReconcileResult *reconcile.Result
 	}{
 		{
-			name: "Success",
+			name:         "Success",
+			expectReport: true,
 		},
 		{
 			name:        "Maximum sha error gets swallowed",
@@ -192,41 +201,74 @@ func TestReport(t *testing.T) {
 			githubError:   errors.New("something went wrong :("),
 			expectedError: "error setting status: something went wrong :(",
 		},
+		{
+			name:                  "Presubmit that is currently locked doesn't report, doesn't block and returns with RequeueAfter",
+			jobType:               prowv1.PresubmitJob,
+			locks:                 &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{{}: semaphore.NewWeighted(0)}},
+			expectReconcileResult: &reconcile.Result{RequeueAfter: 5 * time.Second},
+			expectReport:          false,
+		},
+		{
+			name:         "Presubmit that is currently unlocked reports",
+			jobType:      prowv1.PresubmitJob,
+			locks:        &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{{}: semaphore.NewWeighted(1)}},
+			expectReport: true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			githubClient := &fakegithub.FakeClient{Error: tc.githubError}
 			c := Client{
-				gc: &fakegithub.FakeClient{Error: tc.githubError},
+				gc: githubClient,
 				config: func() *config.Config {
 					return &config.Config{
 						ProwConfig: config.ProwConfig{
 							GitHubReporter: config.GitHubReporter{
-								JobTypesToReport: []v1.ProwJobType{v1.PostsubmitJob},
+								JobTypesToReport: []prowv1.ProwJobType{prowv1.PostsubmitJob, prowv1.PresubmitJob},
 							},
 						},
 					}
 				},
+				prLocks: tc.locks,
 			}
-			pj := &v1.ProwJob{
-				Spec: v1.ProwJobSpec{
-					Type:   v1.PostsubmitJob,
+			pj := &prowv1.ProwJob{
+				Spec: prowv1.ProwJobSpec{
+					Type:   prowv1.PostsubmitJob,
 					Report: true,
-					Refs:   &v1.Refs{},
+					Refs:   &prowv1.Refs{},
 				},
-				Status: v1.ProwJobStatus{
-					State: v1.SuccessState,
+				Status: prowv1.ProwJobStatus{
+					State: prowv1.SuccessState,
 				},
+			}
+			if tc.jobType != "" {
+				pj.Spec.Type = tc.jobType
+			}
+			if pj.Spec.Type == prowv1.PresubmitJob {
+				pj.Spec.Refs.Pulls = []prowv1.Pull{{}}
 			}
 
 			errMsg := ""
-			_, _, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
+			_, reconcileResult, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if err != nil {
 				errMsg = err.Error()
 			}
 			if errMsg != tc.expectedError {
 				t.Errorf("expected error %q got error %q", tc.expectedError, errMsg)
 			}
+			if err != nil {
+				return
+			}
+
+			if diff := cmp.Diff(reconcileResult, tc.expectReconcileResult); diff != "" {
+				t.Errorf("received reconcileResult differs from expected: %s", diff)
+			}
+
+			if reported := len(githubClient.CreatedStatuses) > 0; reported != tc.expectReport {
+				t.Errorf("did report: %t, expected report: %t", reported, tc.expectReport)
+			}
+
 		})
 	}
 }

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -146,13 +146,13 @@ func TestPresumitReportingLocks(t *testing.T) {
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
-		if _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
+		if _, _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
 			t.Errorf("error reporting: %v", err)
 		}
 		wg.Done()
 	}()
 	go func() {
-		if _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
+		if _, _, err := reporter.Report(logrus.NewEntry(logrus.StandardLogger()), pj); err != nil {
 			t.Errorf("error reporting: %v", err)
 		}
 		wg.Done()
@@ -220,7 +220,7 @@ func TestReport(t *testing.T) {
 			}
 
 			errMsg := ""
-			_, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
+			_, _, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if err != nil {
 				errMsg = err.Error()
 			}

--- a/prow/crier/reporters/pubsub/BUILD.bazel
+++ b/prow/crier/reporters/pubsub/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//prow/spyglass/api:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@com_google_cloud_go_pubsub//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/slack/BUILD.bazel
+++ b/prow/crier/reporters/slack/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//prow/config:go_default_library",
         "//prow/slack:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/crier/reporters/slack/reporter_test.go
+++ b/prow/crier/reporters/slack/reporter_test.go
@@ -513,7 +513,7 @@ func TestReportDefaultsToExtraRefs(t *testing.T) {
 		client: &fakeSlackClient{},
 	}
 
-	if _, err := sr.Report(logrus.NewEntry(logrus.StandardLogger()), job); err != nil {
+	if _, _, err := sr.Report(logrus.NewEntry(logrus.StandardLogger()), job); err != nil {
 		t.Fatalf("reporting failed: %v", err)
 	}
 	if sr.client.(*fakeSlackClient).messages["emercengy"] != "there you go" {

--- a/prow/pubsub/subscriber/BUILD.bazel
+++ b/prow/pubsub/subscriber/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_google_cloud_go_pubsub//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
         "@org_golang_x_sync//errgroup:go_default_library",
     ],
 )
@@ -36,6 +37,7 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
     ],
 )
 

--- a/prow/pubsub/subscriber/subscriber.go
+++ b/prow/pubsub/subscriber/subscriber.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sirupsen/logrus"
 	coreapi "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
@@ -93,7 +94,7 @@ type messageInterface interface {
 }
 
 type reportClient interface {
-	Report(log *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error)
+	Report(log *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, *reconcile.Result, error)
 	ShouldReport(log *logrus.Entry, pj *prowapi.ProwJob) bool
 }
 
@@ -164,7 +165,7 @@ func (s *Subscriber) handlePeriodicJob(l *logrus.Entry, msg messageInterface, su
 		pj.Status.State = prowapi.ErrorState
 		pj.Status.Description = err.Error()
 		if s.Reporter.ShouldReport(l, &prowJob) {
-			if _, err := s.Reporter.Report(l, &prowJob); err != nil {
+			if _, _, err := s.Reporter.Report(l, &prowJob); err != nil {
 				l.Warningf("failed to report status. %v", err)
 			}
 		}

--- a/prow/pubsub/subscriber/subscriber_test.go
+++ b/prow/pubsub/subscriber/subscriber_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 	clienttesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/client/clientset/versioned/fake"
@@ -101,9 +102,9 @@ type fakeReporter struct {
 	reported bool
 }
 
-func (r *fakeReporter) Report(_ *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, error) {
+func (r *fakeReporter) Report(_ *logrus.Entry, pj *prowapi.ProwJob) ([]*prowapi.ProwJob, *reconcile.Result, error) {
 	r.reported = true
-	return nil, nil
+	return nil, nil, nil
 }
 
 func (r *fakeReporter) ShouldReport(_ *logrus.Entry, pj *prowapi.ProwJob) bool {


### PR DESCRIPTION
This PR:
* Extends crier so reporters can defer their reporting ( Same commit as in https://github.com/kubernetes/test-infra/pull/19048)
* Fixes a lock contention issue in the github reporter:

    Crier github reporter: Don't block workers waiting for lock
    
    In 00562873e0c597be9d186ebc3887c3fa0690400c we introduced PR-Level
    locking for presubmits to the crier github reporter in order to allow
    running it with multiple workers without having the workers race with
    each other when creating the GitHub comment.
    
    The implementation naively used a map of sync.Mutex, blocking workers
    that are waiting for their lock. This can result in all workers being
    blocked, which is worse than the initial problem of only having one
    worker.
    
    This commit updates that to instead use a semaphore.Weightened and
    TryAcquire, returning a RequeueAfter if the lock is occupied in order to
    minimize lock contention.
