### PR TITLE
Cluster API: set ignore_review_state to true

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -81,6 +81,7 @@ approve:
   - kubernetes-sigs/cluster-api-provider-gcp
   - kubernetes-sigs/cluster-api-provider-vsphere
   require_self_approval: true
+  ignore_review_state: true
 - repos:
   - bazelbuild
   - kubernetes-sigs/boskos


### PR DESCRIPTION
Sets `ignore_review_state` to true for Cluster API repos and thus restores behavior before https://github.com/kubernetes/test-infra/pull/19579 merged which caused the default behavior to take the GitHub review state into account for "approve". This avoids approvers accidentally applying the `/approve` label on PRs when reviewing.

https://github.com/kubernetes-sigs/cluster-api/pull/3616#issuecomment-712393419

/assign @vincepri @fabriziopandini @devigned @randomvariable @detiber 