### PR TITLE
Rename seccomp-operator to security-profiles-operator

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -1,6 +1,6 @@
 postsubmits:
-  kubernetes-sigs/seccomp-operator:
-    - name: post-seccomp-operator-push-image
+  kubernetes-sigs/security-profiles-operator:
+    - name: post-security-profiles-operator-push-image
       cluster: k8s-infra-prow-build-trusted
       decorate: true
       always_run: true
@@ -13,8 +13,8 @@ postsubmits:
             command:
               - /run.sh
             args:
-              - --project=k8s-staging-seccomp-operator
-              - --scratch-bucket=gs://k8s-staging-seccomp-operator-gcb
+              - --project=k8s-staging-security-profiles-operator
+              - --scratch-bucket=gs://k8s-staging-security-profiles-operator-gcb
               - .
             env:
               - name: LOG_TO_STDOUT

--- a/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/seccomp-operator/seccomp-operator-presubmits.yaml
@@ -1,6 +1,6 @@
 presubmits:
-  kubernetes-sigs/seccomp-operator:
-  - name: pull-seccomp-operator-build
+  kubernetes-sigs/security-profiles-operator:
+  - name: pull-security-profiles-operator-build
     always_run: true
     decorate: true
     annotations:
@@ -10,9 +10,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - hack/pull-seccomp-operator-build
+        - hack/pull-security-profiles-operator-build
 
-  - name: pull-seccomp-operator-verify
+  - name: pull-security-profiles-operator-verify
     always_run: true
     decorate: true
     annotations:
@@ -22,9 +22,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - hack/pull-seccomp-operator-verify
+        - hack/pull-security-profiles-operator-verify
 
-  - name: pull-seccomp-operator-test-unit
+  - name: pull-security-profiles-operator-test-unit
     always_run: true
     decorate: true
     annotations:
@@ -34,9 +34,9 @@ presubmits:
       containers:
       - image: golang:1.15
         command:
-        - hack/pull-seccomp-operator-test-unit
+        - hack/pull-security-profiles-operator-test-unit
 
-  - name: pull-seccomp-operator-build-image
+  - name: pull-security-profiles-operator-build-image
     always_run: true
     decorate: true
     annotations:
@@ -58,9 +58,9 @@ presubmits:
         command:
         - runner.sh
         args:
-        - hack/pull-seccomp-operator-build-image
+        - hack/pull-security-profiles-operator-build-image
 
-  - name: pull-seccomp-operator-test-e2e
+  - name: pull-security-profiles-operator-test-e2e
     always_run: true
     decorate: true
     annotations:
@@ -83,4 +83,4 @@ presubmits:
         command:
         - runner.sh
         args:
-        - hack/pull-seccomp-operator-test-e2e
+        - hack/pull-security-profiles-operator-test-e2e

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -540,7 +540,7 @@ tide:
     kubernetes-sigs/krew-index: squash
     kubernetes-sigs/krew: squash
     kubernetes-sigs/kubespray: squash
-    kubernetes-sigs/seccomp-operator: rebase
+    kubernetes-sigs/security-profiles-operator: rebase
     kubernetes-sigs/service-catalog: squash
     kubernetes-sigs/go-open-service-broker-client: squash
     kubernetes-sigs/minibroker: squash
@@ -801,4 +801,3 @@ presets:
 - env:
   - name: GOPROXY
     value: "https://proxy.golang.org"
-

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -929,7 +929,7 @@ plugins:
   kubernetes-sigs/contributor-playground:
   - require-matching-label
 
-  kubernetes-sigs/seccomp-operator:
+  kubernetes-sigs/security-profiles-operator:
   - release-note
 
   containerd/cri:

--- a/config/testgrids/kubernetes/sig-node/config.yaml
+++ b/config/testgrids/kubernetes/sig-node/config.yaml
@@ -14,7 +14,7 @@ dashboard_groups:
     - sig-node-docker
     - sig-node-node-feature-discovery
     - sig-node-node-problem-detector
-    - sig-node-seccomp-operator
+    - sig-node-security-profiles-operator
 
 
 dashboards:
@@ -130,25 +130,25 @@ dashboards:
 
 - name: sig-node-node-problem-detector
 
-- name: sig-node-seccomp-operator
+- name: sig-node-security-profiles-operator
   dashboard_tab:
   - name: build
-    test_group_name: pull-seccomp-operator-build
+    test_group_name: pull-security-profiles-operator-build
     base_options: width=10
   - name: build-image
-    test_group_name: pull-seccomp-operator-build-image
+    test_group_name: pull-security-profiles-operator-build-image
     base_options: width=10
   - name: verify
-    test_group_name: pull-seccomp-operator-verify
+    test_group_name: pull-security-profiles-operator-verify
     base_options: width=10
   - name: test-unit
-    test_group_name: pull-seccomp-operator-test-unit
+    test_group_name: pull-security-profiles-operator-test-unit
     base_options: width=10
   - name: test-e2e
-    test_group_name: pull-seccomp-operator-test-e2e
+    test_group_name: pull-security-profiles-operator-test-e2e
     base_options: width=10
   - name: push-image
-    test_group_name: post-seccomp-operator-push-image
+    test_group_name: post-security-profiles-operator-push-image
     base_options: width=10
 
 test_groups:


### PR DESCRIPTION
Renaming the operator to it's new proposed name.

Refers to https://github.com/kubernetes/org/issues/2177