### PR TITLE
Change cilium periodic filter

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-network-plugins.yaml
@@ -133,7 +133,7 @@ periodics:
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
       - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|load-balancer|hairpin|affinity\stimeout|service\.kubernetes\.io
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|TCP.CLOSE_WAIT.timeout|affinity.*clusterIP|switch.session.affinity|service.type.to.nodeport|Services.*rejected.*endpoints
       - --timeout=60m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200901-eeeadc5-master
   annotations:


### PR DESCRIPTION
Looks like the periodic runs for cilium still fails. Tried to make the filters a bit more specific and clear. This at least seems to run stable when running kubetest locally.

/cc @hakman 