### PR TITLE
Change defunct kubeconfig error level to Error

### DIFF
--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -118,7 +118,7 @@ func main() {
 
 	buildClusterClients, err := o.kubernetes.BuildClusterUncachedRuntimeClients(o.dryRun)
 	if err != nil {
-		logrus.WithError(err).Warning("Error creating build cluster clients.")
+		logrus.WithError(err).Error("Error creating build cluster clients. Is there a bad entry in the kubeconfig secret?")
 	}
 
 	c, err := plank.NewController(mgr.GetClient(), buildClusterClients, nil, cfg, o.totURL, o.selector)

--- a/prow/cmd/prow-controller-manager/main.go
+++ b/prow/cmd/prow-controller-manager/main.go
@@ -155,7 +155,7 @@ func main() {
 		},
 	)
 	if err != nil {
-		logrus.WithError(err).Warning("Failed to construct build cluster managers")
+		logrus.WithError(err).Error("Failed to construct build cluster managers. Is there a bad entry in the kubeconfig secret?")
 	}
 
 	for _, buildManager := range buildManagers {


### PR DESCRIPTION
Changes error level for issues caused similar to #18866

The change was also moved to the Prow controller manager, since it looked similar. What does that do differently, and should we be moving to that from plank? I didn't see a readme for that component, so I'm not sure.

/assign @alvaroaleman 