### PR TITLE
add conformance gate prow job

### DIFF
--- a/config/jobs/kubernetes/sig-arch/OWNERS
+++ b/config/jobs/kubernetes/sig-arch/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the owner of the test code.  The test data itself is owned by sig-architecture.
+reviewers:
+  - cheftako
+  - oomichi
+  - johnbelamaric
+  - bobymcbobs
+approvers:
+  - cheftako
+  - spiffxp
+  - johnbelamaric
+  - hh
+labels:
+  - area/conformance
+  - sig/architecture

--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -1,0 +1,16 @@
+periodics:
+- interval: 3h
+  name: apisnoop-conformance-gate
+  annotations:
+    testgrid-dashboards: sig-arch-conformance
+    testgrid-tab-name: apisnoop-conformance-gate
+    test-grid-alert-email: kubernetes-sig-arch-conformance-test-failures@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+    description: 'Uses APISnoop to check that new GA endpoints are conformance tested in latest e2e test run'
+  decorate: true
+  spec:
+    containers:
+    - name: apisnoop-gate
+      image: gcr.io/k8s-staging-apisnoop/snoopdb:v20200923-v2020.09.23-1-gb3afc41
+      args:
+      - postgres

--- a/config/testgrids/kubernetes/sig-arch/OWNERS
+++ b/config/testgrids/kubernetes/sig-arch/OWNERS
@@ -1,0 +1,16 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+# This is the owner of the test code.  The test data itself is owned by sig-architecture.
+reviewers:
+  - cheftako
+  - oomichi
+  - johnbelamaric
+  - bobymcbobs
+approvers:
+  - cheftako
+  - spiffxp
+  - johnbelamaric
+  - hh
+labels:
+  - area/conformance
+  - sig/architecture

--- a/config/testgrids/kubernetes/sig-arch/config.yaml
+++ b/config/testgrids/kubernetes/sig-arch/config.yaml
@@ -1,0 +1,11 @@
+# Dashboard Group
+#
+dashboard_groups:
+- name: sig-arch
+  dashboard_names:
+  - sig-arch-conformance
+
+# Dashboards
+#
+dashboards:
+- name: sig-arch-conformance


### PR DESCRIPTION
## Summary
This PR introduces a job to check whether any stable endpoints promoted in the release are without conformance tests.  
## Background
It is [a requirement that GA/stable API's have conformance tests](https://github.com/kubernetes/community/pull/1806).  This requirement is hard to enforce and multiple releases have had stable endpoints promoted without tests.  This creates technical debt for conformance,with test writers working on new tests to target API's from older releases.  You can see this in this graph from [APISnoop](https://apisnoop.cncf.io/conformance-progress):
![visualization(3)](https://user-images.githubusercontent.com/21327413/92675194-ed395400-f372-11ea-8bd4-f52ea728734b.png)
where the orange bars in each release mark newly promoted endpoints without tests, and the accumulation of technical debt.
## This job
This prow job uses the same [APISnoop database](https://github.com/cncf/apisnoop/tree/master/apps/snoopdb) to pull in the audit logs from the most recent runs of these two e2e jobs:
- [ci-kubernetes-e2e-gci-gce](https://testgrid.k8s.io/google-gce#gce-cos-master-default)
- [ci-kubernetes-gce-conformance-latest](https://testgrid.k8s.io/conformance-all#Conformance%20-%20GCE%20-%20master)
It compares the endpoints hit by conformance tests in the audit logs to the  endpoints defined in the open API spec, and lists any new GA endpoints that are not hit by a conformance test.  If the list is empty, the job succeeds.  If not, the job fails.  One can then look at the bottom of the logs to find a list of untested endpoints.
You can see an example of this job on [prow.cncf.io](https://prow.cncf.io).

This job is intended to ultimately work as a release blocking job, and so its configured to fit  the [release blocking criteria](https://github.com/kubernetes/sig-release/blob/master/release-blocking-jobs.md#release-blocking-criteria-and-dashboard).  