### PR TITLE
CAPZ: add anonymous pull to PR E2E job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -39,6 +39,7 @@ presubmits:
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
       preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-1.18


### PR DESCRIPTION
This is needed for https://github.com/kubernetes-sigs/cluster-api-provider-azure/pull/974 to enable the private cluster management cluster to pull the capz manager image.

/assign @devigned 