### PR TITLE
Modify the invalid commit comment to include hashtag

### DIFF
--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg.go
@@ -36,7 +36,7 @@ import (
 const (
 	pluginName                  = "invalidcommitmsg"
 	invalidCommitMsgLabel       = "do-not-merge/invalid-commit-message"
-	invalidCommitMsgCommentBody = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+	invalidCommitMsgCommentBody = `[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) or hashtag(#) mentions are not allowed in commit messages.
 
 **The list of commits with invalid commit messages**:
 

--- a/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
+++ b/prow/plugins/invalidcommitmsg/invalidcommitmsg_test.go
@@ -52,7 +52,7 @@ func makeFakePullRequestEvent(action github.PullRequestEventAction, title string
 	}
 }
 
-var invalidCommitComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) mentions are not allowed in commit messages.
+var invalidCommitComment = `k/k#3:[Keywords](https://help.github.com/articles/closing-issues-using-keywords) which can automatically close issues and at(@) or hashtag(#) mentions are not allowed in commit messages.
 
 **The list of commits with invalid commit messages**:
 


### PR DESCRIPTION
Adding hashtag (#) to the invalid commit message plugin which already handles both `@` and `#` in the PR title