### PR TITLE
update apisnoop image build to work with new apisnoop app structure

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -43,4 +43,4 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/snoopdb/
+              - apps/snoopdb

--- a/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
+++ b/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
@@ -1,27 +1,5 @@
 postsubmits:
   cncf/apisnoop:
-    - name: apisnoop-push-webapp-images
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: conformance-apisnoop
-        testgrid-tab-name: apisnoop-webapp-image
-        testgrid-alert-email: apisnoop@ii.coop
-        description: Builds the webapp image for APISnoop deployments
-      decorate: true
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
-            command:
-              - /run.sh
-            args:
-              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
-              - --project=k8s-staging-apisnoop
-              - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
-              - --env-passthrough=PULL_BASE_REF
-              - apps/webapp/app
     - name: apisnoop-push-auditlogger-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -43,14 +21,14 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/auditlogger/app
-    - name: apisnoop-push-postgres-images
+              - apps/auditlogger
+    - name: apisnoop-push-snoopdb-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: conformance-apisnoop
-        testgrid-tab-name: apisnoop-postgres-image
+        testgrid-tab-name: apisnoop-snoopdb-image
         testgrid-alert-email: apisnoop@ii.coop
-        description: Builds the postgres image for APISnoop deployments
+        description: Builds the snoopdb image for APISnoop deployments
       decorate: true
       branches:
         - ^master$
@@ -65,26 +43,4 @@ postsubmits:
               - --project=k8s-staging-apisnoop
               - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
               - --env-passthrough=PULL_BASE_REF
-              - apps/postgres/app
-    - name: apisnoop-push-hasura-images
-      cluster: k8s-infra-prow-build-trusted
-      annotations:
-        testgrid-dashboards: conformance-apisnoop
-        testgrid-tab-name: apisnoop-hasura-image
-        testgrid-alert-email: apisnoop@ii.coop
-        description: Builds the hasura image for APISnoop deployments
-      decorate: true
-      branches:
-        - ^master$
-      spec:
-        serviceAccountName: gcb-builder
-        containers:
-          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
-            command:
-              - /run.sh
-            args:
-              # this is the project GCB will run in, which is the same as the GCR images are pushed to.
-              - --project=k8s-staging-apisnoop
-              - --scratch-bucket=gs://k8s-staging-apisnoop-gcb
-              - --env-passthrough=PULL_BASE_REF
-              - apps/hasura/app
+              - apps/snoopdb/


### PR DESCRIPTION
APISnoop recently reduced the number of components needed to run, and reorganized its repo  to be easier to navigate and maintain.   

This PR updates the prow jobs attached to the apisnoop images to reflect both changes.  It removes the deprecated `hasura`, `webapp`, and `postgres` images, adds a `snoopdb` image, and slightly adjusts the build paths.


