### PR TITLE
secrets-store-csi-driver: remove preset creds

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -9,7 +9,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
@@ -32,7 +31,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
@@ -57,7 +55,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
@@ -82,7 +79,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
@@ -115,7 +111,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
@@ -151,7 +146,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
       preset-azure-cred: "true"
       preset-azure-windows: "true"
       preset-k8s-ssh: "true"
@@ -243,7 +237,6 @@ presubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201005-0b243c0-master
@@ -271,7 +264,6 @@ postsubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind
@@ -304,7 +296,6 @@ postsubmits:
     branches:
     - master
     labels:
-      preset-service-account: "true"
       # this is required because we want to run kind in docker
       preset-dind-enabled: "true"
       # this is required to make CNI installation to succeed for kind


### PR DESCRIPTION
Per comment on https://github.com/kubernetes/test-infra/pull/19512#discussion_r503456849

Remove `preset-service-account: "true"` as this:
1. gives the running job access to modify its own output
2. should not be needed by the providers

The gcp tests are now passing on https://github.com/kubernetes-sigs/secrets-store-csi-driver/pull/340 without this label.