### PR TITLE
Allow junit files to be under subdirectories.

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -70,7 +70,7 @@ deck:
     - lens:
         name: junit
       required_files:
-        - ^artifacts/junit.*\.xml$
+        - ^artifacts(/.*/|/)junit.*\.xml$ # https://regex101.com/r/vCSegS/1
     - lens:
         name: coverage
       required_files:


### PR DESCRIPTION
This enables the Junit spyglass lens to look at junit files under subdirectories in addition to top-level artifacts.

The junit files aren't generated first class by prow and some jobs (e.g kubetest2) may emit these under subdirectories instead of in top-level artifacts. 

/cc @spiffxp @BenTheElder 

I'm not sure if there are some cases where we are currently intentionally depending on this to not surface junit recursively (I think not) ?