### PR TITLE
Fetch only object names from GCS

### DIFF
--- a/prow/io/iterator.go
+++ b/prow/io/iterator.go
@@ -49,6 +49,7 @@ type gcsObjectIterator struct {
 
 func (g gcsObjectIterator) Next(_ context.Context) (ObjectAttributes, error) {
 	oAttrs, err := g.Iterator.Next()
+	// oAttrs object has only 'Name' or 'Prefix' field set.
 	if err == iterator.Done {
 		return ObjectAttributes{}, io.EOF
 	}


### PR DESCRIPTION
Context: Loading a prow results for 5k jobs is quite slow. I'm trying to make it a little bit faster.

Ref: https://github.com/kubernetes/test-infra/issues/17505

ObjectAttributes object we return contains only a name of an object.
We can use this property to implement performance optimization where we fetch only that field from storage API. This should significantly reduce size of output (~10x based on experiment in https://github.com/kubernetes/test-infra/issues/17505#issuecomment-625190906)

/assign @spiffxp 