### PR TITLE
fix enable-workload-identity.sh based on the latest doc

### DIFF
--- a/workload-identity/README.md
+++ b/workload-identity/README.md
@@ -43,7 +43,7 @@ bind-service-accounts.sh \
   SOMEBODY@PROJECT.iam.gserviceaccount.com
 ```
 
-This script assumes the same person can access both `K8S\_PROJECT` and
+This script assumes the same person can access both `K8S_PROJECT` and
 `PROJECT`. If that is not true then the `PROJECT` owner can just run this
 command directly:
 

--- a/workload-identity/enable-workload-identity.sh
+++ b/workload-identity/enable-workload-identity.sh
@@ -31,7 +31,7 @@ cluster=$3
 
 
 cluster_namespace="$project.svc.id.goog"
-pool_metadata=GKE_METADATA_SERVER
+pool_metadata=GKE_METADATA
 
 
 call-gcloud() {
@@ -48,7 +48,7 @@ cluster-identity() {
 
 pool-identities() {
   call-gcloud node-pools list "--cluster=$cluster" --format='value(name)' \
-    --filter="config.workloadMetadataConfig.nodeMetadata != $pool_metadata"
+    --filter="config.workloadMetadataConfig.mode != $pool_metadata"
 }
 
 fix_service=
@@ -98,11 +98,11 @@ if [[ -n "$fix_service" ]]; then
 fi
 
 if [[ -n "$fix_cluster" ]]; then
-  call-gcloud clusters update "$cluster" "--identity-namespace=$cluster_namespace"
+  call-gcloud clusters update "$cluster" "--workload-pool=$cluster_namespace"
 fi
 
 for pool in "${fix_pools[@]}"; do
-  call-gcloud node-pools update --cluster="$cluster" "$pool" "--workload-metadata-from-node=$pool_metadata"
+  call-gcloud node-pools update --cluster="$cluster" "$pool" "--workload-metadata=$pool_metadata"
 done
 
 echo "DONE"


### PR DESCRIPTION
According to https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity, some parameters in the `gcloud` command that enables workload identity for existing clusters and node pools have been updated. Fix enable-workload-identity.sh based on it.