### PR TITLE
really remove kubetest2

### DIFF
--- a/kubetest2/README.md
+++ b/kubetest2/README.md
@@ -1,4 +1,0 @@
-# kubetest2
-
-Moved to https://github.com/kubernetes-sigs/kubetest2.  
-This README will be removed after 1st of October 2020.


### PR DESCRIPTION
`kubetest2` is said to be removed after October 1st 2020. Let's really remove it.