### PR TITLE
remove sig-network testgrid base filter

### DIFF
--- a/config/testgrids/kubernetes/sig-network/config.yaml
+++ b/config/testgrids/kubernetes/sig-network/config.yaml
@@ -35,7 +35,6 @@ dashboards:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-ip-alias
       test_group_name: ci-kubernetes-e2e-gci-gce-ip-alias
-      base_options: include-filter-by-regex=\[sig-network\]
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-ipvs
@@ -50,67 +49,56 @@ dashboards:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-coredns
       test_group_name: ci-kubernetes-e2e-gci-gce-coredns
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce tests with CoreDNS
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-coredns-nodecache
       test_group_name: ci-kubernetes-e2e-gci-gce-coredns-nodecache
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce tests with CoreDNS and nodelocaldns cache enabled
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-kube-dns
       test_group_name: ci-kubernetes-e2e-gci-gce-kube-dns
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce tests with kube-dns
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-kube-dns-nodecache
       test_group_name: ci-kubernetes-e2e-gci-gce-kube-dns-nodecache
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce tests with kube-dns and nodelocaldns cache enabled
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce
       test_group_name: ci-kubernetes-e2e-gci-gce
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-slow
       test_group_name: ci-kubernetes-e2e-gci-gce-slow
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce slow e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-serial
       test_group_name: ci-kubernetes-e2e-gci-gce-serial
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce serial e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-serial-kube-dns
       test_group_name: ci-kubernetes-e2e-gci-gce-serial-kube-dns
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce with kube-dns serial e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-serial-kube-dns-nodecache
       test_group_name: ci-kubernetes-e2e-gci-gce-serial-kube-dns-nodecache
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce with kube-dns and nodelocaldns cache serial e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: gci-gce-alpha-features
       test_group_name: ci-kubernetes-e2e-gci-gce-alpha-features
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network gci-gce alpha features e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com
     - name: ubuntu-gce-basic-sctp
       test_group_name: ci-kubernetes-e2e-ubuntu-gce-basic-sctp
-      base_options: include-filter-by-regex=\[sig-network\]
       description: network ubuntu-gce SCTP support basic e2e tests for master branch
       alert_options:
         alert_mail_to_addresses: kubernetes-sig-network-test-failures@googlegroups.com


### PR DESCRIPTION
TIL that if you use a regex filter the overall status in testgrid is the one from obtained from the filter, not from the job.

https://github.com/kubernetes/test-infra/issues/19360

We should check that the jobs are healthy, noty that some test pass only, we can filter not working test if necessary.

