### PR TITLE
OWNERS_ALIASES: Add xmudrii to release-engineering-reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -222,6 +222,7 @@ aliases:
     - justaugustus # SIG Chair
     - saschagrunert # Branch Manager
     - tpepper # SIG Chair / Patch Release Team
+    - xmudrii # Branch Manager
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES
   enhancements-approvers:

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -215,14 +215,14 @@ aliases:
     - saschagrunert # SIG Technical Lead
     - tpepper # SIG Chair
   release-engineering-reviewers:
-    - cpanato # Branch Manager
-    - feiskyer # Patch Release Team
-    - hasheddan # Branch Manager
-    - hoegaarden # Patch Release Team
-    - justaugustus # SIG Chair
-    - saschagrunert # Branch Manager
-    - tpepper # SIG Chair / Patch Release Team
-    - xmudrii # Branch Manager
+    - cpanato # Release Manager
+    - feiskyer # Release Manager
+    - hasheddan # Release Manager
+    - hoegaarden # Release Manager
+    - justaugustus # SIG Chair / Release Manager
+    - saschagrunert # SIG Technical Lead / Release Manager
+    - tpepper # SIG Chair / Release Manager
+    - xmudrii # Release Manager
 
   # copied from git.k8s.io/enhancements/OWNERS_ALIASES
   enhancements-approvers:


### PR DESCRIPTION
Adding myself to the release-engineering-reviewers group, as per https://github.com/kubernetes/sig-release/issues/1226.

/assign @justaugustus 