### PR TITLE
Sync OWNERS_ALIASES for release engineering

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -210,18 +210,18 @@ aliases:
 
   # copied from git.k8s.io/kubernetes/OWNERS_ALIASES
   release-engineering-approvers:
-    - calebamiles # subproject owner
-    - justaugustus # subproject owner / Release Manager
-    - tpepper # subproject owner / Release Manager
+    - alejandrox1 # SIG Technical Lead
+    - justaugustus # SIG Chair
+    - saschagrunert # SIG Technical Lead
+    - tpepper # SIG Chair
   release-engineering-reviewers:
-    - calebamiles # subproject owner
-    - cpanato # Release Manager
-    - feiskyer # Release Manager
-    - hasheddan # Release Manager
-    - hoegaarden # Release Manager
-    - justaugustus # subproject owner / Release Manager
-    - saschagrunert # Release Manager
-    - tpepper # subproject owner / Release Manager
+    - cpanato # Branch Manager
+    - feiskyer # Patch Release Team
+    - hasheddan # Branch Manager
+    - hoegaarden # Patch Release Team
+    - justaugustus # SIG Chair
+    - saschagrunert # Branch Manager
+    - tpepper # SIG Chair / Patch Release Team
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES
   enhancements-approvers:


### PR DESCRIPTION
This fixes the outdated `OWNERS_ALIASES` for SIG Release in the Release
Engineering subproject.

cc @kubernetes/release-engineering 