### PR TITLE
Update Descheduler Master Branch Jobs To Use Go 1.15.2

### DIFF
--- a/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
+++ b/config/jobs/kubernetes-sigs/descheduler/descheduler-presubmits-master.yaml
@@ -13,7 +13,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.2
         command:
         - make
         args:
@@ -30,7 +30,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.2
         command:
         - make
         args:
@@ -47,7 +47,7 @@ presubmits:
     always_run: true
     spec:
       containers:
-      - image: golang:1.15.0
+      - image: golang:1.15.2
         command:
         - make
         args:


### PR DESCRIPTION
Required for https://github.com/kubernetes-sigs/descheduler/pull/416.