### PR TITLE
Revert memory bump in ci-kubernetes-e2e-gce-scale-correctness

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -39,10 +39,10 @@ periodics:
       resources:
         requests:
           cpu: 6
-          memory: "120Gi"
+          memory: "48Gi"
         limits:
           cpu: 6
-          memory: "120Gi"
+          memory: "48Gi"
 
 # This is a sig-release-master-blocking job.
 - cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)


### PR DESCRIPTION
After revert https://github.com/kubernetes/kubernetes/pull/94800, the test takes ~12-15GiB now, so 48GiB should be really safe.

/assign @mm4tt 