### PR TITLE
Make buildlimit max if set to 0 (per --help)

### DIFF
--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -357,6 +357,7 @@ def get_options(argv):
 
 if __name__ == '__main__':
     OPTIONS = get_options(sys.argv[1:])
+    OPTIONS.buildlimit = OPTIONS.buildlimit or sys.maxsize
     main(
         model.Database(),
         yaml.safe_load(open(OPTIONS.buckets)),


### PR DESCRIPTION
Changed it and it no longer matched the comment
I don't think we ever want to run and collect nothing.
This also make the logic to handle staging vs prod cleaner