### PR TITLE
Make heartbeat job run on trusted cluster to stabilize runtime.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-periodics.yaml
@@ -24,37 +24,6 @@ periodics:
     testgrid-tab-name: ci-bazel
     description: Runs bazel test //... on the test-infra repo every hour
 
-# This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
-# Alerts expect it to run every 9 mins and will fire after 20 mins without a successful run.
-# Please keep this in sync with the `pull-test-infra-prow-checkconfig` job
-- name: ci-test-infra-prow-checkconfig
-  interval: 9m
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: test-infra
-    base_ref: master
-  spec:
-    containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20201013-3e48dad509
-      command:
-      - /checkconfig
-      args:
-      - --config-path=config/prow/config.yaml
-      - --job-config-path=config/jobs
-      - --plugin-config=config/prow/plugins.yaml
-      - --strict
-      - --warnings=mismatched-tide-lenient
-      - --warnings=tide-strict-branch
-      - --warnings=needs-ok-to-test
-      - --warnings=validate-owners
-      - --warnings=missing-trigger
-      - --warnings=validate-urls
-      - --warnings=unknown-fields
-      - --warnings=duplicate-job-refs
-  annotations:
-    testgrid-dashboards: sig-testing-misc
-
 - name: ci-test-infra-triage
   decorate: true
   decoration_config:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1126,3 +1126,35 @@ periodics:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
     testgrid-num-failures-to-alert: '1'
+
+# This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
+# Alerts expect it to run every 9 mins and will fire after 20 mins without a successful run.
+# Please keep this in sync with the `pull-test-infra-prow-checkconfig` job
+- name: ci-test-infra-prow-checkconfig
+  interval: 9m
+  cluster: test-infra-trusted
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: test-infra
+    base_ref: master
+  spec:
+    containers:
+    - image: gcr.io/k8s-prow/checkconfig:v20201013-c02a7cb212
+      command:
+      - /checkconfig
+      args:
+      - --config-path=config/prow/config.yaml
+      - --job-config-path=config/jobs
+      - --plugin-config=config/prow/plugins.yaml
+      - --strict
+      - --warnings=mismatched-tide-lenient
+      - --warnings=tide-strict-branch
+      - --warnings=needs-ok-to-test
+      - --warnings=validate-owners
+      - --warnings=missing-trigger
+      - --warnings=validate-urls
+      - --warnings=unknown-fields
+      - --warnings=duplicate-job-refs
+  annotations:
+    testgrid-dashboards: sig-testing-misc


### PR DESCRIPTION
The runtime of the `ci-test-infra-prow-checkconfig` job has been pretty variable, but it doesn't appear to be caused by the job's own runtime (which is always <1min). The occasional large delays seem to be caused by pod scheduling or start up. Here is an example of a job that did not write `started.json` until 6 mins after it's pod was created https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-test-infra-prow-checkconfig/1316425509474668544

A quick comparison of the runtime durations on these two sites shows the discrepancy:
https://prow.k8s.io/?job=ci-test-infra-prow-checkconfig
https://testgrid.k8s.io/sig-testing-misc#ci-test-infra-prow-checkconfig&graph-metrics=test-duration-minutes&width=5

In order for this heartbeat job to provide a fast and reliable signal we need to avoid these scheduling or start up delays. I'd like to try running the job in the trusted cluster (which is less utilized) to determine if this is likely to be caused by neighboring workloads.

/assign @chaodaiG 