### PR TITLE
Update approval configuration for k/website

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -67,6 +67,10 @@ approve:
   require_self_approval: false
   lgtm_acts_as_approve: true
 - repos:
+  - kubernetes/website
+  require_self_approval: true
+  lgtm_acts_as_approve: false
+- repos:
   - kubernetes/enhancements
   - kubernetes/kops
   - kubernetes/kubernetes


### PR DESCRIPTION
Match configuration to current, typical review process for SIG Docs.

[k/website](https://github.com/kubernetes/website) uses lgtm label to indicate technical review and approved label to indicate that the content change is acceptable.

@kubernetes/sig-docs-leads FYI