### PR TITLE
Bump gce-scale-correctness mem limit to 64 GBs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -39,10 +39,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "48Gi"
+          memory: "64Gi"
         limits:
           cpu: 6
-          memory: "48Gi"
+          memory: "64Gi"
 
 # This is a sig-release-master-blocking job.
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)


### PR DESCRIPTION
The currently set 48 GBs is not enough. The last run OOMed - https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-gce-scale-correctness/1303302432754765825

![9jxVd3sYJweEggq](https://user-images.githubusercontent.com/2604887/92590407-729e0500-f29c-11ea-8925-7512062f2f2a.png)
