### PR TITLE
Add petr-muller to Prow reviewers

### DIFF
--- a/prow/OWNERS
+++ b/prow/OWNERS
@@ -16,6 +16,7 @@ reviewers:
   - fejta
   - matthyx
   - michelle192837
+  - petr-muller
   - stevekuznetsov
 labels:
   - area/prow


### PR DESCRIPTION
I am [reviewing Prow PRs](https://github.com/search?l=&p=9&q=repo%3Akubernetes%2Ftest-infra+assignee%3Apetr-muller&ref=advsearch&type=Issues), know Prow well enough and I can commit to reviewing PRs when assigned.

/cc @cjwagner @fejta 