### PR TITLE
add family image to sctp job

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -513,6 +513,8 @@ periodics:
       - --extract=ci/latest
       - --gcp-master-image=ubuntu
       - --gcp-node-image=ubuntu
+      - --image-family=ubuntu-2004-lts
+      - --image-project=ubuntu-os-cloud
       - --gcp-zone=us-west1-b
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:(SCTP|SCTPConnectivity)\] --ginkgo.skip=\[Feature:NetworkPolicy\]


### PR DESCRIPTION
the job is failing to run

W0923 10:26:04.903] ERROR: (gcloud.compute.instances.create) Must specify either [--image] or [--image-family] when specifying [--image-project] flag.
W0923 10:26:04.904] Failed to create master instance due to non-retryable error
W0923 10:26:06.620] Creating firewall...
W0923 10:26:06.621] ..Created [https://www.googleapis.com/compute/v1/projects/k8s-jkns-gce-alpha-1-6/global/firewalls/bootstrap-e2e-minion-all].
I0923 10:26:06.881] NAME                      NETWORK        DIRECTION  PRIORITY  ALLOW                     DENY  DISABLED
I0923 10:26:06.881] bootstrap-e2e-minion-all  bootstrap-e2e  INGRESS    1000      tcp,udp,icmp,esp,ah,sctp        False
W0923 10:26:06.982] done.
W0923 10:26:07.108] �[0;31mSome commands failed.�[0m
I0923 10:26:07.209] Creating nodes.
W0923 10:26:12.555] /workspace/kubernetes/cluster/../cluster/../cluster/gce/util.sh: line 1527: WINDOWS_CONTAINER_RUNTIME_ENDPOINT: unbound variable
I0923 10:26:12.767] Using subnet bootstrap-e2e
https://gcsweb.k8s.io/gcs/kubernetes-jenkins/logs/ci-kubernetes-e2e-ubuntu-gce-basic-sctp/

is this the problem?

Must specify either [--image] or [--image-family] when specifying [--image-project] flag.

xref https://github.com/kubernetes/test-infra/pull/19238#issuecomment-697376432