### PR TITLE
Spyglass artifact fetcher: Swallow request cancelled errors

### DIFF
--- a/prow/cmd/deck/main.go
+++ b/prow/cmd/deck/main.go
@@ -1660,5 +1660,5 @@ func httpStatusForError(e error) int {
 }
 
 func shouldLogHTTPErrors(e error) bool {
-	return httpStatusForError(e) >= http.StatusInternalServerError // 5XX
+	return e != context.Canceled || httpStatusForError(e) >= http.StatusInternalServerError // 5XX
 }

--- a/prow/spyglass/storageartifact_fetcher.go
+++ b/prow/spyglass/storageartifact_fetcher.go
@@ -149,6 +149,9 @@ func (af *StorageArtifactFetcher) artifacts(ctx context.Context, key string) ([]
 			break
 		}
 		if err != nil {
+			if err == context.Canceled {
+				return nil, err
+			}
 			logrus.WithFields(fieldsForJob(src)).WithError(err).Error("Error accessing GCS artifact.")
 			if i >= len(wait) {
 				return artifacts, fmt.Errorf("timed out: error accessing GCS artifact: %v", err)


### PR DESCRIPTION
We have quite a bit of these in the log, however the `context .Caleled` just means that the request was canceled which is not an error condition:

```

@ingestionTime | 1602691108838
-- | --
@log | 320297955214:app-ci-pod-logs
@logStream | ip-10-0-137-140
@message | {"component":"deck","container_name":"deck","error":"context canceled","file":"prow/spyglass/storageartifact_fetcher.go:152","func":"k8s.io/test-infra/prow/spyglass.(*StorageArtifactFetcher).artifacts","host":"ip-10-0-137-140","jobPrefix":"origin-ci-test/logs/release/","level":"error","msg":"Error accessing GCS artifact.","multiline_tag":"F","object_uid":"687c9d00-69b9-4691-893f-2214890a82bf","pod_name":"deck-f486999c5-rs95s","pod_namespace":"ci","severity":"error","source_type":"kubernetes","stream":"stderr","time":"2020-10-14T15:58:28Z"}
@timestamp | 1602691108607
component | deck
container_name | deck
error | context canceled
file | prow/spyglass/storageartifact_fetcher.go:152
func | k8s.io/test-infra/prow/spyglass.(*StorageArtifactFetcher).artifacts
host | ip-10-0-137-140
jobPrefix | origin-ci-test/logs/release/
level | error
msg | Error accessing GCS artifact.
multiline_tag | F
object_uid | 687c9d00-69b9-4691-893f-2214890a82bf
pod_name | deck-f486999c5-rs95s
pod_namespace | ci
severity | error
source_type | kubernetes
stream | stderr
time | 2020-10-14T15:58:28Z


```