### PR TITLE
Add an alert to detect missing successful results from heartbeat jobs.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -25,10 +25,10 @@ periodics:
     description: Runs bazel test //... on the test-infra repo every hour
 
 # This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
-# Alerts expect it to run every 10 mins and will fire after 20 mins without a successful run.
+# Alerts expect it to run every 9 mins and will fire after 20 mins without a successful run.
 # Please keep this in sync with the `pull-test-infra-prow-checkconfig` job
 - name: ci-test-infra-prow-checkconfig
-  interval: 10m
+  interval: 9m
   decorate: true
   extra_refs:
   - org: kubernetes

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -36,7 +36,7 @@
 
     // Heartbeat jobs
     heartbeatJobs: [
-      {name: 'ci-test-infra-prow-checkconfig', interval: '10m', alertInterval: '20m'},
+      {name: 'ci-test-infra-prow-checkconfig', interval: '9m', alertInterval: '20m'},
     ],
   },
 }

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -15,6 +15,7 @@
       hook: 'hook',
       horologium: 'horologium',
       monitoring: 'monitoring', // Aggregate of prometheus, alertmanager, and grafana.
+      plank: 'plank',
       prowControllerManager: 'prow-controller-manager',
       sinker: 'sinker',
       tide: 'tide',
@@ -26,10 +27,16 @@
       components: [
         comps.deck,
         comps.hook,
+        comps.plank,
         comps.sinker,
         comps.tide,
         comps.monitoring,
       ],
-    }
+    },
+
+    // Heartbeat jobs
+    heartbeatJobs: [
+      {name: 'ci-test-infra-prow-checkconfig', interval: '10m', alertInterval: '20m'},
+    ],
   },
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/plank_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/plank_alerts.libsonnet
@@ -1,0 +1,35 @@
+{
+  prometheusAlerts+:: {
+    local componentName = $._config.components.plank,
+    groups+: [
+      {
+        name: 'Heartbeat ProwJobs',
+        # To add more heartbeat PJs add entries to `heartbeatJobs` in config.libsonnet
+        # NOTE: These alerts are associated with plank, but may be
+        #       triggered by problems with horologium or the pod utils.
+        rules: [
+          {
+            alert: 'No recent successful runs: `%s`' % job.name,
+
+            # This query counts the number of PJs with the specified name that
+            # transitioned to the success state in the last job.alertInterval
+            # amount of time. If that number is < 1 we return a result causing
+            # the alert to fire. (We use 0.5 instead of 1 because query
+            # results are not precise integers due to how prometheus interpolates.)
+            expr: |||
+              increase(prowjob_state_transitions{job_name="%s", state="success"}[%s]) < 0.5
+            ||| % [job.name, job.alertInterval],
+            labels: {
+              severity: 'critical',
+              slo: componentName,
+            },
+            annotations: {
+              message: '@test-infra-oncall The heartbeat job `%s` has not had a successful run in the past %s (should run every %s).' % [job.name, job.alertInterval, job.interval],
+            },
+          }
+          for job in $._config.heartbeatJobs
+        ],
+      },
+    ],
+  },
+}

--- a/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/prometheus.libsonnet
@@ -8,4 +8,5 @@
 (import 'tide_alerts.libsonnet') +
 (import 'prober_alerts.libsonnet') +
 (import 'boskos_alerts.libsonnet') +
+(import 'plank_alerts.libsonnet') +
 (import 'slo_recordrules.libsonnet')


### PR DESCRIPTION
/hold
Holding as this is a follow up to https://github.com/kubernetes/test-infra/pull/19470 (The first commit is from that PR)