### PR TITLE
Update Experimental query for Pod-Util Support

### DIFF
--- a/metrics/configs/flakes-experiment-config.yaml
+++ b/metrics/configs/flakes-experiment-config.yaml
@@ -58,7 +58,7 @@ query: |
             ifnull(repo_commit, version) version, /* git version, empty for ci  */
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
-                repos,
+                ifnull(repos, (select i.value from t.metadata i where i.key = 'repos')),
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
               ifnull(repo_commit, version)
@@ -71,7 +71,13 @@ query: |
             and (version != 'unknown' or repo_commit is not null)
             and (
               substr(job, 0, 3) = 'ci-' or
-              array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
+              exists(
+                select as struct
+                  i
+                from t.metadata i
+                where (i.key = 'repos' or repos is not null) and
+                array_length(split(replace(ifnull(t.repos, i.value),', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
+              )
             )
         )
         group by job, commit

--- a/metrics/configs/flakes-experiment-config.yaml
+++ b/metrics/configs/flakes-experiment-config.yaml
@@ -65,7 +65,7 @@ query: |
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
             test  /* repeated tuple of tests */
-          FROM `k8s-gubernator.build.week` as t
+          FROM `k8s-gubernator.build.staging` as t
           where
             datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
             and version != 'unknown'

--- a/metrics/configs/flakes-experiment-config.yaml
+++ b/metrics/configs/flakes-experiment-config.yaml
@@ -55,22 +55,22 @@ query: |
           SELECT
             job,
             if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,  /* pull or ci */
-            ifnull(repo_commit, version) version, /* bootstrap git version, empty for ci  */
+            ifnull(repo_commit, version) version, /* git version, empty for ci  */
             if(substr(job, 0, 3) = 'pr:',
               regexp_extract(
                 repos,
                 r'[^,]+,\d+:([a-f0-9]+)"'
               ),
-              version
+              ifnull(repo_commit, version)
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
             test  /* repeated tuple of tests */
           FROM `k8s-gubernator.build.staging` as t
           where
             datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
-            and version != 'unknown'
+            and (version != 'unknown' or repo_commit is not null)
             and (
-              (substr(job, 0, 3) = 'ci-' and version != 'unknown') or
+              (substr(job, 0, 3) = 'ci-' and (version != 'unknown' or repo_commit	is not null)) or
               array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
             )
         )

--- a/metrics/configs/flakes-experiment-config.yaml
+++ b/metrics/configs/flakes-experiment-config.yaml
@@ -65,12 +65,12 @@ query: |
             ) commit,  /* repo commit for PR or version for CI */
             result,  /* SUCCESS if the build passed */
             test  /* repeated tuple of tests */
-          FROM `k8s-gubernator.build.staging` as t
+          FROM `k8s-gubernator.build.week` as t
           where
             datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
             and (version != 'unknown' or repo_commit is not null)
             and (
-              (substr(job, 0, 3) = 'ci-' and (version != 'unknown' or repo_commit	is not null)) or
+              substr(job, 0, 3) = 'ci-' or
               array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
             )
         )


### PR DESCRIPTION
This (I believe) adds pod utils support for collecting decorated jobs. *Only validated for ci jobs so far.

If you look at comment on #19666 I had found a decorated job that was flaking by the following query:
`SELECT * FROM `k8s-gubernator.build.staging` where repo_commit is not null and result!='SUCCESS'`

Using this I created queries for that specific job:

```
          SELECT
            job,
            if(substr(job, 0, 3) = 'pr:', 'pull', 'ci') kind,  /* pull or ci */
            ifnull(repo_commit, version) version, /* git version, empty for ci  */
            if(substr(job, 0, 3) = 'pr:',
              regexp_extract(
                repos,
                r'[^,]+,\d+:([a-f0-9]+)"'
              ),
              ifnull(repo_commit, version)
            ) commit,  /* repo commit for PR or version for CI */
            result,  /* SUCCESS if the build passed */
            test  /* repeated tuple of tests */
          FROM `k8s-gubernator.build.staging` as t
          where
            datetime(started) > datetime_sub(current_datetime(), interval 7 DAY)
            and (version != 'unknown' or repo_commit	is not null)
            and (
              (substr(job, 0, 3) = 'ci-' and (version != 'unknown' or repo_commit	is not null)) or
              array_length(split(replace(repos,', ', ''), ',')) = 2 /*serial pr jobs only (# of PR refs +1 == 2)*/
            ) and job='ci-test-infra-bazel'
```
This validated that the flake job was getting collected I also ran the original query and validated the diff (see image).

![image](https://user-images.githubusercontent.com/7189267/96941770-35768680-1488-11eb-9752-bfe8bc911c1f.png)

/area metrics
/assign @spiffxp 
/area kettle