### PR TITLE
fix the modification time format in gcsweb tool

### DIFF
--- a/gcsweb/cmd/gcsweb/gcsweb.go
+++ b/gcsweb/cmd/gcsweb/gcsweb.go
@@ -505,7 +505,7 @@ func (rec *Record) Render(out http.ResponseWriter, inPath string) {
 		gcsPath+inPath+rec.Name,
 		rec.Name,
 		fmt.Sprintf("%v", rec.Size),
-		rec.MTime.Format("01 Jan 2006 15:04:05"),
+		rec.MTime.Format(time.RFC1123),
 	)
 }
 

--- a/gcsweb/cmd/gcsweb/gcsweb_test.go
+++ b/gcsweb/cmd/gcsweb/gcsweb_test.go
@@ -387,19 +387,19 @@ func TestHandleDirectory(t *testing.T) {
     <li class="pure-g grid-row">
 	    <div class="pure-u-2-5"><a href="/gcs/test-bucket/pr-logs/12345/file1"><img src="/icons/file.png"> file1</a></div>
 	    <div class="pure-u-1-5">0</div>
-	    <div class="pure-u-2-5">01 Jan 2000 00:00:00</div>
+	    <div class="pure-u-2-5">Sat, 01 Jan 2000 00:00:00 UTC</div>
 	</li>
 
     <li class="pure-g grid-row">
 	    <div class="pure-u-2-5"><a href="/gcs/test-bucket/pr-logs/12345/file2"><img src="/icons/file.png"> file2</a></div>
 	    <div class="pure-u-1-5">0</div>
-	    <div class="pure-u-2-5">01 Jan 2000 22:00:00</div>
+	    <div class="pure-u-2-5">Sat, 01 Jan 2000 22:00:00 UTC</div>
 	</li>
 
     <li class="pure-g grid-row">
 	    <div class="pure-u-2-5"><a href="/gcs/test-bucket/pr-logs/12345/file3"><img src="/icons/file.png"> file3</a></div>
 	    <div class="pure-u-1-5">0</div>
-	    <div class="pure-u-2-5">01 Jan 2000 23:00:00</div>
+	    <div class="pure-u-2-5">Sat, 01 Jan 2000 23:00:00 UTC</div>
 	</li>
 </ul></body></html>`,
 		},


### PR DESCRIPTION
`2020-10-01 12:47:48.208 +0000 UTC` with the current format becomes `10 Oct 2020 12:47:48`  /shrug

RFC1123 format will make it `Thu, 01 Oct 2020 12:47:48 UTC`  

/cc @stevekuznetsov @alvaroaleman 
Signed-off-by: Nikolaos Moraitis <nmoraiti@redhat.com>