### PR TITLE
censor the potential token in git outputs and messages

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -64,7 +64,7 @@ func Run(refs prowapi.Refs, dir, gitUserName, gitUserEmail, cookiePath string, e
 				message = err.Error()
 				record.Failed = true
 			}
-			record.Commands = append(record.Commands, Command{Command: censorGitCommand(formattedCommand, oauthToken), Output: output, Error: message})
+			record.Commands = append(record.Commands, Command{Command: censorToken(formattedCommand, oauthToken), Output: censorToken(output, oauthToken), Error: censorToken(message, oauthToken)})
 			if err != nil {
 				return err
 			}
@@ -95,11 +95,11 @@ func Run(refs prowapi.Refs, dir, gitUserName, gitUserEmail, cookiePath string, e
 	return record
 }
 
-func censorGitCommand(command, token string) string {
+func censorToken(msg, token string) string {
 	if token == "" {
-		return command
+		return msg
 	}
-	censored := bytes.ReplaceAll([]byte(command), []byte(token), []byte("CENSORED"))
+	censored := bytes.ReplaceAll([]byte(msg), []byte(token), []byte("CENSORED"))
 	return string(censored)
 }
 


### PR DESCRIPTION
The complete git command, output, and messages are being written in a file and they can end up in a public bucket. This can lead to a token leak. 
Before we were censoring only the git command, but it seems that older git clients can output the sensitive data.

This PR makes sure that we censor the OAuth token from output and messages as well. 


/cc @stevekuznetsov @petr-muller @alvaroaleman 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>