### PR TITLE
add rerun_auth_config for csi-secrets-store postsubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -295,6 +295,10 @@ postsubmits:
       testgrid-tab-name: secrets-store-csi-driver-e2e-vault-postsubmit
       description: "Run e2e test with vault provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
+    rerun_auth_config:
+      github_users:
+      - aramase
+      - ritazh
   - name: secrets-store-csi-driver-e2e-azure-postsubmit
     decorate: true
     decoration_config:
@@ -330,6 +334,10 @@ postsubmits:
       testgrid-tab-name: secrets-store-csi-driver-e2e-azure-postsubmit
       description: "Run e2e test with azure provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
+    rerun_auth_config:
+      github_users:
+      - aramase
+      - ritazh
   - name: secrets-store-csi-driver-e2e-gcp-postsubmit
     decorate: true
     decoration_config:
@@ -365,3 +373,7 @@ postsubmits:
       testgrid-tab-name: secrets-store-csi-driver-e2e-gcp-postsubmit
       description: "Run e2e test with gcp provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'
+    rerun_auth_config:
+      github_users:
+      - aramase
+      - ritazh


### PR DESCRIPTION
Adding `rerun_auth_config` for `secrets-store-csi-driver` postsubmit job . This allows users in the list to rerun failed postsubmit jobs.