### PR TITLE
Set global cookiefile once, before running parallel clones.

### DIFF
--- a/prow/clonerefs/run_test.go
+++ b/prow/clonerefs/run_test.go
@@ -255,3 +255,60 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
+
+func TestNeedsGlobalCookiePath(t *testing.T) {
+	cases := []struct {
+		name       string
+		cookieFile string
+		refs       []prowapi.Refs
+		expected   string
+	}{
+		{
+			name: "basically works",
+		},
+		{
+			name: "return empty when no cookieFile",
+			refs: []prowapi.Refs{
+				{},
+			},
+		},
+		{
+			name:       "return empty when no refs",
+			cookieFile: "foo",
+		},
+		{
+			name:       "return empty when all refs skip submodules",
+			cookieFile: "foo",
+			refs: []prowapi.Refs{
+				{SkipSubmodules: true},
+				{SkipSubmodules: true},
+			},
+		},
+		{
+			name:       "return cookieFile when all refs use submodules",
+			cookieFile: "foo",
+			refs: []prowapi.Refs{
+				{},
+				{},
+			},
+			expected: "foo",
+		},
+		{
+			name:       "return cookieFile when any refs uses submodules",
+			cookieFile: "foo",
+			refs: []prowapi.Refs{
+				{SkipSubmodules: true},
+				{},
+			},
+			expected: "foo",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if actual := needsGlobalCookiePath(tc.cookieFile, tc.refs...); actual != tc.expected {
+				t.Errorf("needsGlobalCookiePath(%q,%v) got %q, want %q", tc.cookieFile, tc.refs, actual, tc.expected)
+			}
+		})
+	}
+}

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -180,13 +180,8 @@ func (g *gitCtx) commandsForBaseRef(refs prowapi.Refs, gitUserName, gitUserEmail
 	if gitUserEmail != "" {
 		commands = append(commands, g.gitCommand("config", "user.email", gitUserEmail))
 	}
-	if cookiePath != "" {
-		if refs.SkipSubmodules {
-			commands = append(commands, g.gitCommand("config", "http.cookiefile", cookiePath))
-		} else {
-			// --global to ensure that all submodules can use this auth
-			commands = append(commands, g.gitCommand("config", "--global", "http.cookiefile", cookiePath))
-		}
+	if cookiePath != "" && refs.SkipSubmodules {
+		commands = append(commands, g.gitCommand("config", "http.cookiefile", cookiePath))
 	}
 
 	if refs.CloneDepth > 0 {

--- a/prow/pod-utils/clone/clone_test.go
+++ b/prow/pod-utils/clone/clone_test.go
@@ -221,7 +221,6 @@ func TestCommandsForRefs(t *testing.T) {
 			expectedBase: []runnable{
 				cloneCommand{dir: "/", command: "mkdir", args: []string{"-p", "/go/src/github.com/org/repo"}},
 				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"init"}},
-				cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"config", "--global", "http.cookiefile", "/cookie.txt"}},
 				retryCommand{
 					cloneCommand{dir: "/go/src/github.com/org/repo", command: "git", args: []string{"fetch", "https://github.com/org/repo.git", "--tags", "--prune"}},
 					fetchRetries,


### PR DESCRIPTION
/assign @krzyzacy @cjwagner 

We run the clone for each ref in parallel, which represents a race condition if both attempt to write the file concurrently:

```
$ git config --global http.cookiefile /secrets/cookiefile/cookies
error: could not lock config file /root/.gitconfig: File exists
# Error: exit status 255
```

Even without the race this is wasteful as we only need to do it once. So move this into clonerefs: