### PR TITLE
Rely on default autorepair setting on GKE rapid channel

### DIFF
--- a/kubetest/gke.go
+++ b/kubetest/gke.go
@@ -361,9 +361,6 @@ func (g *gkeDeployer) Up() error {
 
 	if *gkeReleaseChannel != "" {
 		args = append(args, "--release-channel="+*gkeReleaseChannel)
-		if strings.EqualFold(*gkeReleaseChannel, "rapid") {
-			args = append(args, "--enable-autorepair")
-		}
 	} else {
 		// TODO(zmerlynn): The version should be plumbed through Extract
 		// or a separate flag rather than magic env variables.


### PR DESCRIPTION
Autorepair is default currently, no need to set it explicitly

/cc @krzyzacy 
/cc @wojtek-t 