### PR TITLE
allow gcs web browser prefix link by org, org/repo or default

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -3,6 +3,9 @@
 ## New features
 
 New features added to each component:
+ - *August 31th, 2020* Added `gcs_browser_prefixes` field in spyglass configuration. `gcs_browser_prefix` will
+    be deprecated in February 2021. You can now specify different values for different repositories. The
+    format should be in org, org/repo or '\*' which is the default value.
  - *July 13th, 2020* Configuring `job_url_prefix_config` with `gcs/` prefix is now deprecated.
     Please configure a job url prefix without the `gcs/` storage provider suffix. From now on the storage
     provider is appended automatically so multiple storage providers can be used for builds of

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1025,8 +1025,14 @@ lensesLoop:
 		log.WithError(err).Warningf("Error getting ProwJob name for source %q.", src)
 	}
 
+	prHistLink := ""
+	org, repo, number, err := sg.RunToPR(src)
+	if err == nil {
+		prHistLink = "/pr-history?org=" + org + "&repo=" + repo + "&pr=" + strconv.Itoa(number)
+	}
+
 	artifactsLink := ""
-	gcswebPrefix := cfg().Deck.Spyglass.GCSBrowserPrefix
+	gcswebPrefix := cfg().Deck.Spyglass.GCSBrowserPrefixes.GetGCSBrowserPrefix(org, repo)
 	if gcswebPrefix != "" {
 		runPath, err := sg.RunPath(src)
 		if err == nil {
@@ -1036,12 +1042,6 @@ lensesLoop:
 				artifactsLink += "/"
 			}
 		}
-	}
-
-	prHistLink := ""
-	org, repo, number, err := sg.RunToPR(src)
-	if err == nil {
-		prHistLink = "/pr-history?org=" + org + "&repo=" + repo + "&pr=" + strconv.Itoa(number)
 	}
 
 	jobName, buildID, err := common.KeyToJob(src)

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -216,6 +216,17 @@ deck:
 `,
 			expectError: true,
 		},
+		{
+			name: "Invalid Spyglass gcs browser web prefix",
+			spyglassConfig: `
+deck:
+  spyglass:
+    gcs_browser_prefix: https://gcsweb.k8s.io/gcs/
+    gcs_browser_prefixes:
+      '*': https://gcsweb.k8s.io/gcs/
+`,
+			expectError: true,
+		},
 	}
 	for _, tc := range testCases {
 		// save the config
@@ -279,6 +290,49 @@ deck:
 		}
 	}
 
+}
+
+func TestGetGCSBrowserPrefix(t *testing.T) {
+	testCases := []struct {
+		id       string
+		config   Spyglass
+		expected string
+	}{
+		{
+			id: "only default",
+			config: Spyglass{
+				GCSBrowserPrefixes: map[string]string{
+					"*": "https://default.com/gcs/",
+				},
+			},
+			expected: "https://default.com/gcs/",
+		},
+		{
+			id: "org exists",
+			config: Spyglass{
+				GCSBrowserPrefixes: map[string]string{
+					"org": "https://org.com/gcs/",
+				},
+			},
+			expected: "https://org.com/gcs/",
+		},
+		{
+			id: "repo exists",
+			config: Spyglass{
+				GCSBrowserPrefixes: map[string]string{
+					"org/repo": "https://repo.com/gcs/",
+				},
+			},
+			expected: "https://repo.com/gcs/",
+		},
+	}
+
+	for _, tc := range testCases {
+		actual := tc.config.GCSBrowserPrefixes.GetGCSBrowserPrefix("org", "repo")
+		if !reflect.DeepEqual(actual, tc.expected) {
+			t.Fatalf("%s", cmp.Diff(tc.expected, actual))
+		}
+	}
 }
 
 func TestDecorationRawYaml(t *testing.T) {


### PR DESCRIPTION
Add a new field in spyglass config `gcs_browser_prefixes` that can hold values for different org, org/repo, or the default '*'. 

/cc @stevekuznetsov @alvaroaleman 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>