### PR TITLE
jira: don't alias an error variable

### DIFF
--- a/prow/jira/jira.go
+++ b/prow/jira/jira.go
@@ -199,9 +199,9 @@ func maskAuthorizationHeader(key string, value string) string {
 func JiraError(response *jira.Response, err error) error {
 	if err != nil && strings.Contains(err.Error(), "Please analyze the request body for more details.") {
 		if response != nil && response.Response != nil {
-			body, err := ioutil.ReadAll(response.Body)
-			if err != nil {
-				logrus.WithError(err).Warn("Failed to read Jira response body.")
+			body, readErr := ioutil.ReadAll(response.Body)
+			if readErr != nil {
+				logrus.WithError(readErr).Warn("Failed to read Jira response body.")
 			}
 			return fmt.Errorf("%w: %v", err, string(body))
 		}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

/assign @alvaroaleman 