### PR TITLE
Remove unmaintained stackdriver logging e2e test

### DIFF
--- a/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
+++ b/config/jobs/kubernetes/sig-instrumentation/sig-instrumentation-config.yaml
@@ -25,29 +25,3 @@ periodics:
   annotations:
     testgrid-dashboards: google-gce
     testgrid-tab-name: gci-gce-es-logging
-- interval: 12h
-  name: ci-kubernetes-e2e-gci-gce-sd-logging
-  labels:
-    preset-service-account: "true"
-    preset-k8s-ssh: "true"
-  spec:
-    containers:
-    - args:
-      - --timeout=1340
-      - --bare
-      - --scenario=kubernetes_e2e
-      - --
-      - --check-leaked-resources
-      - --env=KUBE_LOGGING_DESTINATION=gcp
-      - --env=TEST_CLUSTER_LOG_LEVEL=--v=2
-      - --extract=ci/latest
-      - --gcp-node-image=gci
-      - --gcp-zone=us-west1-b
-      - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:StackdriverLogging\] --minStartupPods=8
-      - --timeout=1320m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200918-58bdf8d-master
-
-  annotations:
-    testgrid-dashboards: google-gce
-    testgrid-tab-name: gci-gce-sd-logging

--- a/config/testgrids/kubernetes/sig-instrumentation/config.yaml
+++ b/config/testgrids/kubernetes/sig-instrumentation/config.yaml
@@ -20,9 +20,5 @@ dashboards:
       test_group_name: ci-kubernetes-e2e-gci-gce-es-logging
       base_options: include-filter-by-regex=sig-instrumentation
       description: sig-instrumentation gce elasticsearch logging e2e tests for master branch
-    - name: gci-gce-sd-logging
-      test_group_name: ci-kubernetes-e2e-gci-gce-sd-logging
-      base_options: include-filter-by-regex=sig-instrumentation
-      description: sig-instrumentation gce stackdriver logging e2e tests for master branch
 - name: sig-instrumentation-image-pushes
 - name: sig-instrumentation-metrics-server


### PR DESCRIPTION
- Related Issue: https://github.com/kubernetes/kubernetes/issues/92731

- The PR for removeing the test itself:
  https://github.com/kubernetes/kubernetes/pull/95014

Signed-off-by: Yu Yi <yiyu@google.com>