### PR TITLE
CAPZ: update periodic conformance job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -13,31 +13,22 @@ periodics:
       repo: cluster-api-provider-azure
       base_ref: master
       path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: v1.18.6
-      path_alias: k8s.io/kubernetes
   spec:
     containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-1.18
         command:
-          - "runner.sh"
-          - "./scripts/ci-entrypoint.sh"
+        - "runner.sh"
+        - "./scripts/ci-conformance.sh"
         env:
-          - name: FOCUS
-            value: "\\[Conformance\\]|\\[NodeConformance\\]"
-          - name: SKIP
-            value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
-          - name: PARALLEL
-            value: "true"
-          - name: KUBERNETES_VERSION
-            value: "v1.18.6"
+          - name: GINKGO_FOCUS
+            value: "Conformance Tests"
+        # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
         resources:
           requests:
-            cpu: 1
-            memory: "4Gi"
+            cpu: 2
+            memory: "9Gi"
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
     testgrid-tab-name: periodic-conformance-v1alpha3

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -202,48 +202,6 @@ presubmits:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pull-conformance-v1alpha3
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
-  - name: pull-cluster-api-provider-azure-conformance-machine-pool-v1alpha3
-    always_run: false
-    optional: true
-    decorate: true
-    decoration_config:
-      timeout: 4h
-    labels:
-      preset-dind-enabled: "true"
-      preset-kind-volume-mounts: "true"
-      preset-azure-cred: "true"
-    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
-    extra_refs:
-    - org: kubernetes
-      repo: kubernetes
-      base_ref: v1.18.6
-      path_alias: k8s.io/kubernetes
-    spec:
-      containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-1.18
-          command:
-            - "runner.sh"
-            - "./scripts/ci-entrypoint.sh"
-          env:
-            - name: FOCUS
-              value: "\\[Conformance\\]|\\[NodeConformance\\]"
-            - name: SKIP
-              value: "\\[Slow\\]|\\[Serial\\]|\\[Flaky\\]"
-            - name: PARALLEL
-              value: "true"
-            - name: KUBERNETES_VERSION
-              value: "v1.18.6"
-            - name: EXP_MACHINE_POOL
-              value: "true"
-          securityContext:
-            privileged: true
-          resources:
-            requests:
-              cpu: 1
-              memory: "4Gi"
-    annotations:
-      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
-      testgrid-tab-name: pull-conformance-machine-pool-v1alpha3
   - name: pull-cluster-api-provider-azure-apidiff
     decorate: true
     path_alias: sigs.k8s.io/cluster-api-provider-azure


### PR DESCRIPTION
Following #19546 and kubernetes-sigs/cluster-api-provider-azure#986 merging, this updates the periodic conformance job to match the presubmit job. Also removes the machine pool conformance presubmit since it's no longer valid.

/assign @cpanato 
/cc @nader-ziada @mboersma 