### PR TITLE
use scenarios/kubernetes_e2e.py as kubetest doesn't work with gce

### DIFF
--- a/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
+++ b/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
@@ -17,7 +17,7 @@ periodics:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201014-882eb3f-master
         command:
         - runner.sh
-        - kubetest
+        - /workspace/scenarios/kubernetes_e2e.py
         args:
         - --check-leaked-resources
         - --check-version-skew=false


### PR DESCRIPTION
the job failed due to `2020/10/16 04:05:02 main.go:312: Something went wrong: failed to prepare test environment: stat /root/.ssh/google_compute_engine: no such file or directory`. see logs in https://storage.googleapis.com/kubernetes-jenkins/logs/sig-auth-serviceaccount-admission-controller-migration/1316953242881495040/build-log.txt.

the reason is that `preset-k8s-ssh: "true"` would not add volume mounts at `/root/.ssh/google_compute_engine` but at `/etc/ssh-key-secret`. however kubetest expects the public and private keys at `/ssh/google_compute_engine` https://github.com/kubernetes/test-infra/blob/090dec5dd535d5f61b7ba52e671a810f5fc13dfd/kubetest/main.go#L774-L783

i think (not verified) `/workspace/scenarios/kubernetes_e2e.py` will work because https://github.com/kubernetes/test-infra/blob/ca145527281c6d42c5895913af5ff1301d6a6a9f/scenarios/kubernetes_e2e.py#L198-L201 would copy the public and private keys.