### PR TITLE
removes canary job that tested migration changes

### DIFF
--- a/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
+++ b/config/jobs/kubernetes/sig-api-machinery/sig-api-machinery-config.yaml
@@ -79,6 +79,7 @@ periodics:
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-e2e-gce-network-proxy-http-connect
+    cluster: k8s-infra-prow-build
     always_run: false
     run_if_changed: '^(cluster/gce/manifests/konnectivity-server.yaml$|cluster/gce/addons/konnectivity-agent)'
     labels:
@@ -105,7 +106,6 @@ presubmits:
         - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
         - --gcp-node-image=gci
         - --gcp-zone=us-west1-b
-        - --gcp-project=k8s-network-proxy-e2e
         - --ginkgo-parallel=30
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy-http-connect
         - --provider=gce
@@ -121,51 +121,6 @@ presubmits:
             memory: 6Gi
     annotations:
       testgrid-dashboards: sig-api-machinery-network-proxy
-  - name: pull-kubernetes-e2e-gce-network-proxy-http-connect-canary
-    cluster: k8s-infra-prow-build
-    always_run: false
-    optional: true
-    run_if_changed: '^(cluster/gce/manifests/konnectivity-server.yaml$|cluster/gce/addons/konnectivity-agent)'
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-bazel-scratch-dir: "true"
-      preset-bazel-remote-cache-enabled: "true"
-      preset-pull-kubernetes-e2e: "true"
-      preset-pull-kubernetes-e2e-gce: "true"
-    spec:
-      containers:
-      - args:
-        - --root=/go/src
-        - --repo=k8s.io/kubernetes=$(PULL_REFS)
-        - --repo=k8s.io/release
-        - --upload=gs://kubernetes-jenkins/pr-logs
-        - --timeout=105
-        - --scenario=kubernetes_e2e
-        - --
-        - --build=bazel
-        - --cluster=
-        - --extract=local
-        - --env=ENABLE_EGRESS_VIA_KONNECTIVITY_SERVICE=true
-        - --env=KONNECTIVITY_SERVICE_PROXY_PROTOCOL_MODE=http-connect
-        - --gcp-node-image=gci
-        - --gcp-zone=us-west1-b
-        - --ginkgo-parallel=30
-        - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-network-proxy-http-connect
-        - --provider=gce
-        - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=9
-        - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200903-fd282bc-master
-        resources:
-          requests:
-            cpu: 2
-            memory: 6Gi
-          limits:
-            cpu: 2
-            memory: 6Gi
-    annotations:
-      testgrid-dashboards: sig-testing-canaries
-      testgrid-tab-name: pull-http-connect-canary
   - name: pull-kubernetes-e2e-gce-network-proxy-grpc
     always_run: false
     optional: true


### PR DESCRIPTION
fixes #18854

  The configuration changes were ...

  migrating pull-kubernetes-e2e-gce-network-proxy-http-connect
  onto the k8s-infra-prow-build cluster

  removing container startup flag --gcp-project=k8s-network-proxy-e2e 

@spiffxp 
This is a second PR to implement this change I closed the previous one.

The presentation of the diff here by git is awkward owing to the duplication of the job to canary test the changes.