### PR TITLE
[cluster-api] Enable smoke test for pre-submit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -117,6 +117,9 @@ presubmits:
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "[PR-Blocking]"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true


### PR DESCRIPTION
This PR modifies pre-submit script to run only smoke tests.

cc @neolit123 @fabriziopandini @wfernandes @ncdc @vincepri 

/hold until https://github.com/kubernetes-sigs/cluster-api/pull/3582 and https://github.com/kubernetes-sigs/cluster-api/pull/3583 are merged.