### PR TITLE
Update DNS image push yaml to trigger on new tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-dns.yaml
+++ b/config/jobs/image-pushing/k8s-staging-dns.yaml
@@ -7,8 +7,10 @@ postsubmits:
         # this is the name of some testgrid dashboard to report to.
         testgrid-dashboards: sig-network-dns
       decorate: true
+      # match on regex '^\d+\.\d+\.\d+$' to trigger job on new tags
       branches:
         - ^master$
+        - ^\d+\.\d+\.\d+$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Using '^\d+\.\d+\.\d+$' instead of 'refs/tags/\d+\.\d+\.\d+$' since it appears the prefix might be getting trimmed:
https://github.com/kubernetes/test-infra/issues/5962#issuecomment-657715030

/assign @fejta @BenTheElder @cjwagner 