### PR TITLE
Kops - add optional e2e presubmit using kubetest2

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -99,6 +99,50 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
       testgrid-tab-name: e2e-docker
+  - name: pull-kops-e2e-kubernetes-aws-kubetest2
+    branches:
+    - master
+    always_run: false
+    skip_report: true
+    labels:
+      preset-service-account: "true"
+      preset-aws-ssh: "true"
+      preset-aws-credential: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-e2e-platform-aws: "true"
+    decorate: true
+    decoration_config:
+      timeout: 90m
+    path_alias: k8s.io/kops
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:latest-experimental
+        imagePullPolicy: Always
+        command:
+        - runner.sh
+        args:
+        - bash
+        - -c
+        - set -o errexit;
+          set -o nounset;
+          set -o pipefail;
+          set -o xtrace;
+          export GO111MODULE=on;
+          go get sigs.k8s.io/kubetest2@latest;
+          go install -o /workspace/kubetest2-kops ./kubetest2-kops;
+          kubetest2 kops -v 2 --build --up --down --cloud-provider=aws --kops-binary-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64;
+        workingDir: /home/prow/go/src/k8s.io/kops/tests/e2e
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            memory: "6Gi"
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-kops, presubmits-kops, kops-presubmits
+      testgrid-tab-name: e2e-kubetest2
   - name: pull-kops-e2e-k8s-containerd
     skip_report: false
     run_if_changed: '^nodeup\/pkg\/'


### PR DESCRIPTION
Using [this](https://github.com/kubernetes/test-infra/blob/3d3b325c98b739b526ba5d93ce21c90a05e1f46d/config/jobs/kubernetes/cloud-provider-gcp/cloud-provider-gcp-presubmits.yaml#L27) kubetest2 job as an example.

ref: https://github.com/kubernetes/kops/issues/9598