### PR TITLE
CAPZ: update CAPI periodic job to use cred-only preset

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -50,7 +50,8 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred: "true"
+    preset-azure-cred-only: "true"
+    preset-azure-anonymous-pull: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure


### PR DESCRIPTION
This updates the periodic CAPI + Azure e2e job to match the pull job so it:
1) runs the self hosted spec
2) collects workload cluster logs