### PR TITLE
releng: Update k/release CI image to not use bazel and update presubmits

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/k8s-staging-releng.yaml
@@ -97,7 +97,7 @@ postsubmits:
       rerun_auth_config:
         github_team_ids:
           - 2241179 # release-managers
-    - name: post-release-push-image-releng-ci-bazel
+    - name: post-release-push-image-releng-ci
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
@@ -116,7 +116,8 @@ postsubmits:
               - --project=k8s-staging-releng
               - --scratch-bucket=gs://k8s-staging-releng-gcb
               - --env-passthrough=PULL_BASE_REF
-              - images/releng-ci-bazel
+              - --build-dir=.
+              - images/releng/ci
             env:
               - name: LOG_TO_STDOUT
                 value: "y"

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -42,22 +42,30 @@ presubmits:
     always_run: true
     decorate: true
     path_alias: k8s.io/release
-    extra_refs:
-    - org: kubernetes
-      repo: test-infra
-      base_ref: master
-      path_alias: k8s.io/test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-staging-releng/releng-ci-bazel:latest
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
         command:
-        - ../test-infra/hack/bazel.sh
-        args:
+        - make
         - test
-        - //...
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-test
+      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-num-columns-recent: '30'
+  - name: pull-release-verify
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/release
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-verify
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
 periodics:


### PR DESCRIPTION
(Needed for https://github.com/kubernetes/release/pull/1552)

- releng: Update k/release CI image to not use bazel
- releng: Update k/release presubmits
  - Don't use bazel
  - Add a verify test

/assign @hasheddan 
cc: @kubernetes/release-engineering 