### PR TITLE
label: ignore trailing whitespace in commands

### DIFF
--- a/prow/plugins/label/label.go
+++ b/prow/plugins/label/label.go
@@ -88,7 +88,7 @@ type githubClient interface {
 // Get Labels from Regexp matches
 func getLabelsFromREMatches(matches [][]string) (labels []string) {
 	for _, match := range matches {
-		for _, label := range strings.Split(match[0], " ")[1:] {
+		for _, label := range strings.Split(strings.TrimSpace(match[0]), " ")[1:] {
 			label = strings.ToLower(match[1] + "/" + strings.TrimSpace(label))
 			labels = append(labels, label)
 		}

--- a/prow/plugins/label/label_test.go
+++ b/prow/plugins/label/label_test.go
@@ -227,6 +227,16 @@ func TestLabel(t *testing.T) {
 			action:                github.GenericCommentActionCreated,
 		},
 		{
+			name:                  "Add Multiple Area Labels, With Trailing Whitespace",
+			body:                  "/area api infra ",
+			repoLabels:            []string{"area/infra", "area/api"},
+			issueLabels:           []string{},
+			expectedNewLabels:     formatLabels("area/api", "area/infra"),
+			expectedRemovedLabels: []string{},
+			commenter:             orgMember,
+			action:                github.GenericCommentActionCreated,
+		},
+		{
 			name:                  "Label Prefix Must Match Command (Area-Priority Mismatch)",
 			body:                  "/area urgent",
 			repoLabels:            []string{"area/infra", "area/api", "priority/critical", "priority/urgent"},


### PR DESCRIPTION
Currently, if the comment contains a trailing whitespace, the whitespace character is also considered. For example, in https://github.com/kubernetes/test-infra/pull/19272#issuecomment-694780386, the comment was `/sig contributor-experience `.

To avoid this, we need to remove the trailing whitespace characters. This is similar to how we do for the custom label command:

https://github.com/kubernetes/test-infra/blob/ea1ce418cfd73704d8e7837cf74b763f23045d98/prow/plugins/label/label.go#L111

https://github.com/kubernetes/test-infra/blob/ea1ce418cfd73704d8e7837cf74b763f23045d98/prow/plugins/label/label_test.go#L454-L462

Tried playing around with the regex but couldn't find a solution with it.

/assign @cblecker @mrbobbytables 