### PR TITLE
Remove presubmit job for Kubeflow pytorch-operator

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -55,20 +55,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for Kubeflow.
       testgrid-num-columns-recent: '30'
-  kubeflow/pytorch-operator:
-  - name: kubeflow-pytorch-operator-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/pytorch-operator.
-      testgrid-num-columns-recent: '30'
   kubeflow/reporting:
   - name: kubeflow-reporting-presubmit
     cluster: kubeflow


### PR DESCRIPTION
We are doing POC to move pytorch-operator jobs to a separate Prow cluster.  https://github.com/kubeflow/testing/issues/737
The reason we'd like to remove pytorch-operator presubmit job is 

1. E2E test flow now is configured to use AWS ECR images and GCP environment can not fetch images. It's wasting resources.

http://testing-argo.kubeflow.org/workflows/kubeflow-test-infra/kubeflow-pytorch-operator-presubmit-e2e-305-d13b055-6944-436b?tab=workflow&nodeId=kubeflow-pytorch-operator-presubmit-e2e-305-d13b055-6944-436b-597936768

2. Github send events to two webhooks and both prow cluster kick off jobs. However, following window only shows one job. I am not sure if it's a problem that both prow kick off job with exact same name. 

![Screenshot from 2020-10-18 12-10-22](https://user-images.githubusercontent.com/4739316/96377532-0e901b80-113b-11eb-8d1f-4555bed909ef.png)

pytorch-operator e2e job on AWS prow cluster

http://8069b97e-prow-prow-6530-1439048706.us-west-2.elb.amazonaws.com/?repo=kubeflow%2Fpytorch-operator

http://86308603-argo-argo-5ce9-1162466691.us-west-2.elb.amazonaws.com/workflows/kubeflow-test-infra/presubmit-pytorch-e2e-e2e-305-d13b055-5008-c61e?tab=workflow&nodeId=presubmit-pytorch-e2e-e2e-305-d13b055-5008-c61e-2126833750

/cc @PatrickXYS @johnugeorge @jlewi @Bobgy  