### PR TITLE
Validate all Spyglass artifact requests against size limits

### DIFF
--- a/prow/spyglass/lenses/lenses.go
+++ b/prow/spyglass/lenses/lenses.go
@@ -23,9 +23,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	"path/filepath"
+
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/spyglass/api"
 )
@@ -42,6 +43,8 @@ var (
 	// ErrFileTooLarge will be thrown when a size-limited operation (ex. ReadAll) is called on an
 	// artifact whose size exceeds the configured limit.
 	ErrFileTooLarge = errors.New("file size over specified limit")
+	// ErrRequestSizeTooLarge will be thrown when any operation is called whose size exceeds the configured limit.
+	ErrRequestSizeTooLarge = errors.New("request size over specified limit")
 	// ErrContextUnsupported is thrown when attempting to use a context with an artifact that
 	// does not support context operations (cancel, withtimeout, etc.)
 	ErrContextUnsupported = errors.New("artifact does not support context operations")

--- a/prow/spyglass/podlogartifact.go
+++ b/prow/spyglass/podlogartifact.go
@@ -96,6 +96,9 @@ func (a *PodLogArtifact) JobPath() string {
 
 // ReadAt implements reading a range of bytes from the pod logs endpoint
 func (a *PodLogArtifact) ReadAt(p []byte, off int64) (n int, err error) {
+	if int64(len(p)) > a.sizeLimit {
+		return 0, lenses.ErrRequestSizeTooLarge
+	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
 		return 0, fmt.Errorf("error getting pod log: %v", err)
@@ -129,6 +132,9 @@ func (a *PodLogArtifact) ReadAll() ([]byte, error) {
 
 // ReadAtMost reads at most n bytes
 func (a *PodLogArtifact) ReadAtMost(n int64) ([]byte, error) {
+	if n > a.sizeLimit {
+		return nil, lenses.ErrRequestSizeTooLarge
+	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pod log: %v", err)
@@ -152,6 +158,9 @@ func (a *PodLogArtifact) ReadAtMost(n int64) ([]byte, error) {
 
 // ReadTail reads the last n bytes of the pod log
 func (a *PodLogArtifact) ReadTail(n int64) ([]byte, error) {
+	if n > a.sizeLimit {
+		return nil, lenses.ErrRequestSizeTooLarge
+	}
 	logs, err := a.jobAgent.GetJobLog(a.name, a.buildID, a.container)
 	if err != nil {
 		return nil, fmt.Errorf("error getting pod log tail: %v", err)

--- a/prow/spyglass/storageartifact.go
+++ b/prow/spyglass/storageartifact.go
@@ -91,6 +91,9 @@ func (a *StorageArtifact) CanonicalLink() string {
 
 // ReadAt reads len(p) bytes from a file in GCS at offset off
 func (a *StorageArtifact) ReadAt(p []byte, off int64) (n int, err error) {
+	if int64(len(p)) > a.sizeLimit {
+		return 0, lenses.ErrRequestSizeTooLarge
+	}
 	gzipped, err := a.gzipped()
 	if err != nil {
 		return 0, fmt.Errorf("error checking artifact for gzip compression: %v", err)
@@ -138,6 +141,9 @@ func (a *StorageArtifact) ReadAt(p []byte, off int64) (n int, err error) {
 // ReadAtMost reads at most n bytes from a file in GCS. If the file is compressed (gzip) in GCS, n bytes
 // of gzipped content will be downloaded and decompressed into potentially GREATER than n bytes of content.
 func (a *StorageArtifact) ReadAtMost(n int64) ([]byte, error) {
+	if n > a.sizeLimit {
+		return nil, lenses.ErrRequestSizeTooLarge
+	}
 	var reader io.ReadCloser
 	var p []byte
 	gzipped, err := a.gzipped()
@@ -211,6 +217,9 @@ func (a *StorageArtifact) ReadAll() ([]byte, error) {
 
 // ReadTail reads the last n bytes from a file in GCS
 func (a *StorageArtifact) ReadTail(n int64) ([]byte, error) {
+	if n > a.sizeLimit {
+		return nil, lenses.ErrRequestSizeTooLarge
+	}
 	gzipped, err := a.gzipped()
 	if err != nil {
 		return nil, fmt.Errorf("error checking artifact for gzip compression: %v", err)


### PR DESCRIPTION
Limits can be modified via `deck.spyglass.size_limit` Prow config field.

(Previously, only `ReadAll` operations were validated against the size limit.)