### PR TITLE
Fix several issues in Kettle

### DIFF
--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -33,7 +33,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
 RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.27.0 influxdb ruamel.yaml==0.16
 
 RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 | tar xj -C opt  && \
-    ln -s /opt/pypy*/bin/pypy /usr/bin
+    ln -s /opt/pypy*/bin/pypy3 /usr/bin
 
 RUN curl -o installer https://sdk.cloud.google.com && \
     bash installer --disable-prompts --install-dir=/ && \

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -149,7 +149,13 @@ class Build:
 def parse_junit(xml):
     """Generate failed tests as a series of dicts. Ignore skipped tests."""
     # NOTE: this is modified from gubernator/view_build.py
-    tree = ET.fromstring(xml)
+
+    try:
+        tree = ET.fromstring(xml)
+    except ET.ParseError:
+        print("Malformed xml, skipping")
+        return [] #return empty itterator to skip results for this test
+
 
     # pylint: disable=redefined-outer-name
 

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -30,25 +30,18 @@ def print_dump(file):
         print(f'unable to find dump file: {file}')
 
 
-def call(cmd, dump=False):
-    started = datetime.now()
-
-    cmd = f'{cmd} > {DUMP}' if dump else cmd
+def call(cmd):
+    print('+', cmd)
     status = os.system(cmd)
-
-    ended = datetime.now()
-    print(f'+{cmd} completed in {started-ended}')
     if status:
-        if dump:
-            print_dump(DUMP)
-        raise OSError(f'invocation failed: {dump}')
+        raise OSError('invocation failed')
 
 
 def main():
     call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32')
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
-    mj_cmd = 'pypy make_json.py'
+    mj_cmd = 'pypy3 make_json.py'
 
     mj_ext = ''
     bq_ext = ''

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -16,7 +16,7 @@
 
 
 import os
-from datetime import datetime
+
 
 DUMP = 'dump.txt'
 


### PR DESCRIPTION
First, kettle would die if any malformed xml was collected in a job
This is now skipped for failing jobs

Pypy was being installed as pypy3

Also fully reverted cmd change incase it was an issue in writing to BQ
```
root@kettle-57f5b7f9f-h4ph2:/kettle# ln -s /opt/pypy*/bin/pypy3 /usr/bin
root@kettle-57f5b7f9f-h4ph2:/kettle# pypy
bash: pypy: command not found
```
```
root@kettle-57f5b7f9f-h4ph2:/kettle# pypy3
Python 3.6.9 (2ad108f17bdb, Apr 07 2020, 02:59:05)
[PyPy 7.3.1 with GCC 7.3.1 20180303 (Red Hat 7.3.1-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>>
```
```
root@kettle-57f5b7f9f-h4ph2:/kettle# ls -lart /usr/bin/pypy*
lrwxrwxrwx 1 root root 19 Sep 24 14:25 /usr/bin/pypy -> '/opt/pypy*/bin/pypy'
lrwxrwxrwx 1 root root 37 Sep 25 10:08 /usr/bin/pypy3 -> /opt/pypy3.6-v7.3.1-linux64/bin/pypy3
```


#19359
/area kettle
/cc @RobertKielty @spiffxp 