### PR TITLE
Plank: Pass on error when pod can not be created

### DIFF
--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -317,7 +317,7 @@ func (c *Controller) syncPendingJob(pj prowapi.ProwJob, pm map[string]corev1.Pod
 			}
 			pj.Status.State = prowapi.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = fmt.Sprintf("Job cannot be started: %v", err)
+			pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
 			c.log.WithFields(pjutil.ProwJobFields(&pj)).WithError(err).Warning("Request error starting pod.")
 		} else {
 			c.log.WithFields(pjutil.ProwJobFields(&pj)).Info("Pod is missing, starting a new pod")
@@ -539,7 +539,7 @@ func (c *Controller) syncTriggeredJob(pj prowapi.ProwJob, pm map[string]corev1.P
 			}
 			pj.Status.State = prowapi.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = fmt.Sprintf("Job cannot be started: %v", err)
+			pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
 			logrus.WithField("job", pj.Spec.Job).WithError(err).Warning("Request error starting pod.")
 		}
 	} else {

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -264,7 +264,7 @@ func (r *reconciler) syncPendingJob(pj *prowv1.ProwJob) error {
 			}
 			pj.Status.State = prowv1.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = "Job cannot be processed."
+			pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
 			r.log.WithFields(pjutil.ProwJobFields(pj)).WithError(err).Warning("Unprocessable pod.")
 		} else {
 			pj.Status.BuildID = id
@@ -479,7 +479,7 @@ func (r *reconciler) syncTriggeredJob(pj *prowv1.ProwJob) (*reconcile.Result, er
 			}
 			pj.Status.State = prowv1.ErrorState
 			pj.SetComplete()
-			pj.Status.Description = "Job cannot be processed."
+			pj.Status.Description = fmt.Sprintf("Pod can not be created: %v", err)
 			logrus.WithField("job", pj.Spec.Job).WithError(err).Warning("Unprocessable pod.")
 		}
 	}


### PR DESCRIPTION
Currently we only log this. After this change, the error will be in the
ProwJobs .status.description which in turn is displayed by the metadata
lense if the job errored and no pod exists.

Fixes https://github.com/kubernetes/test-infra/issues/19511