### PR TITLE
Sum heartbeat job metrics across plank pods.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/prometheus/plank_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/plank_alerts.libsonnet
@@ -17,7 +17,7 @@
             # the alert to fire. (We use 0.5 instead of 1 because query
             # results are not precise integers due to how prometheus interpolates.)
             expr: |||
-              increase(prowjob_state_transitions{job_name="%s", state="success"}[%s]) < 0.5
+              sum(increase(prowjob_state_transitions{job_name="%s", state="success"}[%s])) < 0.5
             ||| % [job.name, job.alertInterval],
             labels: {
               severity: 'critical',


### PR DESCRIPTION
Without this sum we get a time series for each plank pod which causes us to incorrectly fire an alert twice. Once as the new pod starts with no recent successful runs and once for the old pod as recent runs drop to 0.
<img width="623" alt="Screen Shot 2020-10-09 at 12 58 36 PM" src="https://user-images.githubusercontent.com/5334145/95626579-66d66780-0a2f-11eb-8ea9-3907e7b3949e.png">

/assign @e-blackwelder 
