### PR TITLE
add optional ipvs presubmit job for dual stack

### DIFF
--- a/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-kind.yaml
@@ -51,6 +51,59 @@ presubmits:
       testgrid-tab-name: sig-network-kind, dual
       description: Runs tests against a Dual Stack Kubernetes in Docker cluster
       testgrid-alert-email: antonio.ojea.garcia@gmail.com
+  - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+    optional: true
+    always_run: false
+    skip_report: false
+    decorate: true
+    labels:
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    decoration_config:
+      timeout: 60m
+      grace_period: 15m
+    path_alias: k8s.io/kubernetes
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/krte:v20200916-8dd1247-master
+        command:
+        - wrapper.sh
+        - bash
+        - -c
+        - curl -sSL https://github.com/aojea/kind/releases/download/dualstack/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/" && e2e-k8s.sh
+        env:
+        - name: FOCUS
+          value: \[Conformance\]|DualStack
+        - name: PARALLEL
+          value: "true"
+        - name: BUILD_TYPE
+          value: bazel
+        # enable IPV6 in bootstrap image
+        - name: "DOCKER_IN_DOCKER_IPV6_ENABLED"
+          value: "true"
+        # tell kind CI script to use DualStack
+        - name: "IP_FAMILY"
+          value: "DualStack"
+        - name: KUBE_PROXY_MODE
+          value: "ipvs"
+        # we need privileged mode in order to do docker in docker
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            # TODO(BenTheElder): adjust these everywhere
+            # these are both a bit below peak usage during build
+            # this is mostly for building kubernetes
+            memory: "4000Mi"
+            # during the tests more like 3-20m is used
+            cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-network-kind
+      testgrid-tab-name: sig-network-kind, ipvs, dual
+      description: Runs tests against a Dual Stack Kubernetes in Docker cluster
+      testgrid-alert-email: antonio.ojea.garcia@gmail.com
 
 periodics:
 # network test against kubernetes master branch with `kind`

--- a/config/testgrids/kubernetes/presubmits/config.yaml
+++ b/config/testgrids/kubernetes/presubmits/config.yaml
@@ -100,8 +100,9 @@ dashboards:
   - name: pull-kubernetes-e2e-kind-dual-canary
     test_group_name: pull-kubernetes-e2e-kind-dual-canary
     base_options: width=10
-    alert_options:
-      alert_mail_to_addresses: antonio.ojea.garcia@gmail.com
+  - name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+    test_group_name: pull-kubernetes-e2e-kind-ipvs-dual-canary
+    base_options: width=10
   - name: pull-kubernetes-e2e-aks-engine-azure
     test_group_name: pull-kubernetes-e2e-aks-engine-azure
     base_options: width=10


### PR DESCRIPTION
It turns out that the optional presubmit job that we added for dual stack uses kube-proxy in IPVS mode, hence we can not compare the results with the current kind jobs that uses iptables mode.

Adding another optional job, will allow us to compare the results and help to troubleshoot issues

xref: https://github.com/kubernetes/kubernetes/pull/91824#issuecomment-706106538