### PR TITLE
Add github token to CAPI periodic link check job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-ci.yaml
@@ -65,6 +65,19 @@ periodics:
       - "runner.sh"
       - "make"
       - "verify-book-links"
+      env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cluster-lifecycle-github-token
+            key: cluster-lifecycle-github-token
+  volumes:
+  - name: cluster-lifecycle-github-token
+    secret:
+      secretName: cluster-lifecycle-github-token
+      items:
+      - key: cluster-lifecycle-github-token
+        path: cluster-lifecycle-github-token
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
     testgrid-tab-name: periodic docs link verification


### PR DESCRIPTION
This will keep us from getting rate-limited by GitHub, hopefully :smile_cat: 

@vincepri 