### PR TITLE
Create ci-audit-kind-conformance job

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-audit.yaml
@@ -1,0 +1,53 @@
+periodics:
+# conformance test against kubernetes master branch with `kind` and auditlogs
+# Other than annotations and modified ci-audit-logging e2e-k8s.sh
+# This should be the same as ci-kubernetes-kind-conformance
+- interval: 3h
+  name: ci-audit-kind-conformance
+  labels:
+    preset-service-account: "true"
+    preset-bazel-scratch-dir: "true"
+    preset-bazel-remote-cache-enabled: "true"
+    preset-dind-enabled: "true"
+    preset-kind-volume-mounts: "true"
+  decorate: true
+  decoration_config:
+    timeout: 150m
+  extra_refs:
+  - org: kubernetes
+    repo: kubernetes
+    base_ref: master
+    path_alias: k8s.io/kubernetes
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/krte:v20200916-8dd1247-master
+      command:
+        - wrapper.sh
+        - bash
+        - -c
+        -
+            curl -sSL https://kind.sigs.k8s.io/dl/latest/linux-amd64.tgz | tar xvfz - -C "${PATH%%:*}/"
+            curl -sO https://raw.githubusercontent.com/ii/kind/ci-audit-logging/hack/ci/e2e-k8s.sh
+            bash e2e-k8s.sh
+      env:
+      # don't retry conformance tests
+      - name: GINKGO_TOLERATE_FLAKES
+        value: "n"
+      - name: BUILD_TYPE
+        value: bazel
+      # we need privileged mode in order to do docker in docker
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          # these are both a bit below peak usage during build
+          # this is mostly for building kubernetes
+          memory: "9000Mi"
+          # during the tests more like 3-20m is used
+          cpu: 2000m
+  annotations:
+    testgrid-dashboards: sig-arch-conformance
+    testgrid-tab-name: kind-conformance-audit
+    test-grid-alert-email: kubernetes-sig-arch-conformance-test-failures@googlegroups.com
+    testgrid-num-failures-to-alert: '1'
+    description: 'Uses patched ci-kubernetes-kind-conformance job to generate ARTIFACT/audit/audit.log'


### PR DESCRIPTION
Thanks for all the help today, I think this should generate our logs.

The modifications to *e2e-k8s.sh* can be viewed here:
- https://github.com/kubernetes-sigs/kind/pull/1904/files#diff-98bb12b6291eabbba932e60390b23119b40a58f7ba14a864f1ab4dce33e88f66

Co-Authored-By: Antonio Ojea <aojea@redhat.com>
Co-Authored-By: Berno Kleinhans <bb@ii.coop>
Co-Authored-By: Zach Mandeville <zz@ii.coop>