### PR TITLE
Remove `--release-kind` and `--federation` from push-build.sh

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -43,7 +43,7 @@ def check_output(*cmd):
     return subprocess.check_output(cmd)
 
 def check_build_exists(gcs, suffix, fast):
-    """ check if a k8s/federation build with same version
+    """ check if a k8s build with same version
         already exists in remote path
     """
     if not os.path.exists('hack/print-workspace-status.sh'):
@@ -90,10 +90,9 @@ def main(args):
 
     This is a python port of the kubernetes/hack/jenkins/build.sh script.
     """
-    if os.path.split(os.getcwd())[-1] != 'kubernetes' and \
-        os.path.split(os.getcwd())[-1] != 'federation':
+    if os.path.split(os.getcwd())[-1] != 'kubernetes':
         print >>sys.stderr, (
-            'Scenario should only run from either kubernetes or federation directory!')
+            'Scenario should only run from either kubernetes directory!')
         sys.exit(1)
 
     # pre-check if target build exists in gcs bucket or not
@@ -111,13 +110,6 @@ def main(args):
     push_build_args = ['--nomock', '--verbose', '--ci']
     if args.suffix:
         push_build_args.append('--gcs-suffix=%s' % args.suffix)
-    if args.federation:
-        # TODO: do we need to set these?
-        env['PROJECT'] = args.federation
-        env['FEDERATION_PUSH_REPO_BASE'] = 'gcr.io/%s' % args.federation
-        push_build_args.append('--federation')
-    if args.release_kind:
-        push_build_args.append('--release-kind=%s' % args.release_kind)
     if args.release:
         push_build_args.append('--bucket=%s' % args.release)
     if args.registry:
@@ -154,13 +146,6 @@ if __name__ == '__main__':
         '--release', help='Upload binaries to the specified gs:// path')
     PARSER.add_argument(
         '--suffix', help='Append suffix to the upload path if set')
-    PARSER.add_argument(
-        '--federation',
-        help='Push federation images to the specified project')
-    PARSER.add_argument(
-        '--release-kind',
-        default='kubernetes',
-        help='The release kind to push to GCS. Supported values are kubernetes or federation')
     PARSER.add_argument(
         '--registry', help='Push images to the specified docker registry')
     PARSER.add_argument(


### PR DESCRIPTION
The kubernetes_build scenario was referencing two more or less
deprecated flags `--release-kind` and `--federation`. Since the scripts
to execute those build does not exist any more inside k/k we can safely
remove them.

/assign @dims @justaugustus 
/cc @kubernetes/release-managers 

related to https://github.com/kubernetes/test-infra/pull/19328