### PR TITLE
create ci-kubernetes-build-fast canary job to validate job running in the cluster

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -103,6 +103,44 @@ periodics:
     testgrid-alert-email: release-team@kubernetes.io
     description: 'Ends up running: make quick-release'
 
+- interval: 5m
+  name: ci-kubernetes-build-fast-canary
+  cluster: k8s-infra-prow-build
+  labels:
+    preset-service-account: "true"
+    preset-dind-enabled: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/bootstrap:v20200924-7fcf543
+      args:
+      - --repo=k8s.io/kubernetes
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=40
+      - --scenario=kubernetes_build
+      - --
+      - --allow-dup
+      - --fast
+      - --release=k8s-release-dev/ci-canary
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        limits:
+          cpu: 6
+          memory: "12Gi"
+        requests:
+          cpu: 6
+          memory: "12Gi"
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
+  annotations:
+    testgrid-dashboards: sig-release-master-informing, sig-testing-canaries
+    testgrid-tab-name: build-master-fast-canary
+    testgrid-alert-email: release-team@kubernetes.io
+    description: 'Ends up running: make quick-release. Canary: runs in k8s-infra-prow-build, pushes to gs://k8s-release-dev'
+
 - interval: 4h
   name: ci-release-build-packages-debs
   decorate: true


### PR DESCRIPTION
create duplicate `ci-kubernetes-build-fast` to run in the `k8s-infra-prow-build` cluster to validate the execution build

ref: https://github.com/kubernetes/test-infra/issues/19484 and https://github.com/kubernetes/kubernetes/issues/95173

/cc @spiffxp Dont know if there is anything else that we need to change, but this is an initial PR, let me know if this is correct.