### PR TITLE
Enable slackevents prow plugin for kops

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -322,6 +322,12 @@ slack:
     - wg-k8s-infra
     exempt_users:
     - k8s-ci-robot
+  - repos:
+    - kubernetes/kops
+    channels:
+    - kops-dev
+    exempt_users:
+    - k8s-ci-robot
 
 milestone_applier:
   kubernetes/enhancements:


### PR DESCRIPTION
This notifies #kops-dev of any manual merges or pushes. This seems like a good idea, not only for security but to increase visibility in our release process as we work towards more release automation.

Also announced here: https://kubernetes.slack.com/archives/C8MKE2G5P/p1602768301056500