### PR TITLE
Remove Kops unenforceable required checks

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -231,9 +231,6 @@ branch-protection:
         kops:
           required_status_checks:
             contexts:
-            - build-linux-amd64
-            - build-macos-amd64
-            - verify
             - continuous-integration/travis-ci/pr
         kubelet:
           restrictions:


### PR DESCRIPTION
The GitHub checks cannot be enforced due to https://github.com/kubernetes/test-infra/issues/15611.