### PR TITLE
Remove auto-update from gcloud run step from Kettle

### DIFF
--- a/kettle/runner.sh
+++ b/kettle/runner.sh
@@ -19,9 +19,6 @@ set -o pipefail
 
 # A wrapper script for running kettle
 
-# Update gcloud
-gcloud components update
-
 # Authenticate gcloud
 if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"


### PR DESCRIPTION
This step will auto update `google-cloud-sdk` versions of the sdk > 294.0.0 have an http2lib conflict and causes `bq load` to fail out. This was fixed for pulling in #19369

This should be added back if #19414 is completed