### PR TITLE
peribolos: fix updating teams 

### DIFF
--- a/prow/cmd/peribolos/BUILD.bazel
+++ b/prow/cmd/peribolos/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//prow/config/org:go_default_library",
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_sigs_yaml//:go_default_library",

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -1145,7 +1145,7 @@ func configureTeam(client editTeamClient, orgName, teamName string, team org.Tea
 
 type teamRepoClient interface {
 	ListTeamRepos(id int) ([]github.Repo, error)
-	UpdateTeamRepo(id int, org, repo string, permission github.RepoPermissionLevel) error
+	UpdateTeamRepo(id int, org, repo string, permission github.TeamPermission) error
 	RemoveTeamRepo(id int, org, repo string) error
 }
 
@@ -1186,11 +1186,17 @@ func configureTeamRepos(client teamRepoClient, githubTeams map[string]github.Tea
 	var updateErrors []error
 	for repo, permission := range actions {
 		var err error
-		if permission == github.None {
+		switch permission {
+		case github.None:
 			err = client.RemoveTeamRepo(gt.ID, orgName, repo)
-		} else {
-			err = client.UpdateTeamRepo(gt.ID, orgName, repo, permission)
+		case github.Admin:
+			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoAdmin)
+		case github.Write:
+			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoPush)
+		case github.Read:
+			err = client.UpdateTeamRepo(gt.ID, orgName, repo, github.RepoPull)
 		}
+
 		if err != nil {
 			updateErrors = append(updateErrors, fmt.Errorf("failed to update team %d(%s) permissions on repo %s to %s: %v", gt.ID, name, repo, permission, err))
 		}

--- a/prow/cmd/peribolos/main.go
+++ b/prow/cmd/peribolos/main.go
@@ -29,6 +29,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
 	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/flagutil"

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -2271,22 +2271,23 @@ func (c *fakeTeamRepoClient) ListTeamRepos(id int) ([]github.Repo, error) {
 	return c.repos[id], nil
 }
 
-func (c *fakeTeamRepoClient) UpdateTeamRepo(id int, org, repo string, permission github.RepoPermissionLevel) error {
+func (c *fakeTeamRepoClient) UpdateTeamRepo(id int, org, repo string, permission github.TeamPermission) error {
 	if c.failUpdate {
 		return errors.New("injected failure to UpdateTeamRepos")
 	}
 
+	permissions := github.PermissionsFromTeamPermission(permission)
 	updated := false
 	for i, repository := range c.repos[id] {
 		if repository.Name == repo {
-			c.repos[id][i].Permissions = github.PermissionsFromLevel(permission)
+			c.repos[id][i].Permissions = permissions
 			updated = true
 			break
 		}
 	}
 
 	if !updated {
-		c.repos[id] = append(c.repos[id], github.Repo{Name: repo, Permissions: github.PermissionsFromLevel(permission)})
+		c.repos[id] = append(c.repos[id], github.Repo{Name: repo, Permissions: permissions})
 	}
 
 	return nil

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -24,7 +24,9 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"k8s.io/apimachinery/pkg/util/diff"
+
 	"k8s.io/test-infra/prow/config/org"
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
@@ -188,7 +190,7 @@ func TestOptions(t *testing.T) {
 		case err != nil && tc.expected != nil:
 			t.Errorf("%s: unexpected error: %v", tc.name, err)
 		case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
-			t.Errorf("%s: got incorrect options: %v", tc.name, diff.ObjectReflectDiff(actual, *tc.expected))
+			t.Errorf("%s: got incorrect options: %v", tc.name, cmp.Diff(actual, *tc.expected))
 		}
 	}
 }
@@ -2518,7 +2520,7 @@ func TestConfigureTeamRepos(t *testing.T) {
 			t.Errorf("%s: expected no error but got one: %v", testCase.name, err)
 		}
 		if actual, expected := client.repos, testCase.expected; !reflect.DeepEqual(actual, expected) {
-			t.Errorf("%s: got incorrect team repos: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			t.Errorf("%s: got incorrect team repos: %v", testCase.name, cmp.Diff(actual, expected))
 		}
 	}
 }
@@ -2962,7 +2964,7 @@ func TestConfigureRepos(t *testing.T) {
 				t.Fatalf("%s: unexpected GetRepos error: %v", tc.description, err)
 			}
 			if !reflect.DeepEqual(reposAfter, tc.expectedRepos) {
-				t.Errorf("%s: unexpected repos after configureRepos():\n%s", tc.description, diff.ObjectReflectDiff(reposAfter, tc.expectedRepos))
+				t.Errorf("%s: unexpected repos after configureRepos():\n%s", tc.description, cmp.Diff(reposAfter, tc.expectedRepos))
 			}
 		})
 	}
@@ -3100,7 +3102,7 @@ func TestNewRepoUpdateRequest(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			update := newRepoUpdateRequest(tc.current, tc.name, tc.newState)
 			if !reflect.DeepEqual(tc.expected, update) {
-				t.Errorf("%s: update request differs from expected:%s", tc.description, diff.ObjectReflectDiff(tc.expected, update))
+				t.Errorf("%s: update request differs from expected:%s", tc.description, cmp.Diff(tc.expected, update))
 			}
 		})
 	}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -176,7 +176,7 @@ type TeamClient interface {
 	RemoveTeamMembership(id int, user string) error
 	ListTeamMembers(id int, role string) ([]TeamMember, error)
 	ListTeamRepos(id int) ([]Repo, error)
-	UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error
+	UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error
 	RemoveTeamRepo(id int, org, repo string) error
 	ListTeamInvitations(id int) ([]OrgInvitation, error)
 	TeamHasMember(teamID int, memberLogin string) (bool, error)
@@ -3069,7 +3069,7 @@ func (c *client) ListTeamRepos(id int) ([]Repo, error) {
 // UpdateTeamRepo adds the repo to the team with the provided role.
 //
 // https://developer.github.com/v3/teams/#add-or-update-team-repository
-func (c *client) UpdateTeamRepo(id int, org, repo string, permission RepoPermissionLevel) error {
+func (c *client) UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error {
 	durationLogger := c.log("UpdateTeamRepo", id, org, repo, permission)
 	defer durationLogger()
 

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -82,23 +82,6 @@ func LevelFromPermissions(permissions RepoPermissions) RepoPermissionLevel {
 	}
 }
 
-// PermissionsFromLevel adapts a repo permission level to the
-// appropriate permissions struct used elsewhere.
-func PermissionsFromLevel(permission RepoPermissionLevel) RepoPermissions {
-	switch permission {
-	case None:
-		return RepoPermissions{}
-	case Read:
-		return RepoPermissions{Pull: true}
-	case Write:
-		return RepoPermissions{Pull: true, Push: true}
-	case Admin:
-		return RepoPermissions{Pull: true, Push: true, Admin: true}
-	default:
-		return RepoPermissions{}
-	}
-}
-
 // PermissionsFromTeamPermissions
 func PermissionsFromTeamPermission(permission TeamPermission) RepoPermissions {
 	switch permission {

--- a/prow/github/helpers.go
+++ b/prow/github/helpers.go
@@ -98,3 +98,18 @@ func PermissionsFromLevel(permission RepoPermissionLevel) RepoPermissions {
 		return RepoPermissions{}
 	}
 }
+
+// PermissionsFromTeamPermissions
+func PermissionsFromTeamPermission(permission TeamPermission) RepoPermissions {
+	switch permission {
+	case RepoPull:
+		return RepoPermissions{Pull: true}
+	case RepoPush:
+		return RepoPermissions{Pull: true, Push: true}
+	case RepoAdmin:
+		return RepoPermissions{Pull: true, Push: true, Admin: true}
+	default:
+		// Should never happen unless the type gets new value
+		return RepoPermissions{}
+	}
+}

--- a/prow/github/helpers_test.go
+++ b/prow/github/helpers_test.go
@@ -131,3 +131,33 @@ func TestPermissionsFromLevel(t *testing.T) {
 		}
 	}
 }
+
+func TestPermissionsFromTeamPermission(t *testing.T) {
+	var testCases = []struct {
+		level       TeamPermission
+		permissions RepoPermissions
+	}{
+		{
+			level:       TeamPermission("foobar"),
+			permissions: RepoPermissions{},
+		},
+		{
+			level:       RepoPull,
+			permissions: RepoPermissions{Pull: true},
+		},
+		{
+			level:       RepoPush,
+			permissions: RepoPermissions{Pull: true, Push: true},
+		},
+		{
+			level:       RepoAdmin,
+			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
+		},
+	}
+
+	for _, testCase := range testCases {
+		if actual, expected := PermissionsFromTeamPermission(testCase.level), testCase.permissions; actual != expected {
+			t.Errorf("got incorrect permissions from team permissions, expected %v but got %v", expected, actual)
+		}
+	}
+}

--- a/prow/github/helpers_test.go
+++ b/prow/github/helpers_test.go
@@ -98,40 +98,6 @@ func TestLevelFromPermissions(t *testing.T) {
 	}
 }
 
-func TestPermissionsFromLevel(t *testing.T) {
-	var testCases = []struct {
-		level       RepoPermissionLevel
-		permissions RepoPermissions
-	}{
-		{
-			level:       RepoPermissionLevel("foobar"),
-			permissions: RepoPermissions{},
-		},
-		{
-			level:       None,
-			permissions: RepoPermissions{},
-		},
-		{
-			level:       Read,
-			permissions: RepoPermissions{Pull: true},
-		},
-		{
-			level:       Write,
-			permissions: RepoPermissions{Pull: true, Push: true},
-		},
-		{
-			level:       Admin,
-			permissions: RepoPermissions{Pull: true, Push: true, Admin: true},
-		},
-	}
-
-	for _, testCase := range testCases {
-		if actual, expected := PermissionsFromLevel(testCase.level), testCase.permissions; actual != expected {
-			t.Errorf("got incorrect permissions from level, expected %v but got %v", expected, actual)
-		}
-	}
-}
-
 func TestPermissionsFromTeamPermission(t *testing.T) {
 	var testCases = []struct {
 		level       TeamPermission


### PR DESCRIPTION
Recently, peribolos started failing with 422s while updating teams,
turns out the API probably silently changed? [1] We are passing
`read/write/admin` strings as `permission` parameter values, but the
documentation [2] says it receives `pull/push/admin`.

We have existing peribolos configs that say `read/write` so we cannot directly
change that, so we now map the values to `pull/push` ones in peribolos.

I'm not sure how much we care about the API stability for external users.
`UpdateTeamRepo` is exported, so changing it's signature may be a
wrong thing to do. I can prep a backward compatible version that does
the mapping internally to `UpdateTeamRepo`.

[1]
Previously:
```console
$ curl -k -v -XPUT  -H "Accept: application/vnd.github.v3+json" -H "User-Agent: peribolos/v20200922-48e2720306" -H "Authorization: Bearer NOPE" 'https://api.github.com/teams/4099861/repos/openshift/cluster-api-provider-kubevirt' -d '{"permission":"write"}'
...
< Status: 422 Unprocessable Entity
{"message":"Validation Failed","documentation_url":"https://docs.github.com/rest/reference/teams#add-or-update-team-repository-permissions"}
```

After:
```console
$ curl -k -v -XPUT  -H "Accept: application/vnd.github.v3+json" -H "User-Agent: peribolos/v20200922-48e2720306" -H "Authorization: Bearer NOPE" 'https://api.github.com/teams/4099861/repos/openshift/cluster-api-provider-kubevirt' -d '{"permission":"push"}'
< Status: 204 No Content
```

[2] https://docs.github.com/en/rest/reference/teams#add-or-update-team-repository-permissions-legacy

/cc @stevekuznetsov @alvaroaleman 