### PR TITLE
Kettle add option to limit number of builds pulled

### DIFF
--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -81,7 +81,13 @@ class GCSClient:
         return self._request('%s/o/%s' % (bucket, urllib.parse.quote(path, '')),
                              {'alt': 'media'}, as_json=as_json)
 
-    def ls(self, path, dirs=True, files=True, delim=True, item_field='name'):
+    def ls(self,
+           path,
+           dirs=True,
+           files=True,
+           delim=True,
+           item_field='name',
+           build_limit=sys.maxsize,):
         """Lists objects under a path on gcs."""
         # pylint: disable=invalid-name
 
@@ -93,16 +99,19 @@ class GCSClient:
                 params['fields'] += ',prefixes'
         if files:
             params['fields'] += ',items(%s)' % item_field
-        while True:
+        while build_limit > 0:
             resp = self._request('%s/o' % bucket, params)
             if resp is None:  # nothing under path?
                 return
             for prefix in resp.get('prefixes', []):
+                build_limit -= 1
                 yield 'gs://%s/%s' % (bucket, prefix)
             for item in resp.get('items', []):
                 if item_field == 'name':
+                    build_limit -= 1
                     yield 'gs://%s/%s' % (bucket, item['name'])
                 else:
+                    build_limit -= 1
                     yield item[item_field]
             if 'nextPageToken' not in resp:
                 break
@@ -131,7 +140,7 @@ class GCSClient:
         for job_path in self.ls_dirs(self.jobs_dir):
             yield os.path.basename(os.path.dirname(job_path))
 
-    def _get_builds(self, job):
+    def _get_builds(self, job, build_limit=sys.maxsize):
         '''Returns whether builds are precise (guarantees existence)'''
         if self.metadata.get('sequential', True):
             try:
@@ -140,12 +149,12 @@ class GCSClient:
             except (ValueError, TypeError):
                 pass
             else:
-                return False, (str(n) for n in range(latest_build, 0, -1))
+                return False, (str(n) for n in range(latest_build, 0, -1)[:build_limit])
         # Invalid latest-build or bucket is using timestamps
         build_paths = self.ls_dirs('%s%s/' % (self.jobs_dir, job))
         return True, sorted(
             (os.path.basename(os.path.dirname(b)) for b in build_paths),
-            key=pad_numbers, reverse=True)
+            key=pad_numbers, reverse=True)[:build_limit]
 
     def get_started_finished(self, job, build):
         if self.metadata.get('pr'):
@@ -156,10 +165,10 @@ class GCSClient:
         finished = self.get('%s/finished.json' % build_dir, as_json=True)
         return build_dir, started, finished
 
-    def get_builds(self, builds_have):
+    def get_builds(self, builds_have, build_limit=sys.maxsize):
         """Generates all (job, build) pairs ever."""
         if self.metadata.get('pr'):
-            files = self.ls(self.jobs_dir + '/directory/', delim=False)
+            files = self.ls(self.jobs_dir + '/directory/', delim=False, build_limit=build_limit)
             for fname in files:
                 if fname.endswith('.txt') and 'latest-build' not in fname:
                     job, build = fname[:-4].split('/')[-2:]
@@ -171,7 +180,7 @@ class GCSClient:
             if job in self.metadata.get('exclude_jobs', []):
                 continue
             have = 0
-            precise, builds = self._get_builds(job)
+            precise, builds = self._get_builds(job, build_limit)
             for build in builds:
                 if (job, build) in builds_have:
                     have += 1
@@ -211,7 +220,7 @@ def get_junits(build_info):
         raise
 
 
-def get_builds(db, jobs_dir, metadata, threads, client_class):
+def get_builds(db, jobs_dir, metadata, threads, client_class, build_limit):
     """
     Adds information about tests to a dictionary.
 
@@ -230,7 +239,7 @@ def get_builds(db, jobs_dir, metadata, threads, client_class):
     print('already have %d builds' % len(builds_have))
     sys.stdout.flush()
 
-    jobs_and_builds = gcs.get_builds(builds_have)
+    jobs_and_builds = gcs.get_builds(builds_have, build_limit)
     pool = None
     if threads > 1:
         pool = multiprocessing.Pool(threads, mp_init_worker,
@@ -305,14 +314,14 @@ def download_junit(db, threads, client_class):
         pool.join()
 
 
-def main(db, jobs_dirs, threads, get_junit, client_class=GCSClient):
+def main(db, jobs_dirs, threads, get_junit, build_limit, client_class=GCSClient):
     """Collect test info in matching jobs."""
     get_builds(db, 'gs://kubernetes-jenkins/pr-logs', {'pr': True},
-               threads, client_class)
+               threads, client_class, build_limit)
     for bucket, metadata in jobs_dirs.items():
         if not bucket.endswith('/'):
             bucket += '/'
-        get_builds(db, bucket, metadata, threads, client_class)
+        get_builds(db, bucket, metadata, threads, client_class, build_limit)
     if get_junit:
         download_junit(db, threads, client_class)
 
@@ -336,12 +345,22 @@ def get_options(argv):
         action='store_true',
         help='Download JUnit results from each build'
     )
+    parser.add_argument(
+        '--buildlimit',
+        help='maximum number of runs within each job to pull, \
+         all jobs will be collected if unset or 0',
+        default=sys.maxsize,
+        type=int,
+    )
     return parser.parse_args(argv)
 
 
 if __name__ == '__main__':
     OPTIONS = get_options(sys.argv[1:])
-    main(model.Database(),
-         yaml.safe_load(open(OPTIONS.buckets)),
-         OPTIONS.threads,
-         OPTIONS.junit)
+    main(
+        model.Database(),
+        yaml.safe_load(open(OPTIONS.buckets)),
+        OPTIONS.threads,
+        OPTIONS.junit,
+        OPTIONS.buildlimit,
+        )

--- a/kettle/make_db_test.py
+++ b/kettle/make_db_test.py
@@ -17,6 +17,7 @@
 """Tests for make_db."""
 
 import time
+import sys
 import unittest
 
 import make_db
@@ -97,6 +98,12 @@ class GCSClientTest(unittest.TestCase):
         self.assertFalse(precise)
         self.assertEqual(['4', '3', '2', '1'], list(gen))
 
+    def test_get_builds_limit(self):
+        # optimization: does a range based on build-latest.txt
+        precise, gen = self.client._get_builds('latest', build_limit=2)
+        self.assertFalse(precise)
+        self.assertEqual(['4', '3'], list(gen))
+
     def test_get_builds_latest_fallback(self):
         # fallback: still lists a directory when build-latest.txt isn't an int
         self.assertEqual((True, ['6']), self.client._get_builds('bad-latest'))
@@ -144,7 +151,7 @@ class MainTest(unittest.TestCase):
             expected = self.get_expected_builds()
         if db is None:
             db = model.Database(':memory:')
-        make_db.main(db, {self.JOBS_DIR: {}}, threads, True, client)
+        make_db.main(db, {self.JOBS_DIR: {}}, threads, True, sys.maxsize, client)
 
         result = {path: (started, finished, db.test_results_for_build(path))
                   for _rowid, path, started, finished in db.get_builds()}


### PR DESCRIPTION
This will be primarily used for staging to make the process faster and to limit the space used on the staging deployment

/area kettle
