### PR TITLE
Split Kettle staging execution out

### DIFF
--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -19,7 +19,6 @@ spec:
         env:
         - name: BUILD_LIMIT
           value: 1000
-        env:
         - name: DEPLOYMENT
           value: staging
         volumeMounts:

--- a/kettle/deployment-staging.yaml
+++ b/kettle/deployment-staging.yaml
@@ -19,6 +19,9 @@ spec:
         env:
         - name: BUILD_LIMIT
           value: 1000
+        env:
+        - name: DEPLOYMENT
+          value: staging
         volumeMounts:
         - name: service
           mountPath: /etc/service-account

--- a/kettle/deployment.yaml
+++ b/kettle/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         env:
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/service-account/service-account.json
+        - name: DEPLOYMENT
+          value: prod
         volumeMounts:
         - name: service
           mountPath: /etc/service-account

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -55,10 +55,7 @@ def main():
         bq_ext = ' --replace'
         mj_ext = ' --reset-emitted'
 
-    if os.getenv('DEPLOYMENT', 'prod') == "staging":
-        call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
-        call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
-    else:
+    if os.getenv('DEPLOYMENT', 'staging') == "prod":
         call(f'{mj_cmd} {mj_ext} --days 1 | pv | gzip > build_day.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.day build_day.json.gz schema.json')
 
@@ -70,6 +67,9 @@ def main():
 
         call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
             ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')
+    else:
+        call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
+        call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
 
 
 if __name__ == '__main__':

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -63,7 +63,7 @@ def main():
         call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json')
 
         call(f'{mj_cmd} {mj_ext} --days 7 | pv | gzip > build_week.json.gz')
-        call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.week build_week.json.gz schema.json')
 
         call(f'{mj_cmd} | pv | gzip > build_all.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.all build_all.json.gz schema.json')

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -41,7 +41,7 @@ def call(cmd):
 
 
 def main():
-    call('time python3 make_db.py --buckets buckets.yaml --junit --threads {THREADS}')
+    call(f'time python3 make_db.py --buckets buckets.yaml --junit --threads {THREADS}')
 
     bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS}'
     mj_cmd = 'pypy3 make_json.py'

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -65,7 +65,7 @@ def main():
         call(f'{mj_cmd} | pv | gzip > build_all.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.all build_all.json.gz schema.json')
 
-        call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
+        call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle ' \
             ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')
     else:
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -60,7 +60,7 @@ def main():
         call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
     else:
         call(f'{mj_cmd} {mj_ext} --days 1 | pv | gzip > build_day.json.gz')
-        call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json')
+        call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.day build_day.json.gz schema.json')
 
         call(f'{mj_cmd} {mj_ext} --days 7 | pv | gzip > build_week.json.gz')
         call(f'{bq_cmd} {bq_ext} k8s-gubernator:build.week build_week.json.gz schema.json')

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -49,7 +49,7 @@ def main():
     mj_ext = ''
     bq_ext = ''
     try:
-        call(mj_cmd + ' --days 1 --assert-oldest {DAYS_OLD}')
+        call(f'{mj_cmd} --days 1 --assert-oldest {DAYS_OLD}')
     except OSError:
         # cycle daily/weekly tables
         bq_ext = ' --replace'

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -43,7 +43,7 @@ def call(cmd):
 def main():
     call(f'time python3 make_db.py --buckets buckets.yaml --junit --threads {THREADS}')
 
-    bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS}'
+    bq_cmd = f'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS}'
     mj_cmd = 'pypy3 make_json.py'
 
     mj_ext = ''

--- a/kettle/update.py
+++ b/kettle/update.py
@@ -19,6 +19,9 @@ import os
 
 
 DUMP = 'dump.txt'
+THREADS = 32
+MAX_BAD_RECORDS = 1000
+DAYS_OLD = 1.9
 
 def print_dump(file):
     if os.path.exists(file):
@@ -38,31 +41,35 @@ def call(cmd):
 
 
 def main():
-    call('time python3 make_db.py --buckets buckets.yaml --junit --threads 32')
+    call('time python3 make_db.py --buckets buckets.yaml --junit --threads {THREADS}')
 
-    bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records=1000'
+    bq_cmd = 'bq load --source_format=NEWLINE_DELIMITED_JSON --max_bad_records={MAX_BAD_RECORDS}'
     mj_cmd = 'pypy3 make_json.py'
 
     mj_ext = ''
     bq_ext = ''
     try:
-        call(mj_cmd + ' --days 1 --assert-oldest 1.9')
+        call(mj_cmd + ' --days 1 --assert-oldest {DAYS_OLD}')
     except OSError:
         # cycle daily/weekly tables
         bq_ext = ' --replace'
         mj_ext = ' --reset-emitted'
 
-    call(mj_cmd + mj_ext + ' --days 1 | pv | gzip > build_day.json.gz')
-    call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json')
+    if os.getenv('DEPLOYMENT', 'prod') == "staging":
+        call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
+        call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
+    else:
+        call(f'{mj_cmd} {mj_ext} --days 1 | pv | gzip > build_day.json.gz')
+        call(bq_cmd + bq_ext + ' k8s-gubernator:build.day build_day.json.gz schema.json')
 
-    call(mj_cmd + mj_ext + ' --days 7 | pv | gzip > build_week.json.gz')
-    call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json')
+        call(f'{mj_cmd} {mj_ext} --days 7 | pv | gzip > build_week.json.gz')
+        call(bq_cmd + bq_ext + ' k8s-gubernator:build.week build_week.json.gz schema.json')
 
-    call(mj_cmd + ' | pv | gzip > build_all.json.gz')
-    call(bq_cmd + ' k8s-gubernator:build.all build_all.json.gz schema.json')
+        call(f'{mj_cmd} | pv | gzip > build_all.json.gz')
+        call(f'{bq_cmd} k8s-gubernator:build.all build_all.json.gz schema.json')
 
-    call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
-         ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')
+        call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle '
+            ' --dataset k8s-gubernator:build --tables all:0 day:1 week:7 --stop_at=1')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Break up kettle execution paths so that staging reports to it's own table

@amwat Do you think it would be worth it to replicate all three tables here? I think 'all' encompasses the logic for `day` and `week` but I am unsure. 

/area kettle 