### PR TITLE
Sidecar: Limit memory usage to prevent oom kills

### DIFF
--- a/prow/pod-utils/gcs/BUILD.bazel
+++ b/prow/pod-utils/gcs/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_utils//pointer:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -118,6 +118,9 @@ func FileUploadWithOptions(file string, opts pkgio.WriterOptions) UploadFunc {
 		}
 		if fi, err := reader.Stat(); err == nil {
 			opts.BufferSize = utilpointer.Int64Ptr(fi.Size())
+			if *opts.BufferSize > 25*1024*1024 {
+				*opts.BufferSize = 25 * 1024 * 1024
+			}
 		}
 
 		uploadErr := DataUploadWithOptions(reader, opts)(writer)

--- a/prow/pod-utils/gcs/upload.go
+++ b/prow/pod-utils/gcs/upload.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/semaphore"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	utilpointer "k8s.io/utils/pointer"
 
@@ -76,11 +77,14 @@ func LocalExport(exportDir string, uploadTargets map[string]UploadFunc) error {
 func upload(dtw destToWriter, uploadTargets map[string]UploadFunc) error {
 	errCh := make(chan error, len(uploadTargets))
 	group := &sync.WaitGroup{}
+	sem := semaphore.NewWeighted(4)
 	group.Add(len(uploadTargets))
 	for dest, upload := range uploadTargets {
 		log := logrus.WithField("dest", dest)
 		log.Info("Queued for upload")
 		go func(f UploadFunc, writer dataWriter, log *logrus.Entry) {
+			sem.Acquire(context.Background(), 1)
+			defer sem.Release(1)
 			defer group.Done()
 			if err := f(writer); err != nil {
 				errCh <- err


### PR DESCRIPTION
This pr:
* Limits the buffer size in sidecar for uploads to 25 MiB (from buffersize == filesize)
* Limits the number of parallel uploads in sidecar to four

In order to prevent high memory usage which in turn can lead to oom kills.

/assign @fejta @stevekuznetsov 