### PR TITLE
Update PR blockers for k/release

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -181,7 +181,7 @@ blockades:
 - repos:
   - kubernetes/release
   blockregexps:
-  - ^(anago|compile-release-tools|find_green_build|gcb\/|lib\/|prin|push-build.sh|release-notify|relnotes)
+  - ^(anago|compile-release-tools|gcb\/|lib\/|prin|push-build.sh)
   explanation: "Changes to certain release tools can affect our ability to test, build, and release Kubernetes. This PR must be explicitly approved by SIG Release repo admins."
 
 blunderbuss:


### PR DESCRIPTION
This reflects the latest changes to k/release where some of the scripts
already have been removed.
