### PR TITLE
bugzilla plugin: don't handle close with missing bug

### DIFF
--- a/prow/plugins/bugzilla/bugzilla.go
+++ b/prow/plugins/bugzilla/bugzilla.go
@@ -1010,6 +1010,9 @@ Please contact an administrator to resolve this issue, then request a bug refres
 
 func handleClose(e event, gc githubClient, bc bugzilla.Client, options plugins.BugzillaBranchOptions, log *logrus.Entry) error {
 	comment := e.comment(gc)
+	if e.missing {
+		return nil
+	}
 	if options.AddExternalLink != nil && *options.AddExternalLink {
 		response := fmt.Sprintf(`This pull request references `+bugLink+`. The bug has been updated to no longer refer to the pull request using the external bug tracker.`, e.bugId, bc.Endpoint(), e.bugId)
 		changed, err := bc.RemovePullRequestAsExternalBug(e.bugId, e.org, e.repo, e.number)

--- a/prow/plugins/bugzilla/bugzilla_test.go
+++ b/prow/plugins/bugzilla/bugzilla_test.go
@@ -1270,6 +1270,16 @@ Instructions for interacting with me using PR comments are available [here](http
 			expectedExternalBugs: []bugzilla.ExternalBug{},
 		},
 		{
+			name:        "closed PR with missing bug does nothing",
+			merged:      false,
+			closed:      true,
+			missing:     true,
+			bugs:        []bugzilla.Bug{},
+			prs:         []github.PullRequest{{Number: base.number, Merged: false}},
+			options:     plugins.BugzillaBranchOptions{AddExternalLink: &yes, StateAfterClose: &plugins.BugzillaBugState{Status: "NEW"}},
+			expectedBug: &bugzilla.Bug{},
+		},
+		{
 			name:   "closed PR with multiple exernal links removes link, does not change bug state, and comments",
 			merged: false,
 			closed: true,


### PR DESCRIPTION
This PR fixes an issue where the bugzilla plugin would attempt to handle
PRs being closed that weren't linked to a bug.

/cc @stevekuznetsov 