### PR TITLE
Kettle dropping out of path population early

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -36,7 +36,7 @@ SECONDS_PER_DAY = 86400
 
 def buckets_yaml():
     import ruamel.yaml as yaml  # pylint: disable=import-outside-toplevel
-    with open(os.path.dirname(os.path.abspath('__file__'))+'/buckets.yaml') as fp:
+    with open(os.path.dirname(os.path.abspath(__file__))+'/buckets.yaml') as fp:
         return yaml.safe_load(fp)
 
 # pypy compatibility hack
@@ -45,7 +45,7 @@ def python_buckets_yaml(python='python3'):
         [python, '-c',
          'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'
          ],
-        cwd=os.path.dirname(os.path.abspath('__file__'))).decode("utf-8"))
+        cwd=os.path.dirname(os.path.abspath(__file__))).decode("utf-8"))
 
 for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
     try:

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -59,9 +59,6 @@ else:
     raise
 
 
-class BuildError(Exception):
-    pass
-
 class Build:
     """
     Represent Metadata and Details of a build. Leveraging the information in
@@ -103,15 +100,17 @@ class Build:
 
     def populate_path_to_job_and_number(self):
         assert not self.path.endswith('/')
+        prefix = ''
         for bucket, meta in BUCKETS.items():
             if self.path.startswith(bucket):
                 prefix = meta['prefix']
                 break
+        #if job path not in buckets.yaml or gs://kubernetes-jenkins/pr-logs it is unmatched
         else:
             if self.path.startswith('gs://kubernetes-jenkins/pr-logs'):
                 prefix = 'pr:'
             else:
-                raise BuildError(f'unknown build path for {self.path} in known bucket paths')
+                raise ValueError(f'unknown build path for {self.path} in known bucket paths')
         build = os.path.basename(self.path)
         job = prefix + os.path.basename(os.path.dirname(self.path))
         self.job = job

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -36,7 +36,7 @@ SECONDS_PER_DAY = 86400
 
 def buckets_yaml():
     import ruamel.yaml as yaml  # pylint: disable=import-outside-toplevel
-    with open(os.path.dirname(os.path.abspath(__file__))+'/buckets.yaml') as fp:
+    with open(os.path.dirname(os.path.abspath('__file__'))+'/buckets.yaml') as fp:
         return yaml.safe_load(fp)
 
 # pypy compatibility hack
@@ -45,7 +45,7 @@ def python_buckets_yaml(python='python3'):
         [python, '-c',
          'import json, ruamel.yaml as yaml; print(json.dumps(yaml.safe_load(open("buckets.yaml"))))'
          ],
-        cwd=os.path.dirname(os.path.abspath(__file__))).decode("utf-8"))
+        cwd=os.path.dirname(os.path.abspath('__file__'))).decode("utf-8"))
 
 for attempt in [python_buckets_yaml, buckets_yaml, lambda: python_buckets_yaml(python='python')]:
     try:
@@ -57,6 +57,10 @@ else:
     # pylint: disable=misplaced-bare-raise
     # This is safe because the only way we get here is by faling all attempts
     raise
+
+
+class BuildError(Exception):
+    pass
 
 class Build:
     """
@@ -103,11 +107,11 @@ class Build:
             if self.path.startswith(bucket):
                 prefix = meta['prefix']
                 break
-
+        else:
             if self.path.startswith('gs://kubernetes-jenkins/pr-logs'):
                 prefix = 'pr:'
             else:
-                raise ValueError('unknown build path')
+                raise BuildError(f'unknown build path for {self.path} in known bucket paths')
         build = os.path.basename(self.path)
         job = prefix + os.path.basename(os.path.dirname(self.path))
         self.job = job

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -100,7 +100,6 @@ class Build:
 
     def populate_path_to_job_and_number(self):
         assert not self.path.endswith('/')
-        prefix = ''
         for bucket, meta in BUCKETS.items():
             if self.path.startswith(bucket):
                 prefix = meta['prefix']

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -499,7 +499,7 @@ class MakeJsonTest(unittest.TestCase):
         expect('gs://kubernetes-jenkins/logs/some-build/123asdf', 'some-build', None)
         expect('gs://kubernetes-jenkins/pr-logs/123/e2e-node/456', 'pr:e2e-node', 456)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(make_json.BuildError):
             expect('gs://unknown-bucket/foo/123', None, None)
             expect('gs://unknown-bucket/foo/123/', None, None)
 

--- a/kettle/make_json_test.py
+++ b/kettle/make_json_test.py
@@ -499,7 +499,7 @@ class MakeJsonTest(unittest.TestCase):
         expect('gs://kubernetes-jenkins/logs/some-build/123asdf', 'some-build', None)
         expect('gs://kubernetes-jenkins/pr-logs/123/e2e-node/456', 'pr:e2e-node', 456)
 
-        with self.assertRaises(make_json.BuildError):
+        with self.assertRaises(ValueError):
             expect('gs://unknown-bucket/foo/123', None, None)
             expect('gs://unknown-bucket/foo/123/', None, None)
 


### PR DESCRIPTION
This error was causing builds to be existed to early if they were not prs, else was missed in the Build class migration. Will avoid lots of log spam as well

/area kettle
