### PR TITLE
Fix a race in planks aborting and make it more robust

### DIFF
--- a/prow/pjutil/BUILD.bazel
+++ b/prow/pjutil/BUILD.bazel
@@ -76,7 +76,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/diff:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
     ],
 )

--- a/prow/pjutil/abort.go
+++ b/prow/pjutil/abort.go
@@ -44,12 +44,6 @@ type prowClient interface {
 	Patch(ctx context.Context, name string, pt ktypes.PatchType, data []byte, o metav1.PatchOptions, subresources ...string) (result *prowapi.ProwJob, err error)
 }
 
-// ProwJobResourcesCleanup type for a callback function which it is expected to clean up
-// all k8s resources associated with the given prow job. It should do the best effort to
-// remove these resources, but if for any reason there is an error, it should only log a warning
-// message.
-type ProwJobResourcesCleanup func(pj prowapi.ProwJob) error
-
 // digestRefs digests a Refs to the fields we care about
 // for termination, ensuring that permutations of pulls
 // do not cause different digests
@@ -62,10 +56,10 @@ func digestRefs(ref prowapi.Refs) string {
 	return fmt.Sprintf("%s/%s@%s %v", ref.Org, ref.Repo, ref.BaseRef, pulls)
 }
 
-// TerminateOlderJobs aborts all presubmit jobs from the given list that have a newer version. It calls
-// the cleanup callback for each job before updating its status as aborted.
-func TerminateOlderJobs(pjc patchClient, log *logrus.Entry, pjs []prowapi.ProwJob,
-	cleanup ProwJobResourcesCleanup) error {
+// TerminateOlderJobs aborts all presubmit jobs from the given list that have a newer version. It does not set
+// the prowjob to complete. The responsible agent is expected to react to the aborted state by aborting the actual
+// test payload and then setting the ProwJob to completed.
+func TerminateOlderJobs(pjc patchClient, log *logrus.Entry, pjs []prowapi.ProwJob) error {
 	dupes := map[string]int{}
 	for i, pj := range pjs {
 		if pj.Complete() || pj.Spec.Type != prowapi.PresubmitJob {
@@ -107,14 +101,6 @@ func TerminateOlderJobs(pjc patchClient, log *logrus.Entry, pjs []prowapi.ProwJo
 		toCancel := pjs[cancelIndex]
 		prevPJ := toCancel.DeepCopy()
 
-		// TODO cancel the prow job before cleaning up its resources and make this system
-		// independent.
-		// See this discussion for more details:  https://github.com/kubernetes/test-infra/pull/11451#discussion_r263523932
-		if err := cleanup(toCancel); err != nil {
-			log.WithError(err).WithFields(ProwJobFields(&toCancel)).Warn("Cannot clean up job resources")
-		}
-
-		toCancel.SetComplete()
 		toCancel.Status.State = prowapi.AbortedState
 		if toCancel.Status.PrevReportStates == nil {
 			toCancel.Status.PrevReportStates = map[string]prowapi.ProwJobState{}

--- a/prow/pjutil/abort_test.go
+++ b/prow/pjutil/abort_test.go
@@ -18,7 +18,6 @@ package pjutil
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"testing"
 	"time"
@@ -27,10 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
-	ctrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	prowjobv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 )
 
 func TestTerminateOlderJobs(t *testing.T) {
@@ -41,435 +39,437 @@ func TestTerminateOlderJobs(t *testing.T) {
 		return &reallyNow
 	}
 	cases := []struct {
-		name           string
-		pjs            []prowjobv1.ProwJob
-		terminateddPJs sets.String
+		name               string
+		pjs                []prowv1.ProwJob
+		expectedAbortedPJs sets.String
 	}{
 		{
 			name: "terminate all older presubmit jobs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "older", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-2 * time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "postsubmit", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PostsubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PostsubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-2 * time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "completed", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime:      metav1.NewTime(now.Add(-2 * time.Hour)),
 						CompletionTime: nowFn(),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old", "older"),
+			expectedAbortedPJs: sets.NewString("old", "older"),
 		},
 		{
 			name: "Don't terminate older batch jobs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.BatchJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.BatchJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "older", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.BatchJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-2 * time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "postsubmit", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PostsubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PostsubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-2 * time.Hour)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "completed", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.BatchJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.BatchJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime:      metav1.NewTime(now.Add(-2 * time.Hour)),
 						CompletionTime: nowFn(),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString(),
+			expectedAbortedPJs: sets.NewString(),
 		},
 		{
 			name: "terminate older jobs with different orders of refs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}, {Number: 2}},
+							Pulls: []prowv1.Pull{{Number: 1}, {Number: 2}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 2}, {Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 2}, {Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old"),
+			expectedAbortedPJs: sets.NewString("old"),
 		},
 		{
 			name: "terminate older jobs with different orders of extra refs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
-						ExtraRefs: []prowjobv1.Refs{
+						ExtraRefs: []prowv1.Refs{
 							{
 								Repo:  "other",
-								Pulls: []prowjobv1.Pull{{Number: 2}},
+								Pulls: []prowv1.Pull{{Number: 2}},
 							},
 							{
 								Repo:  "something",
-								Pulls: []prowjobv1.Pull{{Number: 3}},
+								Pulls: []prowv1.Pull{{Number: 3}},
 							},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1}},
+							Pulls: []prowv1.Pull{{Number: 1}},
 						},
-						ExtraRefs: []prowjobv1.Refs{
+						ExtraRefs: []prowv1.Refs{
 							{
 								Repo:  "something",
-								Pulls: []prowjobv1.Pull{{Number: 3}},
+								Pulls: []prowv1.Pull{{Number: 3}},
 							},
 							{
 								Repo:  "other",
-								Pulls: []prowjobv1.Pull{{Number: 2}},
+								Pulls: []prowv1.Pull{{Number: 2}},
 							},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old"),
+			expectedAbortedPJs: sets.NewString("old"),
 		},
 		{
 			name: "terminate older jobs with no main refs, only extra refs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						ExtraRefs: []prowjobv1.Refs{
+						ExtraRefs: []prowv1.Refs{
 							{
 								Repo:  "test",
-								Pulls: []prowjobv1.Pull{{Number: 1}},
+								Pulls: []prowv1.Pull{{Number: 1}},
 							},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						ExtraRefs: []prowjobv1.Refs{
+						ExtraRefs: []prowv1.Refs{
 							{
 								Repo:  "test",
-								Pulls: []prowjobv1.Pull{{Number: 1}},
+								Pulls: []prowv1.Pull{{Number: 1}},
 							},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old"),
+			expectedAbortedPJs: sets.NewString("old"),
 		},
 		{
 			name: "terminate older jobs with different base SHA",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:    "test",
 							BaseSHA: "foo",
-							Pulls:   []prowjobv1.Pull{{Number: 1}},
+							Pulls:   []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:    "test",
 							BaseSHA: "bar",
-							Pulls:   []prowjobv1.Pull{{Number: 1}},
+							Pulls:   []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old"),
+			expectedAbortedPJs: sets.NewString("old"),
 		},
 		{
 			name: "don't terminate older jobs with different base refs",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:    "test",
 							BaseRef: "foo",
-							Pulls:   []prowjobv1.Pull{{Number: 1}},
+							Pulls:   []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:    "test",
 							BaseRef: "bar",
-							Pulls:   []prowjobv1.Pull{{Number: 1}},
+							Pulls:   []prowv1.Pull{{Number: 1}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString(),
+			expectedAbortedPJs: sets.NewString(),
 		},
 		{
 			name: "terminate older jobs with different pull sha",
-			pjs: []prowjobv1.ProwJob{
+			pjs: []prowv1.ProwJob{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1, SHA: "foo"}},
+							Pulls: []prowv1.Pull{{Number: 1, SHA: "foo"}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: fakePJNS},
-					Spec: prowjobv1.ProwJobSpec{
-						Type: prowjobv1.PresubmitJob,
+					Spec: prowv1.ProwJobSpec{
+						Type: prowv1.PresubmitJob,
 						Job:  "j1",
-						Refs: &prowjobv1.Refs{
+						Refs: &prowv1.Refs{
 							Repo:  "test",
-							Pulls: []prowjobv1.Pull{{Number: 1, SHA: "bar"}},
+							Pulls: []prowv1.Pull{{Number: 1, SHA: "bar"}},
 						},
 					},
-					Status: prowjobv1.ProwJobStatus{
+					Status: prowv1.ProwJobStatus{
 						StartTime: metav1.NewTime(now.Add(-time.Minute)),
 					},
 				},
 			},
-			terminateddPJs: sets.NewString("old"),
+			expectedAbortedPJs: sets.NewString("old"),
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var clientPJs []runtime.Object
-			var origPJs []prowjobv1.ProwJob
+			var origPJs []prowv1.ProwJob
 			for i := range tc.pjs {
 				clientPJs = append(clientPJs, &tc.pjs[i])
 				origPJs = append(origPJs, tc.pjs[i])
 			}
-			fakeProwJobClient := &patchTrackingFakeClient{Client: fakectrlruntimeclient.NewFakeClient(clientPJs...)}
+			fakeProwJobClient := fakectrlruntimeclient.NewFakeClient(clientPJs...)
 			log := logrus.NewEntry(logrus.StandardLogger())
-			cleanedupPJs := sets.NewString()
-			err := TerminateOlderJobs(fakeProwJobClient, log, tc.pjs, func(pj prowjobv1.ProwJob) error {
-				cleanedupPJs.Insert(pj.GetName())
-				return nil
-			})
-			if err != nil {
+			if err := TerminateOlderJobs(fakeProwJobClient, log, tc.pjs); err != nil {
 				t.Fatalf("%s: error terminating the older presubmit jobs: %v", tc.name, err)
 			}
 
-			if missing := tc.terminateddPJs.Difference(cleanedupPJs); missing.Len() > 0 {
-				t.Errorf("%s: did not cleaned up the expected jobs: %v", tc.name, missing.List())
-			}
-			if extra := cleanedupPJs.Difference(tc.terminateddPJs); extra.Len() > 0 {
-				t.Errorf("%s: found unexpectedly cleaned up jobs: %v", tc.name, extra.List())
+			var actualPJs prowv1.ProwJobList
+			if err := fakeProwJobClient.List(context.Background(), &actualPJs); err != nil {
+				t.Fatalf("failed to list prowjobs: %v", err)
 			}
 
-			replacedJobs := fakeProwJobClient.patched
-			if missing := tc.terminateddPJs.Difference(replacedJobs); missing.Len() > 0 {
+			actuallyAbortedJobs := sets.String{}
+			for _, job := range actualPJs.Items {
+				if job.Status.State == prowv1.AbortedState {
+					if job.Complete() {
+						t.Errorf("job %s was set to complete, TerminateOlderJobs must never set prowjobs as completed", job.Name)
+					}
+					actuallyAbortedJobs.Insert(job.Name)
+				}
+			}
+
+			if missing := tc.expectedAbortedPJs.Difference(actuallyAbortedJobs); missing.Len() > 0 {
 				t.Errorf("%s: did not replace the expected jobs: %v", tc.name, missing.Len())
 			}
-			if extra := replacedJobs.Difference(tc.terminateddPJs); extra.Len() > 0 {
+			if extra := actuallyAbortedJobs.Difference(tc.expectedAbortedPJs); extra.Len() > 0 {
 				t.Errorf("%s: found unexpectedly replaced job: %v", tc.name, extra.List())
 			}
 
 			// Validate that terminated PJs are marked terminated in the passed slice.
 			// Only consider jobs that we expected to be replaced and that were replaced.
-			replacedAsExpected := replacedJobs.Intersection(tc.terminateddPJs)
+			replacedAsExpected := actuallyAbortedJobs.Intersection(tc.expectedAbortedPJs)
 			for i := range origPJs {
 				if replacedAsExpected.Has(origPJs[i].Name) {
 					if reflect.DeepEqual(origPJs[i], tc.pjs[i]) {
@@ -479,21 +479,4 @@ func TestTerminateOlderJobs(t *testing.T) {
 			}
 		})
 	}
-}
-
-type patchTrackingFakeClient struct {
-	ctrlruntimeclient.Client
-	patched sets.String
-}
-
-func (c *patchTrackingFakeClient) Patch(ctx context.Context, obj runtime.Object, patch ctrlruntimeclient.Patch, opts ...ctrlruntimeclient.PatchOption) error {
-	if c.patched == nil {
-		c.patched = sets.NewString()
-	}
-	metaObject, ok := obj.(metav1.Object)
-	if !ok {
-		return errors.New("Object is no metav1.Object")
-	}
-	c.patched.Insert(metaObject.GetName())
-	return c.Client.Patch(ctx, obj, patch, opts...)
 }

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -222,7 +222,7 @@ func (c *Controller) Sync() error {
 		return k8sJobs[i].CreationTimestamp.Before(&k8sJobs[j].CreationTimestamp)
 	})
 
-	if err := c.terminateDupes(k8sJobs, pm); err != nil {
+	if err := c.terminateDupes(k8sJobs); err != nil {
 		syncErrs = append(syncErrs, err)
 	}
 
@@ -268,21 +268,8 @@ func (c *Controller) SyncMetrics() {
 
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs
 // in-place when it aborts.
-// TODO: Dry this out - need to ensure we can abstract children cancellation first.
-func (c *Controller) terminateDupes(pjs []prowapi.ProwJob, pm map[string]corev1.Pod) error {
-	log := c.log.WithField("aborter", "pod")
-	return pjutil.TerminateOlderJobs(c.prowJobClient, log, pjs, func(toCancel prowapi.ProwJob) error {
-		// Abort presubmit jobs for commits that have been superseded by newer commits
-		if pod, exists := pm[toCancel.ObjectMeta.Name]; exists {
-			c.log.WithField("name", pod.ObjectMeta.Name).Debug("Delete Pod.")
-			if client, ok := c.buildClients[toCancel.ClusterAlias()]; !ok {
-				return fmt.Errorf("unknown cluster alias %q", toCancel.ClusterAlias())
-			} else if err := client.Delete(c.ctx, &pod); err != nil {
-				return fmt.Errorf("deleting pod: %v", err)
-			}
-		}
-		return nil
-	})
+func (c *Controller) terminateDupes(pjs []prowapi.ProwJob) error {
+	return pjutil.TerminateOlderJobs(c.prowJobClient, c.log.WithField("aborter", "pod"), pjs)
 }
 
 // TODO: Dry this out

--- a/prow/plank/controller_test.go
+++ b/prow/plank/controller_test.go
@@ -125,11 +125,9 @@ func TestTerminateDupes(t *testing.T) {
 		Name string
 
 		PJs  []prowapi.ProwJob
-		PM   map[string]v1.Pod
 		IsV2 bool
 
-		TerminatedPJs  sets.String
-		TerminatedPods sets.String
+		TerminatedPJs sets.String
 	}
 	var testcases = []testCase{
 		{
@@ -258,13 +256,8 @@ func TestTerminateDupes(t *testing.T) {
 					},
 				},
 			},
-			PM: map[string]v1.Pod{
-				"newest": {ObjectMeta: metav1.ObjectMeta{Name: "newest", Namespace: "pods"}},
-				"old":    {ObjectMeta: metav1.ObjectMeta{Name: "old", Namespace: "pods"}},
-			},
 
-			TerminatedPJs:  sets.NewString("old"),
-			TerminatedPods: sets.NewString("old"),
+			TerminatedPJs: sets.NewString("old"),
 		},
 	}
 
@@ -289,14 +282,6 @@ func TestTerminateDupes(t *testing.T) {
 			fakeProwJobClient := &patchTrackingFakeClient{
 				Client: fakectrlruntimeclient.NewFakeClient(prowJobs...),
 			}
-			var pods []runtime.Object
-			for name := range tc.PM {
-				pod := tc.PM[name]
-				pods = append(pods, &pod)
-			}
-			fakePodClient := &deleteTrackingFakeClient{
-				Client: fakectrlruntimeclient.NewFakeClient(pods...),
-			}
 			fca := &fca{
 				c: &config.Config{
 					ProwConfig: config.ProwConfig{
@@ -310,22 +295,20 @@ func TestTerminateDupes(t *testing.T) {
 			if !tc.IsV2 {
 				c := Controller{
 					prowJobClient: fakeProwJobClient,
-					buildClients:  map[string]ctrlruntimeclient.Client{prowapi.DefaultClusterAlias: fakePodClient},
 					log:           log,
 					config:        fca.Config,
 					clock:         clock.RealClock{},
 				}
-				if err := c.terminateDupes(tc.PJs, tc.PM); err != nil {
+				if err := c.terminateDupes(tc.PJs); err != nil {
 					t.Fatalf("Error terminating dupes: %v", err)
 				}
 
 			} else {
 				r := &reconciler{
-					pjClient:     fakeProwJobClient,
-					buildClients: map[string]ctrlruntimeclient.Client{prowapi.DefaultClusterAlias: fakePodClient},
-					log:          log,
-					config:       fca.Config,
-					clock:        clock.RealClock{},
+					pjClient: fakeProwJobClient,
+					log:      log,
+					config:   fca.Config,
+					clock:    clock.RealClock{},
 				}
 				for _, pj := range tc.PJs {
 					res, err := r.reconcile(&pj)
@@ -346,13 +329,6 @@ func TestTerminateDupes(t *testing.T) {
 				t.Errorf("found unexpectedly deleted prowJobs: %v", extra.List())
 			}
 
-			observedTerminatedPods := fakePodClient.deleted
-			if missing := tc.TerminatedPods.Difference(observedTerminatedPods); missing.Len() > 0 {
-				t.Errorf("did not delete expected pods: %v", missing.List())
-			}
-			if extra := observedTerminatedPods.Difference(tc.TerminatedPods); extra.Len() > 0 {
-				t.Errorf("found unexpectedly deleted pods: %v", extra.List())
-			}
 		})
 	}
 }

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -242,24 +242,7 @@ func (r *reconciler) terminateDupes(pj *prowv1.ProwJob) error {
 		return fmt.Errorf("failed to list prowjobs: %v", err)
 	}
 
-	return pjutil.TerminateOlderJobs(r.pjClient, r.log, pjs.Items, r.terminateDupesCleanup)
-}
-
-func (r *reconciler) terminateDupesCleanup(pj prowv1.ProwJob) error {
-	client, ok := r.buildClients[pj.ClusterAlias()]
-	if !ok {
-		return fmt.Errorf("no client for cluster %q present", pj.ClusterAlias())
-	}
-	podToDelete := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: r.config().PodNamespace,
-			Name:      pj.Name,
-		},
-	}
-	if err := client.Delete(r.ctx, podToDelete); err != nil && !kerrors.IsNotFound(err) {
-		return fmt.Errorf("failed to delete pod %s/%s in cluster %s: %w", podToDelete.Namespace, podToDelete.Name, pj.ClusterAlias(), err)
-	}
-	return nil
+	return pjutil.TerminateOlderJobs(r.pjClient, r.log, pjs.Items)
 }
 
 // syncPendingJob syncs jobs for which we already created the test workload

--- a/prow/plank/reconciler_test.go
+++ b/prow/plank/reconciler_test.go
@@ -459,16 +459,6 @@ func (ecc *eventuallyConsistentClient) Create(ctx context.Context, obj runtime.O
 	return nil
 }
 
-func TestTerminateDupesToleratesNotFound(t *testing.T) {
-	r := &reconciler{
-		buildClients: map[string]ctrlruntimeclient.Client{"default": fakectrlruntimeclient.NewFakeClient()},
-		config:       func() *config.Config { return &config.Config{} },
-	}
-	if err := r.terminateDupesCleanup(prowv1.ProwJob{}); err != nil {
-		t.Errorf("expected no error when deleting absent pod, got %v", err)
-	}
-}
-
 func TestStartPodBlocksUntilItHasThePodInCache(t *testing.T) {
 	t.Parallel()
 	r := &reconciler{


### PR DESCRIPTION
Currently, its possible for the logic that aborts older instances of a
given prowjob to race and first set a prowjob to aborted, then to error:

{"component":"prow-controller-manager","controller":"plank","event-GUID":"bba62c80-03f6-11eb-86e5-e53548611fe1","file":"prow/pjutil/abort.go:126","from":"pending","func":"k8s.io/test-infra/prow/pjutil.TerminateOlderJobs","job":"pull-ci-kubevirt-hyperconverged-cluster-operator-release-1.2-hco-e2e-aws","level":"info","msg":"Transitioning states","name":"bdd0d20a-03f6-11eb-8b65-0a580a800dea","org":"kubevirt","pr":852,"repo":"hyperconverged-cluster-operator","severity":"info","time":"2020-10-01T15:01:38Z","to":"aborted","type":"presubmit"}
{"component":"prow-controller-manager","controller":"plank","event-GUID":"bba62c80-03f6-11eb-86e5-e53548611fe1","file":"prow/plank/reconciler.go:455","from":"pending","func":"k8s.io/test-infra/prow/plank.(*reconciler).syncPendingJob","job":"pull-ci-kubevirt-hyperconverged-cluster-operator-release-1.2-hco-e2e-aws","level":"info","msg":"Transitioning states.","name":"bdd0d20a-03f6-11eb-8b65-0a580a800dea","org":"kubevirt","pr":852,"repo":"hyperconverged-cluster-operator","severity":"info","time":"2020-10-01T15:01:38Z","to":"error","type":"presubmit"}

This happens because:
* The abort logic deletes the pod via a callback when processing a newer
  instance of the job
* Then updates the ProwJobs status to aborted and completes it
* The pod deletion causes an event which we might start processing
  before we have the prowjob status update in our cache
* We now see that the pod is gone when the ProwJobs status is still
  pending and mark it as error

This PR changes the logic to instead simply set the prowjobs status to
aborted, without marking it as complete. Plank will then get an event,
delete the pod and mark the job as completed. This also has the added
side-effect that its more robust, if the deletion fails we retry instead
of just logging a warning as before.