### PR TITLE
Retry get-kube.sh up to 5 times during extraction

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -293,7 +293,7 @@ var getKube = func(url, version string, getSrc bool) error {
 		return err
 	}
 	log.Printf("U=%s R=%s get-kube.sh", url, version)
-	for i := 0; i < 3; i++ {
+	for i := 0; i < 5; i++ {
 		err = control.FinishRunning(exec.Command(k))
 		if err == nil {
 			break


### PR DESCRIPTION
Jobs are currently flaking on ECONNRESET errors when extracting k8s
which are not retried by curl. As opposed to adding the
--retry-all-errors flag, which can cause unintended behavior, to
curl in get-kube.sh, we just bump the retry of the whole script in an
attempt to reduce flakiness.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Attempt at remedying #19386 

/cc @eddiezane @thejoycekung @RobertKielty 