### PR TITLE
Make crier use exponential backoff when waiting for lister update.

### DIFF
--- a/prow/crier/controller.go
+++ b/prow/crier/controller.go
@@ -92,11 +92,17 @@ func (r *reconciler) updateReportState(pj *prowv1.ProwJob, log *logrus.Entry, re
 		return fmt.Errorf("failed to patch: %w", err)
 	}
 
+	name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
 	// Block until the update is in the lister to make sure that events from another controller
 	// that also does reporting dont trigger another report because our lister doesn't yet contain
 	// the updated Status
-	name := types.NamespacedName{Namespace: pj.Namespace, Name: pj.Name}
-	if err := wait.Poll(time.Second, 3*time.Second, func() (bool, error) {
+	backoff := wait.Backoff{
+		Duration: 100 * time.Millisecond,
+		Factor:   3.0,
+		Steps:    4,
+		Cap:      3 * time.Second,
+	}
+	if err := wait.ExponentialBackoff(backoff, func() (bool, error) {
 		if err := r.pjclientset.Get(r.ctx, name, pj); err != nil {
 			return false, err
 		}


### PR DESCRIPTION
Previously the initial wait was 1 second which throttled the report rate significantly by blocking the lister. Recent issues with excessive reporting exacerbated this to the point that reporting was 50 mins delayed on some PRs. While we don't need to optimize for the excessive reporting bug, this delay seems unreasonably large even for normal operation as it necessitates blocking reporting for 1 second per job which can be significant when reporting multiple jobs as a group like the gerrit reporter does.

This PR switches to use exponential backoff. Instead of 2 attempts 1 second apart, we now make 4 attempts with intervals of 0.1, 0.3, 0.9, and 2.7 seconds.
/assign @alvaroaleman @fejta 