### PR TITLE
Adds windows servercore cache image periodic job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -32,14 +32,35 @@ postsubmits:
               - --env-passthrough=PULL_BASE_REF
               - --build-dir=.
               - test/images
-            volumeMounts:
-              - name: windows-cert
-                mountPath: /root/.docker-1809
-              - name: windows-cert
-                mountPath: /root/.docker-1903
-              - name: windows-cert
-                mountPath: /root/.docker-1909
-        volumes:
-          - name: windows-cert
-            secret:
-              secretName: windows-img-promoter-cert
+periodics:
+# NOTE(claudiub): The base image for the Windows E2E test images is nanoserver.
+# In most cases, that is sufficient. But in some cases, we are missing some DLLs.
+# We can fetch those DLLs from Windows servercore images, but they are very large
+# (2GB compressed), while the DLLs are only a few megabytes in size. We can build
+# a monthly DLL cache image and use the cache instead.
+# For more info: https://github.com/kubernetes/kubernetes/pull/93889
+- name: kubernetes-e2e-windows-servercore-cache
+  # Since the servercore image is updated once per month, we only need to build this
+  # cache once per month.
+  interval: 744h
+  cluster: k8s-infra-prow-build-trusted
+  annotations:
+    testgrid-dashboards: sig-testing-images
+  decorate: true
+  spec:
+    serviceAccountName: gcb-builder
+    containers:
+      - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+        command:
+          - /run.sh
+        args:
+          - --project=k8s-staging-e2e-test-images
+          - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+          - --env-passthrough=PULL_BASE_REF,WHAT
+          - --build-dir=.
+          - test/images
+        # By default, the E2E test image's WHAT is all-conformance. We override that with
+        # the windows-servercore-cache image.
+        env:
+        - name: WHAT
+          value: "windows-servercore-cache"


### PR DESCRIPTION
The base image for the Windows E2E test images is nanoserver. In most cases,
that is sufficient. But in some cases, we are missing some DLLs.

We can fetch those DLLs from Windows servercore images, but they are very large
(2GB compressed), while the DLLs are only a few megabytes in size. We can build
a monthly DLL cache image and use the cache instead.