### PR TITLE
YAML cleanup: consistent indentation before list elements

### DIFF
--- a/config/prow/cluster/deck_rbac.yaml
+++ b/config/prow/cluster/deck_rbac.yaml
@@ -12,16 +12,16 @@ metadata:
   namespace: default
   name: deck
 rules:
-  - apiGroups:
-      - "prow.k8s.io"
-    resources:
-      - prowjobs
-    verbs:
-      - get
-      - list
-      - watch
-      # Required when deck runs with `--rerun-creates-job=true`
-      - create
+- apiGroups:
+  - "prow.k8s.io"
+  resources:
+  - prowjobs
+  verbs:
+  - get
+  - list
+  - watch
+  # Required when deck runs with `--rerun-creates-job=true`
+  - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -29,12 +29,12 @@ metadata:
   namespace: test-pods
   name: deck
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - pods/log
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/monitoring/grafana_deployment.yaml
+++ b/config/prow/cluster/monitoring/grafana_deployment.yaml
@@ -38,13 +38,13 @@ spec:
         image: grafana/grafana:6.1.4
         name: grafana
         env:
-          - name: GF_SECURITY_ADMIN_USER
-            value: adm
-          - name: GF_SECURITY_ADMIN_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: grafana
-                key: password
+        - name: GF_SECURITY_ADMIN_USER
+          value: adm
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: grafana
+              key: password
         ports:
         - containerPort: 3001
           name: http

--- a/config/prow/cluster/monitoring/grafana_expose.yaml
+++ b/config/prow/cluster/monitoring/grafana_expose.yaml
@@ -35,13 +35,13 @@ metadata:
   namespace: prow-monitoring
 spec:
   tls:
-    - secretName: grafana-tls
-      hosts:
-        - monitoring.prow.k8s.io
+  - secretName: grafana-tls
+    hosts:
+    - monitoring.prow.k8s.io
   rules:
-    - host: monitoring.prow.k8s.io
-      http:
-        paths:
-          - backend:
-              serviceName: grafana
-              servicePort: 80
+  - host: monitoring.prow.k8s.io
+    http:
+      paths:
+      - backend:
+          serviceName: grafana
+          servicePort: 80

--- a/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_deployment.yaml
@@ -17,19 +17,19 @@ spec:
         app: prometheus-operator
     spec:
       containers:
-        - args:
-            - --kubelet-service=kube-system/kubelet
-            - --logtostderr=true
-            - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-            - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-            - --namespaces=prow-monitoring
-          image: quay.io/coreos/prometheus-operator:v0.29.0
-          name: prometheus-operator
-          ports:
-            - containerPort: 8080
-              name: http
-          resources: {}
-          securityContext: {}
+      - args:
+        - --kubelet-service=kube-system/kubelet
+        - --logtostderr=true
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
+        - --namespaces=prow-monitoring
+        image: quay.io/coreos/prometheus-operator:v0.29.0
+        name: prometheus-operator
+        ports:
+        - containerPort: 8080
+          name: http
+        resources: {}
+        securityContext: {}
       nodeSelector: {}
       securityContext: {}
       serviceAccount: prometheus-operator

--- a/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_operator_rbac.yaml
@@ -8,79 +8,79 @@ roleRef:
   kind: ClusterRole
   name: prow-prometheus-operator
 subjects:
-  - kind: ServiceAccount
-    name: prometheus-operator
-    namespace: prow-monitoring
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: prow-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prow-prometheus-operator
 rules:
-  - apiGroups:
-      - apiextensions.k8s.io
-    resources:
-      - customresourcedefinitions
-    verbs:
-      - '*'
-  - apiGroups:
-      - monitoring.coreos.com
-    resources:
-      - alertmanagers
-      - alertmanagers/finalizers
-      - prometheuses
-      - prometheuses/finalizers
-      - prometheusrules
-      - servicemonitors
-    verbs:
-      - '*'
-  - apiGroups:
-      - apps
-    resources:
-      - statefulsets
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-      - secrets
-    verbs:
-      - '*'
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-    verbs:
-      - delete
-      - list
-  - apiGroups:
-      - ""
-    attributeRestrictions: null
-    resources:
-      - endpoints
-      - services
-      - services/finalizers
-    verbs:
-      - create
-      - get
-      - update
-      - delete
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-    verbs:
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - alertmanagers/finalizers
+  - prometheuses
+  - prometheuses/finalizers
+  - prometheusrules
+  - servicemonitors
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - list
+- apiGroups:
+  - ""
+  attributeRestrictions: null
+  resources:
+  - endpoints
+  - services
+  - services/finalizers
+  verbs:
+  - create
+  - get
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/config/prow/cluster/monitoring/prometheus_rbac.yaml
+++ b/config/prow/cluster/monitoring/prometheus_rbac.yaml
@@ -14,35 +14,35 @@ roleRef:
   kind: ClusterRole
   name: prometheus-prow
 subjects:
-  - kind: ServiceAccount
-    name: prometheus-prow
-    namespace: prow-monitoring
+- kind: ServiceAccount
+  name: prometheus-prow
+  namespace: prow-monitoring
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-prow
 rules:
-  - apiGroups:
-      - ""
-    resources:
-      - nodes
-      - services
-      - endpoints
-      - pods
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - ""
-    resources:
-      - configmaps
-    verbs:
-      - get
-  - apiGroups: null
-    nonResourceURLs:
-      - /metrics
-    resources: []
-    verbs:
-      - get
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups: null
+  nonResourceURLs:
+  - /metrics
+  resources: []
+  verbs:
+  - get

--- a/config/prow/cluster/monitoring/prow_prometheus.yaml
+++ b/config/prow/cluster/monitoring/prow_prometheus.yaml
@@ -11,7 +11,7 @@ spec:
         name: prometheus
       spec:
         accessModes:
-          - "ReadWriteOnce"
+        - "ReadWriteOnce"
         storageClassName: "standard"
         resources:
           requests:
@@ -20,9 +20,9 @@ spec:
   serviceAccountName: prometheus-prow
   alerting:
     alertmanagers:
-      - namespace: prow-monitoring
-        name: alertmanager
-        port: http
+    - namespace: prow-monitoring
+      name: alertmanager
+      port: http
   enableAdminAPI: false
   ruleSelector:
     matchLabels:
@@ -30,8 +30,8 @@ spec:
       prometheus: prow
   serviceMonitorSelector:
     matchExpressions:
-      - key: app
-        operator: Exists
+    - key: app
+      operator: Exists
   version: v2.7.1
   baseImage: docker.io/prom/prometheus
   externalLabels: {}

--- a/config/prow/cluster/monitoring/prow_servicemonitors.yaml
+++ b/config/prow/cluster/monitoring/prow_servicemonitors.yaml
@@ -29,12 +29,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: http
-      scheme: http
+  - interval: 30s
+    port: http
+    scheme: http
   namespaceSelector:
     matchNames:
-      - prow-monitoring
+    - prow-monitoring
   selector:
     matchLabels:
       app: alertmanager
@@ -48,12 +48,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: http
-      scheme: http
+  - interval: 30s
+    port: http
+    scheme: http
   namespaceSelector:
     matchNames:
-      - prow-monitoring
+    - prow-monitoring
   selector:
     matchLabels:
       app: grafana
@@ -67,9 +67,9 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
       - default
@@ -86,9 +86,9 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
       - default
@@ -105,12 +105,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: hook
@@ -124,12 +124,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: prow-controller-manager
@@ -143,12 +143,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: sinker
@@ -162,12 +162,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: tide
@@ -181,12 +181,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: horologium
@@ -200,12 +200,12 @@ metadata:
   namespace: prow-monitoring
 spec:
   endpoints:
-    - interval: 30s
-      port: metrics
-      scheme: http
+  - interval: 30s
+    port: metrics
+    scheme: http
   namespaceSelector:
     matchNames:
-      - default
+    - default
   selector:
     matchLabels:
       app: crier


### PR DESCRIPTION
There is a mix of indent exist/not before yaml list elements, make them consistent by removing the indentation