### PR TITLE
Prepare Cluster API periodics and presubmit for v1alpha4

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-main.yaml
@@ -1,0 +1,83 @@
+periodics:
+- name: periodic-cluster-api-test-main
+  interval: 1h
+  decorate: true
+  labels:
+    preset-service-account: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
+      command:
+      - "./scripts/ci-test.sh"
+      resources:
+        requests:
+          cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-test-main
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-e2e-main
+  interval: 1h
+  decorate: true
+  labels:
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-e2e-main
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
+    testgrid-num-failures-to-alert: "2"
+- name: periodic-cluster-api-verify-book-links-main
+  interval: 6h
+  decorate: true
+  extra_refs:
+  - org: kubernetes-sigs
+    repo: cluster-api
+    base_ref: master
+    path_alias: sigs.k8s.io/cluster-api
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
+      command:
+      - "runner.sh"
+      - "make"
+      - "verify-book-links"
+      env:
+      - name: GITHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: cluster-lifecycle-github-token
+            key: cluster-lifecycle-github-token
+  volumes:
+  - name: cluster-lifecycle-github-token
+    secret:
+      secretName: cluster-lifecycle-github-token
+      items:
+      - key: cluster-lifecycle-github-token
+        path: cluster-lifecycle-github-token
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+    testgrid-tab-name: capi-verify-book-links-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-periodics-release-0-3.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: periodic-cluster-api-test
+- name: periodic-cluster-api-test-release-0-3
   interval: 1h
   decorate: true
   labels:
@@ -7,7 +7,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: release-0.3
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
@@ -19,10 +19,10 @@ periodics:
           cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: unit tests
+    testgrid-tab-name: capi-test-release-0-3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-e2e-test
+- name: periodic-cluster-api-e2e-release-0-3
   interval: 1h
   decorate: true
   labels:
@@ -31,7 +31,7 @@ periodics:
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: release-0.3
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
@@ -47,16 +47,16 @@ periodics:
             cpu: 7300m
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: capi e2e tests
+    testgrid-tab-name: capi-e2e-release-0-3
     testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com
     testgrid-num-failures-to-alert: "2"
-- name: periodic-cluster-api-verify-external-links
+- name: periodic-cluster-api-verify-book-links-release-0-3
   interval: 6h
   decorate: true
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api
-    base_ref: master
+    base_ref: release-0.3
     path_alias: sigs.k8s.io/cluster-api
   spec:
     containers:
@@ -80,4 +80,4 @@ periodics:
         path: cluster-lifecycle-github-token
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-    testgrid-tab-name: periodic docs link verification
+    testgrid-tab-name: capi-verify-book-links-release-0-3

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-main.yaml
@@ -1,31 +1,33 @@
 presubmits:
   kubernetes-sigs/cluster-api:
-  - name: pull-cluster-api-build
+  - name: pull-cluster-api-build-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
-    skip_branches:
-    - gh-pages
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         command:
         - runner.sh
         - ./scripts/ci-build.sh
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-build
-  - name: pull-cluster-api-make
+      testgrid-tab-name: capi-pr-build-main
+  - name: pull-cluster-api-make-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
       preset-dind-enabled: "true"
-    skip_branches:
-    - gh-pages
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     spec:
       containers:
       - command:
@@ -34,32 +36,32 @@ presubmits:
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         resources:
           requests:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-make
-  - name: pull-cluster-api-apidiff
+      testgrid-tab-name: capi-pr-make-main
+  - name: pull-cluster-api-apidiff-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     optional: true
     labels:
       preset-service-account: "true"
-    skip_branches:
-    - gh-pages
-    - release-0.2
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     spec:
       containers:
       - command:
         - runner.sh
         - ./scripts/ci-apidiff.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-apidiff
+      testgrid-tab-name: capi-pr-apidiff-main
   - name: pull-cluster-api-verify
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
@@ -70,7 +72,7 @@ presubmits:
     - gh-pages
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         command:
         - "runner.sh"
         - "make"
@@ -80,18 +82,19 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-verify
-  - name: pull-cluster-api-test
+      testgrid-tab-name: capi-pr-verify-main
+  - name: pull-cluster-api-test-main
     decorate: true
     path_alias: sigs.k8s.io/cluster-api
     always_run: true
     labels:
       preset-service-account: "true"
-    skip_branches:
-    - gh-pages
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         args:
         - runner.sh
         - ./scripts/ci-test.sh
@@ -100,20 +103,20 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-test
-  - name: pull-cluster-api-e2e
+      testgrid-tab-name: capi-pr-test-main
+  - name: pull-cluster-api-e2e-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
-    skip_branches:
-      - gh-pages
-      - release-0.2
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     path_alias: sigs.k8s.io/cluster-api
     run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -128,21 +131,21 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-e2e
-  - name: pull-cluster-api-e2e-full
+      testgrid-tab-name: capi-pr-e2e-main
+  - name: pull-cluster-api-e2e-full-main
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
     decorate: true
     optional: true
     always_run: false
-    skip_branches:
-      - gh-pages
-      - release-0.2
+    branches:
+    # The script this job runs is not in all branches.
+    - ^master$
     path_alias: sigs.k8s.io/cluster-api
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.19
         args:
           - runner.sh
           - "./scripts/ci-e2e.sh"
@@ -154,4 +157,4 @@ presubmits:
             cpu: 7300m
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api
-      testgrid-tab-name: pr-e2e-full
+      testgrid-tab-name: capi-pr-e2e-full-main

--- a/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api/cluster-api-presubmits-release-0-3.yaml
@@ -1,0 +1,161 @@
+presubmits:
+  kubernetes-sigs/cluster-api:
+  - name: pull-cluster-api-build-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        command:
+        - runner.sh
+        - ./scripts/ci-build.sh
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-build-release-0-3
+  - name: pull-cluster-api-make
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-dind-enabled: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-make.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-make-release-0-3
+  - name: pull-cluster-api-apidiff-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    optional: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - command:
+        - runner.sh
+        - ./scripts/ci-apidiff.sh
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-apidiff-release-0-3
+  - name: pull-cluster-api-verify-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        command:
+        - "runner.sh"
+        - "make"
+        - "verify"
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-verify-release-0-3
+  - name: pull-cluster-api-test-release-0-3
+    decorate: true
+    path_alias: sigs.k8s.io/cluster-api
+    always_run: true
+    labels:
+      preset-service-account: "true"
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        args:
+        - runner.sh
+        - ./scripts/ci-test.sh
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-test-release-0-3
+  - name: pull-cluster-api-e2e-release-0-3
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    path_alias: sigs.k8s.io/cluster-api
+    run_if_changed: '^((api|bootstrap|cmd|config|controllers|controlplane|errors|exp|feature|hack|scripts|test|third_party|util)/|main\.go|go\.mod|go\.sum|Dockerfile|Makefile)'
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "\\[PR-Blocking\\]"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-release-0-3
+  - name: pull-cluster-api-e2e-full-release-0-3
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decorate: true
+    optional: true
+    always_run: false
+    branches:
+    # The script this job runs is not in all branches.
+    - ^release-0.3$
+    path_alias: sigs.k8s.io/cluster-api
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20200930-82b41a1-1.18
+        args:
+          - runner.sh
+          - "./scripts/ci-e2e.sh"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 7300m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api
+      testgrid-tab-name: capi-pr-e2e-full-release-0-3


### PR DESCRIPTION
This PR splits all periodics and presubmit between release / main branches, and changes the images to the proper version we'll use next.

/assign @ncdc @detiber 