### PR TITLE
Add a checkconfig ci job to use as a heartbeat for alerts.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -24,6 +24,37 @@ periodics:
     testgrid-tab-name: ci-bazel
     description: Runs bazel test //... on the test-infra repo every hour
 
+# This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
+# Alerts expect it to run every 10 mins and will fire after 20 mins without a successful run.
+# Please keep this in sync with the `pull-test-infra-prow-checkconfig` job
+- name: ci-test-infra-prow-checkconfig
+  interval: 10m
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/checkconfig:v20201006-e090651f0c
+      command:
+      - /checkconfig
+      args:
+      - --config-path=config/prow/config.yaml
+      - --job-config-path=config/jobs
+      - --plugin-config=config/prow/plugins.yaml
+      - --strict
+      - --warnings=mismatched-tide-lenient
+      - --warnings=tide-strict-branch
+      - --warnings=needs-ok-to-test
+      - --warnings=validate-owners
+      - --warnings=missing-trigger
+      - --warnings=validate-urls
+      - --warnings=unknown-fields
+      - --warnings=duplicate-job-refs
+  annotations:
+    testgrid-dashboards: sig-testing-misc
+
 - name: ci-test-infra-triage
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -73,6 +73,7 @@ presubmits:
       testgrid-dashboards: presubmits-test-infra
       testgrid-tab-name: verify-yaml
 
+  # Please keep this in sync with the `ci-test-infra-prow-checkconfig` job
   - name: pull-test-infra-prow-checkconfig
     decorate: true
     run_if_changed: '^(config/prow/(config|plugins).yaml$|config/jobs/.*.yaml$)'


### PR DESCRIPTION
The intention is to run this job every 10mins and alert if we don't see at least 1 successful completion in the past 20mins. This will notify us if horologium, plank, or clonerefs are not working.

/assign @chases2 @e-blackwelder 