### PR TITLE
Add Prometheus recording rules and grafana dashboards for SLO compliance.

### DIFF
--- a/config/prow/cluster/monitoring/BUILD.bazel
+++ b/config/prow/cluster/monitoring/BUILD.bazel
@@ -81,6 +81,7 @@ k8s_objects(
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-plank",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-prow",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-sinker",
+        "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-slo",
         "//config/prow/cluster/monitoring/mixins/dashboards_out:grafana-dashboard-tide",
     ],
 )

--- a/config/prow/cluster/monitoring/grafana_deployment.yaml
+++ b/config/prow/cluster/monitoring/grafana_deployment.yaml
@@ -87,6 +87,9 @@ spec:
         - mountPath: /grafana-dashboard-definitions/0/sinker
           name: grafana-dashboard-sinker
           readOnly: false
+        - mountPath: /grafana-dashboard-definitions/0/slo
+          name: grafana-dashboard-slo
+          readOnly: false
         - mountPath: /grafana-dashboard-definitions/0/tide
           name: grafana-dashboard-tide
           readOnly: false
@@ -129,6 +132,9 @@ spec:
       - name: grafana-dashboard-sinker
         configMap:
           name: grafana-dashboard-sinker
+      - name: grafana-dashboard-slo
+        configMap:
+          name: grafana-dashboard-slo
       - name: grafana-dashboard-tide
         configMap:
           name: grafana-dashboard-tide

--- a/config/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
+++ b/config/prow/cluster/monitoring/mixins/dashboards_out/BUILD.bazel
@@ -86,6 +86,16 @@ k8s_configmap(
 )
 
 k8s_configmap(
+    name = "grafana-dashboard-slo",
+    cluster = "{STABLE_PROW_CLUSTER}",
+    data = {
+        "slo.json": "//config/prow/cluster/monitoring/mixins/grafana_dashboards:slo",
+    },
+    namespace = "prow-monitoring",
+    visibility = ["//visibility:public"],
+)
+
+k8s_configmap(
     name = "grafana-dashboard-tide",
     cluster = "{STABLE_PROW_CLUSTER}",
     data = {

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/BUILD.bazel
@@ -135,6 +135,21 @@ jsonnet_to_json(
     ],
 )
 
+jsonnet_to_json(
+    name = "slo",
+    src = "slo.jsonnet",
+    outs = ["slo.json"],
+    imports = [
+        "../lib/",
+        "../vendor/",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//config/prow/cluster/monitoring/mixins/lib",
+        "//config/prow/cluster/monitoring/mixins/vendor/grafonnet",
+    ],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
@@ -1,0 +1,41 @@
+local config =  import 'config.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+local dashboard = grafana.dashboard;
+local graphPanel = grafana.graphPanel;
+local prometheus = grafana.prometheus;
+
+
+local dashboardConfig = {
+        uid: config._config.grafanaDashboardIDs['slo.json'],
+    };
+
+dashboard.new(
+        'SLO Compliance Dashboard',
+        time_from='now-7d',
+        schemaVersion=18,
+      )
+.addPanel(
+    graphPanel.new(
+        'Prow overall SLO compliance',
+        description='slo_prow_ok',
+        datasource='prometheus',
+        legend_rightSide=true,
+    )
+    .addTarget(prometheus.target(
+        'slo_prow_ok'
+    )),
+    gridPos={h: 4, w: 24, x: 0, y: 0})
+.addPanels([
+    graphPanel.new(
+        '%s SLO compliance' % comp,
+        description='slo_component_ok{slo="%s"}' % comp,
+        datasource='prometheus',
+        legend_rightSide=true,
+    )
+    .addTarget(prometheus.target(
+        'slo_component_ok{slo="%s"}' % comp
+    ))
+
+    for comp in config._config.slo.components
+])
++ dashboardConfig

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -4,6 +4,14 @@
     grafanaDashboardIDs: {
       'boskos-http.json': 'eec46c579cbf4a518e5bbcbbf4913de9',
       'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
+      'slo.json': 'ea313af4b7904c7c983d20d9572235a5',
     },
+    components: {
+      tide: 'Tide'
+    },
+    local components = self.components,
+    slo: {
+      components: [components.tide],
+    }
   },
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -7,4 +7,5 @@
 (import 'sinker_alerts.libsonnet') +
 (import 'tide_alerts.libsonnet') +
 (import 'prober_alerts.libsonnet') +
-(import 'boskos_alerts.libsonnet')
+(import 'boskos_alerts.libsonnet') +
+(import 'slo_recordrules.libsonnet')

--- a/config/prow/cluster/monitoring/mixins/prometheus/prow_prometheusrule.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prow_prometheusrule.jsonnet
@@ -1,4 +1,4 @@
-local alerts = (import 'prometheus.libsonnet').prometheusAlerts;
+local rules = (import 'prometheus.libsonnet').prometheusAlerts;
 
 {
 	"apiVersion": "monitoring.coreos.com/v1",
@@ -11,5 +11,5 @@ local alerts = (import 'prometheus.libsonnet').prometheusAlerts;
 		"name": "prometheus-prow-rules",
 		"namespace": "prow-monitoring"
 	},
-	"spec": alerts
+	"spec": rules
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/slo_recordrules.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/slo_recordrules.libsonnet
@@ -1,0 +1,37 @@
+{
+  prometheusAlerts+:: {
+    local components = $._config.slo.components,
+
+    groups+: [
+      {
+       name: 'SLO Compliance',
+       interval: '1m',
+       rules: [
+          {
+            record: 'slo_component_ok',
+            # We can't check for the absence of alerts without explicitly listing the components we are checking for. These are defined in config.
+            # We want the SLO metrics to include alert-specific labels when SLO is violated. This means there may be multiple time series per component when out of SLO since multiple alerts may be firing, but all should have value 0.
+            # If a component is SLO compliant there will be a single timeseries for that "slo" label: vector(1){slo="component-name"}
+
+            local absents = std.join(
+              ' or ',
+              ['absent(ALERTS{alertstate="firing", slo="%s"})' % comp for comp in components],
+            ),
+            local allCompsRE = std.join('|', components),
+
+            expr: |||
+              min((%s) or (ALERTS{alertstate="firing", slo=~"%s"} - 1)) without (alertstate)
+            ||| % [absents, allCompsRE],
+
+            # Example compiled query for components=['tide', 'hook']
+            # min((absent(ALERTS{alertstate="firing", slo="tide"}) or absent(ALERTS{alertstate="firing", slo="hook"})) or (ALERTS{alertstate="firing", slo=~"tide|hook"} - 1)) without (alertstate)
+          },
+          {
+            record: 'slo_prow_ok',
+            expr: '(vector(1) unless min(slo_component_ok == 0)) or (slo_component_ok == 0)',
+          },
+       ],
+      },
+    ],
+  },
+}

--- a/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -1,5 +1,6 @@
 {
   prometheusAlerts+:: {
+    local tideName = $._config.components.tide,
     groups+: [
       {
         name: 'Tide progress',
@@ -12,6 +13,7 @@
             'for': '5m',
             labels: {
               severity: 'critical',
+              slo: tideName,
             },
             annotations: {
               message: 'The Tide "sync" controller has not synced in 15 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
@@ -25,6 +27,7 @@
             'for': '5m',
             labels: {
               severity: 'critical',
+              slo: tideName,
             },
             annotations: {
               message: 'The Tide "status-update" controller has not synced in 30 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
@@ -51,6 +54,7 @@
             'for': '5m',
             labels: {
               severity: 'critical',
+              slo: tideName,
             },
             annotations: {
               message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <https://prow.k8s.io/tide-history|tide-history> page and the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now|sync error graph>.',


### PR DESCRIPTION
This PR provides a mechanism for easily defining and tracking SLO compliance across Prow. Compliance is defined per-component by labelling prometheus alerts as SLO violation indicators. Compliance will be recorded per-component and overall using prometheus recording rules to define synthetic metrics. The SLO metrics will have a value of 1 if SLO compliance is met or a value of 0 if there are alerts indicating an SLO violation. In the case of a violation, the metrics will include the labels from the source alert(s). This will help us answer questions like "What percentage of the time was hook working?", "What percentage of outages were caused by problems with hook?", and "What percentage of the outages caused by hook were due to a specific symptom?".

The PR also includes a dashboard for the SLO metrics. New graph panels will be automatically generated when alerts are marked as SLO indicators for new components.

I've marked some Tide alerts as SLIs to demo and test this. Once I've confirmed things are working well I'll extend this to track SLO for other components as well.

/assign @hongkailiu @MushuEE  