### PR TITLE
Allow alvaroaleman to rerun post-test-infra-push-prow

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -191,6 +191,9 @@ postsubmits:
       testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
       testgrid-num-failures-to-alert: '1'
       description: builds and pushes all prow on each commit by running prow/push.sh
+    rerun_auth_config:
+      github_users:
+      - alvaroaleman
   - name: post-test-infra-push-kettle
     cluster: test-infra-trusted
     annotations:


### PR DESCRIPTION
The job doesn't seem to be very stable, right now its for example not possible to update Prow because the bumper errors with a
```
error="Expected a consistent version for all \"gcr.io/k8s-prow/\" images, but found multiple: map[v20200914-1ac05b0ca2:true v20200915-1ac05b0ca2:true]"
```

even though the last job run claims to be a success. With this PR I am giving myself perms to restart the job.
