### PR TITLE
Alert if crier, horologium, prow-controller-manager are down.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
@@ -17,7 +17,16 @@
               message: '@test-infra-oncall The service %s has been down for 5 minutes.' % name,
             },
           }
-          for name in ['deck', 'ghproxy', 'hook', 'prow-controller-manager', 'sinker', 'tide']
+          for name in [
+              'crier',
+              'deck',
+              'ghproxy',
+              'hook',
+              'horologium',
+              'prow-controller-manager',
+              'sinker',
+              'tide',
+          ]
         ],
       },
     ],


### PR DESCRIPTION
Remove plank alert (turned down).

/assign @alvaroaleman 

Will rebase after #19246 (or feel free to just approve this one)