### PR TITLE
simplifypath: actually handle `/` paths

### DIFF
--- a/ghproxy/ghmetrics/ghpath.go
+++ b/ghproxy/ghmetrics/ghpath.go
@@ -95,6 +95,7 @@ func organizationTree() []simplifypath.Node {
 }
 
 var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the root
+	l(""),
 	l("repos",
 		v("owner",
 			v("repo",

--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -223,6 +223,7 @@ func init() {
 }
 
 var simplifier = simplifypath.NewSimplifier(l("", // shadow element mimicing the root
+	l(""),
 	l("badge.svg"),
 	l("command-help"),
 	l("config"),

--- a/prow/simplifypath/simplify_test.go
+++ b/prow/simplifypath/simplify_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package simplifypath
 
 import (
+	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -29,6 +30,16 @@ func TestLiteral(t *testing.T) {
 	}
 	if actual, expected := l.Represent(), "fragment"; actual != expected {
 		t.Errorf("expected literal to be represented by %v, but saw: %v", expected, actual)
+	}
+}
+
+func TestEmptyLiteral(t *testing.T) {
+	l := L("", Node{})
+	if !l.Matches(strings.Split("/", "/")[0]) {
+		t.Errorf("expected empty literal to match root, but didn't")
+	}
+	if actual, expected := l.Represent(), ""; actual != expected {
+		t.Errorf("expected empty literal to be represented by %v, but saw: %v", expected, actual)
 	}
 }
 
@@ -47,6 +58,7 @@ func TestVariable(t *testing.T) {
 
 func TestSimplify(t *testing.T) {
 	s := NewSimplifier(L("", // shadow element mimicing the root
+		L(""),
 		L("repos",
 			V("owner",
 				V("repo",
@@ -65,6 +77,10 @@ func TestSimplify(t *testing.T) {
 	var testCases = []struct {
 		name, path, expected string
 	}{
+		{
+			name:     "root",
+			path:     "/",
+			expected: "/"},
 		{
 			name:     "repo branches",
 			path:     "/repos/testOwner/testRepo/branches",


### PR DESCRIPTION
It turns out that the first `""` element is an artifact of how the
library works (we always get an empty part when splitting the path by
"/" tokens) but we need another to actually handle the root path.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>