### PR TITLE
Add Kubebuilder Maintainers to milestone command

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -407,6 +407,10 @@ repo_milestone:
     maintainers_id: 2195382
     maintainers_team: kubeadm-maintainers
     maintainers_friendly_name: Kubeadm maintainers
+  kubernetes-sigs/kubebuilder:
+    maintainers_id: 2688053
+    maintainers_team: kubebuilder-maintainers
+    maintainers_friendly_name: Kubebuilder Maintainers
 
 project_config:
   project_org_configs:


### PR DESCRIPTION
Adds kubebuilder mainainers to list of groups with milestone command features. cc @camilamacedo86 @pwittrock 