### PR TITLE
releng: Update build directory for kube-cross images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/k8s-staging-build-image.yaml
@@ -128,6 +128,7 @@ postsubmits:
             args:
               - --project=k8s-staging-build-image
               - --scratch-bucket=gs://k8s-staging-build-image-gcb
+              - --build-dir=.
               - images/build/cross
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
**Needed for https://github.com/kubernetes/release/pull/1418 and https://github.com/kubernetes/release/issues/1517.**

We're taking advantage of some scripts that are above the kube-cross
subdirectory, so we need to pull in the repo root as the build directory
for image building now.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims 
cc: @kubernetes/release-engineering 