### PR TITLE
Move pull-kubernetes-bazel-build-canary to k8s-infra-prow-build

### DIFF
--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -1,6 +1,7 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-bazel-build-canary
+    cluster: k8s-infra-prow-build
     decorate: true
     always_run: false
     labels:
@@ -17,11 +18,21 @@ presubmits:
       containers:
       - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
         command:
-        - bash
+        - ../test-infra/hack/bazel.sh
         args:
-        - -c
-        - |
-          ../test-infra/hack/bazel.sh build --config=remote --remote_instance_name=projects/k8s-prow-builds/instances/default_instance -- //... -//vendor/... -//build/... //build/release-tars
+        - build
+        - --
+        - //...
+        - -//vendor/...
+        - -//build/...
+        - //build/release-tars
+        resources:
+          limits:
+            cpu: 4
+            memory: 36Gi
+          requests:
+            cpu: 4
+            memory: 36Gi
   - name: pull-kubernetes-bazel-test-canary
     cluster: k8s-infra-prow-build
     decorate: true


### PR DESCRIPTION
Updated formatting to match pull-kubernetes-bazel-build, then
dropped the flag for RBE. Matched the resources of the RBE job,
we'll find out what's actually needed via this job

Part of https://github.com/kubernetes/test-infra/issues/19073
The bazel build equivalent of https://github.com/kubernetes/test-infra/pull/19069