### PR TITLE
Add exclusion list to buckets.yaml in Kettle

### DIFF
--- a/kettle/README.md
+++ b/kettle/README.md
@@ -70,6 +70,22 @@ It might take a couple of hours to be fully functional and start updating BigQue
 
 To add fields to the BQ table, Visit the [k8s-gubernator:build BigQuery dataset](https://bigquery.cloud.google.com/dataset/k8s-gubernator:build) and Select the table (Ex. Build > All). Schema -> Edit Schema -> Add field. As well as update [schema.json](./schema.json)
 
+## Adding Buckets
+
+To add a new GCS bucket to Kettle, simply update [buckets.yaml](./buckets.yaml) in `master`, it will be auto pulled by Kettle on the next cycle.
+
+```yaml
+gs://<bucket path>: #bucket url
+  contact: "username" #Git Hub Username
+  prefix: "abc:" #the identifier prefixed to jobs from this bucket (ends in :).
+  sequential: (bool) #an optional boolean that indicates whether test runs in this
+  #                  bucket are numbered sequentially
+  exclude_jobs: [
+    'job_name1',
+    'job_name2',
+  ] #List of jobs to explicitly exclude from kettle data collection
+```
+
 # CI
 
 A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml#L203-L210) runs that pushes Kettle on changes.

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -80,10 +80,9 @@ gs://<bucket path>: #bucket url
   prefix: "abc:" #the identifier prefixed to jobs from this bucket (ends in :).
   sequential: (bool) #an optional boolean that indicates whether test runs in this
   #                  bucket are numbered sequentially
-  exclude_jobs: [
-    'job_name1',
-    'job_name2',
-  ] #List of jobs to explicitly exclude from kettle data collection
+  exclude_jobs: # list of jobs to explicitly exclude from kettle data collection
+    - job_name1
+    - job_name2
 ```
 
 # CI
@@ -93,4 +92,3 @@ A [postsubmit job](https://github.com/kubernetes/test-infra/blob/master/config/j
 # Known Issues
 
 - Occasionally data from Kettle stops updating, we suspect this is due to a transient hang when contacting GCS ([#8800](https://github.com/kubernetes/test-infra/issues/8800)). If this happens, [restart kettle](#restarting)
-

--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -6,11 +6,16 @@
 #   sequential: an optional boolean that indicates whether test runs in this
 #     bucket are numbered sequentially. This is used for an optimization in the
 #     collection phase, and defaults to true.
+#   exclude_jobs: A list of job names that will not be uploaded to BQ
 
 gs://kubernetes-jenkins/logs/:
   contact: "fejta"
   prefix: ""
   sequential: false
+  exclude_jobs: [
+    'ci-test-infra-benchmark-demo',
+    'ci-kubernetes-coverage-unit',
+  ]
 gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"

--- a/kettle/buckets.yaml
+++ b/kettle/buckets.yaml
@@ -12,10 +12,9 @@ gs://kubernetes-jenkins/logs/:
   contact: "fejta"
   prefix: ""
   sequential: false
-  exclude_jobs: [
-    'ci-test-infra-benchmark-demo',
-    'ci-kubernetes-coverage-unit',
-  ]
+  exclude_jobs:
+    - ci-test-infra-benchmark-demo
+    - ci-kubernetes-coverage-unit
 gs://canonical-kubernetes-tests/logs/:
   contact: "chuckbutler"
   prefix: "juju:"

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -39,10 +39,7 @@ def pad_numbers(string):
     return re.sub(r'\d+', lambda m: m.group(0).rjust(16, '0'), string)
 
 WORKER_CLIENT = None  # used for multiprocessing
-GARBAGE_JOBS = (
-    'ci-test-infra-benchmark-demo',
-    'ci-kubernetes-coverage-unit',
-    )
+
 
 class GCSClient:
     def __init__(self, jobs_dir, metadata=None):
@@ -171,7 +168,7 @@ class GCSClient:
                     yield job, build
             return
         for job in self._get_jobs():
-            if job in GARBAGE_JOBS:
+            if job in self.metadata.get('exclude_jobs', []):
                 continue
             have = 0
             precise, builds = self._get_builds(job)

--- a/kettle/make_db_test.py
+++ b/kettle/make_db_test.py
@@ -97,7 +97,6 @@ class GCSClientTest(unittest.TestCase):
         self.assertFalse(precise)
         self.assertEqual(['4', '3', '2', '1'], list(gen))
 
-
     def test_get_builds_latest_fallback(self):
         # fallback: still lists a directory when build-latest.txt isn't an int
         self.assertEqual((True, ['6']), self.client._get_builds('bad-latest'))
@@ -108,6 +107,15 @@ class GCSClientTest(unittest.TestCase):
         self.assertEqual((True, ['4', '3']),
                          self.client._get_builds('latest'))
 
+    def test_get_builds_exclude_list_no_match(self):
+        # special case: job is in excluded list
+        self.client.metadata = {'exclude_jobs': ['notfake']}
+        self.assertEqual([('fake', '123'), ('fake', '122')], list(self.client.get_builds(set())))
+
+    def test_get_builds_exclude_list_match(self):
+        # special case: job is in excluded list
+        self.client.metadata = {'exclude_jobs': ['fake']}
+        self.assertEqual([], list(self.client.get_builds(set())))
 
 class MainTest(unittest.TestCase):
     """End-to-end test of the main function's output."""

--- a/kettle/make_db_test.py
+++ b/kettle/make_db_test.py
@@ -108,7 +108,7 @@ class GCSClientTest(unittest.TestCase):
                          self.client._get_builds('latest'))
 
     def test_get_builds_exclude_list_no_match(self):
-        # special case: job is in excluded list
+        # special case: job is not in excluded list
         self.client.metadata = {'exclude_jobs': ['notfake']}
         self.assertEqual([('fake', '123'), ('fake', '122')], list(self.client.get_builds(set())))
 


### PR DESCRIPTION
This adds Tests, Docs, and code to ignore a list of jobs pulled from that bucket URL. This does not require kettle redeploy to update the exclude list, just merge changes in `buckets.yaml` to master. 

/area kettle
/cc @spiffxp @michaelkolber 
/kind feature