### PR TITLE
Kops - Add KOPS_RUN_TOO_NEW_VERSION to job template

### DIFF
--- a/config/jobs/kubernetes/kops/build-pipeline.py
+++ b/config/jobs/kubernetes/kops/build-pipeline.py
@@ -37,6 +37,9 @@ template = """
   spec:
     containers:
     - image: {{e2e_image}}
+      env:
+      - name: KOPS_RUN_TOO_NEW_VERSION
+        value: "1"
       command:
       - runner.sh
       - kubetest

--- a/config/jobs/kubernetes/kops/kops-pipeline.yaml
+++ b/config/jobs/kubernetes/kops/kops-pipeline.yaml
@@ -70,6 +70,9 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-1.19
+      env:
+      - name: KOPS_RUN_TOO_NEW_VERSION
+        value: "1"
       command:
       - runner.sh
       - kubetest
@@ -120,6 +123,9 @@ periodics:
   spec:
     containers:
     - image: gcr.io/k8s-testimages/kubekins-e2e:v20201021-a62ce8a-1.18
+      env:
+      - name: KOPS_RUN_TOO_NEW_VERSION
+        value: "1"
       command:
       - runner.sh
       - kubetest


### PR DESCRIPTION
This will prevent https://github.com/kubernetes/test-infra/pull/19683 from being reverted the next time someone runs `make`.