### PR TITLE
CAPZ: update conformance test k8s version to 1.18.9

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
     - org: kubernetes
       repo: kubernetes
-      base_ref: v1.18.6
+      base_ref: v1.18.9
       path_alias: k8s.io/kubernetes
   spec:
     containers:
@@ -31,7 +31,7 @@ periodics:
           - name: PARALLEL
             value: "true"
           - name: KUBERNETES_VERSION
-            value: "v1.18.6"
+            value: "v1.18.9"
         securityContext:
           privileged: true
         resources:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -184,7 +184,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: v1.18.6
+      base_ref: v1.18.9
       path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -200,7 +200,7 @@ presubmits:
             - name: PARALLEL
               value: "true"
             - name: KUBERNETES_VERSION
-              value: "v1.18.6"
+              value: "v1.18.9"
           securityContext:
             privileged: true
           resources:
@@ -224,7 +224,7 @@ presubmits:
     extra_refs:
     - org: kubernetes
       repo: kubernetes
-      base_ref: v1.18.6
+      base_ref: v1.18.9
       path_alias: k8s.io/kubernetes
     spec:
       containers:
@@ -240,7 +240,7 @@ presubmits:
             - name: PARALLEL
               value: "true"
             - name: KUBERNETES_VERSION
-              value: "v1.18.6"
+              value: "v1.18.9"
             - name: EXP_MACHINE_POOL
               value: "true"
           securityContext:


### PR DESCRIPTION
Updated all conformance jobs to use 1.18.9 instead of 1.18.6.

/assign @nader-ziada @mboersma 