### PR TITLE
image-pushing: add config for nfd-operator

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-nfd-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-nfd-operator.yaml
@@ -1,0 +1,32 @@
+postsubmits:
+  # This is the github repo we'll build from. This block needs to be repeated
+  # for each repo.
+  kubernetes-sigs/node-feature-discovery-operator:
+    # The name should be changed to match the repo name above
+    - name: post-node-feature-discovery-operator-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        # This is the name of some testgrid dashboard to report to.
+        # If this is the first one for your sig, you may need to create one
+        testgrid-dashboards: sig-node-node-feature-discovery
+        testgrid-tab-name: operator-push-image
+      decorate: true
+      # this causes the job to only run on the master branch. Remove it if your
+      # job makes sense on every branch (unless it's setting a `latest` tag it
+      # probably does).
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-nfd
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-nfd-gcb
+              - --env-passthrough=PULL_BASE_REF,PULL_BASE_SHA
+              - .


### PR DESCRIPTION
Introduce new config for pushing node-feature-discovery-operator container images
to it's gcr staging repository.
Also, add a testgrid for nfd-operator.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>