### PR TITLE
config/prow: apply needs-triage on PRs too

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -511,6 +511,7 @@ require_matching_label:
   org: kubernetes
   repo: kubernetes
   issues: true
+  prs: true
   regexp: ^triage/accepted$
   missing_comment: |
     This issue is currently awaiting triage.


### PR DESCRIPTION
Ref: https://github.com/kubernetes/enhancements/pull/2017

/assign @mrbobbytables @cblecker 