### PR TITLE
Revert tag-match flag for image builder

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-descheduler.yaml
+++ b/config/jobs/image-pushing/k8s-staging-descheduler.yaml
@@ -27,6 +27,4 @@ postsubmits:
               # This is the same as above, but with -gcb appended.
               - --scratch-bucket=gs://k8s-staging-descheduler-gcb
               - --env-passthrough=PULL_BASE_REF
-              # This makes sure that only tags matching, eg v0.18.0 get published (and not Helm chart tags)
-              - --tag-match="v*"
               - .


### PR DESCRIPTION
This flag was introduced in #18506 and later attempted to be fixed in #18540. However,
this command won't work with Go's cmd libraries as this Git flag takes a `glob`, which are
not expanded by Go.

While this would be a nice feature to have, we should continue searching for a way to implement it.
Though in order to get image builds working for the Descheduler again, we need to remove
it for now.