### PR TITLE
Add golangci-lint to presubmit checks with minimal configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,8 @@
+run:
+  deadline: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - gofmt
+    - misspell

--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -97,3 +97,17 @@ presubmits:
         - --warnings=duplicate-job-refs
     annotations:
       testgrid-dashboards: presubmits-test-infra
+
+  - name: pull-test-infra-verify-golangci-lint
+    decorate: true
+    run_if_changed: '\.go'
+    spec:
+      containers:
+        - image: golangci/golangci-lint:v1.31.0
+          command:
+            - golangci-lint
+          args:
+            - run
+    annotations:
+      testgrid-dashboards: presubmits-test-infra
+      testgrid-tab-name: verify-golangci-lint


### PR DESCRIPTION
Add golangci-lint to presubmit commits to address #19588.