### PR TITLE
Set ssh username with KUBE_SSH_USER if available

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -561,6 +561,18 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone string) e
 		artifactsDir = filepath.Join(os.Getenv("WORKSPACE"), "_artifacts")
 	}
 
+	var sshUser string
+	// Use the KUBE_SSH_USER environment variable if it is set. This is particularly
+	// required for Fedora CoreOS hosts that only have the user 'core`. Tests
+	// using Fedora CoreOS as a host for node tests must set KUBE_SSH_USER
+	// environment variable so that test infrastructure can communicate with the host
+	// successfully using ssh.
+	if os.Getenv("KUBE_SSH_USER") != "" {
+		sshUser = os.Getenv("KUBE_SSH_USER")
+	} else {
+		sshUser = os.Getenv("USER")
+	}
+
 	// prep node args
 	runner := []string{
 		"run",
@@ -572,7 +584,7 @@ func nodeTest(nodeArgs []string, testArgs, nodeTestArgs, project, zone string) e
 		fmt.Sprintf("--results-dir=%s", artifactsDir),
 		fmt.Sprintf("--project=%s", project),
 		fmt.Sprintf("--zone=%s", zone),
-		fmt.Sprintf("--ssh-user=%s", os.Getenv("USER")),
+		fmt.Sprintf("--ssh-user=%s", sshUser),
 		fmt.Sprintf("--ssh-key=%s", sshKeyPath),
 		fmt.Sprintf("--ginkgo-flags=%s", testArgs),
 		fmt.Sprintf("--test_args=%s", nodeTestArgs),


### PR DESCRIPTION
**Which jobs are failing**:
/test pull-kubernetes-node-crio1-18-e2e

**Which test(s) are failing**:
pull-kubernetes-node-crio1-18-e2e


**Reason for failure**:
Just before node e2e tests are started, we verify that the runtime (containerd or docker) is properly running or not on the target system. Currently, `--ssh-user` is set using the local env variable `USER` which happens to be `prow` from where the tests are running. But this username doesn't exists on Fedora CoreOS based system. 
```bash
prow@104.199.120.168: Permission denied (publickey,gssapi-keyex,gssapi-with-mic)
```

Based on the [feedback](https://github.com/kubernetes/kubernetes/pull/94760#discussion_r488235660) from @oomichi and @BenTheElder, I am proposing this change to set the correct value for `--ssh-user` that could work with Fedora CoreOS as well as other hosts. 

Signed-off-by: Harshal Patil <harpatil@redhat.com>