### PR TITLE
Fix nondeterminism in /prow/git squash merge unit test.

### DIFF
--- a/prow/git/git_test.go
+++ b/prow/git/git_test.go
@@ -483,6 +483,9 @@ func testMerging(clients localgit.Clients, t *testing.T) {
 			}
 
 			for branchName, branchContent := range tc.branches {
+				if err := lg.Checkout(org, repo, baseSHA); err != nil {
+					t.Fatalf("checkout baseSHA: %v", err)
+				}
 				if err := lg.CheckoutNewBranch(org, repo, branchName); err != nil {
 					t.Fatalf("checkout new branch: %v", err)
 				}
@@ -492,6 +495,7 @@ func testMerging(clients localgit.Clients, t *testing.T) {
 			}
 
 			if err := lg.Checkout(org, repo, baseSHA); err != nil {
+				t.Fatalf("checkout baseSHA: %v", err)
 			}
 
 			r, err := c.ClientFor(org, repo)


### PR DESCRIPTION
Previously the `Multiple branches, squash strategy` test case for the v1 implementation could either pass or fail depending on loop ordering over maps. This was because the test setup made one of the two branches a subset of the other and merging the superset first caused the second merge to fail due to a lack of changes:
```
msg="Commit after squash failed with output: HEAD detached from 91cde79\nnothing to commit, working tree clean\n" client=git error="exit status 1
```

I'm not sure why this bug doesn't seem to affect the v2 implementation or the `Multiple branches, mergeMerge strategy` test case...

This PR addresses the issue by making all branches based off the `baseSHA` rather than basing subsequent branches on top of each other.  I validated that this resolves the nondeterminism by running the `//prow/git/...` tests 100 times.

/assign @alvaroaleman @petr-muller 