### PR TITLE
Part2: Api endpoint updates for Team and Repo endpoints

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -228,23 +228,14 @@ func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient
 			return true, nil
 		}
 	}
-	for _, ght := range rac.GitHubTeamIDs {
-		member, err := cli.TeamHasMember(ght, user)
-		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of team %v, verify that you have the correct team number and access token: %v", ght, err)
-		}
-		if member {
-			return true, nil
-		}
-	}
 	for _, ghts := range rac.GitHubTeamSlugs {
 		team, err := cli.GetTeamBySlug(ghts.Slug, ghts.Org)
 		if err != nil {
 			return false, fmt.Errorf("GitHub failed to fetch team with slug %s and org %s: %v", ghts.Slug, ghts.Org, err)
 		}
-		member, err := cli.TeamHasMember(team.ID, user)
+		member, err := cli.TeamHasMember(ghts.Org, team.ID, user)
 		if err != nil {
-			return false, fmt.Errorf("GitHub failed to fetch members of team %v: %v", team, err)
+			return false, fmt.Errorf("GitHub failed to fetch members of org %s team %v: %v", ghts.Org, team, err)
 		}
 		if member {
 			return true, nil

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1270,7 +1270,7 @@ func configureTeamMembers(client teamMembersClient, gt github.Team, orgName stri
 		}
 		tm, err := client.UpdateTeamMembership(orgName, gt.ID, user, super)
 		if err != nil {
-			logrus.WithError(err).Warnf("UpdateTeamMembership(%s, %d(%s), %s, %t) failed",orgName, gt.ID, gt.Name, user, super)
+			logrus.WithError(err).Warnf("UpdateTeamMembership(%s, %d(%s), %s, %t) failed", orgName, gt.ID, gt.Name, user, super)
 		} else if tm.State == github.StatePending {
 			logrus.Infof("Invited %s to %d(%s) as a %s", user, gt.ID, gt.Name, role)
 		} else {

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -280,7 +280,7 @@ func (c *fakeClient) UpdateOrgMembership(org, user string, admin bool) (*github.
 	}, nil
 }
 
-func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team 66 supported, not %d", id)
 	}
@@ -294,7 +294,7 @@ func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, 
 	}
 }
 
-func (c *fakeClient) ListTeamInvitations(id int) ([]github.OrgInvitation, error) {
+func (c *fakeClient) ListTeamInvitations(org string, id int) ([]github.OrgInvitation, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team 66 supported, not %d", id)
 	}
@@ -314,7 +314,7 @@ func (c *fakeClient) ListTeamInvitations(id int) ([]github.OrgInvitation, error)
 
 const teamID = 66
 
-func (c *fakeClient) UpdateTeamMembership(id int, user string, maintainer bool) (*github.TeamMembership, error) {
+func (c *fakeClient) UpdateTeamMembership(org string, id int, user string, maintainer bool) (*github.TeamMembership, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team %d supported, not %d", teamID, id)
 	}
@@ -345,7 +345,7 @@ func (c *fakeClient) UpdateTeamMembership(id int, user string, maintainer bool) 
 	}, nil
 }
 
-func (c *fakeClient) RemoveTeamMembership(id int, user string) error {
+func (c *fakeClient) RemoveTeamMembership(org string, id int, user string) error {
 	if id != teamID {
 		return fmt.Errorf("only team %d supported, not %d", teamID, id)
 	}
@@ -1355,7 +1355,7 @@ func TestConfigureTeamMembers(t *testing.T) {
 				newAdmins:  sets.String{},
 				newMembers: sets.String{},
 			}
-			err := configureTeamMembers(fc, gt, tc.team)
+			err := configureTeamMembers(fc, gt, "whatevOrg", tc.team)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -2120,7 +2120,7 @@ func (c fakeDumpClient) ListTeams(name string) ([]github.Team, error) {
 	return c.teams, nil
 }
 
-func (c fakeDumpClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c fakeDumpClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	var mapping map[int][]string
 	switch {
 	case id < 0:
@@ -2139,7 +2139,7 @@ func (c fakeDumpClient) ListTeamMembers(id int, role string) ([]github.TeamMembe
 	return c.makeMembers(people)
 }
 
-func (c fakeDumpClient) ListTeamRepos(id int) ([]github.Repo, error) {
+func (c fakeDumpClient) ListTeamRepos(org string, id int) ([]github.Repo, error) {
 	if id < 0 {
 		return nil, errors.New("injected ListTeamRepos error")
 	}
@@ -2264,14 +2264,14 @@ type fakeTeamRepoClient struct {
 	failList, failUpdate, failRemove bool
 }
 
-func (c *fakeTeamRepoClient) ListTeamRepos(id int) ([]github.Repo, error) {
+func (c *fakeTeamRepoClient) ListTeamRepos(org string, id int) ([]github.Repo, error) {
 	if c.failList {
 		return nil, errors.New("injected failure to ListTeamRepos")
 	}
 	return c.repos[id], nil
 }
 
-func (c *fakeTeamRepoClient) UpdateTeamRepo(id int, org, repo string, permission github.RepoPermissionLevel) error {
+func (c *fakeTeamRepoClient) UpdateTeamRepo(org string, id int, owner, repo string, permission github.RepoPermissionLevel) error {
 	if c.failUpdate {
 		return errors.New("injected failure to UpdateTeamRepos")
 	}
@@ -2292,7 +2292,7 @@ func (c *fakeTeamRepoClient) UpdateTeamRepo(id int, org, repo string, permission
 	return nil
 }
 
-func (c *fakeTeamRepoClient) RemoveTeamRepo(id int, org, repo string) error {
+func (c *fakeTeamRepoClient) RemoveTeamRepo(org string, id int, owner, repo string) error {
 	if c.failRemove {
 		return errors.New("injected failure to RemoveTeamRepos")
 	}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -171,14 +171,14 @@ type TeamClient interface {
 	EditTeam(org string, t Team) (*Team, error)
 	DeleteTeam(org string, id int) error
 	ListTeams(org string) ([]Team, error)
-	UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error)
-	RemoveTeamMembership(id int, user string) error
-	ListTeamMembers(id int, role string) ([]TeamMember, error)
-	ListTeamRepos(id int) ([]Repo, error)
-	UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error
-	RemoveTeamRepo(id int, org, repo string) error
-	ListTeamInvitations(id int) ([]OrgInvitation, error)
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error)
+	RemoveTeamMembership(org string, id int, user string) error
+	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
+	ListTeamRepos(org string, id int) ([]Repo, error)
+	UpdateTeamRepo(org string, id int, owner, repo string, permission RepoPermissionLevel) error
+	RemoveTeamRepo(org string, id int, owner, repo string) error
+	ListTeamInvitations(org string, id int) ([]OrgInvitation, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 	GetTeamBySlug(slug string, org string) (*Team, error)
 }
 
@@ -210,7 +210,7 @@ type MilestoneClient interface {
 
 // RerunClient interface for job rerun access check related API actions
 type RerunClient interface {
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 	GetTeamBySlug(slug string, org string) (*Team, error)
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
@@ -2901,7 +2901,7 @@ func (c *client) ListTeams(org string) ([]Team, error) {
 // If the user is not a member of the org, GitHub will invite them to become an outside collaborator, setting their status to pending.
 //
 // https://developer.github.com/v3/teams/members/#add-or-update-team-membership
-func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error) {
+func (c *client) UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error) {
 	durationLogger := c.log("UpdateTeamMembership", id, user, maintainer)
 	defer durationLogger()
 
@@ -2921,7 +2921,7 @@ func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*Te
 
 	_, err := c.request(&request{
 		method:      http.MethodPut,
-		path:        fmt.Sprintf("/teams/%d/memberships/%s", id, user),
+		path:        fmt.Sprintf("/orgs/%s/teams/%d/memberships/%s", org, id, user),
 		requestBody: &tm,
 		exitCodes:   []int{200},
 	}, &tm)
@@ -2931,8 +2931,8 @@ func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*Te
 // RemoveTeamMembership removes the user from the team (but not the org).
 //
 // https://developer.github.com/v3/teams/members/#remove-team-member
-func (c *client) RemoveTeamMembership(id int, user string) error {
-	durationLogger := c.log("RemoveTeamMembership", id, user)
+func (c *client) RemoveTeamMembership(org string, id int, user string) error {
+	durationLogger := c.log("RemoveTeamMembership", org, id, user)
 	defer durationLogger()
 
 	if c.fake {
@@ -2940,7 +2940,7 @@ func (c *client) RemoveTeamMembership(id int, user string) error {
 	}
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
-		path:      fmt.Sprintf("/teams/%d/memberships/%s", id, user),
+		path:      fmt.Sprintf("/orgs/%s/teams/%d/memberships/%s", org, id, user),
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -2951,14 +2951,14 @@ func (c *client) RemoveTeamMembership(id int, user string) error {
 // Role options are "all", "maintainer" and "member"
 //
 // https://developer.github.com/v3/teams/members/#list-team-members
-func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
-	durationLogger := c.log("ListTeamMembers", id, role)
+func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember, error) {
+	durationLogger := c.log("ListTeamMembers", org, id, role)
 	defer durationLogger()
 
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/teams/%d/members", id)
+	path := fmt.Sprintf("/orgs/%s/teams/%d/members", org, id)
 	var teamMembers []TeamMember
 	err := c.readPaginatedResultsWithValues(
 		path,
@@ -2992,7 +2992,7 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/teams/%d/repos", id)
+	path := fmt.Sprintf("/orgs/%s/teams/%d/repos", org, id)
 	var repos []Repo
 	err := c.readPaginatedResultsWithValues(
 		path,
@@ -3042,14 +3042,14 @@ func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermiss
 
 	_, err := c.request(&request{
 		method:      http.MethodPut,
-		path:        fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo),
+		path:        fmt.Sprintf("/orgs/%s/teams/%d/repos/%s/%s", org, id, owner, repo),
 		requestBody: &data,
 		exitCodes:   []int{204},
 	}, nil)
 	return err
 }
 
-// RemoveTeamRepo removes the team from the repo.
+// RemoveTeamRepo removes the repo from the team.
 //
 // https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions
 func (c *client) RemoveTeamRepo(id int, org, repo string) error {
@@ -3062,7 +3062,7 @@ func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
-		path:      fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo),
+		path:      fmt.Sprintf("orgs/%s/teams/%d/repos/%s/%s", org, id, owner, repo),
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -3072,14 +3072,14 @@ func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 // given team id
 //
 // https://developer.github.com/v3/teams/members/#list-pending-team-invitations
-func (c *client) ListTeamInvitations(id int) ([]OrgInvitation, error) {
-	durationLogger := c.log("ListTeamInvites", id)
+func (c *client) ListTeamInvitations(org string, id int) ([]OrgInvitation, error) {
+	durationLogger := c.log("ListTeamInvites", org, id)
 	defer durationLogger()
 
 	if c.fake {
 		return nil, nil
 	}
-	path := fmt.Sprintf("/teams/%d/invitations", id)
+	path := fmt.Sprintf("/orgs/%s/teams/%d/invitations", org, id)
 	var ret []OrgInvitation
 	err := c.readPaginatedResults(
 		path,
@@ -3658,11 +3658,11 @@ func (c *client) DeleteProjectCard(projectCardID int) error {
 }
 
 // TeamHasMember checks if a user belongs to a team
-func (c *client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
-	durationLogger := c.log("TeamHasMember", teamID, memberLogin)
+func (c *client) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
+	durationLogger := c.log("TeamHasMember", org, teamID, memberLogin)
 	defer durationLogger()
 
-	projectMaintainers, err := c.ListTeamMembers(teamID, RoleAll)
+	projectMaintainers, err := c.ListTeamMembers(org, teamID, RoleAll)
 	if err != nil {
 		return false, err
 	}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1630,10 +1630,10 @@ func TestDeleteTeam(t *testing.T) {
 }
 
 func TestListTeamMembers(t *testing.T) {
-	ts := simpleTestServer(t, "/teams/1/members", []TeamMember{{Login: "foo"}})
+	ts := simpleTestServer(t, "/orgs/foo/teams/1/members", []TeamMember{{Login: "foo"}})
 	defer ts.Close()
 	c := getClient(ts.URL)
-	teamMembers, err := c.ListTeamMembers(1, RoleAll)
+	teamMembers, err := c.ListTeamMembers("foo", 1, RoleAll)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	} else if len(teamMembers) != 1 {
@@ -2453,8 +2453,9 @@ func TestAuthHeaderGetsSet(t *testing.T) {
 		})
 	}
 }
+
 func TestListTeamRepos(t *testing.T) {
-	ts := simpleTestServer(t, "/teams/1/repos",
+	ts := simpleTestServer(t, "/orgs/foo/teams/1/repos",
 		[]Repo{
 			{
 				Name:        "repo-bar",
@@ -2467,7 +2468,7 @@ func TestListTeamRepos(t *testing.T) {
 	)
 	defer ts.Close()
 	c := getClient(ts.URL)
-	repos, err := c.ListTeamRepos(1)
+	repos, err := c.ListTeamRepos("foo", 1)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	} else if len(repos) != 1 {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -439,7 +439,7 @@ func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
 }
 
 // ListTeamMembers return a fake team with a single "sig-lead" GitHub teammember
-func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]github.TeamMember, error) {
+func (f *FakeClient) ListTeamMembers(org string, teamID int, role string) ([]github.TeamMember, error) {
 	if role != github.RoleAll {
 		return nil, fmt.Errorf("unsupported role %v (only all supported)", role)
 	}
@@ -687,8 +687,8 @@ func (f *FakeClient) MoveProjectCard(projectCardID int, newColumnID int) error {
 }
 
 // TeamHasMember checks if a user belongs to a team
-func (f *FakeClient) TeamHasMember(teamID int, memberLogin string) (bool, error) {
-	teamMembers, _ := f.ListTeamMembers(teamID, github.RoleAll)
+func (f *FakeClient) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
+	teamMembers, _ := f.ListTeamMembers(org, teamID, github.RoleAll)
 	for _, member := range teamMembers {
 		if member.Login == memberLogin {
 			return true, nil

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -121,7 +121,7 @@ type githubClient interface {
 	GetSingleCommit(org, repo, SHA string) (github.SingleCommit, error)
 	IsMember(org, user string) (bool, error)
 	ListTeams(org string) ([]github.Team, error)
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 // reviewCtx contains information about each review event
@@ -365,7 +365,7 @@ func stickyLgtm(log *logrus.Entry, gc githubClient, config *plugins.Configuratio
 			for _, teamInOrg := range teams {
 				// lgtm.TrustedAuthorTeams is supposed to be a very short list.
 				if strings.Compare(teamInOrg.Name, lgtm.StickyLgtmTeam) == 0 {
-					if members, err := gc.ListTeamMembers(teamInOrg.ID, github.RoleAll); err == nil {
+					if members, err := gc.ListTeamMembers(org, teamInOrg.ID, github.RoleAll); err == nil {
 						for _, member := range members {
 							if strings.Compare(member.Login, author) == 0 {
 								// The author is in a trusted team

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -46,7 +46,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	ClearMilestone(org, repo string, num int) error
 	SetMilestone(org, repo string, issueNum, milestoneNum int) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 	ListMilestones(org, repo string) ([]github.Milestone, error)
 }
 
@@ -113,7 +113,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		milestone = repoMilestone[""]
 	}
 
-	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, github.RoleAll)
+	milestoneMaintainers, err := gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -47,7 +47,7 @@ var (
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	AddLabel(owner, repo string, number int, label string) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 func init() {

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -106,7 +106,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		milestone = repoMilestone[""]
 	}
 
-	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, github.RoleAll)
+	milestoneMaintainers, err := gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -101,7 +101,7 @@ func (c client) ListTeams(org string) ([]github.Team, error) {
 	return c.ghc.ListTeams(org)
 }
 func (c client) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
-	return c.ghc.ListTeamMembers(org string, id, role)
+	return c.ghc.ListTeamMembers(org, id, role)
 }
 
 func (c client) Create(ctx context.Context, pj *prowapi.ProwJob, o metav1.CreateOptions) (*prowapi.ProwJob, error) {
@@ -235,7 +235,7 @@ func authorizedGitHubTeamMember(gc githubClient, log *logrus.Entry, teamSlugs ma
 	for _, slug := range teamSlugs[fmt.Sprintf("%s/%s", org, repo)] {
 		for _, team := range teams {
 			if team.Slug == slug {
-				members, err := gc.ListTeamMembers(team.ID, github.RoleAll)
+				members, err := gc.ListTeamMembers(org, team.ID, github.RoleAll)
 				if err != nil {
 					log.WithError(err).Warnf("cannot find members of team %s in org %s", slug, org)
 					continue

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -51,7 +51,7 @@ type githubClient interface {
 	HasPermission(org, repo, user string, role ...string) (bool, error)
 	ListStatuses(org, repo, ref string) ([]github.Status, error)
 	ListTeams(org string) ([]github.Team, error)
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 type prowJobClient interface {
@@ -100,8 +100,8 @@ func (c client) HasPermission(org, repo, user string, role ...string) (bool, err
 func (c client) ListTeams(org string) ([]github.Team, error) {
 	return c.ghc.ListTeams(org)
 }
-func (c client) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
-	return c.ghc.ListTeamMembers(id, role)
+func (c client) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
+	return c.ghc.ListTeamMembers(org string, id, role)
 }
 
 func (c client) Create(ctx context.Context, pj *prowapi.ProwJob, o metav1.CreateOptions) (*prowapi.ProwJob, error) {

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -101,11 +101,7 @@ func (c client) ListTeams(org string) ([]github.Team, error) {
 	return c.ghc.ListTeams(org)
 }
 func (c client) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
-<<<<<<< HEAD
 	return c.ghc.ListTeamMembers(org, id, role)
-=======
-	return c.ghc.ListTeamMembers(org string, id, role)
->>>>>>> 7752835d1847ff31c5e0f97d01cd535920c020c2
 }
 
 func (c client) Create(ctx context.Context, pj *prowapi.ProwJob, o metav1.CreateOptions) (*prowapi.ProwJob, error) {

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -219,7 +219,7 @@ func (c *fakeClient) ListTeams(org string) ([]github.Team, error) {
 	return []github.Team{}, nil
 }
 
-func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	if id == 1 {
 		return []github.TeamMember{
 			{Login: "user1"},

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -56,7 +56,7 @@ var (
 type githubClient interface {
 	BotName() (string, error)
 	CreateComment(owner, repo string, number int, comment string) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	GetRepoProjects(owner, repo string) ([]github.Project, error)
 	GetOrgProjects(org string) ([]github.Project, error)

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -187,7 +187,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	if maintainerTeamID == -1 {
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, notTeamConfigMsg))
 	}
-	isAMember, err := gc.TeamHasMember(maintainerTeamID, e.User.Login)
+	isAMember, err := gc.TeamHasMember(org, maintainerTeamID, e.User.Login)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -65,7 +65,7 @@ type githubClient interface {
 	GetColumnProjectCard(columnID int, contentURL string) (*github.ProjectCard, error)
 	MoveProjectCard(projectCardID int, newColumnID int) error
 	DeleteProjectCard(projectCardID int) error
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 }
 
 func init() {


### PR DESCRIPTION
This is the second Part of change #19200. This updates a few more end points but was more complicated due to OrgName not being available in`prow/apis/prowjobs/v1/types.go` Loop. However the functionality in that loop seems to repeat in the following loops so it seemed safe to remove. 

This change consisted mostly of adding `org` args to all endpoints. 

**Question** we were using `org` in place of `owner` (See [ref](https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions)) in [main.go](https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions). It looks like the `owner` we use is also `orgName` in code... is that correct?