### PR TITLE
Add a PDB to prevent cluster autoscaler from evicting test workloads

### DIFF
--- a/config/prow/cluster/BUILD.bazel
+++ b/config/prow/cluster/BUILD.bazel
@@ -77,6 +77,15 @@ release(
         MULTI_KIND,
         cluster = BUILD_CLUSTER,
     ),
+    component(
+        "test_pods",
+        "pdb",
+    ),
+    component(
+        "test_pods",
+        "pdb",
+        cluster = BUILD_CLUSTER,
+    ),
 )
 
 # TODO(fejta): do we want to auto-apply this?

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -1251,3 +1251,15 @@ spec:
   resources:
     requests:
       storage: 100Gi
+---
+# Keep cluster-autoscaler from evicting running test workloads when scaling down
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prow-pods
+  namespace: test-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      created-by-prow: "true"

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -1354,3 +1354,15 @@ spec:
     protocol: TCP
   selector:
     app: minio
+---
+# Keep cluster-autoscaler from evicting running test workloads when scaling down
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prow-pods
+  namespace: test-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      created-by-prow: "true"

--- a/config/prow/cluster/test_pods_pdb.yaml
+++ b/config/prow/cluster/test_pods_pdb.yaml
@@ -1,0 +1,31 @@
+# Copyright 2020 The Kubernetes Authors All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The purpose of the PodDisruptionBudget here is to never allow evicting pods created by prow.
+# Eviction of pods can happen for one of two reasons:
+# * Cluster autoscaler downscaling
+# * Someome/Something using `kubectl drain`
+#
+# It is still possible to delete the pods via a normal delete call. See https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#the-eviction-api
+
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: prow-pods
+  namespace: test-pods
+spec:
+  maxUnavailable: 0
+  selector:
+    matchLabels:
+      created-by-prow: "true"

--- a/prow/def.bzl
+++ b/prow/def.bzl
@@ -160,6 +160,8 @@ def component(cmd, *kinds, **kwargs):
         else:
             n = "%s_%s" % (cmd, k)
         kwargs["name"] = _basename(n)
+        if "cluster" in kwargs:
+          kwargs["name"] += "_" + kwargs["cluster"]
         kwargs["kind"] = k
         kwargs["template"] = ":%s.yaml" % n
         object(**kwargs)


### PR DESCRIPTION
IIRC the prow.k8s.io build cluster doesn't use the cluster autoscaler but I think its still good to put the PDB in its config, because its often used as a reference by other prow setups (and without CA its just a no-op).

/assign @fejta 