### PR TITLE
kubernetes-sigs/k8s-container-image-promoter: add prow plugins

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -947,6 +947,11 @@ plugins:
   kubernetes-sigs/security-profiles-operator:
   - release-note
 
+  kubernetes-sigs/k8s-container-image-promoter:
+  - mergecommitblocker
+  - override
+  - release-note
+
   containerd/cri:
   - assign
   - cla


### PR DESCRIPTION
Add common prow plugins to kubernetes-sigs/k8s-container-image-promoter repo

ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/266

/cc @justaugustus @nikhita 