### PR TITLE
Change CRIO systemd service type to exec

### DIFF
--- a/jobs/e2e_node/crio/crio.ign
+++ b/jobs/e2e_node/crio/crio.ign
@@ -4,7 +4,7 @@
     "units": [{
       "name": "crio.service",
       "enabled": true,
-      "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error  -o /usr/local/sbin/crio-config.sh https://raw.githubusercontent.com/harche/crio-fcos-config/master/test.sh\nExecStartPre=/bin/chmod 544 /usr/local/sbin/crio-config.sh\nExecStart=/usr/local/sbin/crio-config.sh\n\n[Install]\nWantedBy=multi-user.target\n" 
+      "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=exec\nExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error  -o /usr/local/sbin/crio-config.sh https://raw.githubusercontent.com/harche/crio-fcos-config/master/test.sh\nExecStartPre=/bin/chmod 544 /usr/local/sbin/crio-config.sh\nExecStart=/usr/local/sbin/crio-config.sh\n\n[Install]\nWantedBy=multi-user.target\n" 
     }]
   }
 }

--- a/jobs/e2e_node/crio/fcos_cgroupv2.ign
+++ b/jobs/e2e_node/crio/fcos_cgroupv2.ign
@@ -9,7 +9,7 @@
     {
       "name": "crio.service",
       "enabled": true,
-      "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=oneshot\nExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error  -o /usr/local/sbin/crio-config.sh https://raw.githubusercontent.com/harche/crio-fcos-config/master/test.sh\nExecStartPre=/bin/chmod 544 /usr/local/sbin/crio-config.sh\nExecStart=/usr/local/sbin/crio-config.sh\n\n[Install]\nWantedBy=multi-user.target\n" 
+      "contents": "[Unit]\nDescription=Download and install crio binaries and configurations.\nAfter=network-online.target\n\n[Service]\nType=exec\nExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error  -o /usr/local/sbin/crio-config.sh https://raw.githubusercontent.com/harche/crio-fcos-config/master/test.sh\nExecStartPre=/bin/chmod 544 /usr/local/sbin/crio-config.sh\nExecStart=/usr/local/sbin/crio-config.sh\n\n[Install]\nWantedBy=multi-user.target\n" 
     }]
   }
 }


### PR DESCRIPTION
Just before node e2e tests start, [we check](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/runner/remote/run_remote.go#L671) if the runtime service is in `running` state on the target host. 

The current crio service stays in `activating (start)` status, but the [expected status](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/runner/remote/run_remote.go#L671) is `running`. Since the crio start up script downloads and starts the crio deamon it never returns and hence changing the [systemd service Type](https://www.freedesktop.org/software/systemd/man/systemd.service.html) to `exec`. 

I know the [existing check](https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/runner/remote/run_remote.go#L676) for the runtime on the remote host doesn't look for `crio.service` but I will send that fix in a separate PR. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>