### PR TITLE
Fix checkconfig cluster test to tolerate defaulted cluster field

### DIFF
--- a/prow/cmd/checkconfig/BUILD.bazel
+++ b/prow/cmd/checkconfig/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//prow/flagutil:go_default_library",
         "//prow/github:go_default_library",
         "//prow/hook/plugin-imports:go_default_library",
+        "//prow/kube:go_default_library",
         "//prow/labels:go_default_library",
         "//prow/logrusutil:go_default_library",
         "//prow/plugins:go_default_library",

--- a/prow/cmd/checkconfig/main.go
+++ b/prow/cmd/checkconfig/main.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/test-infra/prow/flagutil"
 	"k8s.io/test-infra/prow/github"
 	_ "k8s.io/test-infra/prow/hook/plugin-imports"
+	"k8s.io/test-infra/prow/kube"
 	"k8s.io/test-infra/prow/labels"
 	"k8s.io/test-infra/prow/logrusutil"
 	"k8s.io/test-infra/prow/plugins"
@@ -1070,7 +1071,7 @@ func validateTideContextPolicy(cfg *config.Config) error {
 var agentsNotSupportingCluster = sets.NewString("jenkins")
 
 func validateJobCluster(job config.JobBase) error {
-	if job.Cluster != "" && agentsNotSupportingCluster.Has(job.Agent) {
+	if job.Cluster != "" && job.Cluster != kube.DefaultClusterAlias && agentsNotSupportingCluster.Has(job.Agent) {
 		return fmt.Errorf("%s: cannot set cluster field if agent is %s", job.Name, job.Agent)
 	}
 	return nil

--- a/prow/cmd/checkconfig/main_test.go
+++ b/prow/cmd/checkconfig/main_test.go
@@ -1501,7 +1501,7 @@ func TestValidateClusterField(t *testing.T) {
 		expectedError string
 	}{
 		{
-			name: "valid case for a jenkins job",
+			name: "Jenkins job with unset cluster",
 			cfg: &config.Config{
 				JobConfig: config.JobConfig{
 					PresubmitsStatic: map[string][]config.Presubmit{
@@ -1509,6 +1509,20 @@ func TestValidateClusterField(t *testing.T) {
 							{
 								JobBase: config.JobBase{
 									Agent: "jenkins",
+								},
+							}}}}},
+		},
+		{
+			name: "jenkins job with defaulted cluster",
+			cfg: &config.Config{
+				JobConfig: config.JobConfig{
+					PresubmitsStatic: map[string][]config.Presubmit{
+						"org1/repo1": {
+							{
+								JobBase: config.JobBase{
+									Agent:   "jenkins",
+									Cluster: "default",
+									Name:    "some-job",
 								},
 							}}}}},
 		},
@@ -1521,7 +1535,7 @@ func TestValidateClusterField(t *testing.T) {
 							{
 								JobBase: config.JobBase{
 									Agent:   "jenkins",
-									Cluster: "default",
+									Cluster: "build1",
 									Name:    "some-job",
 								},
 							}}}}},


### PR DESCRIPTION
Currently we fail if a jenkins job has the cluster field set to
anything, however we check a config after it got defaulted and the
defaulting sets the cluster to "default", meaning this check will always
fail for jenkins type jobs.