### PR TITLE
Rerun prow job: log debug instead of error on user errors

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1462,12 +1462,12 @@ func handleRerun(prowJobClient prowv1.ProwJobInterface, createProwJob bool, cfg 
 				if goa == nil {
 					msg := "GitHub oauth must be configured to rerun jobs unless 'allow_anyone: true' is specified."
 					http.Error(w, msg, http.StatusInternalServerError)
-					l.Error(msg)
+					l.Debug(msg)
 					return
 				}
 				login, err := goa.GetLogin(r, ghc)
 				if err != nil {
-					l.WithError(err).Errorf("Error retrieving GitHub login")
+					l.WithError(err).Debugf("Error retrieving GitHub login")
 					http.Error(w, "Error retrieving GitHub login", http.StatusUnauthorized)
 					return
 				}
@@ -1475,7 +1475,7 @@ func handleRerun(prowJobClient prowv1.ProwJobInterface, createProwJob bool, cfg 
 				allowed, err = canTriggerJob(login, newPJ, authConfig, cli, pluginAgent.Config, l)
 				if err != nil {
 					http.Error(w, fmt.Sprintf("Error checking if user can trigger job: %v", err), http.StatusInternalServerError)
-					l.WithError(err).Errorf("Error checking if user can trigger job")
+					l.WithError(err).Debugf("Error checking if user can trigger job")
 					return
 				}
 			}


### PR DESCRIPTION
These errors are already surfaced to users as http errors, no need to bring immediate attention of prow operator