### PR TITLE
Use RepoLink in pod-utilities/clonerefs

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -131,6 +131,8 @@ func gitCtxForRefs(refs prowapi.Refs, baseDir string, env []string, oauthToken s
 	}
 	if refs.CloneURI != "" {
 		g.repositoryURI = refs.CloneURI
+	} else if refs.RepoLink != "" {
+		g.repositoryURI = fmt.Sprintf("%s.git", refs.RepoLink)
 	}
 
 	if len(oauthToken) > 0 {


### PR DESCRIPTION
clonerefs doesn't treat `repo_link` like other utilities. So I just add one.