### PR TITLE
add 'k8s-infra-gcr-vuln-dashboard' KSA

### DIFF
--- a/config/prow/cluster/trusted_serviceaccounts.yaml
+++ b/config/prow/cluster/trusted_serviceaccounts.yaml
@@ -46,6 +46,14 @@ metadata:
     iam.gke.io/gcp-service-account: k8s-infra-gcr-promoter@k8s-artifacts-prod-bak.iam.gserviceaccount.com
   name: k8s-infra-gcr-promoter-bak
   namespace: test-pods
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  annotations:
+    iam.gke.io/gcp-service-account: k8s-infra-gcr-vuln-dashboard@k8s-artifacts-prod.iam.gserviceaccount.com
+  name: k8s-infra-gcr-vuln-dashboard
+  namespace: test-pods
 # TODO(fejta): https://github.com/kubernetes/test-infra/issues/15806
 # * Run experiment/workload-identity/bind-service-accounts.sh on the above
 # * Config service account on job


### PR DESCRIPTION
This is a followup to #19003. Currently the
"ci-k8sio-vuln-dashboard-update" job added by #19003 is broken with the
following error:

    Job execution failed: Job cannot be started: pods
    "995fe144-ebaa-11ea-b653-e644ef4dd131" is forbidden: error looking up
    service account test-pods/k8s-infra-gcr-vuln-dashboard: serviceaccount
    "k8s-infra-gcr-vuln-dashboard" not found

This commit adds the missing 'k8s-infra-gcr-vuln-dashboard' KSA for setting up
Workload Identity.

Related commits:

    - (This repo) Setting up the Prow job (trusted cluster): https://github.com/kubernetes/test-infra/pull/19003
    - (k8s.io repo) Setting up GSA: https://github.com/kubernetes/k8s.io/pull/1135
    - (CIP repo) Business logic: https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/256