### PR TITLE
Clear env var so Azure e2e generates a local keypair

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
     labels:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
-      preset-azure-cred: "true"
+      preset-azure-cred-only: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-1.18

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -722,21 +722,13 @@ presets:
   env:
     - name: AZURE_CREDENTIALS
       value: /etc/azure-cred/credentials
-    - name: AZURE_SSH_PUBLIC_KEY_FILE
-      value: /etc/azure-ssh/azure-ssh-pub
   volumes:
     - name: azure-cred
       secret:
         secretName: azure-cred
-    - name: azure-ssh
-      secret:
-        secretName: azure-ssh
   volumeMounts:
     - name: azure-cred
       mountPath: /etc/azure-cred
-      readOnly: true
-    - name: azure-ssh
-      mountPath: /etc/azure-ssh
       readOnly: true
 # storage / caching presets
 - labels:
@@ -801,4 +793,3 @@ presets:
 - env:
   - name: GOPROXY
     value: "https://proxy.golang.org"
-


### PR DESCRIPTION
To implement [`ClusterLogCollector`](https://github.com/kubernetes-sigs/cluster-api/blob/59faa7b1c63ba301cb780836891e7b10098fce34/test/framework/cluster_proxy.go#L81) for CAPZ using an SSH mechanism, Azure e2e tests need access to the private key as well. By leaving `AZURE_SSH_PUBLIC_KEY_FILE` empty, testing will fall back to [generating a local keypair](https://github.com/kubernetes-sigs/cluster-api-provider-azure/blob/master/scripts/ci-e2e.sh#L78-L86) just for that run.

This works well as demonstrated in kubernetes-sigs/cluster-api-provider-azure#976.

Since the key materials aren't accessible outside of the prow CI environment, I don't think this introduces a security risk. But please let me know if you disagree or have any other feedback. cc: @nader-ziada @CecileRobertMichon @devigned 