### PR TITLE
Add call timing and error dumping to kettle

### DIFF
--- a/kettle/update.py
+++ b/kettle/update.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 
 
-
-
-
 import os
 from datetime import datetime
 
@@ -34,7 +31,6 @@ def print_dump(file):
 
 
 def call(cmd, dump=False):
-
     started = datetime.now()
 
     redirect = ' > {DUMP}}' if dump else ''

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -39,7 +39,8 @@ def call(cmd, dump=False):
     ended = datetime.now()
     print(f'+{cmd} completed in {started-ended}')
     if status:
-        if dump: print_dump(DUMP)
+        if dump:
+            print_dump(DUMP)
         raise OSError(f'invocation failed: {dump}')
 
 

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -33,8 +33,8 @@ def print_dump(file):
 def call(cmd, dump=False):
     started = datetime.now()
 
-    redirect = ' > {DUMP}}' if dump else ''
-    status = os.system(f'{cmd}{redirect}')
+    cmd = f'{cmd} > {DUMP}' if dump else cmd
+    status = os.system(cmd)
 
     ended = datetime.now()
     print(f'+{cmd} completed in {started-ended}')


### PR DESCRIPTION
To better debug kettle failures and stale build tables, I added some more debugging information to the updater. #13432 investigation 

/area kettle

/cc @spiffxp 

Currently output only looks like :
```
  File "/kettle/update.py", line 59, in <module>
    main()
  File "/kettle/update.py", line 47, in main
    call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json')
  File "/kettle/update.py", line 25, in call
    raise OSError('invocation failed')
OSError: invocation failed
" 
```
I chose the redirect because subprocess lib sometimes has memory issue with large calls and I didn't want to hit that. 
