### PR TITLE
disable sanity test job on `k-csi/csi-driver-nfs`

### DIFF
--- a/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
+++ b/config/jobs/kubernetes-csi/csi-driver-nfs/csi-driver-nfs-unmanaged.yaml
@@ -2,7 +2,7 @@ presubmits:
   kubernetes-csi/csi-driver-nfs:
   - name: pull-csi-driver-nfs-sanity
     decorate: true
-    always_run: true
+    always_run: false
     path_alias: sigs.k8s.io/csi-driver-nfs
     branches:
     - master


### PR DESCRIPTION
Following https://github.com/kubernetes-csi/csi-driver-nfs/pull/53#issuecomment-707422392, it was decided to disable the sanity tests prow job for k-csi/csi-driver-nfs repo.

Signed-off-by: Mayank Shah <mayankshah1614@gmail.com>