### PR TITLE
do not run other e2e tests for upgrade test

### DIFF
--- a/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
+++ b/config/jobs/kubernetes/sig-auth/serviceaccount-admission-controller-migration-config.yaml
@@ -19,6 +19,9 @@ periodics:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
+        # this flag controls whether `--test` is passed to kubetest via kubernetes_e2e.py.
+        # we don't need to test other e2e tests when `--upgrade_args` is specified.
+        - --test=false
         - --check-leaked-resources
         - --check-version-skew=false
         # TODO: change to release/stable-x.y


### PR DESCRIPTION
kubenetes_e2e.py is wrapper over kubetest where we need to explicitly
tell it not to run other e2e tests.