### PR TITLE
ci-kubernetes-build-fast-canary: update gs bucket to use the same path as the original job

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -121,7 +121,7 @@ periodics:
       - --
       - --allow-dup
       - --fast
-      - --release=k8s-release-dev/ci-canary
+      - --release=k8s-release-dev
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Follow up of: https://github.com/kubernetes/test-infra/pull/19487#discussion_r502679562



/cc @spiffxp 