### PR TITLE
Kops - Add k8s 1.19 to grid, drop 1.16

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -74,8 +74,6 @@ skip_jobs = [
     'kops-grid-cilium-amzn2',
     'kops-grid-cilium-amzn2-k18',
     'kops-grid-cilium-centos7',
-    'kops-grid-cilium-centos7-k16',
-    'kops-grid-cilium-centos7-k16-ko18',
     'kops-grid-cilium-centos7-k17',
     'kops-grid-cilium-centos7-k17-ko18',
     'kops-grid-cilium-centos7-k18',
@@ -84,16 +82,12 @@ skip_jobs = [
     'kops-grid-cilium-deb9',
     'kops-grid-cilium-deb9-k18',
     'kops-grid-cilium-rhel7',
-    'kops-grid-cilium-rhel7-k16',
-    'kops-grid-cilium-rhel7-k16-ko18',
     'kops-grid-cilium-rhel7-k17',
     'kops-grid-cilium-rhel7-k17-ko18',
     'kops-grid-cilium-rhel7-k18',
     'kops-grid-cilium-rhel7-k18-ko18',
     'kops-grid-cilium-rhel7-ko18',
     'kops-grid-cilium-u1604',
-    'kops-grid-cilium-u1604-k16',
-    'kops-grid-cilium-u1604-k16-ko18',
     'kops-grid-cilium-u1604-k17',
     'kops-grid-cilium-u1604-k17-ko18',
     'kops-grid-cilium-u1604-k18',
@@ -314,9 +308,9 @@ distro_options = [
 
 k8s_versions = [
     None,
-    "1.16",
     "1.17",
     "1.18",
+    "1.19"
 ]
 
 kops_versions = [

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -87,92 +87,6 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko18
 
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-amzn2-k16
-  cron: '2 1 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-amzn2-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-amzn2-k16
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-amzn2-k16-ko18
-  cron: '49 0 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-amzn2-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-amzn2-k16-ko18
-
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-amzn2-k17
   cron: '48 7 * * 1'
@@ -345,6 +259,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18
 
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-amzn2-k19
+  cron: '47 8 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-amzn2-k19
+
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k19-ko18
+  cron: '28 21 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-amzn2-k19-ko18
+
 # {"cloud": "aws", "distro": "centos7", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-centos7
   cron: '30 19 * * 2'
@@ -430,92 +430,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-centos7-ko18
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-centos7-k16
-  cron: '24 23 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-centos7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-centos7-k16
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-centos7-k16-ko18
-  cron: '48 6 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-centos7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-centos7-k16-ko18
 
 # {"cloud": "aws", "distro": "centos7", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-centos7-k17
@@ -689,6 +603,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-centos7-k18-ko18
 
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-centos7-k19
+  cron: '21 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-centos7-k19
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k19-ko18
+  cron: '33 19 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-centos7-k19-ko18
+
 # {"cloud": "aws", "distro": "deb9", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9
   cron: '59 19 * * 0'
@@ -774,92 +774,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko18
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-deb9-k16
-  cron: '10 20 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-deb9-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-deb9-k16
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-deb9-k16-ko18
-  cron: '9 13 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-deb9-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-deb9-k16-ko18
 
 # {"cloud": "aws", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb9-k17
@@ -1033,6 +947,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18
 
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-deb9-k19
+  cron: '51 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb9-k19
+
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k19-ko18
+  cron: '4 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb9-k19-ko18
+
 # {"cloud": "aws", "distro": "deb10", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10
   cron: '54 21 * * 0'
@@ -1118,92 +1118,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko18
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-deb10-k16
-  cron: '51 0 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-deb10-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-deb10-k16
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-deb10-k16-ko18
-  cron: '0 21 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-deb10-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-deb10-k16-ko18
 
 # {"cloud": "aws", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-deb10-k17
@@ -1377,6 +1291,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18
 
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-deb10-k19
+  cron: '58 9 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb10-k19
+
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k19-ko18
+  cron: '17 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb10-k19-ko18
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar
   cron: '24 5 * * 4'
@@ -1462,92 +1462,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko18
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-flatcar-k16
-  cron: '28 11 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flatcar-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flatcar-k16
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-flatcar-k16-ko18
-  cron: '12 22 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flatcar-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flatcar-k16-ko18
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-flatcar-k17
@@ -1721,6 +1635,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-flatcar-k19
+  cron: '37 18 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flatcar-k19
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k19-ko18
+  cron: '9 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flatcar-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7
   cron: '14 21 * * 5'
@@ -1806,92 +1806,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko18
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-rhel7-k16
-  cron: '30 21 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-rhel7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-rhel7-k16
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-rhel7-k16-ko18
-  cron: '45 20 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-rhel7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-rhel7-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel7-k17
@@ -2065,6 +1979,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-rhel7-k19
+  cron: '51 12 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel7-k19
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k19-ko18
+  cron: '24 9 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel7-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8
   cron: '11 4 * * 6'
@@ -2150,92 +2150,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko18
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-rhel8-k16
-  cron: '55 4 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-rhel8-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-rhel8-k16
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-rhel8-k16-ko18
-  cron: '32 9 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-rhel8-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-rhel8-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-rhel8-k17
@@ -2409,6 +2323,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-rhel8-k19
+  cron: '18 13 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel8-k19
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k19-ko18
+  cron: '49 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel8-k19-ko18
+
 # {"cloud": "aws", "distro": "u1604", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1604
   cron: '53 6 * * 1'
@@ -2494,92 +2494,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1604-ko18
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-u1604-k16
-  cron: '36 15 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u1604-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u1604-k16
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-u1604-k16-ko18
-  cron: '4 1 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u1604-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u1604-k16-ko18
 
 # {"cloud": "aws", "distro": "u1604", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1604-k17
@@ -2753,6 +2667,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1604-k18-ko18
 
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-u1604-k19
+  cron: '33 22 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1604-k19
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k19-ko18
+  cron: '49 4 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1604-k19-ko18
+
 # {"cloud": "aws", "distro": "u1804", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804
   cron: '59 4 * * 4'
@@ -2838,92 +2838,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko18
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-u1804-k16
-  cron: '45 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u1804-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u1804-k16
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-u1804-k16-ko18
-  cron: '46 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u1804-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u1804-k16-ko18
 
 # {"cloud": "aws", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u1804-k17
@@ -3097,6 +3011,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18
 
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-u1804-k19
+  cron: '40 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1804-k19
+
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k19-ko18
+  cron: '47 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1804-k19-ko18
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004
   cron: '5 18 * * *'
@@ -3182,92 +3182,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko18
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": null, "networking": null}
-- name: e2e-kops-grid-u2004-k16
-  cron: '29 6 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u2004-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u2004-k16
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": "1.18", "networking": null}
-- name: e2e-kops-grid-u2004-k16-ko18
-  cron: '2 15 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-u2004-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-u2004-k16-ko18
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-u2004-k17
@@ -3441,6 +3355,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": null}
+- name: e2e-kops-grid-u2004-k19
+  cron: '12 15 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u2004-k19
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k19-ko18
+  cron: '35 10 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u2004-k19-ko18
+
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2
   cron: '10 18 * * 4'
@@ -3526,92 +3526,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko18
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k16
-  cron: '10 4 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-amzn2-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-amzn2-k16
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-amzn2-k16-ko18
-  cron: '7 12 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-amzn2-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-amzn2-k16-ko18
 
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17
@@ -3785,6 +3699,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18
 
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k19
+  cron: '7 5 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn2-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-amzn2-k19
+
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k19-ko18
+  cron: '30 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn2-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18
+
 # {"cloud": "aws", "distro": "centos7", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7
   cron: '16 5 * * 1'
@@ -3870,92 +3870,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-centos7-ko18
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-centos7-k16
-  cron: '36 2 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-centos7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-centos7-k16
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-centos7-k16-ko18
-  cron: '2 14 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-centos7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-centos7-k16-ko18
 
 # {"cloud": "aws", "distro": "centos7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k17
@@ -4129,6 +4043,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-centos7-k18-ko18
 
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k19
+  cron: '17 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-centos7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-centos7-k19
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k19-ko18
+  cron: '15 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-centos7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-centos7-k19-ko18
+
 # {"cloud": "aws", "distro": "deb9", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9
   cron: '10 5 * * 5'
@@ -4214,92 +4214,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko18
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb9-k16
-  cron: '21 11 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-deb9-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-deb9-k16
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb9-k16-ko18
-  cron: '44 21 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-deb9-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-deb9-k16-ko18
 
 # {"cloud": "aws", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17
@@ -4473,6 +4387,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18
 
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k19
+  cron: '56 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb9-k19
+
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k19-ko18
+  cron: '49 16 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb9-k19-ko18
+
 # {"cloud": "aws", "distro": "deb10", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10
   cron: '14 18 * * 2'
@@ -4558,92 +4558,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko18
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k16
-  cron: '43 21 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-deb10-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-deb10-k16
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-deb10-k16-ko18
-  cron: '58 1 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-deb10-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-deb10-k16-ko18
 
 # {"cloud": "aws", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17
@@ -4817,6 +4731,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18
 
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k19
+  cron: '10 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb10-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb10-k19
+
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k19-ko18
+  cron: '19 20 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb10-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb10-k19-ko18
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar
   cron: '50 19 * * 6'
@@ -4902,92 +4902,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko18
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k16
-  cron: '36 22 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-flatcar-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-flatcar-k16
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-flatcar-k16-ko18
-  cron: '34 22 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-flatcar-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-flatcar-k16-ko18
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17
@@ -5161,6 +5075,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k19
+  cron: '25 15 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flatcar-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-flatcar-k19
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k19-ko18
+  cron: '19 19 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flatcar-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7
   cron: '26 18 * * 5'
@@ -5246,92 +5246,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko18
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel7-k16
-  cron: '34 8 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-rhel7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-rhel7-k16
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel7-k16-ko18
-  cron: '27 16 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-rhel7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-rhel7-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17
@@ -5505,6 +5419,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k19
+  cron: '39 1 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel7-k19
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k19-ko18
+  cron: '46 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8
   cron: '51 19 * * 5'
@@ -5590,92 +5590,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko18
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k16
-  cron: '39 9 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-rhel8-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-rhel8-k16
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-rhel8-k16-ko18
-  cron: '58 21 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-rhel8-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-rhel8-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17
@@ -5849,6 +5763,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k19
+  cron: '18 16 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel8-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel8-k19
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k19-ko18
+  cron: '19 16 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel8-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18
+
 # {"cloud": "aws", "distro": "u1604", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604
   cron: '45 17 * * 3'
@@ -5934,92 +5934,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1604-ko18
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u1604-k16
-  cron: '8 2 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u1604-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u1604-k16
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-u1604-k16-ko18
-  cron: '22 13 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u1604-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u1604-k16-ko18
 
 # {"cloud": "aws", "distro": "u1604", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k17
@@ -6193,6 +6107,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1604-k18-ko18
 
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k19
+  cron: '53 11 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u1604-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1604-k19
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k19-ko18
+  cron: '51 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u1604-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1604-k19-ko18
+
 # {"cloud": "aws", "distro": "u1804", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804
   cron: '59 11 * * 5'
@@ -6278,92 +6278,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko18
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u1804-k16
-  cron: '49 15 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u1804-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u1804-k16
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-u1804-k16-ko18
-  cron: '8 3 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u1804-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u1804-k16-ko18
 
 # {"cloud": "aws", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17
@@ -6537,6 +6451,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18
 
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k19
+  cron: '28 22 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u1804-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1804-k19
+
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k19-ko18
+  cron: '45 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u1804-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1804-k19-ko18
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": null, "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004
   cron: '57 13 * * *'
@@ -6622,92 +6622,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko18
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": null, "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k16
-  cron: '37 19 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u2004-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u2004-k16
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": "1.18", "networking": "calico"}
-- name: e2e-kops-grid-calico-u2004-k16-ko18
-  cron: '16 3 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-calico-u2004-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=calico
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-calico-u2004-k16-ko18
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17
@@ -6881,6 +6795,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k19
+  cron: '32 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u2004-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u2004-k19
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k19-ko18
+  cron: '29 22 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u2004-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u2004-k19-ko18
+
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-ko18
   cron: '7 13 * * 6'
@@ -6923,92 +6923,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko18
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k16
-  cron: '16 22 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-amzn2-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-amzn2-k16
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-amzn2-k16-ko18
-  cron: '3 16 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-amzn2-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-amzn2-k16-ko18
 
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17
@@ -7139,6 +7053,178 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18
 
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k19
+  cron: '25 23 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn2-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-amzn2-k19
+
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k19-ko18
+  cron: '10 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn2-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k19
+  cron: '22 4 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-centos7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-centos7-k19
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k19-ko18
+  cron: '49 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-centos7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-centos7-k19-ko18
+
 # {"cloud": "aws", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-ko18
   cron: '21 19 * * 3'
@@ -7181,92 +7267,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko18
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb9-k16
-  cron: '58 8 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-deb9-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-deb9-k16
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb9-k16-ko18
-  cron: '34 11 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-deb9-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-deb9-k16-ko18
 
 # {"cloud": "aws", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17
@@ -7397,6 +7397,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18
 
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k19
+  cron: '31 17 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb9-k19
+
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k19-ko18
+  cron: '51 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18
+
 # {"cloud": "aws", "distro": "deb10", "k8s_version": null, "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10
   cron: '42 2 * * 0'
@@ -7482,92 +7568,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko18
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k16
-  cron: '21 7 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-deb10-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-deb10-k16
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-deb10-k16-ko18
-  cron: '2 21 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-deb10-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-deb10-k16-ko18
 
 # {"cloud": "aws", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17
@@ -7741,6 +7741,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18
 
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k19
+  cron: '36 6 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb10-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb10-k19
+
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k19-ko18
+  cron: '3 0 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb10-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": null, "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar
   cron: '10 15 * * 5'
@@ -7826,92 +7912,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko18
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k16
-  cron: '19 17 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-flatcar-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-flatcar-k16
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-flatcar-k16-ko18
-  cron: '24 12 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-flatcar-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-flatcar-k16-ko18
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17
@@ -8085,6 +8085,178 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k19
+  cron: '22 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flatcar-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-flatcar-k19
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k19-ko18
+  cron: '57 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flatcar-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k19
+  cron: '53 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel7-k19
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k19-ko18
+  cron: '54 17 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": null, "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8
   cron: '31 19 * * 4'
@@ -8170,92 +8342,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko18
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k16
-  cron: '25 3 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-rhel8-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-rhel8-k16
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-rhel8-k16-ko18
-  cron: '50 17 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-rhel8-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-rhel8-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17
@@ -8429,6 +8515,178 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k19
+  cron: '52 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel8-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel8-k19
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k19-ko18
+  cron: '7 20 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel8-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k19
+  cron: '47 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u1604-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1604-k19
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k19-ko18
+  cron: '43 12 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u1604-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1604-k19-ko18
+
 # {"cloud": "aws", "distro": "u1804", "k8s_version": null, "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804
   cron: '43 11 * * 6'
@@ -8514,92 +8772,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko18
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u1804-k16
-  cron: '15 21 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-u1804-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-u1804-k16
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u1804-k16-ko18
-  cron: '0 7 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-u1804-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-u1804-k16-ko18
 
 # {"cloud": "aws", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17
@@ -8773,6 +8945,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18
 
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k19
+  cron: '50 12 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u1804-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1804-k19
+
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k19-ko18
+  cron: '45 2 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u1804-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": null, "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004
   cron: '21 21 * * *'
@@ -8858,92 +9116,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko18
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": null, "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k16
-  cron: '43 9 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-u2004-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-u2004-k16
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": "1.18", "networking": "cilium"}
-- name: e2e-kops-grid-cilium-u2004-k16-ko18
-  cron: '0 7 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-cilium-u2004-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=cilium
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-cilium-u2004-k16-ko18
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17
@@ -9117,6 +9289,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k19
+  cron: '6 8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u2004-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u2004-k19
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k19-ko18
+  cron: '21 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u2004-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18
+
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2
   cron: '42 18 * * 6'
@@ -9202,92 +9460,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko18
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k16
-  cron: '9 3 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-amzn2-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-amzn2-k16
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-amzn2-k16-ko18
-  cron: '43 4 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-amzn2-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-amzn2-k16-ko18
 
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17
@@ -9461,6 +9633,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18
 
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k19
+  cron: '48 10 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-amzn2-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-amzn2-k19
+
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k19-ko18
+  cron: '14 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-amzn2-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18
+
 # {"cloud": "aws", "distro": "centos7", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7
   cron: '32 18 * * 5'
@@ -9546,92 +9804,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-centos7-ko18
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-centos7-k16
-  cron: '1 21 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-centos7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-centos7-k16
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-centos7-k16-ko18
-  cron: '39 16 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-centos7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-centos7-k16-ko18
 
 # {"cloud": "aws", "distro": "centos7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k17
@@ -9805,6 +9977,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-centos7-k18-ko18
 
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k19
+  cron: '0 4 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-centos7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-centos7-k19
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k19-ko18
+  cron: '2 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-centos7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-centos7-k19-ko18
+
 # {"cloud": "aws", "distro": "deb9", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9
   cron: '49 17 * * 1'
@@ -9890,92 +10148,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko18
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb9-k16
-  cron: '14 12 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-deb9-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-deb9-k16
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb9-k16-ko18
-  cron: '58 5 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-deb9-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-deb9-k16-ko18
 
 # {"cloud": "aws", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17
@@ -10149,6 +10321,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18
 
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k19
+  cron: '3 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-deb9-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb9-k19
+
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k19-ko18
+  cron: '35 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-deb9-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18
+
 # {"cloud": "aws", "distro": "deb10", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10
   cron: '18 18 * * 3'
@@ -10234,92 +10492,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko18
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k16
-  cron: '40 2 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-deb10-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-deb10-k16
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-deb10-k16-ko18
-  cron: '10 17 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-deb10-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-deb10-k16-ko18
 
 # {"cloud": "aws", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17
@@ -10493,6 +10665,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18
 
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k19
+  cron: '9 3 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-deb10-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb10-k19
+
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k19-ko18
+  cron: '43 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-deb10-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar
   cron: '54 4 * * 5'
@@ -10578,92 +10836,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko18
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k16
-  cron: '53 9 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-flatcar-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-flatcar-k16
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-flatcar-k16-ko18
-  cron: '59 16 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-flatcar-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-flatcar-k16-ko18
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17
@@ -10837,6 +11009,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k19
+  cron: '28 16 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-flatcar-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-flatcar-k19
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k19-ko18
+  cron: '22 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-flatcar-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7
   cron: '14 18 * * 5'
@@ -10922,92 +11180,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko18
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel7-k16
-  cron: '17 7 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-rhel7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-rhel7-k16
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel7-k16-ko18
-  cron: '27 8 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-rhel7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-rhel7-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17
@@ -11181,6 +11353,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k19
+  cron: '24 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-rhel7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel7-k19
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k19-ko18
+  cron: '22 5 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-rhel7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8
   cron: '31 3 * * 5'
@@ -11266,92 +11524,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko18
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k16
-  cron: '12 14 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-rhel8-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-rhel8-k16
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-rhel8-k16-ko18
-  cron: '18 21 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-rhel8-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-rhel8-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17
@@ -11525,6 +11697,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k19
+  cron: '29 23 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-rhel8-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel8-k19
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k19-ko18
+  cron: '51 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-rhel8-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18
+
 # {"cloud": "aws", "distro": "u1604", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604
   cron: '5 17 * * 0'
@@ -11610,92 +11868,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1604-ko18
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u1604-k16
-  cron: '55 5 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u1604-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u1604-k16
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u1604-k16-ko18
-  cron: '22 5 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u1604-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u1604-k16-ko18
 
 # {"cloud": "aws", "distro": "u1604", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k17
@@ -11869,6 +12041,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1604-k18-ko18
 
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k19
+  cron: '42 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u1604-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1604-k19
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k19-ko18
+  cron: '27 8 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u1604-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1604-k19-ko18
+
 # {"cloud": "aws", "distro": "u1804", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804
   cron: '59 11 * * 3'
@@ -11954,92 +12212,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko18
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u1804-k16
-  cron: '30 8 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u1804-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u1804-k16
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u1804-k16-ko18
-  cron: '8 19 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u1804-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u1804-k16-ko18
 
 # {"cloud": "aws", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17
@@ -12213,6 +12385,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18
 
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k19
+  cron: '7 9 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u1804-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1804-k19
+
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k19-ko18
+  cron: '49 14 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u1804-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": null, "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004
   cron: '13 5 * * *'
@@ -12298,92 +12556,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko18
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": null, "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k16
-  cron: '6 20 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u2004-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u2004-k16
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": "1.18", "networking": "flannel"}
-- name: e2e-kops-grid-flannel-u2004-k16-ko18
-  cron: '12 11 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-flanl-u2004-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=flannel
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-flannel-u2004-k16-ko18
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17
@@ -12557,6 +12729,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18
 
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k19
+  cron: '59 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u2004-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u2004-k19
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k19-ko18
+  cron: '1 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flanl-u2004-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18
+
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2
   cron: '8 8 * * 3'
@@ -12642,92 +12900,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko18
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k16
-  cron: '55 21 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-amzn2-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k16
-
-# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-amzn2-k16-ko18
-  cron: '40 3 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-amzn2-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-amzn2-k16-ko18
 
 # {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17
@@ -12901,6 +13073,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18
 
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k19
+  cron: '42 4 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn2-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k19
+
+# {"cloud": "aws", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k19-ko18
+  cron: '17 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn2-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18
+
 # {"cloud": "aws", "distro": "centos7", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7
   cron: '25 8 * * 2'
@@ -12986,92 +13244,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-centos7-ko18
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-centos7-k16
-  cron: '19 1 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-centos7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-centos7-k16
-
-# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-centos7-k16-ko18
-  cron: '14 6 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-centos7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=centos
-      - --env=KUBE_SSH_USER=centos
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-centos7-k16-ko18
 
 # {"cloud": "aws", "distro": "centos7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k17
@@ -13245,6 +13417,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-centos7-k18-ko18
 
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k19
+  cron: '10 0 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-centos7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-centos7-k19
+
+# {"cloud": "aws", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k19-ko18
+  cron: '7 3 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-centos7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-centos7-k19-ko18
+
 # {"cloud": "aws", "distro": "deb9", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9
   cron: '24 15 * * 3'
@@ -13330,92 +13588,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko18
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb9-k16
-  cron: '38 8 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-deb9-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-deb9-k16
-
-# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb9-k16-ko18
-  cron: '11 14 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-deb9-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-deb9-k16-ko18
 
 # {"cloud": "aws", "distro": "deb9", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17
@@ -13589,6 +13761,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18
 
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k19
+  cron: '39 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb9-k19
+
+# {"cloud": "aws", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k19-ko18
+  cron: '22 3 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18
+
 # {"cloud": "aws", "distro": "deb10", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10
   cron: '24 0 * * 0'
@@ -13674,92 +13932,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko18
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k16
-  cron: '10 20 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-deb10-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-deb10-k16
-
-# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-deb10-k16-ko18
-  cron: '5 6 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-deb10-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=admin
-      - --env=KUBE_SSH_USER=admin
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=136693071363/debian-10-amd64-20200511-260
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-deb10-k16-ko18
 
 # {"cloud": "aws", "distro": "deb10", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17
@@ -13933,6 +14105,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18
 
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k19
+  cron: '47 5 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb10-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb10-k19
+
+# {"cloud": "aws", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k19-ko18
+  cron: '36 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb10-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18
+
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar
   cron: '11 14 * * 0'
@@ -14018,92 +14276,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko18
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-flatcar-k16
-  cron: '19 13 * * 4'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-flatcar-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-flatcar-k16
-
-# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-flatcar-k16-ko18
-  cron: '2 6 * * 3'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-flatcar-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=core
-      - --env=KUBE_SSH_USER=core
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-flatcar-k16-ko18
 
 # {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17
@@ -14277,6 +14449,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18
 
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k19
+  cron: '34 12 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flatcar-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k19
+
+# {"cloud": "aws", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k19-ko18
+  cron: '27 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flatcar-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=075585003325/Flatcar-stable-2512.2.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7
   cron: '56 0 * * 2'
@@ -14362,92 +14620,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko18
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel7-k16
-  cron: '27 17 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-rhel7-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-rhel7-k16
-
-# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel7-k16-ko18
-  cron: '12 15 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-rhel7-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-rhel7-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17
@@ -14621,6 +14793,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k19
+  cron: '6 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel7-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k19
+
+# {"cloud": "aws", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k19-ko18
+  cron: '29 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel7-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18
+
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8
   cron: '33 1 * * 1'
@@ -14706,92 +14964,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko18
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k16
-  cron: '50 16 * * 2'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-rhel8-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k16
-
-# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-rhel8-k16-ko18
-  cron: '17 2 * * 1'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-rhel8-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ec2-user
-      - --env=KUBE_SSH_USER=ec2-user
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-rhel8-k16-ko18
 
 # {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17
@@ -14965,6 +15137,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18
 
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k19
+  cron: '11 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel8-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k19
+
+# {"cloud": "aws", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k19-ko18
+  cron: '48 23 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel8-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18
+
 # {"cloud": "aws", "distro": "u1604", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604
   cron: '47 11 * * 6'
@@ -15050,92 +15308,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1604-ko18
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u1604-k16
-  cron: '45 19 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u1604-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u1604-k16
-
-# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u1604-k16-ko18
-  cron: '57 10 * * 5'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u1604-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u1604-k16-ko18
 
 # {"cloud": "aws", "distro": "u1604", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k17
@@ -15309,6 +15481,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1604-k18-ko18
 
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k19
+  cron: '4 18 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u1604-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1604-k19
+
+# {"cloud": "aws", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k19-ko18
+  cron: '36 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u1604-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1604-k19-ko18
+
 # {"cloud": "aws", "distro": "u1804", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804
   cron: '13 9 * * 6'
@@ -15394,92 +15652,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko18
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u1804-k16
-  cron: '32 6 * * 0'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u1804-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u1804-k16
-
-# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u1804-k16-ko18
-  cron: '3 4 * * 6'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u1804-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u1804-k16-ko18
 
 # {"cloud": "aws", "distro": "u1804", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17
@@ -15653,6 +15825,92 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18
 
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k19
+  cron: '5 23 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u1804-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1804-k19
+
+# {"cloud": "aws", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k19-ko18
+  cron: '26 1 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u1804-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18
+
 # {"cloud": "aws", "distro": "u2004", "k8s_version": null, "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004
   cron: '23 23 * * *'
@@ -15738,92 +15996,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko18
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": null, "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k16
-  cron: '52 2 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u2004-k16.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u2004-k16
-
-# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.16", "kops_version": "1.18", "networking": "kopeio"}
-- name: e2e-kops-grid-kopeio-u2004-k16-ko18
-  cron: '55 12 * * *'
-  labels:
-    preset-service-account: "true"
-    preset-aws-ssh: "true"
-    preset-aws-credential: "true"
-  decorate: true
-  decoration_config:
-    timeout: 90m
-  spec:
-    containers:
-    - command:
-      - runner.sh
-      - /workspace/scenarios/kubernetes_e2e.py
-      args:
-      - --cluster=e2e-kops-kopeio-u2004-k16-ko18.test-cncf-aws.k8s.io
-      - --deployment=kops
-      - --kops-ssh-user=ubuntu
-      - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.16.txt
-      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
-      - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/stable-1.16
-      - --ginkgo-parallel
-      - --kops-args=--networking=kopeio
-      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
-      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
-      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
-      - --provider=aws
-      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
-      - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.16
-      resources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: "2"
-          memory: 2Gi
-  annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.16
-    testgrid-tab-name: kops-grid-kopeio-u2004-k16-ko18
 
 # {"cloud": "aws", "distro": "u2004", "k8s_version": "1.17", "kops_version": null, "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17
@@ -15997,4 +16169,90 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18
 
-# 372 jobs, total of 612 runs per week
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": null, "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k19
+  cron: '13 19 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u2004-k19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u2004-k19
+
+# {"cloud": "aws", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k19-ko18
+  cron: '46 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u2004-k19-ko18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20200924-0f4a535-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18
+
+# 378 jobs, total of 618 runs per week

--- a/config/testgrids/kubernetes/kops/config.yaml
+++ b/config/testgrids/kubernetes/kops/config.yaml
@@ -18,7 +18,6 @@ dashboard_groups:
   - kops-distro-u1604
   - kops-distro-u1804
   - kops-distro-u2004
-  - kops-k8s-1.16
   - kops-k8s-1.17
   - kops-k8s-1.18
   - kops-k8s-1.19
@@ -42,7 +41,6 @@ dashboards:
 - name: kops-distro-u1604
 - name: kops-distro-u1804
 - name: kops-distro-u2004
-- name: kops-k8s-1.16
 - name: kops-k8s-1.17
 - name: kops-k8s-1.18
 - name: kops-k8s-1.19


### PR DESCRIPTION
We'll keep an eye on the similar jobs that are no longer being skipped and see if we should skip them as well.