### PR TITLE
Kops - Increase job retention to 90 days for infrequent jobs

### DIFF
--- a/config/testgrids/kubernetes/kops/config.yaml
+++ b/config/testgrids/kubernetes/kops/config.yaml
@@ -42,6 +42,10 @@ dashboards:
 - name: kops-distro-u1804
 - name: kops-distro-u2004
 - name: kops-k8s-1.17
+  days_of_results: 90
 - name: kops-k8s-1.18
+  days_of_results: 90
 - name: kops-k8s-1.19
+  days_of_results: 90
 - name: kops-k8s-latest
+  days_of_results: 90


### PR DESCRIPTION
Many of the kops grid jobs only run weekly. This leaves only 3 jobs in testgrid's history which doesn't provide sufficient context ([example](https://testgrid.k8s.io/kops-k8s-1.17#kops-grid-calico-amzn2-k17)).

This extends the job retention period to 90 days to provide additional historical context.