### PR TITLE
Add --extract-{ci,release}-bucket flags to kubetest

### DIFF
--- a/kubetest/extract_k8s.go
+++ b/kubetest/extract_k8s.go
@@ -129,7 +129,7 @@ func (e extractStrategy) name() string {
 	return filepath.Base(e.option)
 }
 
-func (l extractStrategies) Extract(project, zone, region string, extractSrc bool) error {
+func (l extractStrategies) Extract(project, zone, region, ciBucket, releaseBucket string, extractSrc bool) error {
 	// rm -rf kubernetes*
 	files, err := ioutil.ReadDir(".")
 	if err != nil {
@@ -153,7 +153,7 @@ func (l extractStrategies) Extract(project, zone, region string, extractSrc bool
 				return err
 			}
 		}
-		if err := e.Extract(project, zone, region, extractSrc); err != nil {
+		if err := e.Extract(project, zone, region, ciBucket, releaseBucket, extractSrc); err != nil {
 			return err
 		}
 	}
@@ -415,17 +415,17 @@ func setupGciVars(f string, p string) (string, error) {
 	return i, nil
 }
 
-func setReleaseFromGci(image string, k8sMapBucket string, getSrc bool) error {
+func setReleaseFromGci(image, k8sMapBucket, releaseBucket string, getSrc bool) error {
 	catURL := fmt.Sprintf("gs://%s/k8s-version-map/%s", k8sMapBucket, image)
 	b, err := gsutilCat(catURL)
 	if err != nil {
 		return fmt.Errorf("Failed to set release from %s (%v)", catURL, err)
 	}
 	r := fmt.Sprintf("v%s", b)
-	return getKube("https://storage.googleapis.com/kubernetes-release/release", strings.TrimSpace(r), getSrc)
+	return getKube(fmt.Sprintf("https://storage.googleapis.com/%s/release", releaseBucket), strings.TrimSpace(r), getSrc)
 }
 
-func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) error {
+func (e extractStrategy) Extract(project, zone, region, ciBucket, releaseBucket string, extractSrc bool) error {
 	switch e.mode {
 	case localBazel:
 		vFile := util.K8s("kubernetes", "bazel-bin", "version")
@@ -468,9 +468,9 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		if i, err := setupGciVars(family, project); err != nil {
 			return err
 		} else if e.ciVersion != "" {
-			return setReleaseFromGcs("kubernetes-release-dev/ci", e.ciVersion, extractSrc)
+			return setReleaseFromGcs(fmt.Sprintf("%s/ci", ciBucket), e.ciVersion, extractSrc)
 		} else {
-			return setReleaseFromGci(i, k8sMapBucket, extractSrc)
+			return setReleaseFromGci(i, k8sMapBucket, releaseBucket, extractSrc)
 		}
 	case gke:
 		// TODO(fejta): prod v staging v test
@@ -524,28 +524,28 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		// launch the default.
 		// TODO(fejta): clean up this logic. Setting/unsetting the same env var is gross.
 		defer os.Unsetenv("CLUSTER_API_VERSION")
-		return setReleaseFromGcs("kubernetes-release-dev/ci", "latest-"+mat[1], extractSrc)
+		return setReleaseFromGcs(fmt.Sprintf("%s/ci", ciBucket), "latest-"+mat[1], extractSrc)
 	case ci:
 		if strings.HasPrefix(e.option, "gke-") {
 			return setReleaseFromGcs("gke-release-staging/kubernetes/release", e.option, extractSrc)
 		}
 
-		url, release, err := setReleaseFromHTTP("kubernetes-release-dev/ci", e.option)
+		url, release, err := setReleaseFromHTTP(fmt.Sprintf("%s/ci", ciBucket), e.option)
 		if err != nil {
 			return err
 		}
 		return getKube(url, release, extractSrc)
 	case ciFast:
 		// ciFast latest version marker is published to
-		// 'kubernetes-release-dev/ci/<version>-fast.txt' but the actual source
-		// is at 'kubernetes-release-dev/ci/fast/<version>/kubernetes.tar.gz'
-		url, release, err := setReleaseFromHTTP("kubernetes-release-dev/ci", fmt.Sprintf("%s-fast", e.option))
+		// '<ciBucket>/ci/<version>-fast.txt' but the actual source
+		// is at '<ciBucket>/ci/fast/<version>/kubernetes.tar.gz'
+		url, release, err := setReleaseFromHTTP(fmt.Sprintf("%s/ci", ciBucket), fmt.Sprintf("%s-fast", e.option))
 		if err != nil {
 			return err
 		}
 		return getKube(fmt.Sprintf("%s/fast", url), release, extractSrc)
 	case rc, stable:
-		url, release, err := setReleaseFromHTTP("kubernetes-release/release", e.option)
+		url, release, err := setReleaseFromHTTP(fmt.Sprintf("%s/release", releaseBucket), e.option)
 		if err != nil {
 			return err
 		}
@@ -557,9 +557,9 @@ func (e extractStrategy) Extract(project, zone, region string, extractSrc bool) 
 		if re.FindStringSubmatch(release) != nil {
 			url = "https://storage.googleapis.com/gke-release-staging/kubernetes/release"
 		} else if strings.Contains(release, "+") {
-			url = "https://storage.googleapis.com/kubernetes-release-dev/ci"
+			url = fmt.Sprintf("https://storage.googleapis.com/%s/ci", ciBucket)
 		} else {
-			url = "https://storage.googleapis.com/kubernetes-release/release"
+			url = fmt.Sprintf("https://storage.googleapis.com/%s/release", releaseBucket)
 		}
 		return getKube(url, release, extractSrc)
 	case gcs:

--- a/kubetest/extract_test.go
+++ b/kubetest/extract_test.go
@@ -161,12 +161,12 @@ func TestExtractStrategies(t *testing.T) {
 		},
 		{
 			"v1.8.0-alpha.1",
-			"https://storage.googleapis.com/kubernetes-release/release",
+			"https://storage.googleapis.com/k8s-release/release",
 			"v1.8.0-alpha.1",
 		},
 		{
 			"v1.8.0-alpha.2.899+2c624e590f5670",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci",
+			"https://storage.googleapis.com/k8s-release-dev/ci",
 			"v1.8.0-alpha.2.899+2c624e590f5670",
 		},
 		{
@@ -176,12 +176,12 @@ func TestExtractStrategies(t *testing.T) {
 		},
 		{
 			"ci/latest",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci",
+			"https://storage.googleapis.com/k8s-release-dev/ci",
 			"v1.2.3+abcde",
 		},
 		{
 			"ci/latest-fast",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci/fast",
+			"https://storage.googleapis.com/k8s-release-dev/ci/fast",
 			"v1.2.3+abcde",
 		},
 		{
@@ -263,6 +263,9 @@ func TestExtractStrategies(t *testing.T) {
 		return []byte("v1.2.3+abcde"), nil
 	}
 
+	ciBucket := "k8s-release-dev"
+	releaseBucket := "k8s-release"
+
 	for _, tc := range cases {
 		if d, err := ioutil.TempDir("", "extract"); err != nil {
 			t.Fatal(err)
@@ -274,7 +277,7 @@ func TestExtractStrategies(t *testing.T) {
 		if err := es.Set(tc.option); err != nil {
 			t.Errorf("extractStrategy.Set(%q) returned err: %q", tc.option, err)
 		}
-		if err := es.Extract("", "", "", false); err != nil {
+		if err := es.Extract("", "", "", ciBucket, releaseBucket, false); err != nil {
 			t.Errorf("extractStrategy(%q).Extract() returned err: %q", tc.option, err)
 		}
 
@@ -295,7 +298,7 @@ func TestGciExtractStrategy(t *testing.T) {
 	}{
 		{
 			"gci/gci-canary",
-			"https://storage.googleapis.com/kubernetes-release/release",
+			"https://storage.googleapis.com/k8s-release/release",
 			"v1.2.3+abcde",
 			"gci-canary",
 			"container-vm-image-staging",
@@ -303,7 +306,7 @@ func TestGciExtractStrategy(t *testing.T) {
 		},
 		{
 			"gci/gci-canary?project=test-project:k8s-map-bucket=test-bucket",
-			"https://storage.googleapis.com/kubernetes-release/release",
+			"https://storage.googleapis.com/k8s-release/release",
 			"v1.2.3+abcde",
 			"gci-canary",
 			"test-project",
@@ -311,11 +314,11 @@ func TestGciExtractStrategy(t *testing.T) {
 		},
 		{
 			"gci/gci-canary?project=test-project/latest",
-			"https://storage.googleapis.com/kubernetes-release-dev/ci",
+			"https://storage.googleapis.com/k8s-release-dev/ci",
 			"1.2.3+abcde",
 			"gci-canary",
 			"test-project",
-			"gs://kubernetes-release-dev/ci/latest.txt",
+			"gs://k8s-release-dev/ci/latest.txt",
 		},
 	}
 
@@ -356,6 +359,9 @@ func TestGciExtractStrategy(t *testing.T) {
 		return []byte("test-image"), nil
 	}
 
+	ciBucket := "k8s-release-dev"
+	releaseBucket := "k8s-release"
+
 	for _, tc := range cases {
 		if d, err := ioutil.TempDir("", "extract"); err != nil {
 			t.Fatal(err)
@@ -367,7 +373,7 @@ func TestGciExtractStrategy(t *testing.T) {
 		if err := es.Set(tc.option); err != nil {
 			t.Errorf("extractStrategy.Set(%q) returned err: %q", tc.option, err)
 		}
-		if err := es.Extract("", "", "", false); err != nil {
+		if err := es.Extract("", "", "", ciBucket, releaseBucket, false); err != nil {
 			t.Errorf("extractStrategy(%q).Extract() returned err: %q", tc.option, err)
 		}
 

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -57,32 +57,34 @@ var (
 )
 
 type options struct {
-	build              buildStrategy
-	charts             bool
-	checkLeaks         bool
-	checkSkew          bool
-	cluster            string
-	clusterIPRange     string
-	deployment         string
-	down               bool
-	dump               string
-	dumpPreTestLogs    string
-	extract            extractStrategies
-	extractSource      bool
-	flushMemAfterBuild bool
-	focusRegex         string
-	gcpCloudSdk        string
-	gcpMasterImage     string
-	gcpMasterSize      string
-	gcpNetwork         string
-	gcpNodeImage       string
-	gcpImageFamily     string
-	gcpImageProject    string
-	gcpNodes           string
-	gcpNodeSize        string
-	gcpProject         string
-	gcpProjectType     string
-	gcpServiceAccount  string
+	build                buildStrategy
+	charts               bool
+	checkLeaks           bool
+	checkSkew            bool
+	cluster              string
+	clusterIPRange       string
+	deployment           string
+	down                 bool
+	dump                 string
+	dumpPreTestLogs      string
+	extract              extractStrategies
+	extractCIBucket      string
+	extractReleaseBucket string
+	extractSource        bool
+	flushMemAfterBuild   bool
+	focusRegex           string
+	gcpCloudSdk          string
+	gcpMasterImage       string
+	gcpMasterSize        string
+	gcpNetwork           string
+	gcpNodeImage         string
+	gcpImageFamily       string
+	gcpImageProject      string
+	gcpNodes             string
+	gcpNodeSize          string
+	gcpProject           string
+	gcpProjectType       string
+	gcpServiceAccount    string
 	// gcpSSHProxyInstanceName is the name of the vm instance which ip address will be used to set the
 	// KUBE_SSH_BASTION env. If set, it will result in proxying ssh connections in tests through the
 	// "bastion". It's useful for clusters with nodes without public ssh access, e.g. nodes without
@@ -135,6 +137,8 @@ func defineFlags() *options {
 	flag.StringVar(&o.dump, "dump", "", "If set, dump bring-up and cluster logs to this location on test or cluster-up failure")
 	flag.StringVar(&o.dumpPreTestLogs, "dump-pre-test-logs", "", "If set, dump cluster logs to this location before running tests")
 	flag.Var(&o.extract, "extract", "Extract k8s binaries from the specified release location")
+	flag.StringVar(&o.extractCIBucket, "extract-ci-bucket", "kubernetes-release-dev", "Extract k8s CI binaries from the specified GCS bucket")
+	flag.StringVar(&o.extractReleaseBucket, "extract-release-bucket", "kubernetes-release", "Extract k8s CI binaries from the specified GCS bucket")
 	flag.BoolVar(&o.extractSource, "extract-source", false, "Extract k8s src together with other tarballs")
 	flag.BoolVar(&o.flushMemAfterBuild, "flush-mem-after-build", false, "If true, try to flush container memory after building")
 	flag.Var(&o.ginkgoParallel, "ginkgo-parallel", fmt.Sprintf("Run Ginkgo tests in parallel, default %d runners. Use --ginkgo-parallel=N to specify an exact count.", defaultGinkgoParallel))
@@ -454,7 +458,7 @@ func acquireKubernetes(o *options, d deployer) error {
 			}
 
 			// New deployment, extract new version
-			return o.extract.Extract(o.gcpProject, o.gcpZone, o.gcpRegion, o.extractSource)
+			return o.extract.Extract(o.gcpProject, o.gcpZone, o.gcpRegion, o.extractCIBucket, o.extractReleaseBucket, o.extractSource)
 		})
 		if err != nil {
 			return err

--- a/kubetest/main.go
+++ b/kubetest/main.go
@@ -138,7 +138,7 @@ func defineFlags() *options {
 	flag.StringVar(&o.dumpPreTestLogs, "dump-pre-test-logs", "", "If set, dump cluster logs to this location before running tests")
 	flag.Var(&o.extract, "extract", "Extract k8s binaries from the specified release location")
 	flag.StringVar(&o.extractCIBucket, "extract-ci-bucket", "kubernetes-release-dev", "Extract k8s CI binaries from the specified GCS bucket")
-	flag.StringVar(&o.extractReleaseBucket, "extract-release-bucket", "kubernetes-release", "Extract k8s CI binaries from the specified GCS bucket")
+	flag.StringVar(&o.extractReleaseBucket, "extract-release-bucket", "kubernetes-release", "Extract k8s release binaries from the specified GCS bucket")
 	flag.BoolVar(&o.extractSource, "extract-source", false, "Extract k8s src together with other tarballs")
 	flag.BoolVar(&o.flushMemAfterBuild, "flush-mem-after-build", false, "If true, try to flush container memory after building")
 	flag.Var(&o.ginkgoParallel, "ginkgo-parallel", fmt.Sprintf("Run Ginkgo tests in parallel, default %d runners. Use --ginkgo-parallel=N to specify an exact count.", defaultGinkgoParallel))


### PR DESCRIPTION
This is to support migrating jobs to community-owned buckets:

- ci: kubernetes-release-dev -> k8s-release-dev
- release: kubernetes-release -> k8s-release

The flags default to the google-owned kubernetes buckets, so jobs
will require config changes to migrate

kubetest ends up setting KUBERNETES_RELEASE_URL and calling out
to kubernetes/kubernetes/cluster/get-kube.sh, which will then
use the env var instead of any of its built-in defaults

ref:
https://github.com/kubernetes/k8s.io/issues/846#issuecomment-705722852oref
ref: https://github.com/kubernetes/test-infra/issues/19484#issuecomment-712285724