### PR TITLE
Tide: Add checkrun support

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -218,9 +218,10 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 
 	// fixing label issues takes precedence over status contexts
 	var contexts []string
+	log := logrus.WithFields(pr.logFields())
 	for _, commit := range pr.Commits.Nodes {
 		if commit.Commit.OID == pr.HeadRefOID {
-			for _, ctx := range unsuccessfulContexts(commit.Commit.Status.Contexts, cc, logrus.New().WithFields(pr.logFields())) {
+			for _, ctx := range unsuccessfulContexts(append(commit.Commit.Status.Contexts, checkRunNodesToContexts(log, commit.Commit.StatusCheckRollup.Contexts.Nodes)...), cc, log) {
 				contexts = append(contexts, string(ctx.Context))
 			}
 		}

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -53,6 +53,7 @@ func TestExpectedStatus(t *testing.T) {
 		secondQueryAuthor string
 		milestone         string
 		contexts          []Context
+		checkRuns         []CheckRun
 		inPool            bool
 		blocks            []int
 		prowJobs          []runtime.Object
@@ -191,6 +192,136 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
 		},
 		{
+			name:              "single bad checkrun",
+			labels:            neededLabels,
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)}},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
+		},
+		{
+			name:              "single good checkrun",
+			labels:            neededLabels,
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "multiple good checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "mix of good and bad checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job another-job has not succeeded."),
+		},
+		{
+			name:   "mix of good status contexts and checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "mix of bad status contexts and checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
+		},
+		{
+			name:   "good context, bad checkrun",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
+		},
+		{
+			name:   "bad context, good checkrun",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job other-job-name has not succeeded."),
+		},
+		{
 			name:              "multiple bad contexts",
 			labels:            neededLabels,
 			author:            "batman",
@@ -200,6 +331,22 @@ func TestExpectedStatus(t *testing.T) {
 			contexts: []Context{
 				{Context: githubql.String("job-name"), State: githubql.StatusStateError},
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateError},
+			},
+			inPool: false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
+		},
+		{
+			name:              "multiple bad checkruns",
+			labels:            neededLabels,
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("other-job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			inPool: false,
 
@@ -517,19 +664,26 @@ func TestExpectedStatus(t *testing.T) {
 				)
 			}
 			pr.HeadRefOID = githubql.String("head")
-			if len(tc.contexts) > 0 {
-				pr.Commits.Nodes = append(
-					pr.Commits.Nodes,
-					struct{ Commit Commit }{
-						Commit: Commit{
-							Status: struct{ Contexts []Context }{
-								Contexts: tc.contexts,
+			var checkRunNodes []CheckRunNode
+			for _, checkRun := range tc.checkRuns {
+				checkRunNodes = append(checkRunNodes, CheckRunNode{CheckRun: checkRun})
+			}
+			pr.Commits.Nodes = append(
+				pr.Commits.Nodes,
+				struct{ Commit Commit }{
+					Commit: Commit{
+						Status: struct{ Contexts []Context }{
+							Contexts: tc.contexts,
+						},
+						OID: githubql.String("head"),
+						StatusCheckRollup: StatusCheckRollup{
+							Contexts: StatusCheckRollupContext{
+								Nodes: checkRunNodes,
 							},
-							OID: githubql.String("head"),
 						},
 					},
-				)
-			}
+				},
+			)
 			pr.Author = struct {
 				Login githubql.String
 			}{githubql.String(tc.author)}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1672,7 +1672,26 @@ type Commit struct {
 	Status struct {
 		Contexts []Context
 	}
-	OID githubql.String `graphql:"oid"`
+	OID               githubql.String `graphql:"oid"`
+	StatusCheckRollup StatusCheckRollup
+}
+
+type StatusCheckRollup struct {
+	Contexts StatusCheckRollupContext `graphql:"contexts(last: 100)"`
+}
+
+type StatusCheckRollupContext struct {
+	Nodes []CheckRunNode
+}
+
+type CheckRunNode struct {
+	CheckRun CheckRun `graphql:"... on CheckRun"`
+}
+
+type CheckRun struct {
+	Name       githubql.String
+	Conclusion githubql.String
+	Status     githubql.String
 }
 
 // Context holds graphql response data for github contexts.
@@ -1722,7 +1741,7 @@ func (pr *PullRequest) logFields() logrus.Fields {
 func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Context, error) {
 	for _, node := range pr.Commits.Nodes {
 		if node.Commit.OID == pr.HeadRefOID {
-			return node.Commit.Status.Contexts, nil
+			return append(node.Commit.Status.Contexts, checkRunNodesToContexts(log, node.Commit.StatusCheckRollup.Contexts.Nodes)...), nil
 		}
 	}
 	// We didn't get the head commit from the query (the commits must not be
@@ -1731,6 +1750,8 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 	org := string(pr.Repository.Owner.Login)
 	repo := string(pr.Repository.Name)
 	// Log this event so we can tune the number of commits we list to minimize this.
+	// TODO alvaroaleman: Add checkrun support here. Doesn't seem to happen often though,
+	// openshift doesn't have a single occurrence of this in the past seven days.
 	log.Warnf("'last' %d commits didn't contain logical last commit. Querying GitHub...", len(pr.Commits.Nodes))
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
@@ -1822,4 +1843,48 @@ func nonFailedBatchByNameBaseAndPullsIndexFunc(obj runtime.Object) []string {
 	}
 
 	return []string{nonFailedBatchByNameBaseAndPullsIndexKey(pj.Spec.Job, pj.Spec.Refs)}
+}
+
+func checkRunNodesToContexts(log *logrus.Entry, nodes []CheckRunNode) []Context {
+	var result []Context
+	for _, node := range nodes {
+		// GitHub gives us an empty checkrun per status context. In theory they could
+		// at some point decide to create a virtual check run per status context.
+		// If that were to happen, we would retrieve redundant data as we get the
+		// status context both directly as a status context and as a checkrun, however
+		// the actual data in there should be identical, hence this isn't a problem.
+		if string(node.CheckRun.Name) == "" {
+			continue
+		}
+		result = append(result, checkRunToContext(node.CheckRun))
+	}
+	if len(result) > 0 {
+		log.WithField("checkruns", len(result)).Debug("Transformed checkruns to contexts")
+	}
+	return result
+}
+
+const (
+	checkRunStatusCompleted   = githubql.String("COMPLETED")
+	checkRunConclusionNeutral = githubql.String("NEUTRAL")
+)
+
+// checkRunToContext translates a checkRun to a classic context
+// ref: https://developer.github.com/v3/checks/runs/#parameters
+func checkRunToContext(checkRun CheckRun) Context {
+	context := Context{
+		Context: checkRun.Name,
+	}
+	if checkRun.Status != checkRunStatusCompleted {
+		context.State = githubql.StatusStatePending
+		return context
+	}
+
+	if checkRun.Conclusion == checkRunConclusionNeutral || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
+		context.State = githubql.StatusStateSuccess
+		return context
+	}
+
+	context.State = githubql.StatusStateFailure
+	return context
 }


### PR DESCRIPTION
This PR adds checkrun support to tide by extending its github graphql query to also get checkruns and then translating them back to status contexts to keep the changeset small. This allows tide to respect statuses posted by github apps like for example travis.

Apart from the included unittests I also deployed this to verify it actually works.

Whats not entirely clear to me is the impact this has on token usage, however in Openshift, the available tokens for the merge robot on the v4 api never went below 3k in the last 30 days so I assume this won't be a problem.

Not marking https://github.com/kubernetes/test-infra/issues/15611 as done yet as the PR leaves one todo that I want to fix in a follow-up.

/assign @cjwagner 