### PR TITLE
Add scalability periodics preset enabling new log dumping mechanism for master branch jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -8,6 +8,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-node: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: storage
@@ -47,6 +48,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: calico
@@ -104,6 +106,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: experimental-load
@@ -157,6 +160,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
     preset-e2e-scalability-containerd: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: experimental-load-containerd
@@ -207,6 +211,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
     preset-e2e-scalability-containerd: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: gce-cos-master-scalability-100-containerd-correctness
@@ -246,6 +251,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-experiments
     testgrid-tab-name: gce-cos-master-scalability-100-nodekiller

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -45,6 +45,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-e2e-kubemark-gce-scale: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-alert-email: go-kubernetes-scalability-tickets@googlegroups.com
     testgrid-dashboards: sig-scalability-golang

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -8,6 +8,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-node: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-node
     testgrid-tab-name: node-throughput
@@ -56,6 +57,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-scalability-node: "true"
     preset-e2e-scalability-containerd: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-node
     testgrid-tab-name: node-containerd-throughput
@@ -107,6 +109,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-100
@@ -172,6 +175,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-100-scheduler
@@ -236,6 +240,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 3 * * *, 0 9 * * *, 0 15 * * *, 0 21 * * *
@@ -305,6 +310,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-e2e-kubemark-gce-scale: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-5000
@@ -376,6 +382,7 @@ periodics:
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
     preset-e2e-kubemark-gce-scale: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-5000-scheduler
@@ -436,6 +443,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-dind-enabled: "true"
     preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-kubemark
     testgrid-tab-name: kubemark-100-high-density
@@ -492,6 +500,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-perf-tests
     testgrid-tab-name: kubemark-100-benchmark
@@ -601,6 +610,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: kube-dns
@@ -643,6 +653,7 @@ periodics:
   labels:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-dashboards: sig-scalability-benchmarks
     testgrid-tab-name: node-local-dns

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -284,3 +284,7 @@ presets:
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
+  # Switch to using log-dump.sh script included in the kubekins-e2e image
+  # instead of relying on the deprecated one from k/k repository.
+  - name: USE_KUBEKINS_LOG_DUMPING
+    value: "yes"

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -280,3 +280,7 @@ presets:
 - labels:
     preset-e2e-scalability-presubmits: "true"
   env:
+
+- labels:
+    preset-e2e-scalability-periodics: "true"
+  env:

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -7,6 +7,7 @@ periodics:
     preset-service-account: "true"
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-scalability-gce, google-gce
@@ -56,6 +57,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
     preset-e2e-scalability-containerd: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     testgrid-alert-email: kubernetes-sig-scale@googlegroups.com, kubernetes-scalability-tickets@google.com, release-team@kubernetes.io
     testgrid-dashboards: sig-release-master-informing, sig-scalability-gce, google-gce
@@ -121,6 +123,7 @@ periodics:
     preset-k8s-ssh: "true"
     preset-e2e-scalability-common: "true"
     preset-e2e-scalability-containerd: "true"
+    preset-e2e-scalability-periodics: "true"
   annotations:
     fork-per-release: "true"
     fork-per-release-cron: 0 */6 * * *, 0 0/12 * * *, 0 4-16/12 * * *, 0 8-20/12 * * *


### PR DESCRIPTION
Leverage the mechanism introduced in https://github.com/kubernetes/test-infra/pull/19461 in SIG Scalability test jobs that use `kubekins-e2e` image's log dumping bash script.

/sig scalability
/assign @jkaniuk @wojtek-t