### PR TITLE
[scalability][presubmit] Finish splitting 'pull-perf-tests-verify-all'

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -579,11 +579,13 @@ presubmits:
               cpu: 1
               memory: "2Gi"
 
+  # TODO(jprzychodzen): Remove after deprecation of release-1.19
   - name: pull-perf-tests-verify-all
     decorate: true
     always_run: true
     skip_branches:
     - release-1.1[2-8] # Presubmit has been implemented for 1.19+ releases
+    - master # It's covered by 'pull-perf-tests-verify-all-python' and 'pull-perf-tests-verify-test'
     path_alias: "k8s.io/perf-tests"
     annotations:
       testgrid-dashboards: presubmits-kubernetes-scalability
@@ -606,9 +608,6 @@ presubmits:
   - name: pull-perf-tests-verify-all-python
     decorate: true
     always_run: true
-    # TODO(jprzychodzen): Make this non-optional after verification that it works
-    # See discussion in kubernetes/perf-tests#1470 for context
-    optional: true
     skip_branches:
       - release-1.1[2-9] # Presubmit has been implemented for 1.20+ releases
     path_alias: "k8s.io/perf-tests"


### PR DESCRIPTION
We can safely disable verify-all, as Golang part is covered by `pull-perf-tests-verify-test` and Python part is tested by `pull-perf-tests-verify-all-python`.

Still, we want to keep this test until 1.19 will be deprecated in kubernetes/kubernetes repository.

Tested with kubernetes/perf-tests#1470 and kubernetes/perf-tests#1506 that `pull-perf-tests-verify-all-python` is passing.