### PR TITLE
community: Use slack-infra staging project images for tempelis jobs

### DIFF
--- a/config/jobs/kubernetes/community/community-presubmit.yaml
+++ b/config/jobs/kubernetes/community/community-presubmit.yaml
@@ -25,7 +25,7 @@ presubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20200909-1eb97f5
         command:
         - /tempelis
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -744,7 +744,7 @@ postsubmits:
       testgrid-dashboards: sig-contribex-slack-infra
     spec:
       containers:
-      - image: gcr.io/k8s-tempelis/tempelis:v20190412-7c9b6e51
+      - image: gcr.io/k8s-staging-slack-infra/tempelis:v20200909-1eb97f5
         command:
         - /tempelis
         args:


### PR DESCRIPTION
Switch to `gcr.io/k8s-staging-slack-infra/tempelis:v20200909-1eb97f5`, as
that's the most recent image k-sigs/slack-infra has built (as opposed to
gcr.io/k8s-tempelis/tempelis).

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Affects: https://github.com/kubernetes/community/pull/5150