### PR TITLE
prow/plugins: don't allow invalid keywords in PR titles

### DIFF
--- a/prow/plugins/invalidcommitmsg/BUILD.bazel
+++ b/prow/plugins/invalidcommitmsg/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
     deps = [
         "//prow/github:go_default_library",
         "//prow/github/fakegithub:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],
 )

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -34,9 +34,9 @@ import (
 )
 
 const (
-	pluginName            = "invalidcommitmsg"
-	invalidCommitMsgLabel = "do-not-merge/invalid-commit-message"
-	commentBody           = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+	pluginName                  = "invalidcommitmsg"
+	invalidCommitMsgLabel       = "do-not-merge/invalid-commit-message"
+	invalidCommitMsgCommentBody = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
 
 **The list of commits with invalid commit messages**:
 
@@ -47,12 +47,23 @@ const (
 %s
 </details>
 `
-	commentPruneBody = "**The list of commits with invalid commit messages**:"
+	invalidCommitMsgCommentPruneBody = "**The list of commits with invalid commit messages**:"
+	invalidTitleCommentBody          = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in the title of a Pull Request.
+
+You can edit the title by writing **/retitle <new-title>** in a comment.
+
+<details>
+When GitHub merges a Pull Request, the title is included in the merge commit. To avoid invalid keywords in the merge commit, please edit the title of the PR.
+
+%s
+</details>
+`
+	invalidTitleCommentPruneBody = "not allowed in the title of a Pull Request"
 )
 
 var (
-	closeIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
-	atMentionRegex  = regexp.MustCompile(`\B([@][\w_-]+)`)
+	CloseIssueRegex = regexp.MustCompile(`((?i)(clos(?:e[sd]?))|(fix(?:(es|ed)?))|(resolv(?:e[sd]?)))[\s:]+(\w+/\w+)?#(\d+)`)
+	AtMentionRegex  = regexp.MustCompile(`\B([@][\w_-]+)`)
 )
 
 func init() {
@@ -62,7 +73,7 @@ func init() {
 func helpProvider(config *plugins.Configuration, _ []config.OrgRepo) (*pluginhelp.PluginHelp, error) {
 	// Only the Description field is specified because this plugin is not triggered with commands and is not configurable.
 	return &pluginhelp.PluginHelp{
-			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages contain @ mentions or keywords which can automatically close issues.",
+			Description: "The invalidcommitmsg plugin applies the '" + invalidCommitMsgLabel + "' label to pull requests whose commit messages and titles contain @ mentions or keywords which can automatically close issues.",
 		},
 		nil
 }
@@ -97,6 +108,7 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 		org    = pr.Repo.Owner.Login
 		repo   = pr.Repo.Name
 		number = pr.Number
+		title  = pr.PullRequest.Title
 	)
 
 	labels, err := gc.GetIssueLabels(org, repo, number)
@@ -113,25 +125,31 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 
 	var invalidCommits []github.RepositoryCommit
 	for _, commit := range allCommits {
-		if closeIssueRegex.MatchString(commit.Commit.Message) || atMentionRegex.MatchString(commit.Commit.Message) {
+		if CloseIssueRegex.MatchString(commit.Commit.Message) || AtMentionRegex.MatchString(commit.Commit.Message) {
 			invalidCommits = append(invalidCommits, commit)
 		}
 	}
 
-	// if we have the label but all commits are valid,
+	invalidPRTitle := CloseIssueRegex.MatchString(title) || AtMentionRegex.MatchString(title)
+
+	// if we have the label but all commits and the PR title is valid,
 	// remove the label and prune comments
-	if hasInvalidCommitMsgLabel && len(invalidCommits) == 0 {
+	if hasInvalidCommitMsgLabel && len(invalidCommits) == 0 && !invalidPRTitle {
 		if err := gc.RemoveLabel(org, repo, number, invalidCommitMsgLabel); err != nil {
 			log.WithError(err).Errorf("GitHub failed to remove the following label: %s", invalidCommitMsgLabel)
 		}
 		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, commentPruneBody)
+			return strings.Contains(comment.Body, invalidCommitMsgCommentPruneBody)
+		})
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, invalidTitleCommentPruneBody)
 		})
 	}
 
-	// if we don't have the label and there are invalid commits,
+	// if we don't have the label and
+	// if the PR title is invalid OR there are invalid commits
 	// add the label
-	if !hasInvalidCommitMsgLabel && len(invalidCommits) != 0 {
+	if !hasInvalidCommitMsgLabel && (len(invalidCommits) != 0 || invalidPRTitle) {
 		if err := gc.AddLabel(org, repo, number, invalidCommitMsgLabel); err != nil {
 			log.WithError(err).Errorf("GitHub failed to add the following label: %s", invalidCommitMsgLabel)
 		}
@@ -141,19 +159,32 @@ func handle(gc githubClient, log *logrus.Entry, pr github.PullRequestEvent, cp c
 	if len(invalidCommits) != 0 {
 		// prune old comments before adding a new one
 		cp.PruneComments(func(comment github.IssueComment) bool {
-			return strings.Contains(comment.Body, commentPruneBody)
+			return strings.Contains(comment.Body, invalidCommitMsgCommentPruneBody)
 		})
 
-		log.Debugf("Commenting on PR to advise users of invalid commit messages")
-		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(commentBody, dco.MarkdownSHAList(org, repo, invalidCommits), plugins.AboutThisBot)); err != nil {
-			log.WithError(err).Errorf("Could not create comment for invalid commit messages")
+		log.Debug("Commenting on PR to advise users of invalid commit messages")
+		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(invalidCommitMsgCommentBody, dco.MarkdownSHAList(org, repo, invalidCommits), plugins.AboutThisBot)); err != nil {
+			log.WithError(err).Error("Could not create comment for invalid commit messages")
+		}
+	}
+
+	// if the PR title is invalid, add a comment
+	if invalidPRTitle {
+		// prune old comments before adding a new one
+		cp.PruneComments(func(comment github.IssueComment) bool {
+			return strings.Contains(comment.Body, invalidTitleCommentPruneBody)
+		})
+
+		log.Debug("Commenting on PR to advise users of an invalid PR title")
+		if err := gc.CreateComment(org, repo, number, fmt.Sprintf(invalidTitleCommentBody, plugins.AboutThisBot)); err != nil {
+			log.WithError(err).Error("Could not create comment for invalid PR title")
 		}
 	}
 
 	return nil
 }
 
-// hasPRChanged indicates that the code diff may have changed.
+// hasPRChanged indicates that the code diff or PR title may have changed.
 func hasPRChanged(pr github.PullRequestEvent) bool {
 	switch pr.Action {
 	case github.PullRequestActionOpened:
@@ -161,6 +192,8 @@ func hasPRChanged(pr github.PullRequestEvent) bool {
 	case github.PullRequestActionReopened:
 		return true
 	case github.PullRequestActionSynchronize:
+		return true
+	case github.PullRequestActionEdited:
 		return true
 	default:
 		return false

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/test-infra/prow/github"
@@ -35,7 +36,7 @@ func strP(str string) *string {
 	return &str
 }
 
-func makeFakePullRequestEvent(action github.PullRequestEventAction) github.PullRequestEvent {
+func makeFakePullRequestEvent(action github.PullRequestEventAction, title string) github.PullRequestEvent {
 	return github.PullRequestEvent{
 		Action: action,
 		Number: 3,
@@ -45,8 +46,39 @@ func makeFakePullRequestEvent(action github.PullRequestEventAction) github.PullR
 			},
 			Name: "k",
 		},
+		PullRequest: github.PullRequest{
+			Title: title,
+		},
 	}
 }
+
+var invalidCommitComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+
+**The list of commits with invalid commit messages**:
+
+- [sha1](https://github.com/k/k/commits/sha1) this is a @mention
+- [sha2](https://github.com/k/k/commits/sha2) this @menti-on has a hyphen
+- [sha3](https://github.com/k/k/commits/sha3) this @Menti-On has mixed case letters
+- [sha4](https://github.com/k/k/commits/sha4) fixes k/k#9999
+- [sha5](https://github.com/k/k/commits/sha5) Close k/k#9999
+- [sha6](https://github.com/k/k/commits/sha6) resolved k/k#9999
+
+<details>
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`
+
+var invalidPRTitleComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in the title of a Pull Request.
+
+You can edit the title by writing **/retitle <new-title>** in a comment.
+
+<details>
+When GitHub merges a Pull Request, the title is included in the merge commit. To avoid invalid keywords in the merge commit, please edit the title of the PR.
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
+</details>
+`
 
 func TestHandlePullRequest(t *testing.T) {
 	var testcases = []struct {
@@ -55,16 +87,17 @@ func TestHandlePullRequest(t *testing.T) {
 		// PR settings
 		action                       github.PullRequestEventAction
 		commits                      []github.RepositoryCommit
+		title                        string
 		hasInvalidCommitMessageLabel bool
 
 		// expectations
-		addedLabel   string
-		removedLabel string
-		addedComment string
+		addedLabel    string
+		removedLabel  string
+		addedComments []string
 	}{
 		{
 			name:   "unsupported PR action -> no-op",
-			action: github.PullRequestActionEdited,
+			action: github.PullRequestActionLabeled,
 		},
 		{
 			name:   "contains valid message -> no-op",
@@ -90,23 +123,8 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			hasInvalidCommitMessageLabel: false,
 
-			addedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
-			addedComment: `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
-
-**The list of commits with invalid commit messages**:
-
-- [sha1](https://github.com/k/k/commits/sha1) this is a @mention
-- [sha2](https://github.com/k/k/commits/sha2) this @menti-on has a hyphen
-- [sha3](https://github.com/k/k/commits/sha3) this @Menti-On has mixed case letters
-- [sha4](https://github.com/k/k/commits/sha4) fixes k/k#9999
-- [sha5](https://github.com/k/k/commits/sha5) Close k/k#9999
-- [sha6](https://github.com/k/k/commits/sha6) resolved k/k#9999
-
-<details>
-
-Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository. I understand the commands that are listed [here](https://go.k8s.io/bot-commands).
-</details>
-`,
+			addedLabel:    fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			addedComments: []string{invalidCommitComment},
 		},
 		{
 			name:   "msg does not contain invalid keywords but has label -> remove label",
@@ -118,11 +136,100 @@ Instructions for interacting with me using PR comments are available [here](http
 
 			removedLabel: fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
 		},
+		{
+			name:   "contains valid title -> no-op",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			title:                        "valid title",
+			hasInvalidCommitMessageLabel: false,
+		},
+		{
+			name:   "contains invalid title with @mention -> add label and comment",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			title:                        "title with @mention",
+			hasInvalidCommitMessageLabel: false,
+			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			addedComments:                []string{invalidPRTitleComment},
+		},
+		{
+			name:   "contains invalid title with fixes keyword -> add label and comment",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			title:                        "fixes #9999",
+			hasInvalidCommitMessageLabel: false,
+			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			addedComments:                []string{invalidPRTitleComment},
+		},
+		{
+			name:   "contains invalid title and invalid commits -> add label and 2 comments",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
+				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
+				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+			},
+			title:                        "title with @mention",
+			hasInvalidCommitMessageLabel: false,
+			addedLabel:                   fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+			addedComments:                []string{invalidCommitComment, invalidPRTitleComment},
+		},
+		{
+			name:   "valid commits and invalid title, and has label -> keep label and add comment",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			title:                        "title with @mention",
+			hasInvalidCommitMessageLabel: true,
+			addedComments:                []string{invalidPRTitleComment},
+		},
+		{
+			name:   "invalid commits and valid title, and has label -> keep label and add comment",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha1", Commit: github.GitCommit{Message: "this is a @mention"}},
+				{SHA: "sha2", Commit: github.GitCommit{Message: "this @menti-on has a hyphen"}},
+				{SHA: "sha3", Commit: github.GitCommit{Message: "this @Menti-On has mixed case letters"}},
+				{SHA: "sha4", Commit: github.GitCommit{Message: "fixes k/k#9999"}},
+				{SHA: "sha5", Commit: github.GitCommit{Message: "Close k/k#9999"}},
+				{SHA: "sha6", Commit: github.GitCommit{Message: "resolved k/k#9999"}},
+				{SHA: "sha7", Commit: github.GitCommit{Message: "this is an email@address and is valid"}},
+			},
+			title:                        "valid title",
+			hasInvalidCommitMessageLabel: true,
+			addedComments:                []string{invalidCommitComment},
+		},
+		{
+			name:   "valid title and valid commits, and has label -> remove label",
+			action: github.PullRequestActionOpened,
+			commits: []github.RepositoryCommit{
+				{SHA: "sha", Commit: github.GitCommit{Message: "this is a valid message"}},
+			},
+			title:                        "valid title",
+			hasInvalidCommitMessageLabel: true,
+			removedLabel:                 fmt.Sprintf("k/k#3:%s", invalidCommitMsgLabel),
+		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			event := makeFakePullRequestEvent(tc.action)
+			title := "fake title"
+			if tc.title != "" {
+				title = tc.title
+			}
+
+			event := makeFakePullRequestEvent(tc.action, title)
 			fc := &fakegithub.FakeClient{
 				PullRequests:  map[int]*github.PullRequest{event.Number: &event.PullRequest},
 				IssueComments: make(map[int][]github.IssueComment),
@@ -165,15 +272,13 @@ Instructions for interacting with me using PR comments are available [here](http
 			}
 
 			comments := fc.IssueCommentsAdded
-			if len(comments) == 0 && tc.addedComment != "" {
-				t.Errorf("Expected comment with body %q to be added, but it was not", tc.addedComment)
+			if len(comments) != len(tc.addedComments) {
+				t.Errorf("Expected %v comments, but received %v", len(tc.addedComments), len(comments))
 				return
 			}
-			if len(comments) > 1 {
-				t.Errorf("did not expect more than one comment to be created")
-			}
-			if len(comments) != 0 && comments[0] != tc.addedComment {
-				t.Errorf("expected comment to be \n%q\n but it was \n%q\n", tc.addedComment, comments[0])
+
+			if diff := cmp.Diff(comments, tc.addedComments); diff != "" {
+				t.Errorf("Actual comments differ from expected comments: %s", diff)
 			}
 		})
 	}

--- a/prow/plugins/retitle/BUILD.bazel
+++ b/prow/plugins/retitle/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//prow/github:go_default_library",
         "//prow/pluginhelp:go_default_library",
         "//prow/plugins:go_default_library",
+        "//prow/plugins/invalidcommitmsg:go_default_library",
         "//prow/plugins/trigger:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
     ],

--- a/prow/plugins/retitle/retitle.go
+++ b/prow/plugins/retitle/retitle.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/test-infra/prow/github"
 	"k8s.io/test-infra/prow/pluginhelp"
 	"k8s.io/test-infra/prow/plugins"
+	"k8s.io/test-infra/prow/plugins/invalidcommitmsg"
 	"k8s.io/test-infra/prow/plugins/trigger"
 )
 
@@ -128,6 +129,10 @@ func handleGenericComment(gc githubClient, isTrusted func(string) (bool, error),
 	newTitle := strings.TrimSpace(matches[1])
 	if newTitle == "" {
 		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not be empty.`))
+	}
+
+	if invalidcommitmsg.AtMentionRegex.MatchString(newTitle) || invalidcommitmsg.CloseIssueRegex.MatchString(newTitle) {
+		return gc.CreateComment(org, repo, number, plugins.FormatResponseRaw(gce.Body, gce.HTMLURL, user, `Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.`))
 	}
 
 	if gce.IsPR {

--- a/prow/plugins/retitle/retitle_test.go
+++ b/prow/plugins/retitle/retitle_test.go
@@ -121,6 +121,46 @@ Instructions for interacting with me using PR comments are available [here](http
 </details>`,
 		},
 		{
+			name:   "new comment on open issue comments with a title with @mention",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle Add @mention to OWNERS",
+			trusted: func(user string) (bool, error) {
+				return true, nil
+			},
+			expectedComment: `org/repo#1:@user: Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.
+
+<details>
+
+In response to [this]():
+
+>/retitle Add @mention to OWNERS
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
+			name:   "new comment on open issue comments with a title with invalid keyword",
+			state:  "open",
+			action: github.GenericCommentActionCreated,
+			body:   "/retitle Fixes #9999",
+			trusted: func(user string) (bool, error) {
+				return true, nil
+			},
+			expectedComment: `org/repo#1:@user: Titles may not contain [keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions.
+
+<details>
+
+In response to [this]():
+
+>/retitle Fixes #9999
+
+
+Instructions for interacting with me using PR comments are available [here](https://git.k8s.io/community/contributors/guide/pull-requests.md).  If you have questions or suggestions related to my behavior, please file an issue against the [kubernetes/test-infra](https://github.com/kubernetes/test-infra/issues/new?title=Prow%20issue:) repository.
+</details>`,
+		},
+		{
 			name:   "trusted user edits PR title",
 			state:  "open",
 			action: github.GenericCommentActionCreated,


### PR DESCRIPTION
Fixes https://github.com/kubernetes/test-infra/issues/17893
Fixes https://github.com/kubernetes/test-infra/issues/19492

When a PR is merged, the merge commit created by GitHub contains the PR
title.

So if a PR title contains invalid keywords like @ mentions or a keyword
which can automatically close issues, its corresponding merge commit
would also contain these keywords.

If this merge commit is then pulled into another PR, prow would consider
it invalid.

To avoid problems in the future, this commit disallows such keywords in
PR titles. The change is made in two plugins:

* invalidcommitmsg - if a PR title contains invalid keywords, the
`do-not-merge/invalid-commit-message` label is added along with a
comment.

* retitle - if the new PR title proposed with the /retitle command
contains invalid keywords, it is rejected and a comment is added.

/sig contributor-experience
/assign @cblecker 
/cc @matthyx @mrbobbytables 