### PR TITLE
Do not return early on get-kube.sh errors in extract_k8s.go

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -299,14 +299,11 @@ var getKube = func(url, version string, getSrc bool) error {
 			break
 		}
 		err = fmt.Errorf("U=%s R=%s get-kube.sh failed: %v", url, version, err)
-		if i == 2 {
-			return err
-		}
 		log.Println(err)
 		sleep(time.Duration(i) * time.Second)
 	}
 
-	return nil
+	return err
 }
 
 // wrapper for gsutil cat


### PR DESCRIPTION
Eliminates check that returns early after 3 get-kube.sh errors in order
to actually attempt to run all 5 times.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to #19394 
xref #19386 

/cc @kubernetes/ci-signal
