### PR TITLE
add BoundServiceAccountTokenVolume upgrade test config

### DIFF
--- a/config/jobs/kubernetes/sig-auth/OWNERS
+++ b/config/jobs/kubernetes/sig-auth/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+- liggitt
+- mikedanese
+reviewers:
+- liggitt
+- mikedanese
+labels:
+- sig/auth

--- a/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
+++ b/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
@@ -1,0 +1,33 @@
+periodics:
+- name: sig-auth-serviceaccount-admission-controller-migration
+  annotations:
+    testgrid-dashboards: sig-auth-gce
+    testgrid-tab-name: upgrade-tests
+    # TODO: use sig-auth mailing list
+    testgrid-alert-email: zshihang@google.com
+    testgrid-num-failures-to-alert: "3"
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+  decorate: true
+  # TODO: lower to once a day
+  interval: 2h
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201014-d8fda77-master
+        args:
+        - --timeout=920
+        - --bare
+        - --scenario=kubernetes_e2e
+        - --
+        - --check-leaked-resources
+        - --check-version-skew=false
+        - --env=STORAGE_MEDIA_TYPE=application/vnd.kubernetes.protobuf
+        # TODO: change to release/stable-x.y
+        - --extract=ci/latest
+        - --extract=ci/latest-1.19
+        - --gcp-node-image=gci
+        - --gcp-zone=us-west1-b
+        - --provider=gce
+        - --upgrade_args="--ginkgo.focus=\[Feature:BoundServiceAccountTokenVolume\] --upgrade-target=ci/latest --upgrade-image=gci"
+        - --timeout=60m


### PR DESCRIPTION
add a periodic job config for alpha feature BoundServiceAccountTokenVolume upgrade test.

the test is added in https://github.com/kubernetes/kubernetes/pull/94835.