### PR TITLE
add transistion images for bazel 3.4.1

### DIFF
--- a/images/bazel/variants.yaml
+++ b/images/bazel/variants.yaml
@@ -1,8 +1,8 @@
 variants:
   kubernetes:
     CONFIG: kubernetes-master # Used by the kubernetes repo master branch
-    NEW_VERSION: 2.2.0
-    OLD_VERSION: 0.25.2
+    NEW_VERSION: 3.4.1
+    OLD_VERSION: 2.2.0
   org:
     CONFIG: org # Used by org repo
     NEW_VERSION: 3.0.0

--- a/images/krte/cloudbuild.yaml
+++ b/images/krte/cloudbuild.yaml
@@ -23,8 +23,8 @@ substitutions:
   _CONFIG: master
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
-  _BAZEL_VERSION: 2.2.0
-  _OLD_BAZEL_VERSION: 0.23.2
+  _BAZEL_VERSION: 3.4.1
+  _OLD_BAZEL_VERSION: 2.2.0
   _UPGRADE_DOCKER: 'false'
   _CFSSL_VERSION: R1.2
 options:

--- a/images/kubekins-e2e/cloudbuild.yaml
+++ b/images/kubekins-e2e/cloudbuild.yaml
@@ -32,13 +32,13 @@ steps:
     - gcr.io/$PROJECT_ID/kubekins-e2e:latest-$_CONFIG
     dir: images/kubekins-e2e
 substitutions:
-  _BAZEL_VERSION: 2.2.0
+  _BAZEL_VERSION: 3.4.1
+  _OLD_BAZEL_VERSION: 2.2.0
   _CFSSL_VERSION: R1.2
   _CONFIG: master
   _GIT_TAG: '12345'
   _GO_VERSION: 1.13.5
   _K8S_RELEASE: stable
-  _OLD_BAZEL_VERSION: 0.23.2
   _UPGRADE_DOCKER: 'false'
 options:
   substitution_option: ALLOW_LOOSE

--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -3,21 +3,21 @@ variants:
     CONFIG: experimental
     GO_VERSION: 1.15
     K8S_RELEASE: stable
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.28.1
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
     GO_VERSION: 1.15
     K8S_RELEASE: stable
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   master:
     CONFIG: master
     GO_VERSION: 1.15
     K8S_RELEASE: stable
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.19':
     CONFIG: '1.19'
     GO_VERSION: 1.15


### PR DESCRIPTION
While I'm in the neighborhood...

Ideally, this does not switch the effective bazel version of jobs until
we change the .bazelversion file in each repo, but I would appreciate a
confirmation on that assumption.

I'm not touching images/bazelbuild/variants.yaml because I'm not sure
what they are for.

/assign @fejta @BenTheElder 
cc @justaugustus 