### PR TITLE
Make missing webhook alert interval configurable.

### DIFF
--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -70,5 +70,8 @@
       {instance: "35.225.208.117:9090", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
       {instance: "104.197.27.114:9090", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
     ],
+
+    // How long we go during work hours without seeing a webhook before alerting.
+    webhookMissingAlertInterval: '10m',
   },
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/hook_alert.libsonnet
@@ -12,13 +12,13 @@
               (sum(increase(prow_webhook_counter[1m])) == 0 or absent(prow_webhook_counter))
               and ((day_of_week() > 0) and (day_of_week() < 6) and (hour() >= 16))
             |||,
-            'for': '10m',
+            'for': $._config.webhookMissingAlertInterval,
             labels: {
               severity: 'high',
               slo: componentName,
             },
             annotations: {
-              message: 'There have been no webhook calls on working hours for 10 minutes',
+              message: 'There have been no webhook calls on working hours for %s' % $._config.webhookMissingAlertInterval,
             },
           },
         ],


### PR DESCRIPTION
Some Prow instances don't have enough activity to expect a webhook every 10mins.

/assign @chaodaiG 