### PR TITLE
Fix requests&limits for golang job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -26,11 +26,11 @@ periodics:
           privileged: true
         resources:
           requests:
-            cpu: 8
-            memory: "32Gi"
+            cpu: 4
+            memory: "16Gi"
           limits:
-            cpu: 8
-            memory: "32Gi"
+            cpu: 4
+            memory: "16Gi"
 
 
 - interval: 8h


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/19119. The CPU request was too large for the test pod of `ci-build-and-push-k8s-at-golang-tip`.

Adjusting the memory limit&request as well to match scalability 100 nodes presubmit test jobs.

/sig scalability
/cc mm4tt wojtek-t