### PR TITLE
add cncf/apisnoop to managed_webhooks:

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -112,6 +112,8 @@ managed_webhooks:
       token_created_after: 2020-08-12T00:00:00Z
     containerd/containerd:
       token_created_after: 2020-09-17T00:00:00Z
+    cncf/apisnoop:
+      token_created_after: 2020-09-22T00:00:00Z
 
 slack_reporter_configs:
   '*':


### PR DESCRIPTION
We need to enable prow image builds so our k/k release blocking job can be self-hosted within the kubernetes community:

- add conformance gate prow job #19173
- https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/k8s-staging-apisnoop.yaml
