### PR TITLE
Reduce ci-conformance-kind-ga-only cpu to 7

### DIFF
--- a/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
+++ b/config/jobs/kubernetes/sig-testing/conformance-e2e.yaml
@@ -182,17 +182,10 @@ periodics:
       resources:
         limits:
           memory: 12Gi
-          cpu: 7300m
+          cpu: 7
         requests:
-          # TODO(BenTheElder): adjust these everywhere
-          # these are both a bit below peak usage during build
-          # this is mostly for building kubernetes
           memory: 12Gi
-          # approximately all of the build cluster node CPU, minus:
-          # - GKE system reserved space based on node size
-          # - network policy addon (which we shouldn't need but have enabled in wg-k8s)
-          # - 100m default we've set for prow pod-utilities sidecar
-          cpu: 7300m
+          cpu: 7
   annotations:
     testgrid-num-failures-to-alert: '2'
     testgrid-alert-stale-results-hours: '48'


### PR DESCRIPTION
This was opened in response to https://k8s-testgrid.appspot.com/sig-release-master-blocking#conformance-ga-only being red; when it fails, it's because it can't schedule

I think we're running into the same issue as kind presubmits that were asking for 7300m and failing to find a node with sufficient CPU. If we want "the whole node", 7 cpu is still enough, since everything here asks for cpu, and nothing asks for <1 cpu

ref: https://github.com/kubernetes/test-infra/pull/19081 for the presubmits