### PR TITLE
disable sctp connectivity tests on gce

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -527,6 +527,7 @@ periodics:
       - --gcp-nodes=4
       - --gcp-zone=us-west1-b
       - --provider=gce
-      - --test_args=--ginkgo.focus=\[Feature:(SCTP|SCTPConnectivity)\] --ginkgo.skip=\[Feature:NetworkPolicy\]
+      # SCTPConnectivity hangs on GCE when trying to access the NodePort service, but works for ClusterIP
+      - --test_args=--ginkgo.focus=\[Feature:SCTP\] --ginkgo.skip=\[Feature:NetworkPolicy\]
       - --timeout=50m
       image: gcr.io/k8s-testimages/kubekins-e2e:v20200929-82b41a1-master


### PR DESCRIPTION
It hangs on the test that tries to access the NodePort SCTP service, but is able to access the ClusterIP service, so I assume that is GCE or deployment specific, but not a big deal, so better skip it and reenable if we are more interested later 