### PR TITLE
Bump cpu from 4 to 7 for pull-kubernetes-bazel-test

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -1100,10 +1100,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
   - always_run: true
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -1172,10 +1172,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
   - always_run: true
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -1374,10 +1374,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
   - always_run: true
     branches:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -1314,10 +1314,10 @@ presubmits:
         name: ""
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
   - always_run: true
     branches:

--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -71,10 +71,10 @@ presubmits:
         - -//vendor/...
         resources:
           limits:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
           requests:
-            cpu: 4
+            cpu: 7
             memory: 38Gi
 postsubmits:
   kubernetes/kubernetes:


### PR DESCRIPTION
To match the resources used by the CI version of this job; previous
resources were for running bazel using RBE, we're no longer doing that

Followup to https://github.com/kubernetes/test-infra/pull/19170
Part of https://github.com/kubernetes/test-infra/issues/19070