### PR TITLE
Azure: Fix the nil pointer when the api model is incomplete

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -516,8 +516,11 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 	}}
 
 	if !toBool(v.Properties.OrchestratorProfile.KubernetesConfig.UseManagedIdentity) {
-		v.Properties.ServicePrincipalProfile.ClientID = c.credentials.ClientID
-		v.Properties.ServicePrincipalProfile.Secret = c.credentials.ClientSecret
+		// prevent the nil pointer panic
+		v.Properties.ServicePrincipalProfile = &ServicePrincipalProfile{
+			ClientID: c.credentials.ClientID,
+			Secret:   c.credentials.ClientSecret,
+		}
 	} else {
 		c.useManagedIdentity = true
 		if v.Properties.OrchestratorProfile.KubernetesConfig.UserAssignedID != "" {


### PR DESCRIPTION
The change in aks-engine https://github.com/Azure/aks-engine/pull/3856/files#diff-3c4e95b40043f6f00aa0d3f04416b8a623ade0ca9c33cf92ad652f9ba6f81734 introduces a nil pointer panic, which blocks our test.

/kind bug
/area provider/azure