### PR TITLE
Update Azure e2e focus to allow parallel Ginkgo nodes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -81,7 +81,7 @@ presubmits:
         - "./scripts/ci-e2e.sh"
         env:
           - name: GINKGO_FOCUS
-            value: "Workload cluster creation"
+            value: "Creating .* control-plane cluster"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
I've tested this change locally and through CAPZ's e2e. Focusing on the top-level `Describe` container prevents ginkgo from spawning multiple nodes, but finding the `Context`s under that works as expected:

```
Running in parallel across 3 nodes
```