### PR TITLE
Make Tide dashboard configurable.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -38,5 +38,10 @@
     heartbeatJobs: [
       {name: 'ci-test-infra-prow-checkconfig', interval: '9m', alertInterval: '20m'},
     ],
+
+    // Tide pools that are important enough to have their own graphs on the dashboard.
+    tideDashboardExplicitPools: [
+      {org: 'kubernetes', repo: 'kubernetes', branch: 'master'},
+    ],
   },
 }


### PR DESCRIPTION
The Tide dashboard includes a graph specific to the kubernetes/kubernetes:master pool. This PR makes the tide pool(s) that are explicitly shown in their own graphs configurable so that different tide instances can omit this graph or supply their own tide pools to explicitly graph.
I've confirmed that the output is sensible in the null case and that this change generates an identical tide.json to what was generated previously.

/assign @chaodaiG 