### PR TITLE
Increase memory for pull-kubernetes-node-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -37,10 +37,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 4
-            memory: 3Gi
+            memory: 6Gi
   - name: pull-kubernetes-e2e-containerd-gce
     always_run: false
     optional: true


### PR DESCRIPTION
The presubmit pull-kubernetes-node-e2e has been consistently flaking due to early build failures with a reason of `OOMKilled`.

The job is currently set to 3 gigs of memory which seems a bit low.

This PR bumps the resource limit/request to 6 gigs to match other jobs.

History:

https://prow.k8s.io/job-history/gs/kubernetes-jenkins/pr-logs/directory/pull-kubernetes-node-e2e

Recent:

https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/95625/pull-kubernetes-node-e2e/1317239449473519616/
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/94115/pull-kubernetes-node-e2e/1317172507119194112
https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/95640/pull-kubernetes-node-e2e/1317184022786347008

Note: I could have totally misinterpreted just about everything here.