### PR TITLE
Add link to tekton dashboard

### DIFF
--- a/prow/cmd/pipeline/controller_test.go
+++ b/prow/cmd/pipeline/controller_test.go
@@ -140,6 +140,10 @@ func (r *fakeReconciler) pipelineID(pj prowjobv1.ProwJob) (string, string, error
 	return pipelineID, "", nil
 }
 
+func (r *fakeReconciler) pipelineRunURL(pj prowjobv1.ProwJob) (string, error) {
+	return fmt.Sprintf("https://tekton.k8s.io/#/namespaces/ns/pipelineruns/%s", pj.Name), nil
+}
+
 type fakeLimiter struct {
 	added string
 }
@@ -260,6 +264,7 @@ func TestReconcile(t *testing.T) {
 					State:       prowjobv1.PendingState,
 					Description: descScheduling,
 					BuildID:     pipelineID,
+					URL:         "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name",
 				}
 				return pj
 			},
@@ -455,6 +460,7 @@ func TestReconcile(t *testing.T) {
 			expectedJob: func(pj prowjobv1.ProwJob, _ pipelinev1alpha1.PipelineRun) prowjobv1.ProwJob {
 				pj.Status.State = prowjobv1.PendingState
 				pj.Status.Description = descScheduling
+				pj.Status.URL = "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name"
 				return pj
 			},
 			expectedPipelineRun: noPipelineRunChange,
@@ -492,6 +498,7 @@ func TestReconcile(t *testing.T) {
 					StartTime:   now,
 					State:       prowjobv1.PendingState,
 					Description: "scheduling",
+					URL:         "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name",
 				}
 				return pj
 			},
@@ -532,6 +539,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.SuccessState,
 					Description:    "hello",
+					URL:            "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name",
 				}
 				return pj
 			},
@@ -572,6 +580,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.FailureState,
 					Description:    "hello",
+					URL:            "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name",
 				}
 				return pj
 			},
@@ -647,6 +656,7 @@ func TestReconcile(t *testing.T) {
 					CompletionTime: &now,
 					State:          prowjobv1.ErrorState,
 					Description:    "start pipeline: injected create pipeline error",
+					URL:            "https://tekton.k8s.io/#/namespaces/ns/pipelineruns/the-object-name",
 				}
 				return pj
 			},

--- a/prow/cmd/pipeline/main.go
+++ b/prow/cmd/pipeline/main.go
@@ -51,6 +51,7 @@ type options struct {
 	configPath             string
 	kubeconfig             string
 	totURL                 string
+	dashboardURLTemplate   string
 	instrumentationOptions prowflagutil.InstrumentationOptions
 }
 
@@ -65,6 +66,7 @@ func parseOptions() options {
 func (o *options) parse(flags *flag.FlagSet, args []string) error {
 	flags.BoolVar(&o.allContexts, "all-contexts", false, "Monitor all cluster contexts, not just default")
 	flags.StringVar(&o.totURL, "tot-url", "", "Tot URL")
+	flags.StringVar(&o.dashboardURLTemplate, "dashboard-url-template", "", "Tekton dashbord URL template")
 	flags.StringVar(&o.kubeconfig, "kubeconfig", "", "Path to kubeconfig. Only required if out of cluster")
 	flags.StringVar(&o.configPath, "config", "", "Path to prow config.yaml")
 	o.instrumentationOptions.AddFlags(flags)
@@ -163,13 +165,14 @@ func main() {
 	}
 
 	opts := controllerOptions{
-		kc:              kc,
-		pjc:             pjc,
-		pji:             pjif.Prow().V1().ProwJobs(),
-		pipelineConfigs: pipelineConfigs,
-		totURL:          o.totURL,
-		prowConfig:      configAgent.Config,
-		rl:              kube.RateLimiter(controllerName),
+		kc:                   kc,
+		pjc:                  pjc,
+		pji:                  pjif.Prow().V1().ProwJobs(),
+		pipelineConfigs:      pipelineConfigs,
+		totURL:               o.totURL,
+		dashboardURLTemplate: o.dashboardURLTemplate,
+		prowConfig:           configAgent.Config,
+		rl:                   kube.RateLimiter(controllerName),
 	}
 	controller, err := newController(opts)
 	if err != nil {


### PR DESCRIPTION
When we use Tekton as ProwJob agent, we do not have a link to [tekton dashboard](https://github.com/tektoncd/dashboard) in the GitHub PR status.

I added `--dashboard-url-template` option to pipeline, and set to ProwJob Status.

Example
```
--dashboard-url-template=http://tekton-dashboard/#/namespaces/{{.Spec.Namespace}}/pipelineruns/{{.Name}}
```