### PR TITLE
Deprecate plank v1

### DIFF
--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -5,7 +5,7 @@
 New features added to each component:
   - *September 15, 2020* Added validation to Deck that will restrict artifact requests based on storage buckets.
     Opt-out by setting `deck.skip_storage_path_validation` in your Prow config.
-    Buckets specified in job configs (`<job>.gcs_configuration.bucket`) and 
+    Buckets specified in job configs (`<job>.gcs_configuration.bucket`) and
     plank configs (`plank.default_decoration_configs[*].gcs_configuration.bucket`) are automatically allowed access.
     Additional buckets can be allowed by adding them to the `deck.additional_allowed_buckets` list.
     (This feature will be enabled by default ~Jan 2021. For now, you will begin to notice violation warnings in your logs.)
@@ -126,6 +126,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *October, 2020*  The `plank` binary has been deprecated in favor of the more modern implementation in the prow-controller-manager that provides the same functionality. Check out
+                  its [README](/prow//prow-controller-manager/README.md) or check out its [deployment](config/prow/cluster/prow_controller_manager_deployment.yaml) and
+                  [rbac](config/prow/cluster/prow_controller_manager_rbac.yaml) manifest. The plank binary will be removed in February, 2021.
  - *September 14th, 2020* Sinker now requires `LIST` and `WATCH` permissions for pods
  - *September 2, 2020* The already deprecated `namespace` and `additional_namespaces` settings in the config updater will be removed in October, 2020
  - *August 28, 2020* `tide` now ignores archived repositories in queries.

--- a/prow/cmd/plank/main.go
+++ b/prow/cmd/plank/main.go
@@ -93,6 +93,9 @@ func main() {
 		logrus.Warning("The deprecated --skip-report flag has been set. It doesn't do anything anymore and will be removed in September 2020.")
 	}
 
+	logrus.Warning("The plank binary has been deprecated. Please migrate to the prow controller manager that provides a more modern implementation of the same functionality. Check out its readme here: https://github.com/kubernetes/test-infra/blob/master/prow/cmd/prow-controller-manager/README.md")
+	logrus.Warning("The plank binary will be removed in February, 2021")
+
 	defer interrupts.WaitForGracefulShutdown()
 
 	pjutil.ServePProf(o.instrumentationOptions.PProfPort)


### PR DESCRIPTION
Prow controller manager/Plank v2 is in use by Openshift since June and by K8s since September and seems to work fine. We do not want to maintain two implementations long term.

/assign @fejta 