### PR TITLE
Start to build infra around Kettle Staging

### DIFF
--- a/kettle/Makefile
+++ b/kettle/Makefile
@@ -35,6 +35,12 @@ deploy: get-cluster-credentials
 update: get-cluster-credentials
 	kubectl set image deployment/kettle kettle=$(IMG):$(TAG) --record
 
+deploy-staging: get-cluster-credentials
+	sed "s/:latest/:$(TAG)/g" deployment-staging.yaml | kubectl apply -f - --record
+
+update-staging: get-cluster-credentials
+	kubectl set image deployment/kettle-staging kettle=$(IMG):$(TAG) --record
+
 rollback: get-cluster-credentials
 	kubectl rollout undo deployments/kettle
 

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -58,13 +58,23 @@ kubectl get pod -l app=kettle # should show a new pod name
 
 #### Verify functionality
 
-You can watch the pod startup and collect data from various GCS buckets by looking at its logs
+You can watch the pod startup and collect data from various GCS buckets by looking at its logs via:
 
 ```sh
 kubectl logs -f $(kubectl get pod -l app=kettle -oname)
 ```
+or access [log history](https://console.cloud.google.com/logs/viewer?project=k8s-gubernator&minLogLevel=0&expandAll=false&timestamp=2020-09-11T21:00:29.231000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-09-10T21:00:29.484Z&dateRangeEnd=2020-09-11T21:00:29.484Z&interval=P1D&resource=k8s_container%2Fcluster_name%2Fg8r%2Fnamespace_name%2Fdefault%2Fcontainer_name%2Fkettle&scrollTimestamp=2020-09-11T20:58:58.783347986Z&filters=text:%2B).
+
 
 It might take a couple of hours to be fully functional and start updating BigQuery. You can always go back to the [Gubernator BigQuery page](https://bigquery.cloud.google.com/table/k8s-gubernator:build.all?pli=1&tab=details) and check to see if data collection has resumed.  Backfill should happen automatically.
+
+#### Kettle Staging
+| :exclamation:  Not Fully Functional Yet |
+|-----------------------------------------|
+
+This is a work in progress. `Kettle Staging` uses a similar deployment to `Kettle` however it is allowed much less dish in it's PVC and has a reduced list of buckets to pull from. It will write to the [build.staging](https://pantheon.corp.google.com/bigquery?project=k8s-gubernator&page=table&t=all&d=build&p=k8s-gubernator&redirect_from_classic=true) table only.
+
+It can be deployed with `make -C kettle deploy-staging`. If already deployed, you may just run `make -C kettle update-staging`.
 
 #### Adding Fields
 

--- a/kettle/README.md
+++ b/kettle/README.md
@@ -63,8 +63,7 @@ You can watch the pod startup and collect data from various GCS buckets by looki
 ```sh
 kubectl logs -f $(kubectl get pod -l app=kettle -oname)
 ```
-or access [log history](https://console.cloud.google.com/logs/viewer?project=k8s-gubernator&minLogLevel=0&expandAll=false&timestamp=2020-09-11T21:00:29.231000000Z&customFacets=&limitCustomFacetWidth=true&dateRangeStart=2020-09-10T21:00:29.484Z&dateRangeEnd=2020-09-11T21:00:29.484Z&interval=P1D&resource=k8s_container%2Fcluster_name%2Fg8r%2Fnamespace_name%2Fdefault%2Fcontainer_name%2Fkettle&scrollTimestamp=2020-09-11T20:58:58.783347986Z&filters=text:%2B).
-
+or access [log history](https://console.cloud.google.com/logs/query?project=k8s-gubernator) with the Query: `resource.labels.container_name="kettle"`.
 
 It might take a couple of hours to be fully functional and start updating BigQuery. You can always go back to the [Gubernator BigQuery page](https://bigquery.cloud.google.com/table/k8s-gubernator:build.all?pli=1&tab=details) and check to see if data collection has resumed.  Backfill should happen automatically.
 
@@ -72,7 +71,10 @@ It might take a couple of hours to be fully functional and start updating BigQue
 | :exclamation:  Not Fully Functional Yet |
 |-----------------------------------------|
 
-This is a work in progress. `Kettle Staging` uses a similar deployment to `Kettle` however it is allowed much less dish in it's PVC and has a reduced list of buckets to pull from. It will write to the [build.staging](https://pantheon.corp.google.com/bigquery?project=k8s-gubernator&page=table&t=all&d=build&p=k8s-gubernator&redirect_from_classic=true) table only.
+This is a work in progress. `Kettle Staging` uses a similar deployment to `Kettle` with the following differences
+- much less disk in its PVC
+- reduced list of buckets to pull from
+- writes to [build.staging](https://console.cloud.google.com/bigquery?project=k8s-gubernator&page=table&t=all&d=build&p=k8s-gubernator&redirect_from_classic=true) table only.
 
 It can be deployed with `make -C kettle deploy-staging`. If already deployed, you may just run `make -C kettle update-staging`.
 

--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -1,0 +1,31 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kettle-staging
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: kettle-staging
+    spec:
+      containers:
+      - name: kettle-staging
+        image: gcr.io/k8s-testimages/kettle:latest
+        imagePullPolicy: Always
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/service-account/service-account.json
+        volumeMounts:
+        - name: service
+          mountPath: /etc/service-account
+          readOnly: true
+        - name: data
+          mountPath: /data
+      volumes:
+      - name: service
+        secret:
+          secretName: kettle-service-account
+      - name: data
+        persistentVolumeClaim:
+          claimName: kettle-data-staging

--- a/kettle/pv-staging.yaml
+++ b/kettle/pv-staging.yaml
@@ -1,0 +1,40 @@
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  labels:
+    app: kettle-staging
+  name: kettle-data-staging
+spec:
+  capacity:
+    storage: 100Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: kettle-data-staging
+    fsType: ext4
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  labels:
+    app: kettle-staging
+  name: kettle-data-staging
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi
+  storageClassName: ssd
+  volumeName: kettle-data-staging
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: ssd
+provisioner: kubernetes.io/gce-pd
+parameters:
+  type: pd-ssd
+allowVolumeExpansion: true
+reclaimPolicy: Delete


### PR DESCRIPTION
Here are the new pv and deployment templates for `kettle-staging` instance that will be used to test kettle changes prior to live deployment. 

My plan is to create `kettle-staging` next to kettle with it's own subset of small buckets and broken buckets to pull from. This should limit its space utilization and still provide e2e testing options.

/area kettle
/sig testing
/cc @amwat @spiffxp 