### PR TITLE
Omit empty override plugin config.

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -87,7 +87,7 @@ type Configuration struct {
 	Size                       Size                         `json:"size,omitempty"`
 	Triggers                   []Trigger                    `json:"triggers,omitempty"`
 	Welcome                    []Welcome                    `json:"welcome,omitempty"`
-	Override                   Override                     `json:"override"`
+	Override                   Override                     `json:"override,omitempty"`
 }
 
 // Golint holds configuration for the golint plugin


### PR DESCRIPTION
Without this we unintentionally include `override: {}` in plugin config help information. 
e.g. 
<img width="533" alt="Screen Shot 2020-10-07 at 10 34 55 AM" src="https://user-images.githubusercontent.com/5334145/95366813-cb0af700-0888-11eb-9f5a-a36068ee2f93.png">


/assign @matthyx 