### PR TITLE
Update version to include row_from_mapping changes released with 0.27.0

### DIFF
--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -30,7 +30,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.24.0 influxdb ruamel.yaml==0.16
+RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.27.0 influxdb ruamel.yaml==0.16
 
 RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 | tar xj -C opt  && \
     ln -s /opt/pypy*/bin/pypy /usr/bin


### PR DESCRIPTION
https://github.com/googleapis/google-cloud-python/pull/3874

I had made a change to use this attr but did not realize how were were pinning versions at the time because I tested locally and not in container env

```
Traceback (most recent call last):
  File "stream.py", line 300, in <module>
    stop=StopWhen(OPTIONS.stop_at))
  File "stream.py", line 202, in main
    emitted = insert_data(table, make_json.make_rows(db, builds))
  File "stream.py", line 123, in insert_data
    row = table.row_from_mapping(row)
AttributeError: 'Table' object has no attribute ‘row_from_mapping'
```