### PR TITLE
Enabling Windows + containerd + csi-proxy azure-disk/azure-file e2e jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
+++ b/config/jobs/kubernetes-sigs/sig-windows/sig-windows-config.yaml
@@ -590,6 +590,67 @@ periodics:
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure Disk e2e test with Azure Disk in-tree volume plugin in a Windows cluster.
 - interval: 48h
+  name: ci-kubernetes-e2e-azure-disk-windows-containerd
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes-sigs
+    repo: azuredisk-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azuredisk-csi-driver
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.19
+      - --aksengine-template-url=https://github.com/kubernetes-sigs/windows-testing/blob/master/job-templates/kubernetes_containerd_csi_proxy.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      - --aksengine-agentpoolcount=2
+      # Specific test args
+      - --test-azure-disk-csi-driver
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_WINDOWS
+        value: "true"
+  annotations:
+    testgrid-dashboards: sig-windows-azure, provider-azure-periodic, provider-azure-windows
+    testgrid-tab-name: aks-engine-azure-windows-azure-disk-containerd
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure Disk e2e test with Azure Disk in a Windows cluster configured with CSI proxy and containerd.
+- interval: 48h
   name: ci-kubernetes-e2e-azure-file-windows
   decorate: true
   decoration_config:
@@ -652,3 +713,64 @@ periodics:
     testgrid-tab-name: aks-engine-azure-windows-azure-file
     testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
     description: Run Azure File e2e test with Azure File in-tree volume plugin in a Windows cluster.
+- interval: 48h
+  name: ci-kubernetes-e2e-azure-file-windows-containerd
+  decorate: true
+  decoration_config:
+    timeout: 2h
+  labels:
+    preset-service-account: "true"
+    preset-azure-cred: "true"
+    preset-azure-windows: "true"
+    preset-windows-repo-list: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  - org: kubernetes-sigs
+    repo: azurefile-csi-driver
+    base_ref: master
+    path_alias: sigs.k8s.io/azurefile-csi-driver
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
+      command:
+      - runner.sh
+      - kubetest
+      args:
+      # Generic e2e test args
+      - --test
+      - --up
+      - --down
+      - --build=quick
+      - --dump=$(ARTIFACTS)
+      # Azure-specific test args
+      - --deployment=aksengine
+      - --provider=skeleton
+      - --aksengine-admin-username=azureuser
+      - --aksengine-admin-password=AdminPassw0rd
+      - --aksengine-creds=$(AZURE_CREDENTIALS)
+      - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+      - --aksengine-public-key=$(K8S_SSH_PUBLIC_KEY_PATH)
+      - --aksengine-private-key=$(K8S_SSH_PRIVATE_KEY_PATH)
+      - --aksengine-winZipBuildScript=$(WIN_BUILD)
+      - --aksengine-orchestratorRelease=1.19
+      - --aksengine-template-url=https://github.com/kubernetes-sigs/windows-testing/blob/master/job-templates/kubernetes_containerd_csi_proxy.json
+      - --aksengine-win-binaries
+      - --aksengine-deploy-custom-k8s
+      - --aksengine-agentpoolcount=2
+      # Specific test args
+      - --test-azure-file-csi-driver
+      securityContext:
+        privileged: true
+      env:
+      - name: TEST_WINDOWS
+        value: "true"
+  annotations:
+    testgrid-dashboards: sig-windows-azure, provider-azure-periodic, provider-azure-windows
+    testgrid-tab-name: aks-engine-azure-windows-azure-file-containerd
+    testgrid-alert-email: kubernetes-provider-azure@googlegroups.com
+    description: Run Azure File e2e test with Azure File in a Windows cluster configured with CSI proxy and containerd.


### PR DESCRIPTION
Adding e2e jobs that validation azure-disk/azure-file CSI plugins on clusters configured with:
- Windows
- Containerd
- CSI-proxy