### PR TITLE
[KEP-1933] Prow Job

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -1,0 +1,49 @@
+presubmits:
+  kubernetes/kubernetes:
+  - name: pull-kubernetes-verify-govet-levee
+    cluster: k8s-infra-prow-build
+    always_run: false
+    decorate: true
+    skip_branches:
+      - release-\d+.\d+ # per-release job
+    optional: true
+    skip_report: false
+    path_alias: k8s.io/kubernetes
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200831-9529f9c-master
+        imagePullPolicy: Always
+        command:
+        - make
+        args:
+        - verify
+        env:
+        # Space separated list of the checks to run
+        - name: WHAT
+          value: govet-levee
+        - name: EXCLUDE_TYPECHECK
+          value: "y"
+        # this is now covered by the optional pull-kubernetes-files-remake that runs when Makefile.generated_files / make-rules changes
+        - name: EXCLUDE_FILES_REMAKE
+          value: "y"
+        - name: EXCLUDE_GODEP
+          value: "y"
+        - name: KUBE_VERIFY_GIT_BRANCH
+          value: master
+        - name: REPO_DIR
+          value: /workspace/k8s.io/kubernetes
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          # Consider reducing memory limits after govet memory usage issue is
+          # addressed in https://github.com/kubernetes/kubernetes/issues/93822
+          limits:
+            cpu: 7
+            memory: 12Gi
+          requests:
+            cpu: 7
+            memory: 12Gi

--- a/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/verify-govet-levee.yaml
@@ -9,6 +9,8 @@ presubmits:
     optional: true
     skip_report: false
     path_alias: k8s.io/kubernetes
+    annotations:
+      testgrid-create-test-group: "true"
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -147,6 +147,9 @@ dashboards:
   - name: pull-kubernetes-files-remake
     test_group_name: pull-kubernetes-files-remake
     base_options: width=10
+  - name: pull-kubernetes-verify-govet-levee
+    test_group_name: pull-kubernetes-verify-govet-levee
+    base_options: width=10
 - name: presubmits-kubernetes-scalability
   dashboard_tab:
   - name: pull-kubernetes-e2e-gce-100-performance


### PR DESCRIPTION
## Summary

This PR introduces a new Prow Job for manually running the [go-flow-levee](https://github.com/google/go-flow-levee/) analyzer on `kubernetes/kubernetes`, as part of the Alpha phase of [KEP-1933](https://github.com/kubernetes/enhancements/tree/master/keps/sig-instrumentation/1933-secret-logging-static-analysis). The test target was introduced in `kubernetes/kubernetes` in [this PR](https://github.com/kubernetes/kubernetes/pull/94661).

The intent is to be able to manually trigger a run of the analyzer on a PR by commenting `/test pull-kubernetes-verify-govet-levee`.

I have tested the Job locally using `pj-on-kind.sh`.

The YAML for the job is based on `config/jobs/kubernetes/sig-testing/verify.yaml`.