### PR TITLE
Add read/liveness probes in all prow external plugins

### DIFF
--- a/prow/external-plugins/cherrypicker/BUILD.bazel
+++ b/prow/external-plugins/cherrypicker/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//prow/git/v2:go_default_library",
         "//prow/github:go_default_library",
         "//prow/interrupts:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/external-plugins/cherrypicker/main.go
+++ b/prow/external-plugins/cherrypicker/main.go
@@ -31,6 +31,7 @@ import (
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/git/v2"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pluginhelp/externalplugins"
 )
 
@@ -137,6 +138,9 @@ func main() {
 
 		repos: repos,
 	}
+
+	health := pjutil.NewHealth()
+	health.ServeReady()
 
 	mux := http.NewServeMux()
 	mux.Handle("/", server)

--- a/prow/external-plugins/needs-rebase/BUILD.bazel
+++ b/prow/external-plugins/needs-rebase/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/interrupts:go_default_library",
         "//prow/labels:go_default_library",
+        "//prow/pjutil:go_default_library",
         "//prow/pluginhelp/externalplugins:go_default_library",
         "//prow/plugins:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/external-plugins/needs-rebase/main.go
+++ b/prow/external-plugins/needs-rebase/main.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config/secret"
@@ -119,6 +120,9 @@ func main() {
 		}
 		log.WithField("duration", fmt.Sprintf("%v", time.Since(start))).Info("Periodic update complete.")
 	}, o.updatePeriod)
+
+	health := pjutil.NewHealth()
+	health.ServeReady()
 
 	mux := http.NewServeMux()
 	mux.Handle("/", server)

--- a/prow/external-plugins/refresh/main.go
+++ b/prow/external-plugins/refresh/main.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"k8s.io/test-infra/prow/interrupts"
+	"k8s.io/test-infra/prow/pjutil"
 
 	"k8s.io/test-infra/pkg/flagutil"
 	"k8s.io/test-infra/prow/config"
@@ -109,6 +110,9 @@ func main() {
 		ghc:            githubClient,
 		log:            log,
 	}
+
+	health := pjutil.NewHealth()
+	health.ServeReady()
 
 	mux := http.NewServeMux()
 	mux.Handle("/", serv)


### PR DESCRIPTION
/cc @stevekuznetsov @alvaroaleman 

NOTE: I will update the manifests to use the read/liveness probes in a follow-up to avoid any outage.

Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>