### PR TITLE
config/prow: enable needs-triage for issues in k/kubectl

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -532,6 +532,17 @@ require_matching_label:
     SIG Docs takes a lead on issue triage for this website, but any Kubernetes member can accept issues by applying the `triage/accepted` label.
 
     The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
+- missing_label: needs-triage
+  org: kubernetes
+  repo: kubectl
+  issues: true
+  regexp: ^triage/accepted$
+  missing_comment: |
+    This issue is currently awaiting triage.
+
+    SIG CLI takes a lead on issue triage for this repo, but any Kubernetes member can accept issues by applying the `triage/accepted` label.
+
+    The `triage/accepted` label can be added by org members by writing `/triage accepted` in a comment.
 - missing_label: needs-sig
   org: kubernetes
   repo: community


### PR DESCRIPTION
@eddiezane requested for this in the contribex meeting today.

/assign @soltysh @eddiezane 
/sig cli
