### PR TITLE
Improve SLO dashboard layout and labeling.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/slo.jsonnet
@@ -5,6 +5,12 @@ local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
 
 
+local legendConfig = {
+        legend+: {
+            sideWidth: 400
+        },
+    };
+
 local dashboardConfig = {
         uid: config._config.grafanaDashboardIDs['slo.json'],
     };
@@ -15,26 +21,40 @@ dashboard.new(
         schemaVersion=18,
       )
 .addPanel(
-    graphPanel.new(
+    (graphPanel.new(
         'Prow overall SLO compliance',
         description='slo_prow_ok',
         datasource='prometheus',
         legend_rightSide=true,
+        decimals=0,
+        min=0,
+        max=1.25,
+        labelY1='Compliant (T/F)',
+        legend_values=true,
+        legend_avg=true,
+        legend_alignAsTable=true,
     )
     .addTarget(prometheus.target(
-        'slo_prow_ok'
-    )),
+        'label_replace(slo_prow_ok, "__name__", "SLO", "", "")'
+    )) + legendConfig),
     gridPos={h: 4, w: 24, x: 0, y: 0})
 .addPanels([
-    graphPanel.new(
+    (graphPanel.new(
         '%s SLO compliance' % comp,
         description='slo_component_ok{slo="%s"}' % comp,
         datasource='prometheus',
         legend_rightSide=true,
+        decimals=0,
+        min=0,
+        max=1.25,
+        labelY1='Compliant (T/F)',
+        legend_values=true,
+        legend_avg=true,
+        legend_alignAsTable=true,
     )
     .addTarget(prometheus.target(
-        'min(slo_component_ok{slo="%s"}) without (slo)' % comp
-    ))
+        'label_replace(min(slo_component_ok{slo="%s"}) without (slo), "__name__", "SLO", "", "")' % comp
+    )) + legendConfig)
     {gridPos:{h: 4, w: 24, x: 0, y: 0}}
     for comp in config._config.slo.components
 ])


### PR DESCRIPTION
This improves the layout of the graphs and changes how the time series results are displayed in the legend. Grafana seems to display the legend differently depending on whether there are multiple time series results, or just one, and depending on whether or not there are labels on the result. The `label_replace` on the `__name__` label is a bit of a hack, but it seems to generate the output I want in all cases (I tested the behavior on a different metric with more data).

Current dashboard: https://monitoring.prow.k8s.io/d/ea313af4b7904c7c983d20d9572235a5/slo-compliance-dashboard?orgId=1
With the changes in this PR: https://monitoring.prow.k8s.io/d/ea313af4b7904c7c983d20d9572235a6/slo-compliance-dashboard-temp?orgId=1
(I'll delete the manually created temp dashboard after this merges.)