### PR TITLE
Update Spyglass docs and configure buildlog lens to highlight start of bazel output.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -51,27 +51,36 @@ deck:
     - lens:
         name: metadata
       required_files:
-      - started.json|finished.json
+      - ^(?:started|finished)\.json$
       optional_files:
-      - podinfo.json|prowjob.json
+      - ^(?:podinfo|prowjob)\.json$
     - lens:
         name: buildlog
+        config:
+          highlight_regexes:
+          - timed out
+          - "ERROR:"
+          - (FAIL|Failure \[)\b
+          - panic\b
+          - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
+          # This highlights the start of bazel tests/runs to skip go importing noise.
+          - "^INFO: Analyzed \\d+ targets"
       required_files:
         - ^.*build-log\.txt$
     - lens:
         name: junit
       required_files:
-        - artifacts/junit.*\.xml
+        - ^artifacts/junit.*\.xml$
     - lens:
         name: coverage
       required_files:
-        - artifacts/filtered.cov
+        - ^artifacts/filtered\.cov$
       optional_files:
-        - artifacts/filtered.html
+        - ^artifacts/filtered\.html$
     - lens:
         name: podinfo
       required_files:
-        - podinfo.json
+        - ^podinfo\.json$
   tide_update_period: 1s
   hidden_repos:
   - kubernetes-security

--- a/prow/spyglass/README.md
+++ b/prow/spyglass/README.md
@@ -63,8 +63,9 @@ The following lenses are available:
 - `junit`: parses junit files and displays their content. It has no configuration
 - `buildlog`: displays the build log (or any other log file), highlighting interesting parts and
   hiding the rest behind expandable folders. You can configure what it considers "interesting" by
-  providing `highlight_regexes`, a list of regexes to highlight. If not specified, it uses defaults
-  optimised for highlighting Kubernetes test results.
+  providing `highlight_regexes`, a list of regexes to highlight. If not specified, it uses [defaults
+  optimised for highlighting Kubernetes test results](https://github.com/kubernetes/test-infra/blob/370da51e0f051504be2e97305e8536ab06b3f0df/prow/spyglass/lenses/buildlog/lens.go#L76). The optional `hide_raw_log` boolean field can be used to omit the link to the raw `build-log.txt` source.
+- `podinfo`: displays info about ProwJob pods including the events and details about containers and volumes. The [`gcsk8sreporter` Crier reporter](https://github.com/kubernetes/test-infra/tree/b6180c95b3383919711cfc97436a2d082281d284/prow/crier/reporters/gcs/kubernetes) must be enabled to upload the required `podinfo.json` file.
 - `coverage`: displays go coverage content
 - `restcoverage`: displays REST API statistics
 
@@ -82,9 +83,9 @@ deck:
     - lens:
         name: metadata
       required_files:
-      - started.json
+      - ^(?:started|finished)\.json$
       optional_files:
-      - finished.json
+      - ^(?:podinfo|prowjob)\.json$
     - lens:
         name: buildlog
         config:
@@ -95,9 +96,13 @@ deck:
           - panic\b
           - ^E\d{4} \d\d:\d\d:\d\d\.\d\d\d]
       required_files:
-      - build-log.txt
+      - ^build-log\.txt$
     - lens:
         name: junit
       required_files:
-      - artifacts/junit.*\.xml
+      - ^artifacts/junit.*\.xml$
+    - lens:
+        name: podinfo
+      required_files:
+        - ^podinfo\.json$
 ```


### PR DESCRIPTION
Bazel output in the `buildlog` spyglass lens has been a pain to view since `go` started outputing all this garbage: ([e.g.](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/19204/pull-test-infra-bazel/1305620250233933830))
```
...
go: downloading github.com/docker/libnetwork v0.5.6
go: extracting github.com/docker/libnetwork v0.5.6
go: finding github.com/docker/libkv v0.2.1
...
```

This PR configures [prow.k8s.io](https://prow.k8s.io) to highlight lines like
> INFO: Analyzed 2772 targets (1666 packages loaded, 26131 targets configured). 

which appear just before the start of the interesting bazel output after all 4000+ lines of go importing noise. Users can then choose to expand the logs below this point rather than only being provided with an option to expand all 4682 lines.

I also updated the docs and improved the scope of some of the other regexes in the lens configs.

/assign @fejta 
