### PR TITLE
Make GenericCommentEvent synthesis aware of PR (un)locked actions.

### DIFF
--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -209,8 +209,12 @@ const (
 	PullRequestActionSynchronize PullRequestEventAction = "synchronize"
 	// PullRequestActionReadyForReview means the PR is no longer a draft PR.
 	PullRequestActionReadyForReview PullRequestEventAction = "ready_for_review"
-	// PullRequestConvertedToDraft means the PR is now a draft PR.
-	PullRequestConvertedToDraft PullRequestEventAction = "converted_to_draft"
+	// PullRequestActionConvertedToDraft means the PR is now a draft PR.
+	PullRequestActionConvertedToDraft PullRequestEventAction = "converted_to_draft"
+	// PullRequestActionLocked means labels were added.
+	PullRequestActionLocked PullRequestEventAction = "locked"
+	// PullRequestActionUnlocked means labels were removed
+	PullRequestActionUnlocked PullRequestEventAction = "unlocked"
 )
 
 // GenericEvent is a lightweight struct containing just Sender, Organization and Repo as

--- a/prow/hook/events.go
+++ b/prow/hook/events.go
@@ -58,7 +58,9 @@ var (
 		github.PullRequestActionReopened:             true,
 		github.PullRequestActionSynchronize:          true,
 		github.PullRequestActionReadyForReview:       true,
-		github.PullRequestConvertedToDraft:           true,
+		github.PullRequestActionConvertedToDraft:     true,
+		github.PullRequestActionLocked:               true,
+		github.PullRequestActionUnlocked:             true,
 	}
 )
 

--- a/prow/plugins/trigger/pull-request.go
+++ b/prow/plugins/trigger/pull-request.go
@@ -148,7 +148,7 @@ func handlePR(c Client, trigger plugins.Trigger, pr github.PullRequestEvent) err
 		}
 	case github.PullRequestActionReadyForReview:
 		return buildAllIfTrusted(c, trigger, pr, baseSHA, presubmits)
-	case github.PullRequestConvertedToDraft:
+	case github.PullRequestActionConvertedToDraft:
 		if err := abortAllJobs(c, &pr.PullRequest); err != nil {
 			c.Logger.WithError(err).Error("Failed to abort jobs for pull request converted to draft")
 			return err

--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -385,7 +385,7 @@ func TestHandlePullRequest(t *testing.T) {
 
 			Author:      "t",
 			HasOkToTest: true,
-			prAction:    github.PullRequestConvertedToDraft,
+			prAction:    github.PullRequestActionConvertedToDraft,
 			ShouldBuild: false,
 			jobToAbort:  jobToAbort,
 		},

--- a/prow/plugins/wip/wip-label.go
+++ b/prow/plugins/wip/wip-label.go
@@ -77,7 +77,7 @@ func handlePullRequest(pc plugins.Agent, pe github.PullRequestEvent) error {
 		pe.Action != github.PullRequestActionReopened &&
 		pe.Action != github.PullRequestActionEdited &&
 		pe.Action != github.PullRequestActionReadyForReview &&
-		pe.Action != github.PullRequestConvertedToDraft {
+		pe.Action != github.PullRequestActionConvertedToDraft {
 		return nil
 	}
 


### PR DESCRIPTION
> Could not coerce pull_request event to a GenericCommentEvent. Unknown 'action': "locked".

I checked the [GH API docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#pull_request) to make sure we have all the actions that exist as of now covered. That being said, those docs are incomplete (missing the `converted_to_draft` action which we know exists) so 
/shrug

/assign @chaodaiG 