### PR TITLE
Revert debug dump in kettle main loop

### DIFF
--- a/kettle/update.py
+++ b/kettle/update.py
@@ -60,13 +60,13 @@ def main():
         mj_ext = ' --reset-emitted'
 
     call(mj_cmd + mj_ext + ' --days 1 | pv | gzip > build_day.json.gz')
-    call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json', dump=True)
+    call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json')
 
     call(mj_cmd + mj_ext + ' --days 7 | pv | gzip > build_week.json.gz')
-    call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json', dump=True)
+    call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json')
 
     call(mj_cmd + ' | pv | gzip > build_all.json.gz')
-    call(bq_cmd + ' k8s-gubernator:build.all build_all.json.gz schema.json', dump=True)
+    call(bq_cmd + ' k8s-gubernator:build.all build_all.json.gz schema.json')
 
     call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
          ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')


### PR DESCRIPTION
This broke the build.day and build.week tables. I need to dig deeper and maybe create staging kettle so this isn't repeated

Not sure why build.all was fine

/assign @spiffxp 