### PR TITLE
Add default to junit_xml for testsuites without 'name'

### DIFF
--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -191,7 +191,7 @@ def parse_junit(xml):
             yield make_result(name, time, failure_text)
     elif tree.tag == 'testsuites':
         for testsuite in tree:
-            suite_name = testsuite.attrib['name']
+            suite_name = testsuite.attrib.get('name', 'unkown')
             for child in testsuite.findall('testcase'):
                 name = '%s %s' % (suite_name, child.attrib['name'])
                 time, failure_text, skipped = parse_result(child)

--- a/kettle/make_json.py
+++ b/kettle/make_json.py
@@ -191,7 +191,7 @@ def parse_junit(xml):
             yield make_result(name, time, failure_text)
     elif tree.tag == 'testsuites':
         for testsuite in tree:
-            suite_name = testsuite.attrib.get('name', 'unkown')
+            suite_name = testsuite.attrib.get('name', 'unknown')
             for child in testsuite.findall('testcase'):
                 name = '%s %s' % (suite_name, child.attrib['name'])
                 time, failure_text, skipped = parse_result(child)


### PR DESCRIPTION
Jobs like https://prow.k8s.io/view/gs/cel-conformance/test-logs/20200722182231
have xml formed without testsuite names:

```
<testsuites>
<testsuite>
<testcase name="TestSimpleFile">
<failure message="simple_test.go:186: Running tests in file plumbing"/>
</testcase>
```
vs
```
<testsuite name="Kubernetes e2e suite" tests="19" failures="14" errors="0" time="17653.73">
<testcase name="[sig-auth] ServiceAccounts should set ownership and permission when RunAsUser or FsGroup is present [LinuxOnly] [NodeFeature:FSGroup] [Feature:TokenRequestProjection]" classname="Kubernetes e2e suite" time="0">
<skipped/>
```
This causes parse failures

#19376
/area kettle
Will add some tests in a different PR