### PR TITLE
Update containerd jobs to use containerd image config

### DIFF
--- a/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
+++ b/config/jobs/containerd/containerd/containerd-presubmit-jobs.yaml
@@ -67,4 +67,4 @@ presubmits:
           --provider=gce
           '--test_args=--nodes=8 --focus="\[NodeConformance\]|\[NodeFeature:.+\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"'
           --timeout=65m
-          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/cri-master/image-config-pr.yaml -node-env=PULL_REFS=$(PULL_REFS)"
+          "--node-args=--image-config-file=${GOPATH}/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml -node-env=PULL_REFS=$(PULL_REFS)"

--- a/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
+++ b/jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml
@@ -1,0 +1,9 @@
+images:
+  ubuntu:
+    image: ubuntu-gke-1804-1-16-v20200330
+    project: ubuntu-os-gke-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/env"
+  cos-stable:
+    image_family: cos-81-lts
+    project: cos-cloud
+    metadata: "user-data</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/init.yaml,containerd-configure-sh</home/prow/go/src/github.com/containerd/containerd/cluster/gce/configure.sh,containerd-extra-init-sh</home/prow/go/src/github.com/containerd/containerd/test/e2e_node/gci-init.sh,containerd-env</home/prow/go/src/k8s.io/test-infra/jobs/e2e_node/containerd/containerd-master/env,gci-update-strategy=update_disabled"


### PR DESCRIPTION
Updates to use the containerd master config over the cri config

jobs/e2e_node/containerd/containerd-master/image-config-pr.yaml is copied from cri-master with updates to use files from containerd