### PR TITLE
Sinker: Dont incorrectly declare pods orphaned due to outdated pj list

### DIFF
--- a/prow/cmd/sinker/BUILD.bazel
+++ b/prow/cmd/sinker/BUILD.bazel
@@ -36,6 +36,7 @@ go_test(
         "@io_k8s_client_go//kubernetes/fake:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )


### PR DESCRIPTION
When sinker cleans, it does a prowjob list at the very beginning and
then uses this list to determine if a given pod has a corresponding
prowjob. The pods in turn are found by iterating over all build clusters
and doing an uncached list, which may take time.

This allows the pod list to contain pods that correspond to a prowjob
that didn't exist at the time the prowjob list was done, making sinker
delete the pod as orphaned.

This PR changs the orphan detection to:
* Never declare a pod that is youger than 30 seconds as orphaned
* Do an additional GET for the prowjob to check if its indeed absent
  rather than relying on the result of the LIST