### PR TITLE
add auto push for kube-storage-version-migrator

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-storage-migrator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-storage-migrator.yaml
@@ -1,0 +1,20 @@
+postsubmits:
+  kubernetes-sigs/kube-storage-version-migrator:
+    - name: kube-storage-version-migrator-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20190906-d5d7ce3
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-storage-migrator
+              - --scratch-bucket=gs://k8s-staging-storage-migrator-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
Following the instruction in https://github.com/kubernetes/k8s.io/blob/master/k8s.gcr.io/README.md#enabling-automatic-builds. 

Ref: https://github.com/kubernetes-sigs/kube-storage-version-migrator/issues/72