### PR TITLE
Add an integration test suite for k/release

### DIFF
--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -53,6 +53,21 @@ presubmits:
       testgrid-tab-name: release-test
       testgrid-alert-email: release-managers@kubernetes.io
       testgrid-num-columns-recent: '30'
+  - name: pull-release-integration-test
+    always_run: true
+    decorate: true
+    path_alias: k8s.io/release
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - test-go-integration
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: release-integration-test
+      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-num-columns-recent: '30'
   - name: pull-release-verify
     always_run: true
     decorate: true


### PR DESCRIPTION
This commit creates an integration test suite for k/release. Running the
full go test suite in one single job requires too much time, sig-release
is in the effort of splitting it

Reference https://github.com/kubernetes/release/issues/1556

/cc @saschagrunert @justaugustus 