### PR TITLE
fix(kubeflow): don't protect branches created by editing on GitHub UI

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -431,6 +431,7 @@ branch-protection:
       exclude:
       - "^revert-" # don't protect revert branches
       - "^dependabot/" # don't protect branches created by dependabot
+      - "-patch-" # don't protect branches created by editing on GitHub UI
 
 tide:
   sync_period: 2m


### PR DESCRIPTION
Follow up of https://github.com/kubernetes/test-infra/pull/18837

/assign @jlewi 
Right now, when admins edit files on GitHub UI, those branches will be called like `Bobgy-patch-1`, and they automatically get branch protection rules. So they cannot be deleted without removing protection rules first. For example: https://github.com/kubeflow/pipelines/tree/Bobgy-patch-1

I'd like to opt-out for these branches, so they can be deleted after PRs merged.