### PR TITLE
Run "updown-kopsmaster" with the KOPS_RUN_TOO_NEW_VERSION flag

### DIFF
--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -17,6 +17,9 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-master
+      env:
+      - name: KOPS_RUN_TOO_NEW_VERSION
+        value: "1"
       command:
       - runner.sh
       - kubetest


### PR DESCRIPTION
Job is failing:
https://storage.googleapis.com/kubernetes-jenkins/logs/e2e-kops-pipeline-updown-kopsmaster/1320584281038262272/build-log.txt

/cc @rifelpet @olemarkus 