### PR TITLE
prow/override: Trim whitespace in /override  <context>

### DIFF
--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -286,7 +286,7 @@ func handle(oc overrideClient, log *logrus.Entry, e *github.GenericCommentEvent,
 			log.Debug(resp)
 			return oc.CreateComment(org, repo, number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, user, resp))
 		}
-		overrides.Insert(m[2])
+		overrides.Insert(strings.TrimSpace(m[2]))
 	}
 
 	authorized := authorizedUser(oc, log, org, repo, user)

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -412,6 +412,25 @@ func TestHandle(t *testing.T) {
 			checkComments: []string{fmt.Sprintf("%s: broken-test, hung-test", adminUser)},
 		},
 		{
+			name: "override with extra whitespace",
+			// Note two spaces here to start, and trailing whitespace
+			comment: "/override  broken-test \n",
+			contexts: map[string]github.Status{
+				"broken-test": {
+					Context: "broken-test",
+					State:   github.StatusFailure,
+				},
+			},
+			expected: map[string]github.Status{
+				"broken-test": {
+					Context:     "broken-test",
+					Description: description(adminUser),
+					State:       github.StatusSuccess,
+				},
+			},
+			checkComments: []string{fmt.Sprintf("%s: broken-test", adminUser)},
+		},
+		{
 			name:    "ignore non-PRs",
 			issue:   true,
 			comment: "/override broken-test",


### PR DESCRIPTION
It's really confusing if one types e.g.
`/override  ci/prow/blah`
because Markdown compresses two spaces into one when rendered,
so the error is not obvious.  Let's be nice to the humans
and trim whitespace.

Signed-off-by: Colin Walters <walters@verbum.org>