### PR TITLE
Kops - delete GCS bucket during teardown only for GCE

### DIFF
--- a/kubetest/kops.go
+++ b/kubetest/kops.go
@@ -718,7 +718,7 @@ func (k kops) Down() error {
 		return nil
 	}
 	control.FinishRunning(exec.Command(k.path, "delete", "cluster", k.cluster, "--yes"))
-	if kopsState != nil {
+	if kopsState != nil && k.isGoogleCloud() {
 		ctx := context.Background()
 		client, err := storage.NewClient(ctx)
 		if err != nil {


### PR DESCRIPTION
Followup to https://github.com/kubernetes/test-infra/pull/19031
We're accidentally trying to delete S3 buckets using the GCS client during our AWS tests, so only cleanup the bucket for GCE tests.

Fixes [these](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/9813/pull-kops-e2e-k8s-containerd/1300185622979284992) e2e failures