### PR TITLE
Update Legacy Endpoints for Delete and Edit

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -604,7 +604,7 @@ func validateTeamNames(orgConfig org.Config) error {
 type teamClient interface {
 	ListTeams(org string) ([]github.Team, error)
 	CreateTeam(org string, team github.Team) (*github.Team, error)
-	DeleteTeam(id int) error
+	DeleteTeam(org string, id int) error
 }
 
 // configureTeams returns the ids for all expected team names, creating/deleting teams as necessary.
@@ -715,7 +715,7 @@ func configureTeams(client teamClient, orgName string, orgConfig org.Config, max
 	}
 	// Delete undeclared teams.
 	for id := range unused {
-		if err := client.DeleteTeam(id); err != nil {
+		if err := client.DeleteTeam(orgName, id); err != nil {
 			str := fmt.Sprintf("%d(%s)", id, ids[id].Name)
 			logrus.WithError(err).Warnf("Failed to delete team %s from %s", str, orgName)
 			failures = append(failures, str)
@@ -1092,7 +1092,7 @@ func configureTeamAndMembers(opt options, client github.Client, githubTeams map[
 }
 
 type editTeamClient interface {
-	EditTeam(team github.Team) (*github.Team, error)
+	EditTeam(org string, team github.Team) (*github.Team, error)
 }
 
 // configureTeam patches the team name/description/privacy when values differ
@@ -1136,7 +1136,7 @@ func configureTeam(client editTeamClient, orgName, teamName string, team org.Tea
 	}
 
 	if patch { // yes we need to patch
-		if _, err := client.EditTeam(gt); err != nil {
+		if _, err := client.EditTeam(orgName, gt); err != nil {
 			return fmt.Errorf("failed to edit %s team %d(%s): %v", orgName, gt.ID, gt.Name, err)
 		}
 	}

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -756,7 +756,7 @@ func (c *fakeTeamClient) ListTeams(name string) ([]github.Team, error) {
 	return teams, nil
 }
 
-func (c *fakeTeamClient) DeleteTeam(id int) error {
+func (c *fakeTeamClient) DeleteTeam(org string, id int) error {
 	switch _, ok := c.teams[id]; {
 	case !ok:
 		return fmt.Errorf("not found %d", id)
@@ -767,7 +767,7 @@ func (c *fakeTeamClient) DeleteTeam(id int) error {
 	return nil
 }
 
-func (c *fakeTeamClient) EditTeam(team github.Team) (*github.Team, error) {
+func (c *fakeTeamClient) EditTeam(org string, team github.Team) (*github.Team, error) {
 	id := team.ID
 	t, ok := c.teams[id]
 	if !ok {

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -167,9 +167,9 @@ type RepositoryClient interface {
 
 // TeamClient interface for team related API actions
 type TeamClient interface {
-	CreateTeam(org string, team Team) (*Team, error)
-	EditTeam(t Team) (*Team, error)
-	DeleteTeam(id int) error
+	CreateTeam(org string, t Team) (*Team, error)
+	EditTeam(org string, t Team) (*Team, error)
+	DeleteTeam(org string, id int) error
 	ListTeams(org string) ([]Team, error)
 	UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error)
 	RemoveTeamMembership(id int, user string) error
@@ -2787,18 +2787,18 @@ func (c *client) Query(ctx context.Context, q interface{}, vars map[string]inter
 
 // CreateTeam adds a team with name to the org, returning a struct with the new ID.
 //
-// See https://developer.github.com/v3/teams/#create-team
-func (c *client) CreateTeam(org string, team Team) (*Team, error) {
-	durationLogger := c.log("CreateTeam", org, team)
+// See https://docs.github.com/en/rest/reference/teams#create-team
+func (c *client) CreateTeam(org string, t Team) (*Team, error) {
+	durationLogger := c.log("CreateTeam", org, t)
 	defer durationLogger()
 
-	if team.Name == "" {
+	if t.Name == "" {
 		return nil, errors.New("team.Name must be non-empty")
 	}
 	if c.fake {
 		return nil, nil
 	} else if c.dry {
-		return &team, nil
+		return &t, nil
 	}
 	path := fmt.Sprintf("/orgs/%s/teams", org)
 	var retTeam Team
@@ -2808,7 +2808,7 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		accept:      "application/vnd.github.hellcat-preview+json",
-		requestBody: &team,
+		requestBody: &t,
 		exitCodes:   []int{201},
 	}, &retTeam)
 	return &retTeam, err
@@ -2816,9 +2816,9 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 
 // EditTeam patches team.ID to contain the specified other values.
 //
-// See https://developer.github.com/v3/teams/#edit-team
-func (c *client) EditTeam(t Team) (*Team, error) {
-	durationLogger := c.log("EditTeam", t)
+// See https://docs.github.com/en/rest/reference/teams#edit-team
+func (c *client) EditTeam(org string, t Team) (*Team, error) {
+	durationLogger := c.log("EditTeam", org, t)
 	defer durationLogger()
 
 	if t.ID == 0 {
@@ -2838,7 +2838,7 @@ func (c *client) EditTeam(t Team) (*Team, error) {
 		ParentTeamID: t.ParentTeamID,
 	}
 	var retTeam Team
-	path := fmt.Sprintf("/teams/%d", id)
+	path := fmt.Sprintf("/orgs/%s/teams/%d", org, id)
 	_, err := c.request(&request{
 		method: http.MethodPatch,
 		path:   path,
@@ -2853,11 +2853,11 @@ func (c *client) EditTeam(t Team) (*Team, error) {
 
 // DeleteTeam removes team.ID from GitHub.
 //
-// See https://developer.github.com/v3/teams/#delete-team
-func (c *client) DeleteTeam(id int) error {
+// See https://docs.github.com/en/rest/reference/teams#delete-a-team
+func (c *client) DeleteTeam(org string, id int) error {
 	durationLogger := c.log("DeleteTeam", id)
 	defer durationLogger()
-	path := fmt.Sprintf("/teams/%d", id)
+	path := fmt.Sprintf("/orgs/%s/teams/%d", org, id)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      path,
@@ -2868,7 +2868,7 @@ func (c *client) DeleteTeam(id int) error {
 
 // ListTeams gets a list of teams for the given org
 //
-// See https://developer.github.com/v3/teams/#list-teams
+// See https://docs.github.com/en/rest/reference/teams#list-teams
 func (c *client) ListTeams(org string) ([]Team, error) {
 	durationLogger := c.log("ListTeams", org)
 	defer durationLogger()
@@ -2984,7 +2984,7 @@ func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 
 // ListTeamRepos gets a list of team repos for the given team id
 //
-// https://developer.github.com/v3/teams/#list-team-repos
+// https://docs.github.com/en/rest/reference/teams#list-team-repos
 func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 	durationLogger := c.log("ListTeamRepos", id)
 	defer durationLogger()
@@ -3025,7 +3025,7 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 
 // UpdateTeamRepo adds the repo to the team with the provided role.
 //
-// https://developer.github.com/v3/teams/#add-or-update-team-repository
+// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository
 func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error {
 	durationLogger := c.log("UpdateTeamRepo", id, org, repo, permission)
 	defer durationLogger()
@@ -3051,7 +3051,7 @@ func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermiss
 
 // RemoveTeamRepo removes the team from the repo.
 //
-// https://developer.github.com/v3/teams/#add-or-update-team-repository
+// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository
 func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 	durationLogger := c.log("RemoveTeamRepo", id, org, repo)
 	defer durationLogger()
@@ -3676,7 +3676,7 @@ func (c *client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
 
 // GetTeamBySlug returns information about that team
 //
-// See https://developer.github.com/v3/teams/#get-team-by-name
+// See https://docs.github.com/en/rest/reference/teams#get-team-by-name
 func (c *client) GetTeamBySlug(slug string, org string) (*Team, error) {
 	durationLogger := c.log("GetTeamBySlug", slug, org)
 	defer durationLogger()
@@ -3695,3 +3695,4 @@ func (c *client) GetTeamBySlug(slug string, org string) (*Team, error) {
 	}
 	return &team, err
 }
+

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -2984,7 +2984,7 @@ func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 
 // ListTeamRepos gets a list of team repos for the given team id
 //
-// https://docs.github.com/en/rest/reference/teams#list-team-repos
+// https://docs.github.com/en/rest/reference/teams#list-team-repositories
 func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 	durationLogger := c.log("ListTeamRepos", id)
 	defer durationLogger()
@@ -3025,7 +3025,7 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 
 // UpdateTeamRepo adds the repo to the team with the provided role.
 //
-// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository
+// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions
 func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error {
 	durationLogger := c.log("UpdateTeamRepo", id, org, repo, permission)
 	defer durationLogger()
@@ -3051,7 +3051,7 @@ func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermiss
 
 // RemoveTeamRepo removes the team from the repo.
 //
-// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository
+// https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions
 func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 	durationLogger := c.log("RemoveTeamRepo", id, org, repo)
 	defer durationLogger()
@@ -3676,7 +3676,7 @@ func (c *client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
 
 // GetTeamBySlug returns information about that team
 //
-// See https://docs.github.com/en/rest/reference/teams#get-team-by-name
+// See https://docs.github.com/en/rest/reference/teams#get-a-team-by-name
 func (c *client) GetTeamBySlug(slug string, org string) (*Team, error) {
 	durationLogger := c.log("GetTeamBySlug", slug, org)
 	defer durationLogger()
@@ -3695,4 +3695,3 @@ func (c *client) GetTeamBySlug(slug string, org string) (*Team, error) {
 	}
 	return &team, err
 }
-

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1624,7 +1624,7 @@ func TestDeleteTeam(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-        if err := c.DeleteTeam("foo", 63); err != nil {
+	if err := c.DeleteTeam("foo", 63); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
@@ -2498,4 +2498,3 @@ func TestCreateFork(t *testing.T) {
 		}
 	}
 }
-

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1571,7 +1571,7 @@ func TestEditTeam(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
 		}
-		if r.URL.Path != "/teams/63" {
+		if r.URL.Path != "/orgs/foo/teams/63" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 		b, err := ioutil.ReadAll(r.Body)
@@ -1597,10 +1597,10 @@ func TestEditTeam(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if _, err := c.EditTeam(Team{ID: 0, Name: "frobber"}); err == nil {
+	if _, err := c.EditTeam("foo", Team{ID: 0, Name: "frobber"}); err == nil {
 		t.Errorf("client should reject id 0")
 	}
-	switch team, err := c.EditTeam(Team{ID: 63, Name: "frobber"}); {
+	switch team, err := c.EditTeam("foo", Team{ID: 63, Name: "frobber"}); {
 	case err != nil:
 		t.Errorf("unexpected error: %v", err)
 	case team.Name != "hello":
@@ -1609,6 +1609,23 @@ func TestEditTeam(t *testing.T) {
 		t.Errorf("bad description: %s", team.Description)
 	case team.Privacy != "special":
 		t.Errorf("bad privacy: %s", team.Privacy)
+	}
+}
+
+func TestDeleteTeam(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("Bad method: %s", r.Method)
+		}
+		if r.URL.Path != "/orgs/foo/teams/63" {
+			t.Errorf("Bad request path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusNoContent) // 204
+	}))
+	defer ts.Close()
+	c := getClient(ts.URL)
+        if err := c.DeleteTeam("foo", 63); err != nil {
+		t.Errorf("unexpected error: %v", err)
 	}
 }
 
@@ -2481,3 +2498,4 @@ func TestCreateFork(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
Started work on updating Legacy endpoints for prow Github client. Updated references also. 

There was a unit test missing for Delete so I added that as well.

/area Prow
/kind cleanup

see #19186 for more context. More end point TODO

![image](https://user-images.githubusercontent.com/7189267/93035183-2aab1500-f5f1-11ea-82a9-8a8a60482234.png)
