### PR TITLE
Azure: set the resource group value for capz azurefile jobs

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.16.yaml
@@ -513,7 +513,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"
@@ -567,7 +567,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.17.yaml
@@ -513,7 +513,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"
@@ -567,7 +567,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.18.yaml
@@ -513,7 +513,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"
@@ -567,7 +567,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"

--- a/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/azure/release-1.19.yaml
@@ -513,7 +513,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"
@@ -567,7 +567,7 @@ periodics:
       - >-
         kubectl apply -f templates/addons/azurefile-role.yaml &&
         cd ${GOPATH}/src/sigs.k8s.io/azurefile-csi-driver &&
-        make e2e-test
+        RESOURCE_GROUP=${AZURE_RESOURCE_GROUP} make e2e-test
       env:
       - name: SKIP_UPSTREAM_E2E_TESTS
         value: "true"


### PR DESCRIPTION
This is an attempt to fix https://testgrid.k8s.io/provider-azure-periodic#k8s-e2e-azure-file-1-19-capz  `should create a volume on demand and resize it` which has been failing since https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/393 merged as it expects `RESOURCE_GROUP` to be set, whereas CAPZ sets `AZURE_RESOURCE_GROUP`.

Fixes https://github.com/kubernetes-sigs/cluster-api-provider-azure/issues/1010 

/assign @andyzhangx @chewong 