### PR TITLE
Make ci-kubernetes-e2e-gci-gce use k8s-release-dev artifacts

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -483,6 +483,7 @@ periodics:
       - --check-leaked-resources
       - --env=ENABLE_POD_SECURITY_POLICY=true
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-nodes=4


### PR DESCRIPTION
This uses the `--extract-ci-bucket` flag introduced in https://github.com/kubernetes/test-infra/pull/19620

Followup to https://github.com/kubernetes/test-infra/pull/19632

ref: https://github.com/kubernetes/k8s.io/issues/846#issuecomment-705722852oref
ref: https://github.com/kubernetes/test-infra/issues/19484#issuecomment-712285724