### PR TITLE
Bumper: Convert error message to lower case before comparing

### DIFF
--- a/experiment/autobumper/bumper/bumper.go
+++ b/experiment/autobumper/bumper/bumper.go
@@ -536,7 +536,7 @@ func GitCommitAndPush(remote, remoteBranch, name, email, message string, stdout,
 	fetchStderr := &bytes.Buffer{}
 	var remoteTreeRef string
 	if err := Call(stdout, fetchStderr, gitCmd, "fetch", forkRemoteName, remoteBranch); err != nil {
-		if !strings.Contains(fetchStderr.String(), fmt.Sprintf("couldn't find remote ref %s", remoteBranch)) {
+		if !strings.Contains(strings.ToLower(fetchStderr.String()), fmt.Sprintf("couldn't find remote ref %s", remoteBranch)) {
 			return fmt.Errorf("failed to fetch from fork: %w", err)
 		}
 	} else {


### PR DESCRIPTION
Error message returned by git fetch is "Couldn't find remote ref..." while we seem to be checking for "couldn't find remote ref..". Converting it to lowercase to cover both cases ie the error is returned in lower case (this has worked so far).