### PR TITLE
Decrease heartbeat job period to 5mins.

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1128,10 +1128,10 @@ periodics:
     testgrid-num-failures-to-alert: '1'
 
 # This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
-# Alerts expect it to run every 9 mins and will fire after 20 mins without a successful run.
+# Alerts expect it to run every 5 mins and will fire after 20 mins without a successful run.
 # Please keep this in sync with the `pull-test-infra-prow-checkconfig` job
 - name: ci-test-infra-prow-checkconfig
-  interval: 9m
+  interval: 5m
   cluster: test-infra-trusted
   decorate: true
   extra_refs:

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -36,7 +36,7 @@
 
     // Heartbeat jobs
     heartbeatJobs: [
-      {name: 'ci-test-infra-prow-checkconfig', interval: '9m', alertInterval: '20m'},
+      {name: 'ci-test-infra-prow-checkconfig', interval: '5m', alertInterval: '20m'},
     ],
 
     // Tide pools that are important enough to have their own graphs on the dashboard.


### PR DESCRIPTION
Currently the count of successful heartbeat jobs in the past 20mins can drop from 2 down to 1 briefly due to the timing of prometheus scrapes. When this coincides with a timeseries change (e.g. a change to the job's cluster or a Prow bump causing a new plank pod to be created) we can drop down to 0 and unintentionally fire an alert. This is because new counter time series result in an `increase()` of zero the first time a value is seen. So when the new counter is created with a value of 1 this is seen as an increase of 0.
This problem is detailed here: https://github.com/prometheus/prometheus/issues/1673 Unfortunately the project maintainers see this as WAI and won't add the `zero_increase()` function that would be allow this to be addressed reasonably.
I've discussed this with Chao and increasing the number of job intervals in the alert interval seems like the best way to work around this.
/assign @chaodaiG 