### PR TITLE
Allow relying on default GKE cluster shape

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -321,9 +321,11 @@ func (g *gkeDeployer) Up() error {
 	args = append(args,
 		"--project="+g.project,
 		g.location,
-		"--num-nodes="+strconv.Itoa(def.Nodes),
 		"--network="+g.network,
 	)
+	if def.Nodes > 0 {
+		args = append(args, "--num-nodes="+strconv.Itoa(def.Nodes))
+	}
 	if def.MachineType != "" {
 		args = append(args, "--machine-type="+def.MachineType)
 	}

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -691,9 +691,6 @@ func prepareGcp(o *options) error {
 		if o.deployment != "gke" {
 			return fmt.Errorf("expected --deployment=gke for --provider=gke, found --deployment=%s", o.deployment)
 		}
-		if o.gcpNodeImage == "" {
-			return fmt.Errorf("--gcp-node-image must be set for GKE")
-		}
 		if o.gcpMasterImage != "" {
 			return fmt.Errorf("expected --gcp-master-image to be empty for --provider=gke, found --gcp-master-image=%s", o.gcpMasterImage)
 		}


### PR DESCRIPTION
Allow relying on default GKE values for number of nodes or image type

/cc @wojtek-t 
/cc @mm4tt 
/cc @vivekbagade 

Need to test it first
/hold