### PR TITLE
Add BUILD_LIMIT env that can be set via kubectl

### DIFF
--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -16,6 +16,9 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
+        env:
+        - name: BUILD_LIMIT
+          value: 1000
         volumeMounts:
         - name: service
           mountPath: /etc/service-account

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -349,7 +349,7 @@ def get_options(argv):
         '--buildlimit',
         help='maximum number of runs within each job to pull, \
          all jobs will be collected if unset or 0',
-        default=int(os.getenv('BUILD_LIMIT', sys.maxsize)),
+        default=int(os.getenv('BUILD_LIMIT', '0')),
         type=int,
     )
     return parser.parse_args(argv)

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -349,7 +349,7 @@ def get_options(argv):
         '--buildlimit',
         help='maximum number of runs within each job to pull, \
          all jobs will be collected if unset or 0',
-        default=sys.maxsize,
+        default=int(os.getenv('BUILD_LIMIT', sys.maxsize)),
         type=int,
     )
     return parser.parse_args(argv)

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -38,7 +38,7 @@ def call(cmd):
 
 
 def main():
-    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32')
+    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32 --buildlimit ' + os.getenv('BUILD_LIMIT', '0'))
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
     mj_cmd = 'pypy3 make_json.py'

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -38,7 +38,8 @@ def call(cmd):
 
 
 def main():
-    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32 --buildlimit ' + os.getenv('BUILD_LIMIT', '0'))
+    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32 --buildlimit '
+         + os.getenv('BUILD_LIMIT', '0'))
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
     mj_cmd = 'pypy3 make_json.py'

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -38,8 +38,7 @@ def call(cmd):
 
 
 def main():
-    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32 --buildlimit '
-         + os.getenv('BUILD_LIMIT', '0'))
+    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32')
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
     mj_cmd = 'pypy3 make_json.py'


### PR DESCRIPTION
This should allow `--env "BUILD_LIMIT=100"` to be set with the staging image

It will limit the number of builds collected from GCS per job
/area Kettle