### PR TITLE
config/prow: add component-helpers staging repo

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -195,6 +195,11 @@ branch-protection:
             users: []
             teams:
             - stage-bots
+        component-helpers:
+          restrictions:
+            users: []
+            teams:
+            - stage-bots
         controller-manager:
           restrictions:
             users: []
@@ -462,6 +467,7 @@ tide:
     - kubernetes/cluster-bootstrap
     - kubernetes/code-generator
     - kubernetes/component-base
+    - kubernetes/component-helpers
     - kubernetes/controller-manager
     - kubernetes/cri-api
     - kubernetes/csi-api

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -218,10 +218,12 @@ slack:
     - k8s-ci-robot
   - repos:
     - kubernetes/utils
+    - kubernetes/component-helpers
     channels:
     - sig-architecture
     exempt_users:
     - k8s-ci-robot
+    - k8s-publishing-bot
   - repos:
     - kubernetes/api
     - kubernetes/apiextensions-apiserver


### PR DESCRIPTION
Ref: https://github.com/kubernetes/org/issues/2231

/assign @cblecker 

fyi @dims -- for merge-warning notifications being setup for the #sig-architecture channel on slack