### PR TITLE
config/testgrids/openshift: Replace scaleup with workers for 4.6 and 4.7

### DIFF
--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.6-informing.yaml
@@ -289,14 +289,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.6
+    name: periodic-ci-openshift-release-master-ocp-4.6-e2e-aws-workers-rhel7
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.6
+    test_group_name: periodic-ci-openshift-release-master-ocp-4.6-e2e-aws-workers-rhel7
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1592,8 +1592,8 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x
   name: promote-release-openshift-machine-os-content-e2e-aws-4.6-s390x
 - days_of_results: 25
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-e2e-aws-scaleup-rhel7-4.6
-  name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.6
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.6-e2e-aws-workers-rhel7
+  name: periodic-ci-openshift-release-master-ocp-4.6-e2e-aws-workers-rhel7
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.6
   name: release-openshift-ocp-installer-console-aws-4.6

--- a/config/testgrids/openshift/redhat-openshift-ocp-release-4.7-informing.yaml
+++ b/config/testgrids/openshift/redhat-openshift-ocp-release-4.7-informing.yaml
@@ -127,14 +127,14 @@ dashboards:
       - key: comment
         value: 'test: <test-name> failed, see job: <link>'
       url: https://bugzilla.redhat.com/enter_bug.cgi
-    name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.7
+    name: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-workers-rhel7
     open_bug_template:
       url: https://github.com/openshift/origin/issues/
     open_test_template:
       url: https://prow.ci.openshift.org/view/gcs/<gcs_prefix>/<changelist>
     results_url_template:
       url: https://prow.ci.openshift.org/job-history/<gcs_prefix>
-    test_group_name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.7
+    test_group_name: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-workers-rhel7
   - base_options: width=10&exclude-filter-by-regex=Monitor%5Cscluster&exclude-filter-by-regex=%5Eoperator.Run%20template.*container%20test%24
     code_search_path: https://github.com/openshift/origin/search
     code_search_url_template:
@@ -1365,8 +1365,8 @@ test_groups:
   gcs_prefix: origin-ci-test/logs/promote-release-openshift-machine-os-content-e2e-aws-4.7-s390x
   name: promote-release-openshift-machine-os-content-e2e-aws-4.7-s390x
 - days_of_results: 60
-  gcs_prefix: origin-ci-test/logs/release-openshift-ocp-e2e-aws-scaleup-rhel7-4.7
-  name: release-openshift-ocp-e2e-aws-scaleup-rhel7-4.7
+  gcs_prefix: origin-ci-test/logs/periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-workers-rhel7
+  name: periodic-ci-openshift-release-master-ocp-4.7-e2e-aws-workers-rhel7
 - days_of_results: 60
   gcs_prefix: origin-ci-test/logs/release-openshift-ocp-installer-console-aws-4.7
   name: release-openshift-ocp-installer-console-aws-4.7


### PR DESCRIPTION
Updated to coincide with https://github.com/openshift/release/pull/11614

/cc @stevekuznetsov 