### PR TITLE
[sig-scalability] Run 5k performance test with e2-medium instances

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -76,6 +76,7 @@ periodics:
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest-fast
+      - --gcp-node-size=e2-medium
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
Change VM instance type for 5k performance test to `e2-medium`.

According to https://cloud.google.com/products/calculator e2-medium is more cost-effective in 12 hours  x 7 days model.

I've run a one-off test to confirm that test passes, it took similar time as n1-standard-1 version

/assign @wojtek-t 

