### PR TITLE
CAPZ: use capzci registry for periodic conformance job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -7,7 +7,7 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-kind-volume-mounts: "true"
-    preset-azure-cred: "true"
+    preset-azure-cred-only: "true"
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-azure


### PR DESCRIPTION
Switches the CAPZ periodic conformance job to use the cred-only azure cred preset so it uses the default ACR registry instead of using the prow one (same as the presubmit conformance job).

Currently, job is failing with `unauthorized: authentication required, visit https://aka.ms/acr/authorization for more information.
` https://testgrid.k8s.io/sig-cluster-lifecycle-cluster-api-provider-azure#periodic-conformance-v1alpha3

/assign @devigned 