### PR TITLE
Revert "Crier github reporter: Don't block workers waiting for lock"

### DIFF
--- a/prow/crier/reporters/github/BUILD.bazel
+++ b/prow/crier/reporters/github/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//prow/github/report:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
-        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 
@@ -39,10 +38,7 @@ go_test(
         "//prow/config:go_default_library",
         "//prow/gerrit/client:go_default_library",
         "//prow/github/fakegithub:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",
-        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )

--- a/prow/crier/reporters/github/reporter.go
+++ b/prow/crier/reporters/github/reporter.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
@@ -55,36 +54,34 @@ type simplePull struct {
 
 type shardedLock struct {
 	mapLock *sync.Mutex
-	locks   map[simplePull]*semaphore.Weighted
+	locks   map[simplePull]*sync.Mutex
 }
 
-func (s *shardedLock) getLock(key simplePull) *semaphore.Weighted {
+func (s *shardedLock) getLock(key simplePull) *sync.Mutex {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()
 	if _, exists := s.locks[key]; !exists {
-		s.locks[key] = semaphore.NewWeighted(1)
+		s.locks[key] = &sync.Mutex{}
 	}
 	return s.locks[key]
 }
 
 // cleanup deletes all locks by acquiring first
-// the mapLock and then the individual lock via TryAcquire.
-// The latter is required, otherwise the lock might be held,
-// deleted by us and then recreated, resulting in two routines
-// having it in parallel.
-// Because running this function requires acquiring the mapLock,
-// no new presubmit reporting can happen. To minimize lock contention,
-// we use TryAcquire and skip locks we didn't acquire.
+// the mapLock and then each individual lock before
+// deleting it. The individual lock must be acquired
+// because otherwise it may be held, we delete it from
+// the map, it gets recreated and acquired and two
+// routines report in parallel for the same job.
+// Note that while this function is running, no new
+// presubmit reporting can happen, as we hold the mapLock.
 func (s *shardedLock) cleanup() {
 	s.mapLock.Lock()
 	defer s.mapLock.Unlock()
 
 	for key, lock := range s.locks {
-		if !lock.TryAcquire(1) {
-			continue
-		}
+		lock.Lock()
 		delete(s.locks, key)
-		lock.Release(1)
+		lock.Unlock()
 	}
 }
 
@@ -108,7 +105,7 @@ func NewReporter(gc report.GitHubClient, cfg config.Getter, reportAgent v1.ProwJ
 		reportAgent: reportAgent,
 		prLocks: &shardedLock{
 			mapLock: &sync.Mutex{},
-			locks:   map[simplePull]*semaphore.Weighted{},
+			locks:   map[simplePull]*sync.Mutex{},
 		},
 	}
 	c.prLocks.runCleanup()
@@ -147,11 +144,8 @@ func (c *Client) Report(_ *logrus.Entry, pj *v1.ProwJob) ([]*v1.ProwJob, *reconc
 			return nil, nil, fmt.Errorf("failed to get lockkey for job: %v", err)
 		}
 		lock := c.prLocks.getLock(*key)
-		// Don't block a worker waiting for the lock, they are limited.
-		if !lock.TryAcquire(1) {
-			return nil, &reconcile.Result{RequeueAfter: 5 * time.Second}, nil
-		}
-		defer lock.Release(1)
+		lock.Lock()
+		defer lock.Unlock()
 	}
 
 	// TODO(krzyzacy): ditch ReportTemplate, and we can drop reference to config.Getter

--- a/prow/crier/reporters/github/reporter_test.go
+++ b/prow/crier/reporters/github/reporter_test.go
@@ -20,15 +20,11 @@ import (
 	"errors"
 	"sync"
 	"testing"
-	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/semaphore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	prowv1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	v1 "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/config"
 	"k8s.io/test-infra/prow/gerrit/client"
 	"k8s.io/test-infra/prow/github/fakegithub"
@@ -37,15 +33,15 @@ import (
 func TestShouldReport(t *testing.T) {
 	var testcases = []struct {
 		name        string
-		pj          prowv1.ProwJob
+		pj          v1.ProwJob
 		report      bool
-		reportAgent prowv1.ProwJobAgent
+		reportAgent v1.ProwJobAgent
 	}{
 		{
 			name: "should not report periodic job",
-			pj: prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.PeriodicJob,
+			pj: v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PeriodicJob,
 					Report: true,
 				},
 			},
@@ -53,9 +49,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should report postsubmit job",
-			pj: prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.PostsubmitJob,
+			pj: v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PostsubmitJob,
 					Report: true,
 				},
 			},
@@ -63,9 +59,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should not report batch job",
-			pj: prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.BatchJob,
+			pj: v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.BatchJob,
 					Report: true,
 				},
 			},
@@ -73,9 +69,9 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "should report presubmit job",
-			pj: prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.PresubmitJob,
+			pj: v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PresubmitJob,
 					Report: true,
 				},
 			},
@@ -83,14 +79,14 @@ func TestShouldReport(t *testing.T) {
 		},
 		{
 			name: "github should not report gerrit jobs",
-			pj: prowv1.ProwJob{
+			pj: v1.ProwJob{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						client.GerritReportLabel: "plus-one-this-gerrit-label-please",
 					},
 				},
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.PresubmitJob,
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PresubmitJob,
 					Report: true,
 				},
 			},
@@ -123,26 +119,26 @@ func TestPresumitReportingLocks(t *testing.T) {
 			return &config.Config{
 				ProwConfig: config.ProwConfig{
 					GitHubReporter: config.GitHubReporter{
-						JobTypesToReport: []prowv1.ProwJobType{prowv1.PresubmitJob},
+						JobTypesToReport: []v1.ProwJobType{v1.PresubmitJob},
 					},
 				},
 			}
 		},
-		prowv1.ProwJobAgent(""),
+		v1.ProwJobAgent(""),
 	)
 
-	pj := &prowv1.ProwJob{
-		Spec: prowv1.ProwJobSpec{
-			Refs: &prowv1.Refs{
+	pj := &v1.ProwJob{
+		Spec: v1.ProwJobSpec{
+			Refs: &v1.Refs{
 				Org:   "org",
 				Repo:  "repo",
-				Pulls: []prowv1.Pull{{Number: 1}},
+				Pulls: []v1.Pull{{Number: 1}},
 			},
-			Type:   prowv1.PresubmitJob,
+			Type:   v1.PresubmitJob,
 			Report: true,
 		},
-		Status: prowv1.ProwJobStatus{
-			State:          prowv1.ErrorState,
+		Status: v1.ProwJobStatus{
+			State:          v1.ErrorState,
 			CompletionTime: &metav1.Time{},
 		},
 	}
@@ -167,9 +163,9 @@ func TestPresumitReportingLocks(t *testing.T) {
 
 func TestShardedLockCleanup(t *testing.T) {
 	t.Parallel()
-	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{}}
+	sl := &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*sync.Mutex{}}
 	key := simplePull{"org", "repo", 1}
-	sl.locks[key] = semaphore.NewWeighted(1)
+	sl.locks[key] = &sync.Mutex{}
 	sl.cleanup()
 	if _, exists := sl.locks[key]; exists {
 		t.Error("lock didn't get cleaned up")
@@ -180,17 +176,12 @@ func TestShardedLockCleanup(t *testing.T) {
 func TestReport(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
-		name                  string
-		jobType               prowv1.ProwJobType
-		locks                 *shardedLock
-		githubError           error
-		expectedError         string
-		expectReport          bool
-		expectReconcileResult *reconcile.Result
+		name          string
+		githubError   error
+		expectedError string
 	}{
 		{
-			name:         "Success",
-			expectReport: true,
+			name: "Success",
 		},
 		{
 			name:        "Maximum sha error gets swallowed",
@@ -201,74 +192,41 @@ func TestReport(t *testing.T) {
 			githubError:   errors.New("something went wrong :("),
 			expectedError: "error setting status: something went wrong :(",
 		},
-		{
-			name:                  "Presubmit that is currently locked doesn't report, doesn't block and returns with RequeueAfter",
-			jobType:               prowv1.PresubmitJob,
-			locks:                 &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{{}: semaphore.NewWeighted(0)}},
-			expectReconcileResult: &reconcile.Result{RequeueAfter: 5 * time.Second},
-			expectReport:          false,
-		},
-		{
-			name:         "Presubmit that is currently unlocked reports",
-			jobType:      prowv1.PresubmitJob,
-			locks:        &shardedLock{mapLock: &sync.Mutex{}, locks: map[simplePull]*semaphore.Weighted{{}: semaphore.NewWeighted(1)}},
-			expectReport: true,
-		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			githubClient := &fakegithub.FakeClient{Error: tc.githubError}
 			c := Client{
-				gc: githubClient,
+				gc: &fakegithub.FakeClient{Error: tc.githubError},
 				config: func() *config.Config {
 					return &config.Config{
 						ProwConfig: config.ProwConfig{
 							GitHubReporter: config.GitHubReporter{
-								JobTypesToReport: []prowv1.ProwJobType{prowv1.PostsubmitJob, prowv1.PresubmitJob},
+								JobTypesToReport: []v1.ProwJobType{v1.PostsubmitJob},
 							},
 						},
 					}
 				},
-				prLocks: tc.locks,
 			}
-			pj := &prowv1.ProwJob{
-				Spec: prowv1.ProwJobSpec{
-					Type:   prowv1.PostsubmitJob,
+			pj := &v1.ProwJob{
+				Spec: v1.ProwJobSpec{
+					Type:   v1.PostsubmitJob,
 					Report: true,
-					Refs:   &prowv1.Refs{},
+					Refs:   &v1.Refs{},
 				},
-				Status: prowv1.ProwJobStatus{
-					State: prowv1.SuccessState,
+				Status: v1.ProwJobStatus{
+					State: v1.SuccessState,
 				},
-			}
-			if tc.jobType != "" {
-				pj.Spec.Type = tc.jobType
-			}
-			if pj.Spec.Type == prowv1.PresubmitJob {
-				pj.Spec.Refs.Pulls = []prowv1.Pull{{}}
 			}
 
 			errMsg := ""
-			_, reconcileResult, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
+			_, _, err := c.Report(logrus.NewEntry(logrus.StandardLogger()), pj)
 			if err != nil {
 				errMsg = err.Error()
 			}
 			if errMsg != tc.expectedError {
 				t.Errorf("expected error %q got error %q", tc.expectedError, errMsg)
 			}
-			if err != nil {
-				return
-			}
-
-			if diff := cmp.Diff(reconcileResult, tc.expectReconcileResult); diff != "" {
-				t.Errorf("received reconcileResult differs from expected: %s", diff)
-			}
-
-			if reported := len(githubClient.CreatedStatuses) > 0; reported != tc.expectReport {
-				t.Errorf("did report: %t, expected report: %t", reported, tc.expectReport)
-			}
-
 		})
 	}
 }


### PR DESCRIPTION
This reverts commit f117cc57af3ed430c57681279d901ace1190d179.

With this change I tried to be smart and to optimize the usage of the
available worker by not blocking them when waiting for a presubmit lock
but instead just try to acquire it and if that is not successful, try
again five seconds later.

However it turns out that this introduces a very noticeable delay in
reporting on repositories with many presubmits.

Since on the other hand the overhead of an idling goroutine or a
goroutine that waits for a lock is absolutely minimal, the better
approach to cope with with too many blocked workers is to simply
configure a higher number of them.