### PR TITLE
Use command: instead of args: for apisnoop-gate entrypoint + arg

### DIFF
--- a/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
+++ b/config/jobs/kubernetes/sig-arch/conformance-gate.yaml
@@ -12,5 +12,6 @@ periodics:
     containers:
     - name: apisnoop-gate
       image: gcr.io/k8s-staging-apisnoop/snoopdb:v20200923-v2020.09.23-1-gb3afc41
-      args:
+      command:
+      - /usr/local/bin/docker-entrypoint.sh
       - postgres


### PR DESCRIPTION
This is a duplicate of #19655 which seems stuck without `cncf-cla`