### PR TITLE
Move capi link verification to periodic

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -50,3 +50,21 @@ periodics:
     testgrid-tab-name: capi e2e tests
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-verify-external-links
+  interval: 6h
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:e2e:v20200918-58bdf8d-1.18
+      command:
+      - "runner.sh"
+      - "make"
+      - "verify-book-links"
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: periodic docs link verification

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits.yaml
@@ -81,25 +81,6 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
       testgrid-tab-name: pr-verify
-  - name: pull-cluster-api-verify-external-links
-    optional: true
-    decorate: true
-    path_alias: sigs.k8s.io/cluster-api
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    skip_branches:
-    - gh-pages
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200918-58bdf8d-1.18
-        command:
-        - "runner.sh"
-        - "make"
-        - "verify-book-links"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-verify-external-links
   - name: pull-cluster-api-test
     decorate: true
     path_alias: sigs.k8s.io/cluster-api


### PR DESCRIPTION
Fast feedback that this job is providing too much noise as a presubmit. It doesn't help that it's failing since we're getting rate-limited by GitHub, but I will have a separate PR to introduce a GitHub token for this job to consume once that is made available in the Prow environment.

@ncdc @vincepri 