### PR TITLE
Remove required_status_checks travis for node-feature-discovery

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -416,10 +416,6 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
-        node-feature-discovery:
-          required_status_checks:
-            contexts:
-            - continuous-integration/travis-ci
     kubeflow:
       protect: true
       required_status_checks:


### PR DESCRIPTION
required_status_checks is no longer needed can be removed as a PR ready
dependency.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>