### PR TITLE
Add GCS credential path option to deck in starter-*.yaml

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -371,6 +371,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
         - --spyglass=true
         ports:
           - name: http

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -371,7 +371,6 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
-        - --plugin-config=/etc/plugins/plugins.yaml
         - --spyglass=true
         ports:
           - name: http

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -369,7 +369,6 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
-        - --plugin-config=/etc/plugins/plugins.yaml
         - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --spyglass=true
         ports:


### PR DESCRIPTION
Add GCS credential path option to deck to use intended credential not anonymous, and remove duplicate option in `starter-*.yaml`.