### PR TITLE
aks-engine: add WindowsPauseImageURL field

### DIFF
--- a/kubetest/aksengine_helpers.go
+++ b/kubetest/aksengine_helpers.go
@@ -98,6 +98,7 @@ type WindowsProfile struct {
 	EnableCSIProxy        bool             `json:"enableCSIProxy,omitempty"`
 	CSIProxyURL           string           `json:"csiProxyURL,omitempty"`
 	WindowsRuntimes       *WindowsRuntimes `json:"windowsRuntimes,omitempty"`
+	WindowsPauseImageURL  string           `json:"windowsPauseImageURL,omitempty"`
 }
 
 // WindowsRuntimes configures containerd runtimes that are available on the windows nodes


### PR DESCRIPTION
Signed-off-by: Ernest Wong <chuwon@microsoft.com>

Adds the ability for kubetest to read API models with a custom Windows pause image.

/assign @feiskyer 