### PR TITLE
Update query to use new `repos` field and `repo_commit`

### DIFF
--- a/metrics/configs/flakes-config.yaml
+++ b/metrics/configs/flakes-config.yaml
@@ -55,14 +55,10 @@ query: |
           SELECT
             job,
             if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,  /* pull or ci */
-            version, /* bootstrap git version, empty for ci  */
+            ifnull(repo_commit, version) version, /* bootstrap git version, empty for ci  */
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
-                (
-                  select i.value
-                  from t.metadata i
-                  where i.key = 'repos'
-                ),
+                repos,
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
               version
@@ -75,13 +71,7 @@ query: |
             and version != 'unknown'
             and (
               (substr(job, 0, 3) = 'ci-' and version != 'unknown') or
-              exists(
-                select as struct
-                  i
-                from t.metadata i
-                where i.key = 'repos' and
-                array_length(split(replace(i.value,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
-              )
+              array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
             )
         )
         group by job, commit


### PR DESCRIPTION
This is part of the effort to integrate [@spiffxp 's proposal](https://docs.google.com/document/d/139R-4VJjt9_RF2tcNNnH_fi35qQPdCot8CIhaG91HOU/edit#heading=h.x9snb54sjlu9) #14643. These changes are the `Update the query` element of the doc. 

Kettle has been updated so that every job with `repos` in either `Started.json` or `finished.json.metadata` will get populated as a json Blob string. So both Bootstrap and Decorated jobs will populate it. Kettle now also populates `repo-commit` field which was updated in the query to be the default and fall back to `version` if `null`.

*Kettle was only updated to make these changes about a month and a half ago. If this is merged we will not be looking at flakes that far back. Because we only look a week back here... I think this is ok.

/hold
make sure this looks correct... 

/area metrics
/cc @cjwagner @spiffxp 

Reference queries
```
          SELECT
            job,
            if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,  /* pull or ci */
            ifnull(repo_commit, version) version, /* bootstrap git version, empty for ci  */
            if(substr(job, 0, 3) = 'pr:',
              regexp_extract(
                repos,
                r'[^,]+,\d+:([a-f0-9]+)"'
              ),
              version
            ) commit,  /* repo commit for PR or version for CI */
            result,  /* SUCCESS if the build passed */
            test  /* repeated tuple of tests */
          FROM `k8s-gubernator.build.week` as t
          where
            datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
            and version != 'unknown'
            and (
              (substr(job, 0, 3) = 'ci-' and version != 'unknown') or
              array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
            )
```
and
```
SELECT * FROM `k8s-gubernator.build.week` WHERE started > '2020-09-04 23:05:29'
``` 
Just to grab some recent runs