### PR TITLE
Allow staging via krel for kubetest

### DIFF
--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -120,6 +120,7 @@ type options struct {
 	up                      bool
 	upgradeArgs             string
 	boskosWaitDuration      time.Duration
+	useKrel                 bool
 }
 
 func defineFlags() *options {
@@ -163,7 +164,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.metadataSources, "metadata-sources", "images.json", "Comma-separated list of files inside ./artifacts to merge into metadata.json")
 	flag.StringVar(&o.nodeArgs, "node-args", "", "Args for node e2e tests.")
 	flag.StringVar(&o.nodeTestArgs, "node-test-args", "", "Test args specifically for node e2e tests.")
-	flag.BoolVar(&o.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
+	flag.BoolVar(&o.stage.noAllowDup, "no-allow-dup", false, "if set --allow-dup will not be passed to push-build and --stage will error if the build already exists on the gcs path")
 	flag.BoolVar(&o.nodeTests, "node-tests", false, "If true, run node-e2e tests.")
 	flag.StringVar(&o.provider, "provider", "", "Kubernetes provider such as gce, gke, aws, etc")
 	flag.StringVar(&o.publish, "publish", "", "Publish version to the specified gs:// path on success")
@@ -183,6 +184,7 @@ func defineFlags() *options {
 	flag.BoolVar(&o.up, "up", false, "If true, start the e2e cluster. If cluster is already up, recreate it.")
 	flag.StringVar(&o.upgradeArgs, "upgrade_args", "", "If set, run upgrade tests before other tests")
 	flag.DurationVar(&o.boskosWaitDuration, "boskos-wait-duration", 5*time.Minute, "Defines how long it waits until quit getting Boskos resoure, default 5 minutes")
+	flag.BoolVar(&o.stage.useKrel, "use-krel", false, "If true, use the Kubernetes Release Toolbox (krel). Works only for staging right now.")
 
 	// The "-v" flag was also used by glog, which is used by k8s.io/client-go. Duplicate flags cause panics.
 	// 1. Even if we could convince glog to change, they have too many consumers to ever do so.
@@ -429,7 +431,7 @@ func acquireKubernetes(o *options, d deployer) error {
 	// Potentially stage build binaries somewhere on GCS
 	if o.stage.Enabled() {
 		if err := control.XMLWrap(&suite, "Stage", func() error {
-			return o.stage.Stage(o.noAllowDup)
+			return o.stage.Stage()
 		}); err != nil {
 			return err
 		}

--- a/kubetest/stage.go
+++ b/kubetest/stage.go
@@ -22,6 +22,10 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/pkg/errors"
+	krgcs "k8s.io/release/pkg/gcp/gcs"
+	"k8s.io/release/pkg/release"
+
 	"k8s.io/test-infra/kubetest/util"
 )
 
@@ -31,15 +35,20 @@ type stageStrategy struct {
 	gcsSuffix      string
 	versionSuffix  string
 	dockerRegistry string
+	noAllowDup     bool
+	useKrel        bool
 }
 
 // Return something like gs://bucket/ci/suffix
 func (s *stageStrategy) String() string {
-	p := "devel"
+	return fmt.Sprintf("%v%v%v", s.bucket, s.releaseType(), s.gcsSuffix)
+}
+
+func (s *stageStrategy) releaseType() string {
 	if s.ci {
-		p = "ci"
+		return "ci"
 	}
-	return fmt.Sprintf("%v%v%v", s.bucket, p, s.gcsSuffix)
+	return "devel"
 }
 
 // Parse bucket, ci, suffix from gs://BUCKET/ci/SUFFIX
@@ -65,18 +74,42 @@ func (s *stageStrategy) Enabled() bool {
 }
 
 // Stage the release build to GCS.
-// Essentially release/push-build.sh --bucket=B --ci? --gcs-suffix=S --noupdatelatest
-func (s *stageStrategy) Stage(noAllowDup bool) error {
-	name := util.K8s("release", "push-build.sh")
-	b := s.bucket
-	if strings.HasPrefix(b, "gs://") {
-		b = b[len("gs://"):]
+func (s *stageStrategy) Stage() error {
+	// Trim the gcs prefix from the bucket
+	s.bucket = strings.TrimPrefix(s.bucket, krgcs.GcsPrefix)
+
+	// Essentially release/push-build.sh --bucket=B --ci? --gcs-suffix=S
+	// --noupdatelatest
+	if !s.useKrel {
+		return errors.Wrap(s.stageViaPushBuildSh(), "stage via push-build.sh")
 	}
+
+	return errors.Wrap(
+		release.NewPushBuild(&release.PushBuildOptions{
+			Bucket:              s.bucket,
+			BuildDir:            "_output",
+			DockerRegistry:      s.dockerRegistry,
+			ExtraVersionMarkers: "",
+			GCSSuffix:           s.gcsSuffix,
+			ReleaseType:         s.releaseType(),
+			VersionSuffix:       s.versionSuffix,
+			AllowDup:            !s.noAllowDup,
+			CI:                  s.ci,
+			NoUpdateLatest:      true,
+			PrivateBucket:       false,
+			Fast:                false,
+			NoMock:              true,
+		}).Push(), "stage via krel push",
+	)
+}
+
+func (s *stageStrategy) stageViaPushBuildSh() error {
+	name := util.K8s("release", "push-build.sh")
 	args := []string{
 		"--nomock",
 		"--verbose",
 		"--noupdatelatest", // we may need to expose control of this if build jobs start using kubetest
-		fmt.Sprintf("--bucket=%v", b),
+		fmt.Sprintf("--bucket=%v", s.bucket),
 	}
 	if s.ci {
 		args = append(args, "--ci")
@@ -91,7 +124,7 @@ func (s *stageStrategy) Stage(noAllowDup bool) error {
 		args = append(args, fmt.Sprintf("--docker-registry=%s", s.dockerRegistry))
 	}
 
-	if !noAllowDup {
+	if !s.noAllowDup {
 		args = append(args, "--allow-dup")
 	}
 


### PR DESCRIPTION
This adds a new `--use-krel` flag to kubetest to indicate that we want
to stage the sources directly via the API provided by k/release rather
than the deprecated push-build.sh script (lives in k/release, too).

The idea is to add another job later on for testing this flag on a non
critical Kubernetes build+push job (should live in sig-release).

Refers to https://github.com/kubernetes/release/issues/1578, https://github.com/kubernetes/release/issues/1459