### PR TITLE
Make component SLO graphs full width, omit component label.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
@@ -33,9 +33,9 @@ dashboard.new(
         legend_rightSide=true,
     )
     .addTarget(prometheus.target(
-        'slo_component_ok{slo="%s"}' % comp
+        'min(slo_component_ok{slo="%s"}) without (slo)' % comp
     ))
-
+    {gridPos:{h: 4, w: 24, x: 0, y: 0}}
     for comp in config._config.slo.components
 ])
 + dashboardConfig


### PR DESCRIPTION
The components [SLO graphs](https://monitoring.prow.k8s.io/d/ea313af4b7904c7c983d20d9572235a5/slo-compliance-dashboard?orgId=1&from=now%2Fd&to=now) on the dashboard could use a bit of tweaking, specifically this PR makes the graphs full width and removes the redundant `slo` label from the legend.

/assign @MushuEE @fejta 