### PR TITLE
image-pushing/k8s-staging-nfd: add PULL_BASE_SHA as a gcb substitution

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-nfd.yaml
+++ b/config/jobs/image-pushing/k8s-staging-nfd.yaml
@@ -28,5 +28,5 @@ postsubmits:
               - --project=k8s-staging-nfd
               # This is the same as above, but with -gcb appended.
               - --scratch-bucket=gs://k8s-staging-nfd-gcb
-              - --env-passthrough=PULL_BASE_REF
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
               - .


### PR DESCRIPTION
Makes it possible to have per-commit unique container image tag that is
re-producible in other jobs running against the same branch/commit. It
will be used by post-submit end-to-end test job that will test the very
image built and published by the image-pushing job.