### PR TITLE
CAPZ: set LOCAL_ONLY to false for PR e2e

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -49,6 +49,8 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
+          - name: LOCAL_ONLY
+            value: "false"
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
This should have been part of #19659 

As a side note, this will cause all e2e to pull images instead of using the local versions on kind, maybe we should look into making it more granular and only pull from acr when needed to save time?

/assign @devigned 

