### PR TITLE
Revert "Update Legacy Endpoints for Delete and Edit (#19200)"

### DIFF
--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -604,7 +604,7 @@ func validateTeamNames(orgConfig org.Config) error {
 type teamClient interface {
 	ListTeams(org string) ([]github.Team, error)
 	CreateTeam(org string, team github.Team) (*github.Team, error)
-	DeleteTeam(org string, id int) error
+	DeleteTeam(id int) error
 }
 
 // configureTeams returns the ids for all expected team names, creating/deleting teams as necessary.
@@ -715,7 +715,7 @@ func configureTeams(client teamClient, orgName string, orgConfig org.Config, max
 	}
 	// Delete undeclared teams.
 	for id := range unused {
-		if err := client.DeleteTeam(orgName, id); err != nil {
+		if err := client.DeleteTeam(id); err != nil {
 			str := fmt.Sprintf("%d(%s)", id, ids[id].Name)
 			logrus.WithError(err).Warnf("Failed to delete team %s from %s", str, orgName)
 			failures = append(failures, str)
@@ -1092,7 +1092,7 @@ func configureTeamAndMembers(opt options, client github.Client, githubTeams map[
 }
 
 type editTeamClient interface {
-	EditTeam(org string, team github.Team) (*github.Team, error)
+	EditTeam(team github.Team) (*github.Team, error)
 }
 
 // configureTeam patches the team name/description/privacy when values differ
@@ -1136,7 +1136,7 @@ func configureTeam(client editTeamClient, orgName, teamName string, team org.Tea
 	}
 
 	if patch { // yes we need to patch
-		if _, err := client.EditTeam(orgName, gt); err != nil {
+		if _, err := client.EditTeam(gt); err != nil {
 			return fmt.Errorf("failed to edit %s team %d(%s): %v", orgName, gt.ID, gt.Name, err)
 		}
 	}

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -756,7 +756,7 @@ func (c *fakeTeamClient) ListTeams(name string) ([]github.Team, error) {
 	return teams, nil
 }
 
-func (c *fakeTeamClient) DeleteTeam(org string, id int) error {
+func (c *fakeTeamClient) DeleteTeam(id int) error {
 	switch _, ok := c.teams[id]; {
 	case !ok:
 		return fmt.Errorf("not found %d", id)
@@ -767,7 +767,7 @@ func (c *fakeTeamClient) DeleteTeam(org string, id int) error {
 	return nil
 }
 
-func (c *fakeTeamClient) EditTeam(org string, team github.Team) (*github.Team, error) {
+func (c *fakeTeamClient) EditTeam(team github.Team) (*github.Team, error) {
 	id := team.ID
 	t, ok := c.teams[id]
 	if !ok {

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1572,7 +1572,7 @@ func TestEditTeam(t *testing.T) {
 		if r.Method != http.MethodPatch {
 			t.Errorf("Bad method: %s", r.Method)
 		}
-		if r.URL.Path != "/orgs/foo/teams/63" {
+		if r.URL.Path != "/teams/63" {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 		b, err := ioutil.ReadAll(r.Body)
@@ -1598,10 +1598,10 @@ func TestEditTeam(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if _, err := c.EditTeam("foo", Team{ID: 0, Name: "frobber"}); err == nil {
+	if _, err := c.EditTeam(Team{ID: 0, Name: "frobber"}); err == nil {
 		t.Errorf("client should reject id 0")
 	}
-	switch team, err := c.EditTeam("foo", Team{ID: 63, Name: "frobber"}); {
+	switch team, err := c.EditTeam(Team{ID: 63, Name: "frobber"}); {
 	case err != nil:
 		t.Errorf("unexpected error: %v", err)
 	case team.Name != "hello":
@@ -1610,23 +1610,6 @@ func TestEditTeam(t *testing.T) {
 		t.Errorf("bad description: %s", team.Description)
 	case team.Privacy != "special":
 		t.Errorf("bad privacy: %s", team.Privacy)
-	}
-}
-
-func TestDeleteTeam(t *testing.T) {
-	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodDelete {
-			t.Errorf("Bad method: %s", r.Method)
-		}
-		if r.URL.Path != "/orgs/foo/teams/63" {
-			t.Errorf("Bad request path: %s", r.URL.Path)
-		}
-		w.WriteHeader(http.StatusNoContent) // 204
-	}))
-	defer ts.Close()
-	c := getClient(ts.URL)
-	if err := c.DeleteTeam("foo", 63); err != nil {
-		t.Errorf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
This reverts commit 1ac05b0ca2f518bfe4f17fbb1ee351ccfc4680cb.

This PR reverts https://github.com/kubernetes/test-infra/pull/19200 because it breaks peribolos because we generate invalid api calls like for example to `http://ghproxy/orgs/openshift/teams/341648`. However, according to the docs[0] we must either use the slug or the id for both the org and the team.

Sample of such a failed job run: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-org-sync/1308041743899299840


https://docs.github.com/en/rest/reference/teams