### PR TITLE
[CAPZ] cluster-api-provider-azure: not trigger e2e if there is a doc change

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -65,9 +65,10 @@ presubmits:
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    always_run: true
     optional: false
     decorate: true
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
If the PR has a Documentation change don't trigger automatically the e2e tests, if needed can be triggered manually.


The regex came from a slack discussion: https://kubernetes.slack.com/archives/C09QZ4DQB/p1597682186139500?thread_ts=1597342915.088800&cid=C09QZ4DQB

/assign @CecileRobertMichon 

@BenTheElder if you can take a quick look as well will be appreciated :)