### PR TITLE
secrets-store-csi-driver: config for gcp provider tests

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -199,6 +199,41 @@ presubmits:
       testgrid-tab-name: pr-secrets-store-csi-driver-e2e-windows
       description: "Run E2E tests on a Windows cluster for Secrets Store CSI driver."
       testgrid-num-columns-recent: '30'
+  - name: pull-secrets-store-csi-driver-e2e-gcp
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - master
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # sets up the gcp parameters used for testing
+      preset-gcp-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
+          make e2e-bootstrap &&
+          make e2e-gcp
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-tab-name: pr-secrets-store-csi-driver-e2e-gcp
+      description: "Run e2e test with gcp provider for Secrets Store CSI driver."
+      testgrid-num-columns-recent: '30'
   - name: pull-secrets-store-csi-driver-build
     decorate: true
     decoration_config:
@@ -294,4 +329,39 @@ postsubmits:
       testgrid-dashboards: sig-auth-secrets-store-csi-driver
       testgrid-tab-name: secrets-store-csi-driver-e2e-azure-postsubmit
       description: "Run e2e test with azure provider for Secrets Store CSI driver postsubmit"
+      testgrid-num-columns-recent: '30'
+  - name: secrets-store-csi-driver-e2e-gcp-postsubmit
+    decorate: true
+    decoration_config:
+      timeout: 25m
+    always_run: true
+    optional: true
+    path_alias: sigs.k8s.io/secrets-store-csi-driver
+    branches:
+    - master
+    labels:
+      # this is required because we want to run kind in docker
+      preset-dind-enabled: "true"
+      # this is required to make CNI installation to succeed for kind
+      preset-kind-volume-mounts: "true"
+      # sets up the gcp parameters used for testing
+      preset-gcp-secrets-store-creds: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - >-
+          apt-get update && apt-get install bats && apt-get install gettext-base -y &&
+          make e2e-bootstrap &&
+          make e2e-gcp
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-auth-secrets-store-csi-driver
+      testgrid-tab-name: secrets-store-csi-driver-e2e-gcp-postsubmit
+      description: "Run e2e test with gcp provider for Secrets Store CSI driver postsubmit"
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-presets.yaml
@@ -27,3 +27,11 @@ presets:
       secretKeyRef:
         name: azure-secrets-store-cred
         key: tenantid
+- labels:
+    preset-gcp-secrets-store-creds: "true"
+  env:
+  - name: GCP_SA_JSON
+    valueFrom:
+      secretKeyRef:
+        name: gcp-secrets-store-cred
+        key: key.json


### PR DESCRIPTION
Companion to https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/340

Add integration tests for the gcp plugin to https://github.com/kubernetes-sigs/secrets-store-csi-driver