### PR TITLE
Start tracking SLO for deck, hook, sinker, and the monitoring stack.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -6,12 +6,30 @@
       'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
       'slo.json': 'ea313af4b7904c7c983d20d9572235a5',
     },
+    // Component name constants
     components: {
-      tide: 'Tide'
+      // Values should be lowercase for use with prometheus 'job' label.
+      crier: 'crier',
+      deck: 'deck',
+      ghproxy: 'ghproxy',
+      hook: 'hook',
+      horologium: 'horologium',
+      monitoring: 'monitoring', // Aggregate of prometheus, alertmanager, and grafana.
+      prowControllerManager: 'prow-controller-manager',
+      sinker: 'sinker',
+      tide: 'tide',
     },
-    local components = self.components,
+    local comps = self.components,
+
+    // SLO compliance tracking config
     slo: {
-      components: [components.tide],
+      components: [
+        comps.deck,
+        comps.hook,
+        comps.sinker,
+        comps.tide,
+        comps.monitoring,
+      ],
     }
   },
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ci_absent_alerts.libsonnet
@@ -1,5 +1,6 @@
 {
   prometheusAlerts+:: {
+    local comps = $._config.components,
     groups+: [
       {
         name: 'ci-absent',
@@ -12,20 +13,21 @@
             'for': '5m',
             labels: {
               severity: 'critical',
+              slo: name,
             },
             annotations: {
               message: '@test-infra-oncall The service %s has been down for 5 minutes.' % name,
             },
           }
           for name in [
-              'crier',
-              'deck',
-              'ghproxy',
-              'hook',
-              'horologium',
-              'prow-controller-manager',
-              'sinker',
-              'tide',
+              comps.crier,
+              comps.deck,
+              comps.ghproxy,
+              comps.hook,
+              comps.horologium,
+              comps.prowControllerManager,
+              comps.sinker,
+              comps.tide,
           ]
         ],
       },

--- a/config/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -1,5 +1,6 @@
 {
   prometheusAlerts+:: {
+    local componentName = $._config.components.hook,
     groups+: [
       {
         name: 'abnormal webhook behaviors',
@@ -14,6 +15,7 @@
             'for': '10m',
             labels: {
               severity: 'high',
+              slo: componentName,
             },
             annotations: {
               message: 'There have been no webhook calls on working hours for 10 minutes',

--- a/config/prow/cluster/monitoring/mixins/prometheus/prober_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prober_alerts.libsonnet
@@ -1,31 +1,32 @@
 {
   prometheusAlerts+:: {
+    local comps = $._config.components,
     groups+: [
       {
         name: 'Blackbox Prober',
         rules: [
           {
-            alert: 'Site unavailable: %s' % target,
+            alert: 'Site unavailable: %s' % target.url,
             expr: |||
               min(probe_success{instance="%s"}) == 0
-            ||| % target,
+            ||| % target.url,
             'for': '2m', # I think this needs to be at least the scrape_interval and 2*evaluation_interval (which both default to 1m) in order to ignore individual probe failures.
             labels: {
               severity: 'critical',
-            },
+            } + target.labels,
             annotations: {
-              message: 'The blackbox_exporter HTTP probe has detected that the following site has been unhealthy (not 2xx HTTP response) for at least 2 minutes: <%s|%s>.' % [target, target],
+              message: 'The blackbox_exporter HTTP probe has detected that the following site has been unhealthy (not 2xx HTTP response) for at least 2 minutes: <%s|%s>.' % [target.url, target.url],
             },
           }
           for target in [
           # ATTENTION: Keep this in sync with the list in ../../additional-scrape-configs_secret.yaml
-            'https://prow.k8s.io',
-            'https://monitoring.prow.k8s.io',
-            'https://testgrid.k8s.io',
-            'https://gubernator.k8s.io',
-            'https://gubernator.k8s.io/pr/fejta', # Deep health check of someone's PR dashboard.
-            'https://storage.googleapis.com/k8s-gubernator/triage/index.html',
-            'https://storage.googleapis.com/test-infra-oncall/oncall.html'
+            {url: 'https://prow.k8s.io', labels: {slo: comps.deck}},
+            {url: 'https://monitoring.prow.k8s.io', labels: {slo: comps.monitoring}},
+            {url: 'https://testgrid.k8s.io', labels: {}},
+            {url: 'https://gubernator.k8s.io', labels: {}},
+            {url: 'https://gubernator.k8s.io/pr/fejta', labels: {}}, # Deep health check of someone's PR dashboard.
+            {url: 'https://storage.googleapis.com/k8s-gubernator/triage/index.html', labels: {}},
+            {url: 'https://storage.googleapis.com/test-infra-oncall/oncall.html', labels: {}},
           ]
         ],
       },

--- a/config/prow/cluster/monitoring/mixins/prometheus/prow_monitoring_absent_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prow_monitoring_absent_alerts.libsonnet
@@ -1,5 +1,6 @@
 {
   prometheusAlerts+:: {
+    local componentName = $._config.components.monitoring,
     groups+: [
       {
         name: 'prow-monitoring-absent',
@@ -11,6 +12,7 @@
           'for': '5m',
           labels: { 
             severity: 'critical',
+            slo: componentName,
           },
           annotations: {
             message: 'The service {{ $labels.job }} has at most 1 instance for 5 minutes.',
@@ -24,6 +26,7 @@
             'for': '5m',
             labels: {
               severity: 'critical',
+              slo: componentName,
             },
             annotations: {
               message: 'The service %s has been down for 5 minutes.' % name,

--- a/config/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/sinker_alerts.libsonnet
@@ -1,5 +1,6 @@
 {
   prometheusAlerts+:: {
+    local componentName = $._config.components.sinker,
     groups+: [
       {
         name: 'sinker-missing',
@@ -12,6 +13,7 @@
             'for': '5m',
             labels: {
               severity: 'high',
+              slo: componentName,
             },
             annotations: {
               message: 'Sinker has not removed any Pods in the last hour, likely indicating an outage in the service.',
@@ -25,6 +27,7 @@
             'for': '5m',
             labels: {
               severity: 'high',
+              slo: componentName,
             },
             annotations: {
               message: 'Sinker has not removed any Prow jobs in the last hour, likely indicating an outage in the service.',


### PR DESCRIPTION
This PR adds SLO tracking for components with existing alerts that identify SLO violations. In particular I used alerts with severity `high` or `critical` (the ones that route to #testing-ops) that indicate an active outage, not an impending outage.

I chose to use a single combined SLO compliance metric for `grafana`, `prometheus`, and `alertmanager` because these are the constituent components of the monitoring stack and we don't really need to track their SLO as granularly (these components are pretty stable and we don't own their source code). Since we do have uptime, availability, and blackbox prober alerts for the monitoring stack I thought we mind as well track SLO for it, but I don't want to crowd the SLO dashboard. I'm happy to change this if people feel otherwise.

I did not configure SLO to be recorded for components that currently only have uptime alerts. It seems more appropriate to wait until after adding more precise alerts for those components. 

/cc @alvaroaleman @stevekuznetsov