### PR TITLE
fix typo -- s/deleteted/deleted/

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -492,7 +492,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 	if !pj.Complete() && pod.DeletionTimestamp != nil {
 		pj.SetComplete()
 		pj.Status.State = prowapi.ErrorState
-		pj.Status.Description = "Pod got deleteted unexpectedly"
+		pj.Status.Description = "Pod got deleted unexpectedly"
 	}
 
 	var err error

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -441,7 +441,7 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 	if !pj.Complete() && pod != nil && pod.DeletionTimestamp != nil {
 		pj.SetComplete()
 		pj.Status.State = prowv1.ErrorState
-		pj.Status.Description = "Pod got deleteted unexpectedly"
+		pj.Status.Description = "Pod got deleted unexpectedly"
 	}
 
 	pj.Status.URL, err = pjutil.JobURL(r.config().Plank, *pj, r.log)


### PR DESCRIPTION
Fix a typo in two error messages.

[Grep.app results for this typo](https://grep.app/search?q=deleteted&filter[repo][0]=kubernetes/test-infra).

Example where I ran into this:  https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/91592/pull-kubernetes-bazel-build/1310212525932941312

<img width="1402" alt="Screen Shot 2020-09-28 at 7 20 41 AM" src="https://user-images.githubusercontent.com/952655/94426579-cb561480-015b-11eb-8000-02bd46d6a13b.png">
