### PR TITLE
[cluster-api] Skip running tests on docs

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -110,7 +110,7 @@ presubmits:
       - gh-pages
       - release-0.2
     path_alias: sigs.k8s.io/cluster-api
-    always_run: true
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|Dockerfile|Makefile)'
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20200901-eeeadc5-1.18


### PR DESCRIPTION
This PR skips docs/ and logos/ changes to run e2e tests.

cc @neolit123 @fabriziopandini @wfernandes @ncdc @vincepri @randomvariable 