### PR TITLE
add mdtoc presubmit jobs

### DIFF
--- a/config/jobs/kubernetes-sigs/mdtoc/OWNERS
+++ b/config/jobs/kubernetes-sigs/mdtoc/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+- enhancements-approvers
+- tallclair
+reviewers:
+- release-engineering-reviewers
+- enhancements-reviewers
+- tallclair

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/mdtoc:
+  - name: pull-mdtoc-test
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/mdtoc
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - test
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: mdtoc-test
+      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-num-columns-recent: '30'
+  - name: pull-mdtoc-verify
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/mdtoc
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-tab-name: mdtoc-verify
+      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-num-columns-recent: '30'


### PR DESCRIPTION
Adding the presubmit job for the repo https://github.com/kubernetes-sigs/mdtoc

Set the owners as the owners in the repo, please let me know if need to update that.

GitHub Issue: https://github.com/kubernetes-sigs/mdtoc/issues/3

ref: 

/cc @saschagrunert @justaugustus @tallclair 