### PR TITLE
Switch config_updater configuration to use new format

### DIFF
--- a/config/prow-staging/cluster/hook_deployment.yaml
+++ b/config/prow-staging/cluster/hook_deployment.yaml
@@ -47,6 +47,7 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         ports:
           - name: http
             containerPort: 8888
@@ -65,6 +66,9 @@ spec:
           readOnly: true
         - name: plugins
           mountPath: /etc/plugins
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
           readOnly: true
         livenessProbe:
           httpGet:
@@ -95,3 +99,7 @@ spec:
       - name: plugins
         configMap:
           name: plugins
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig

--- a/config/prow/cluster/hook_deployment.yaml
+++ b/config/prow/cluster/hook_deployment.yaml
@@ -48,6 +48,7 @@ spec:
         - --github-token-path=/etc/github/oauth
         - --config-path=/etc/config/config.yaml
         - --job-config-path=/etc/job-config
+        - --kubeconfig=/etc/kubeconfig/config
         ports:
           - name: http
             containerPort: 8888
@@ -74,6 +75,9 @@ spec:
           readOnly: true
         - name: unsplash-api
           mountPath: /etc/unsplash-api
+          readOnly: true
+        - name: kubeconfig
+          mountPath: /etc/kubeconfig
           readOnly: true
         livenessProbe:
           httpGet:
@@ -113,3 +117,7 @@ spec:
       - name: unsplash-api
         secret:
           secretName: unsplash-api-key
+      - name: kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: kubeconfig

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -446,7 +446,9 @@ config_updater:
   maps:
     label_sync/labels.yaml:
       name: label-config
-      namespace: test-pods
+      clusters:
+        test-infra-trusted:
+          - test-pods
     config/prow/config.yaml:
       name: config
     config/prow/plugins.yaml:

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -451,14 +451,26 @@ config_updater:
           - test-pods
     config/prow/config.yaml:
       name: config
+      clusters:
+        test-infra-trusted:
+          - default
     config/prow/plugins.yaml:
       name: plugins
+      clusters:
+        test-infra-trusted:
+          - default
     config/jobs/**/*.yaml:
       name: job-config
       gzip: true
+      clusters:
+        test-infra-trusted:
+          - default
     experiment/test-configmap.txt:
       name: test-configmap
       gzip: true
+      clusters:
+        test-infra-trusted:
+          - default
 
 welcome:
 - repos:


### PR DESCRIPTION
fixes #15662

In order to work we need to mount kubeconfig into `hook` https://github.com/kubernetes/test-infra/issues/15662#issuecomment-694417485