### PR TITLE
Plank: Properly handle pods that get evicted from an unavailable Node

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -431,6 +431,9 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 				return nil
 			}
 		case corev1.PodRunning:
+			if pod.DeletionTimestamp != nil {
+				break
+			}
 			maxPodRunning := c.config().Plank.PodRunningTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
 				// Pod is still running. Do nothing.

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1502,6 +1502,36 @@ func TestSyncPendingJob(t *testing.T) {
 			ExpectedComplete: true,
 			ExpectedNumPods:  1,
 		},
+		{
+			Name: "Pod deleted in running phase, job marked as errored",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-deleted-in-unset-phase",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "pod-deleted-in-unset-phase",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod-deleted-in-unset-phase",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Second)},
+						DeletionTimestamp: func() *metav1.Time { n := metav1.Now(); return &n }(),
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodRunning,
+					},
+				},
+			},
+			ExpectedState:    prowapi.ErrorState,
+			ExpectedComplete: true,
+			ExpectedNumPods:  1,
+		},
 	}
 
 	// Copy the tests for PlankV2

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -1562,6 +1562,38 @@ func TestSyncPendingJob(t *testing.T) {
 			ExpectedComplete: true,
 			ExpectedNumPods:  1,
 		},
+		{
+			Name: "Pod deleted with NodeLost reason in running phase, pod finalizer gets cleaned up",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-deleted-in-running-phase",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "pod-deleted-in-running-phase",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "pod-deleted-in-running-phase",
+						Namespace:         "pods",
+						CreationTimestamp: metav1.Time{Time: time.Now().Add(-time.Second)},
+						DeletionTimestamp: func() *metav1.Time { n := metav1.Now(); return &n }(),
+						Finalizers:        []string{"prow.x-k8s.io/gcsk8sreporter"},
+					},
+					Status: v1.PodStatus{
+						Phase:  v1.PodRunning,
+						Reason: "NodeLost",
+					},
+				},
+			},
+			ExpectedState:    prowapi.PendingState,
+			ExpectedComplete: false,
+			ExpectedNumPods:  1,
+		},
 	}
 
 	// Copy the tests for PlankV2
@@ -1646,6 +1678,11 @@ func TestSyncPendingJob(t *testing.T) {
 			}
 			if got := len(actualPods.Items); got != tc.ExpectedNumPods {
 				t.Errorf("got %d pods, expected %d", len(actualPods.Items), tc.ExpectedNumPods)
+			}
+			for _, pod := range actualPods.Items {
+				if pod.DeletionTimestamp != nil && len(pod.Finalizers) != 0 {
+					t.Errorf("pod %s was deleted but still had finalizers: %v", pod.Name, pod.Finalizers)
+				}
 			}
 			if actual := actual.Complete(); actual != tc.ExpectedComplete {
 				t.Errorf("expected complete: %t, got complete: %t", tc.ExpectedComplete, actual)

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -976,6 +976,36 @@ func TestSyncPendingJob(t *testing.T) {
 			ExpectedNumPods: 0,
 		},
 		{
+			Name: "delete pod in unknown state with gcsreporter finalizer",
+			PJ: prowapi.ProwJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "boop-41",
+					Namespace: "prowjobs",
+				},
+				Spec: prowapi.ProwJobSpec{
+					PodSpec: &v1.PodSpec{Containers: []v1.Container{{Name: "test-name", Env: []v1.EnvVar{}}}},
+				},
+				Status: prowapi.ProwJobStatus{
+					State:   prowapi.PendingState,
+					PodName: "boop-41",
+				},
+			},
+			Pods: []v1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "boop-41",
+						Namespace:  "pods",
+						Finalizers: []string{"prow.x-k8s.io/gcsk8sreporter"},
+					},
+					Status: v1.PodStatus{
+						Phase: v1.PodUnknown,
+					},
+				},
+			},
+			ExpectedState:   prowapi.PendingState,
+			ExpectedNumPods: 0,
+		},
+		{
 			Name: "succeeded pod",
 			PJ: prowapi.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -382,6 +382,9 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 				return nil
 			}
 		case corev1.PodRunning:
+			if pod.DeletionTimestamp != nil {
+				break
+			}
 			maxPodRunning := r.config().Plank.PodRunningTimeout.Duration
 			if pod.Status.StartTime.IsZero() || time.Since(pod.Status.StartTime.Time) < maxPodRunning {
 				// Pod is still running. Do nothing.

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -415,6 +415,27 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 		}
 	}
 
+	// This can happen in any phase and means the node got evicted after it became unresponsive. Delete the finalizer so the pod
+	// vanishes and we will silently re-create it in the next iteration.
+	if pod != nil && pod.DeletionTimestamp != nil && pod.Status.Reason == "NodeLost" {
+		r.log.WithFields(pjutil.ProwJobFields(pj)).Info("Pods Node got lost, deleting & restarting pod")
+		client, ok := r.buildClients[pj.ClusterAlias()]
+		if !ok {
+			return fmt.Errorf("unknown pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
+		}
+
+		if finalizers := sets.NewString(pod.Finalizers...); finalizers.Has(kubernetesreporterapi.FinalizerName) {
+			// We want the end user to not see this, so we have to remove the finalizer, otherwise the pod hangs
+			oldPod := pod.DeepCopy()
+			pod.Finalizers = finalizers.Delete(kubernetesreporterapi.FinalizerName).UnsortedList()
+			if err := client.Patch(r.ctx, pod, ctrlruntimeclient.MergeFrom(oldPod)); err != nil {
+				return fmt.Errorf("failed to patch pod trying to remove %s finalizer: %w", kubernetesreporterapi.FinalizerName, err)
+			}
+		}
+
+		return nil
+	}
+
 	// If a pod gets deleted unexpectedly, it might be in any phase and will stick around until
 	// we complete the job if the kubernetes reporter is used, because it sets a finalizer.
 	if !pj.Complete() && pod != nil && pod.DeletionTimestamp != nil {

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -301,6 +301,14 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 				return fmt.Errorf("unknown pod %s: unknown cluster alias %q", pod.Name, pj.ClusterAlias())
 			}
 
+			if finalizers := sets.NewString(pod.Finalizers...); finalizers.Has(kubernetesreporterapi.FinalizerName) {
+				// We want the end user to not see this, so we have to remove the finalizer, otherwise the pod hangs
+				oldPod := pod.DeepCopy()
+				pod.Finalizers = finalizers.Delete(kubernetesreporterapi.FinalizerName).UnsortedList()
+				if err := client.Patch(r.ctx, pod, ctrlruntimeclient.MergeFrom(oldPod)); err != nil {
+					return fmt.Errorf("failed to patch pod trying to remove %s finalizer: %w", kubernetesreporterapi.FinalizerName, err)
+				}
+			}
 			r.log.WithField("name", pj.ObjectMeta.Name).Debug("Delete Pod.")
 			return client.Delete(r.ctx, pod)
 


### PR DESCRIPTION
This PR makes plank correctly handle pods that got evicted from a node that become unresponsive. This state can not be inferred from a Phase, as Kube only sets `.Status.Reason` to `NodeLost` and deletes the pod.

It also fixes a bug where we wouldn't cleanup the gcsreporter finalizer when the pod was in an `unknown` state and instead only delete the pod.

Fixes https://github.com/kubernetes/test-infra/issues/19274
