### PR TITLE
Pin google-cloud-sdk to 294.0.0

### DIFF
--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -36,7 +36,8 @@ RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 
     ln -s /opt/pypy*/bin/pypy3 /usr/bin
 
 RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz | tar xfz - -C . && \
-    ./google-cloud-sdk/install.sh -q
+    ./google-cloud-sdk/install.sh -q && \
+    ln -s /google-cloud-sdk/bin/* /bin/
 
 ADD *.py schema.json runner.sh buckets.yaml /kettle/
 

--- a/kettle/Dockerfile
+++ b/kettle/Dockerfile
@@ -35,10 +35,8 @@ RUN pip3 install requests google-cloud-pubsub==0.25.0 google-cloud-bigquery==0.2
 RUN curl -fsSL https://downloads.python.org/pypy/pypy3.6-v7.3.1-linux64.tar.bz2 | tar xj -C opt  && \
     ln -s /opt/pypy*/bin/pypy3 /usr/bin
 
-RUN curl -o installer https://sdk.cloud.google.com && \
-    bash installer --disable-prompts --install-dir=/ && \
-    rm installer && \
-    ln -s /google-cloud-sdk/bin/* /bin/
+RUN curl https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-294.0.0-linux-x86_64.tar.gz | tar xfz - -C . && \
+    ./google-cloud-sdk/install.sh -q
 
 ADD *.py schema.json runner.sh buckets.yaml /kettle/
 


### PR DESCRIPTION
Versions greater than this have http redirect issue with 308s

This causes the bq load to fail for the redirect urls

#19368
Fix was seen in internal discussions. 
/cc @spiffxp 
@spiffxp I am not sure if I should untar to `.` or `/tmp` etc. Will trouble shoot locally before deploying 
/hold
/area kettle