### PR TITLE
Enable density in load test for periodic jobs kubemark-100

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -140,6 +140,7 @@ periodics:
       - --test-cmd-args=--prometheus-scrape-node-exporter=true
       - --test-cmd-args=--provider=kubemark
       - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me
+      - --env=CL2_ENABLE_DENSITY_TEST=true
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml


### PR DESCRIPTION
We already had one test that passed on kubemark-100, in this PR: #1485
Now I want to enable it on periodic jobs, if it constantly succeeds I will enable kubemark for presubmits too.

/assing @mborsz 