### PR TITLE
Update ci-kubernetes-e2e-gci-gce to latest kubekins

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -491,7 +491,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
       - --timeout=50m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201014-882eb3f-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201020-9838966-master
       resources:
         limits:
           cpu: 2


### PR DESCRIPTION
This is to verify https://github.com/kubernetes/test-infra/pull/19620 doesn't break anything

Next PR will be to use the new --extract-ci-bucket flag

ref: https://github.com/kubernetes/k8s.io/issues/846#issuecomment-705722852oref
ref: https://github.com/kubernetes/test-infra/issues/19484#issuecomment-712285724