### PR TITLE
Genyaml: Add PopulateStruct func to autopopulate structs

### DIFF
--- a/pkg/genyaml/BUILD.bazel
+++ b/pkg/genyaml/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["genyaml.go"],
+    srcs = [
+        "genyaml.go",
+        "populate_struct.go",
+    ],
     data = ["//prow/plugins:config-src"],
     importpath = "k8s.io/test-infra/pkg/genyaml",
     visibility = ["//visibility:public"],
@@ -15,7 +18,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["genyaml_test.go"],
+    srcs = [
+        "genyaml_test.go",
+        "populate_struct_test.go",
+    ],
     data = [":test-data"],
     embed = [":go_default_library"],
     deps = [

--- a/pkg/genyaml/genyaml.go
+++ b/pkg/genyaml/genyaml.go
@@ -20,7 +20,7 @@ limitations under the License.
 //
 // Example:
 //	cm := NewCommentMap("example_config.go")
-
+//
 //	yamlSnippet, err := cm.GenYaml(&plugins.Configuration{
 //		Approve: []plugins.Approve{
 //			{
@@ -35,6 +35,11 @@ limitations under the License.
 //			},
 //		},
 //	})
+//
+// Alternatively, you can also use `PopulateStruct` to recursively fill all pointer fields, slices and maps of a struct via reflection:
+//
+// yamlSnippet, err := cm.GenYaml(PopulateStruct(&plugins.Configuration{}))
+//
 //
 // 	yamlSnippet will be assigned a string containing the following YAML:
 //
@@ -262,7 +267,7 @@ func getType(typ interface{}) string {
 func (cm *CommentMap) genDocMap(path string) error {
 	pkg, err := astFrom(path)
 	if err != nil {
-		return errors.New("unable to generate AST documentation map")
+		return fmt.Errorf("unable to generate AST documentation map: %w", err)
 	}
 
 	inlineFields := map[string][]string{}
@@ -437,7 +442,7 @@ func (cm *CommentMap) EncodeYaml(config interface{}, encoder *yaml3.Encoder) err
 	// Convert Config object to an abstract YAML node.
 	y1, err := marshal(&config)
 	if err != nil {
-		return errors.New("failed to marshal config to yaml")
+		return fmt.Errorf("failed to marshal config to yaml: %w", err)
 	}
 
 	node := yaml3.Node{}

--- a/pkg/genyaml/genyaml_test.go
+++ b/pkg/genyaml/genyaml_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 
 	yaml3 "gopkg.in/yaml.v3"
+
 	simplealiases "k8s.io/test-infra/pkg/genyaml/testdata/alias_simple_types"
 	aliases "k8s.io/test-infra/pkg/genyaml/testdata/alias_types"
 	embedded "k8s.io/test-infra/pkg/genyaml/testdata/embedded_structs"
@@ -49,9 +50,13 @@ func resolvePath(t *testing.T, filename string) string {
 	return strings.ToLower(filepath.Join(testDir, name, filename))
 }
 
-func readFile(t *testing.T, extension string) []byte {
+func fileName(t *testing.T, extension string) string {
 	name := filepath.Base(t.Name())
-	data, err := ioutil.ReadFile(strings.ToLower(filepath.Join(testDir, name, name+"."+extension)))
+	return strings.ToLower(filepath.Join(testDir, name, name+"."+extension))
+}
+
+func readFile(t *testing.T, extension string) []byte {
+	data, err := ioutil.ReadFile(fileName(t, extension))
 	if err != nil {
 		t.Errorf("Failed reading .%s file: %v.", extension, err)
 	}

--- a/pkg/genyaml/populate_struct.go
+++ b/pkg/genyaml/populate_struct.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genyaml
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// PopulateStruct will recursively populate a struct via reflection for consumption by genyaml by:
+// * Filling all pointer fields
+// * Filling all slices with a one-element slice and filling that one element
+// * Filling all maps with a one-element map and filling that one element
+// NOTE: PopulateStruct will panic if not fed a pointer. Generally if you care about
+// the stability of the app that runs this code, it is strongly recommended to recover panics:
+// defer func(){if r := recover(); r != nil { fmt.Printf("Recovered panic: %v", r } }(
+func PopulateStruct(in interface{}) interface{} {
+	typeOf := reflect.TypeOf(in)
+	if typeOf.Kind() != reflect.Ptr {
+		panic(fmt.Sprintf("got nonpointer type %T", in))
+	}
+	if typeOf.Elem().Kind() != reflect.Struct {
+		return in
+	}
+	valueOf := reflect.ValueOf(in)
+	for i := 0; i < typeOf.Elem().NumField(); i++ {
+		// Unexported
+		if !valueOf.Elem().Field(i).CanSet() {
+			continue
+		}
+		switch k := typeOf.Elem().Field(i).Type.Kind(); k {
+		// We must populate strings, because genyaml uses a custom json lib
+		// that omits structs that have empty values only and we have some
+		// structs that only have string fields
+		// TODO: Is that genyaml behavior intentional?
+		case reflect.String:
+			// ArrayOrString comes from Tekton and has a custom marshaller
+			// that errors when only setting the String field
+			if typeOf.Elem().Name() == "ArrayOrString" {
+				valueOf.Elem().FieldByName("Type").SetString("string")
+			}
+			valueOf.Elem().Field(i).SetString(" ")
+		// Needed because of the String field handling
+		case reflect.Struct:
+			PopulateStruct(valueOf.Elem().Field(i).Addr().Interface())
+		case reflect.Ptr:
+			ptr := createNonNilPtr(valueOf.Elem().Field(i).Type())
+			// Populate our ptr
+			if ptr.Elem().Kind() == reflect.Struct {
+				PopulateStruct(ptr.Interface())
+			}
+			// Set it on the parent struct
+			valueOf.Elem().Field(i).Set(ptr)
+		case reflect.Slice:
+			if typeOf.Elem().Field(i).Type == typeOfBytes || typeOf.Elem().Field(i).Type == typeOfJSONRawMessage {
+				continue
+			}
+			// Create a one element slice
+			slice := reflect.MakeSlice(typeOf.Elem().Field(i).Type, 1, 1)
+			// Get a pointer to the value
+			var sliceElementPtr interface{}
+			if slice.Index(0).Type().Kind() == reflect.Ptr {
+				// Slice of pointers, make it a non-nil pointer, then pass on its address
+				slice.Index(0).Set(createNonNilPtr(slice.Index(0).Type()))
+				sliceElementPtr = slice.Index(0).Interface()
+			} else {
+				// Slice of literals
+				sliceElementPtr = slice.Index(0).Addr().Interface()
+			}
+			PopulateStruct(sliceElementPtr)
+			// Set it on the parent struct
+			valueOf.Elem().Field(i).Set(slice)
+		case reflect.Map:
+			keyType := typeOf.Elem().Field(i).Type.Key()
+			valueType := typeOf.Elem().Field(i).Type.Elem()
+
+			key := reflect.New(keyType).Elem()
+			value := reflect.New(valueType).Elem()
+
+			var keyPtr, valPtr interface{}
+			if key.Kind() == reflect.Ptr {
+				key.Set(createNonNilPtr(key.Type()))
+				keyPtr = key.Interface()
+			} else {
+				keyPtr = key.Addr().Interface()
+			}
+			if value.Kind() == reflect.Ptr {
+				value.Set(createNonNilPtr(value.Type()))
+				valPtr = value.Interface()
+			} else {
+				valPtr = value.Addr().Interface()
+			}
+			PopulateStruct(keyPtr)
+			PopulateStruct(valPtr)
+
+			mapType := reflect.MapOf(typeOf.Elem().Field(i).Type.Key(), typeOf.Elem().Field(i).Type.Elem())
+			concreteMap := reflect.MakeMapWithSize(mapType, 0)
+			concreteMap.SetMapIndex(key, value)
+
+			valueOf.Elem().Field(i).Set(concreteMap)
+		}
+
+	}
+	return in
+}
+
+func createNonNilPtr(in reflect.Type) reflect.Value {
+	// construct a new **type and call Elem() to get the *type
+	ptr := reflect.New(in).Elem()
+	// Give it a value
+	ptr.Set(reflect.New(ptr.Type().Elem()))
+
+	return ptr
+}
+
+var typeOfBytes = reflect.TypeOf([]byte(nil))
+var typeOfJSONRawMessage = reflect.TypeOf(json.RawMessage{})

--- a/pkg/genyaml/populate_struct_test.go
+++ b/pkg/genyaml/populate_struct_test.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genyaml
+
+import (
+	"testing"
+)
+
+func TestPopulateStructHandlesPointerFields(t *testing.T) {
+	s := struct {
+		Field *struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if s.Field == nil {
+		t.Fatalf("Pointer field in struct didn't get set, struct: %+v", s)
+	}
+	if s.Field.NestedField == nil {
+		t.Fatalf("Nested pointer field in struct didn't get set, struct: %+v", s)
+	}
+}
+
+func TestPopulateStructHandlesSlicesOfLiterals(t *testing.T) {
+	s := struct {
+		Field []struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if n := len(s.Field); n != 1 {
+		t.Fatalf("Slice didn't get populated, struct: %+v", s)
+	}
+
+	if s.Field[0].NestedField == nil {
+		t.Fatalf("Slice element field didn't get populated, struct: %+v", s)
+	}
+}
+
+func TestPopulateStructHandlesSliceOfPointers(t *testing.T) {
+	s := struct {
+		Field []*struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if n := len(s.Field); n != 1 {
+		t.Fatalf("Slice didn't get populated, struct: %+v", s)
+	}
+	if s.Field[0] == nil {
+		t.Fatalf("Slice element didn't get populated, struct: %+v", s)
+	}
+
+	if s.Field[0].NestedField == nil {
+		t.Fatalf("Slice element field didn't get populated, struct: %+v", s)
+	}
+}
+
+func TestPopulateStructHandlesMaps(t *testing.T) {
+	s := struct {
+		Field map[string]struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if n := len(s.Field); n != 1 {
+		t.Fatalf("Map didn't get populated, struct: %+v", s)
+	}
+
+	for _, v := range s.Field {
+		if v.NestedField == nil {
+			t.Fatalf("Pointer field in map element didn't get populated, struct: %+v", s)
+		}
+	}
+}
+
+func TestPopulateStructHandlesMapsWithPointerValues(t *testing.T) {
+	s := struct {
+		Field map[string]*struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if n := len(s.Field); n != 1 {
+		t.Fatalf("Map didn't get populated, struct: %+v", s)
+	}
+
+	for _, v := range s.Field {
+		if v == nil {
+			t.Fatalf("Map value is a nilpointer, struct: %+v", s)
+		}
+		if v.NestedField == nil {
+			t.Fatalf("Pointer field in map element didn't get populated, struct: %+v", s)
+		}
+	}
+}
+
+func TestPopulateStructHandlesMapsWithPointerKeys(t *testing.T) {
+	s := struct {
+		Field map[*string]struct {
+			NestedField *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if n := len(s.Field); n != 1 {
+		t.Fatalf("Map didn't get populated, struct: %+v", s)
+	}
+
+	for k, v := range s.Field {
+		if k == nil {
+			t.Fatalf("Map key is a nilpointer, struct: %+v", s)
+		}
+		if v.NestedField == nil {
+			t.Fatalf("Pointer field in map element didn't get populated, struct: %+v", s)
+		}
+	}
+}
+
+// this is needed because genyaml uses a custom json unmarshaler that omits empty structs
+// even if they are not pointers. If we don't do this, structs that only have string fields
+// end up being omitted.
+// TODO: Is there a necessity for genyaml to have this custom unmarshaler?
+func TestPopulateStructSetsStrings(t *testing.T) {
+	s := struct {
+		String string
+		Field  struct {
+			String string
+		}
+	}{}
+
+	PopulateStruct(&s)
+	if s.String == "" {
+		t.Errorf("String field didn't get set, struct: %+v", s)
+	}
+	if s.Field.String == "" {
+		t.Errorf("Nested string field didn't get set, struct: %+v", s)
+	}
+}
+
+func TestPopulateStructHandlesUnexportedFields(_ *testing.T) {
+	s := struct {
+		unexported *struct {
+			justAsUnexported *int
+		}
+	}{}
+
+	PopulateStruct(&s)
+	// This test indicates success by not panicking, so nothing further to check
+}

--- a/prow/config/BUILD.bazel
+++ b/prow/config/BUILD.bazel
@@ -16,11 +16,14 @@ go_test(
         "tide_test.go",
     ],
     data = [
+        ":fixtures",
+        ":package-srcs",
         "//config:prowjobs",
         "//config/prow:configs",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/genyaml:go_default_library",
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/config/secret:go_default_library",
         "//prow/gerrit/client:go_default_library",
@@ -94,4 +97,10 @@ filegroup(
         "//prow/config/secret:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+filegroup(
+    name = "fixtures",
+    srcs = glob(["*.yaml"]),
+    visibility = ["//visibility:private"],
 )

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -1,0 +1,575 @@
+branch-protection:
+    allow_deletions: false
+    allow_force_pushes: false
+    enforce_admins: false
+    exclude:
+      - ""
+    orgs:
+        "":
+            allow_deletions: false
+            allow_force_pushes: false
+            enforce_admins: false
+            exclude:
+              - ""
+            protect: false
+            repos:
+                "":
+                    allow_deletions: false
+                    allow_force_pushes: false
+                    branches:
+                        "":
+                            allow_deletions: false
+                            allow_force_pushes: false
+                            enforce_admins: false
+                            exclude:
+                              - ""
+                            protect: false
+                            required_linear_history: false
+                            required_pull_request_reviews:
+                                dismiss_stale_reviews: false
+                                dismissal_restrictions:
+                                    teams:
+                                      - ""
+                                    users:
+                                      - ""
+                                require_code_owner_reviews: false
+                                required_approving_review_count: 0
+                            required_status_checks:
+                                contexts:
+                                  - ""
+                                strict: false
+                            restrictions:
+                                teams:
+                                  - ""
+                                users:
+                                  - ""
+                    enforce_admins: false
+                    exclude:
+                      - ""
+                    protect: false
+                    required_linear_history: false
+                    required_pull_request_reviews:
+                        dismiss_stale_reviews: false
+                        dismissal_restrictions:
+                            teams:
+                              - ""
+                            users:
+                              - ""
+                        require_code_owner_reviews: false
+                        required_approving_review_count: 0
+                    required_status_checks:
+                        contexts:
+                          - ""
+                        strict: false
+                    restrictions:
+                        teams:
+                          - ""
+                        users:
+                          - ""
+            required_linear_history: false
+            required_pull_request_reviews:
+                dismiss_stale_reviews: false
+                dismissal_restrictions:
+                    teams:
+                      - ""
+                    users:
+                      - ""
+                require_code_owner_reviews: false
+                required_approving_review_count: 0
+            required_status_checks:
+                contexts:
+                  - ""
+                strict: false
+            restrictions:
+                teams:
+                  - ""
+                users:
+                  - ""
+    protect: false
+    required_linear_history: false
+    required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        dismissal_restrictions:
+            teams:
+              - ""
+            users:
+              - ""
+        require_code_owner_reviews: false
+        required_approving_review_count: 0
+    required_status_checks:
+        contexts:
+          - ""
+        strict: false
+    restrictions:
+        teams:
+          - ""
+        users:
+          - ""
+deck:
+    # AdditionalAllowedBuckets is a list of storage buckets to allow in artifact requests
+    # (in addition to those listed in the GCSConfiguration).
+    # Setting this field requires "SkipStoragePathValidation" also be set to `false`.
+    additional_allowed_buckets:
+      - ""
+
+    # Branding of the frontend
+    branding:
+        # BackgroundColor is the color of the background.
+        background_color: ' '
+
+        # Favicon is the location of the favicon that will be loaded in deck.
+        favicon: ' '
+
+        # HeaderColor is the color of the header.
+        header_color: ' '
+
+        # Logo is the location of the logo that will be loaded in deck.
+        logo: ' '
+
+    # ExternalAgentLogs ensures external agents can expose
+    # their logs in prow.
+    external_agent_logs:
+      - # Agent is an external prow agent that supports exposing
+        # logs via deck.
+        agent: ' '
+
+        # SelectorString compiles into Selector at load time.
+        selector: ' '
+
+        # URLTemplateString compiles into URLTemplate at load time.
+        url_template: ' '
+
+    # GoogleAnalytics, if specified, include a Google Analytics tracking code on each page.
+    google_analytics: ' '
+
+    # HiddenRepos is a list of orgs and/or repos that should not be displayed by Deck.
+    hidden_repos:
+      - ""
+
+    # Deprecated: RerunAuthConfig specifies who is able to trigger job reruns if that feature is enabled.
+    # The permissions here apply to all jobs.
+    # This option will be removed in favor of RerunAuthConfigs in July 2020.
+    rerun_auth_config:
+        github_orgs:
+          - ""
+        github_team_ids:
+          - 0
+        github_team_slugs:
+          - org: ' '
+            slug: ' '
+        github_users:
+          - ""
+
+    # RerunAuthConfigs is a map of configs that specify who is able to trigger job reruns. The field
+    # accepts a key of: `org/repo`, `org` or `*` (wildcard) to define what GitHub org (or repo) a particular
+    # config applies to and a value of: `RerunAuthConfig` struct to define the users/groups authorized to rerun jobs.
+    rerun_auth_configs:
+        "":
+            github_orgs:
+              - ""
+            github_team_ids:
+              - 0
+            github_team_slugs:
+              - org: ' '
+                slug: ' '
+            github_users:
+              - ""
+
+    # SkipStoragePathValidation skips validation that restricts artifact requests to specific buckets.
+    # By default, buckets listed in the GCSConfiguration are automatically allowed.
+    # Additional locations can be allowed via `AdditionalAllowedBuckets` fields.
+    # When unspecified (nil), it defaults to true (until ~Jan 2021).
+    skip_storage_path_validation: false
+
+    # Spyglass specifies which viewers will be used for which artifacts when viewing a job in Deck
+    spyglass:
+        # If set, Announcement is used as a Go HTML template string to be displayed at the top of
+        # each spyglass page. Using HTML in the template is acceptable.
+        # Currently the only variable available is .ArtifactPath, which contains the GCS path for the job artifacts.
+        announcement: ' '
+
+        # GCSBrowserPrefix is used to generate a link to a human-usable GCS browser.
+        # If left empty, the link will be not be shown. Otherwise, a GCS path (with no
+        # prefix or scheme) will be appended to GCSBrowserPrefix and shown to the user.
+        gcs_browser_prefix: ' '
+
+        # GCSBrowserPrefixes are used to generate a link to a human-usable GCS browser.
+        # They are mapped by org, org/repo or '*' which is the default value.
+        gcs_browser_prefixes:
+            "": ""
+
+        # Lenses is a list of lens configurations.
+        lenses:
+          - # Lens is the lens to use, alongside any lens-specific configuration.
+            lens:
+                # Name is the name of the lens.
+                name: ' '
+
+            # OptionalFiles is a list of regexes of file paths that will be provided to the lens if they are
+            # present, but will not preclude the lens being rendered by their absence.
+            # The list entries are ORed together, so if only one of them is present it will be provided to
+            # the lens even if the others are not.
+            optional_files:
+              - ""
+
+            # RemoteConfig specifies how to access remote lenses
+            remote_config:
+                # The endpoint for the lense
+                endpoint: ' '
+
+                # HideTitle defines if we will keep showing the title after lens loads
+                hide_title: false
+
+                # Priority for lens ordering, lowest priority first
+                priority: 0
+
+                # The endpoint for static resources
+                static_root: ' '
+
+                # The human-readable title for the lens
+                title: ' '
+
+            # RequiredFiles is a list of regexes of file paths that must all be present for a lens to appear.
+            # The list entries are ANDed together, i.e. all of them are required. You can achieve an OR
+            # by using a pipe in a regex.
+            required_files:
+              - ""
+
+        # TestGridConfig is the path to the TestGrid config proto. If the path begins with
+        # "gs://" it is assumed to be a GCS reference, otherwise it is read from the local filesystem.
+        # If left blank, TestGrid links will not appear.
+        testgrid_config: ' '
+
+        # TestGridRoot is the root URL to the TestGrid frontend, e.g. "https://testgrid.k8s.io/".
+        # If left blank, TestGrid links will not appear.
+        testgrid_root: ' '
+
+        # Viewers is deprecated, prefer Lenses instead.
+        # Viewers was a map of Regexp strings to viewer names that defines which sets
+        # of artifacts need to be consumed by which viewers. It is copied in to Lenses at load time.
+        viewers:
+            "": null
+
+    # TideUpdatePeriod specifies how often Deck will fetch status from Tide. Defaults to 10s.
+    tide_update_period: 0s
+
+
+# DefaultJobTimeout this is default deadline for prow jobs. This value is used when
+# no timeout is configured at the job level. This value is set to 24 hours.
+default_job_timeout: 0s
+gerrit:
+    # TickInterval is how often we do a sync with binded gerrit instance
+    tick_interval: 0s
+
+
+# GitHubOptions allows users to control how prow applications display GitHub website links.
+github:
+    # LinkURLFromConfig is the string representation of the link_url config parameter.
+    # This config parameter allows users to override the default GitHub link url for all plugins.
+    # If this option is not set, we assume "https://github.com".
+    link_url: ' '
+github_reporter:
+    # JobTypesToReport is used to determine which type of prowjob
+    # should be reported to github
+
+    # defaults to both presubmit and postsubmit jobs.
+    job_types_to_report:
+      - ""
+in_repo_config:
+    # AllowedClusters is a list of allowed clusternames that can be used for jobs on
+    # a given repo. All clusters that are allowed for the specific repo, its org or
+    # globally can be used.
+    allowed_clusters:
+        "": null
+
+    # Enabled describes whether InRepoConfig is enabled for a given repository. This can
+    # be set globally, per org or per repo using '*', 'org' or 'org/repo' as key. The
+    # narrowest match always takes precedence.
+    enabled:
+        "": false
+jenkins_operators:
+  - # JobURLTemplateString compiles into JobURLTemplate at load time.
+    job_url_template: ' '
+
+    # LabelSelectorString compiles into LabelSelector at load time.
+    # If set, this option needs to match --label-selector used by
+    # the desired jenkins-operator. This option is considered
+    # invalid when provided with a single jenkins-operator config.
+
+    # For label selector syntax, see below:
+    # https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+    label_selector: ' '
+
+    # ReportTemplateString compiles into ReportTemplate at load time.
+    report_template: ' '
+
+    # ReportTemplateStrings is a mapping of template comments.
+    # Use `org/repo`, `org` or `*` as a key.
+    report_templates:
+        "": ""
+
+
+# LogLevel enables dynamically updating the log level of the
+# standard logger that is used by all prow components.
+
+# Valid values:
+
+# "debug", "info", "warn", "warning", "error", "fatal", "panic"
+
+# Defaults to "info".
+log_level: ' '
+
+
+# ManagedWebhooks contains information about all github repositories and organizations which are using
+# non-global Hmac token.
+managed_webhooks:
+    org_repo_config:
+        "":
+            token_created_after: "0001-01-01T00:00:00Z"
+    respect_legacy_global_token: false
+
+
+# OwnersDirBlacklist is used to configure regular expressions matching directories
+# to ignore when searching for OWNERS{,_ALIAS} files in a repo.
+owners_dir_blacklist:
+    # Default configures a default blacklist for all repos (or orgs).
+    # Some directories like ".git", "_output" and "vendor/.*/OWNERS"
+    # are already preconfigured to be blacklisted, and need not be included here.
+    default:
+      - ""
+
+    # Repos configures a directory blacklist per repo (or org)
+    repos:
+        "": null
+plank:
+    # DefaultDecorationConfigs holds the default decoration config for specific values.
+    # This config will be used on each Presubmit and Postsubmit's corresponding org/repo, and on Periodics
+    # if extraRefs[0] exists.
+    # Use `org/repo`, `org` or `*` as a key.
+    default_decoration_configs:
+        "":
+            cookiefile_secret: ' '
+            gcs_configuration:
+                bucket: ' '
+                default_org: ' '
+                default_repo: ' '
+                local_output_dir: ' '
+                mediaTypes:
+                    "": ""
+                path_prefix: ' '
+                path_strategy: ' '
+            gcs_credentials_secret: ' '
+            grace_period: 0s
+            oauth_token_secret:
+                key: ' '
+                name: ' '
+            resources:
+                clonerefs:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                initupload:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                place_entrypoint:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+                sidecar:
+                    limits:
+                        "": "0"
+                    requests:
+                        "": "0"
+            s3_credentials_secret: ' '
+            skip_cloning: false
+            ssh_host_fingerprints:
+              - ""
+            ssh_key_secrets:
+              - ""
+            timeout: 0s
+            utility_images:
+                clonerefs: ' '
+                entrypoint: ' '
+                initupload: ' '
+                sidecar: ' '
+
+    # JobURLPrefixConfig is the host and path prefix under which job details
+    # will be viewable. Use `org/repo`, `org` or `*`as key and an url as value
+    job_url_prefix_config:
+        "": ""
+
+    # JobURLTemplateString compiles into JobURLTemplate at load time.
+    job_url_template: ' '
+
+    # PodPendingTimeout is after how long the controller will perform a garbage
+    # collection on pending pods. Defaults to one day.
+    pod_pending_timeout: 0s
+
+    # PodRunningTimeout is after how long the controller will abort a prowjob pod
+    # stuck in running state. Defaults to two days.
+    pod_running_timeout: 0s
+
+    # PodUnscheduledTimeout is after how long the controller will abort a prowjob
+    # stuck in an unscheduled state. Defaults to one day.
+    pod_unscheduled_timeout: 0s
+
+    # ReportTemplateString compiles into ReportTemplate at load time.
+    report_template: ' '
+
+    # ReportTemplateStrings is a mapping of template comments.
+    # Use `org/repo`, `org` or `*` as a key.
+    report_templates:
+        "": ""
+
+
+# PodNamespace is the namespace in the cluster that prow
+# components will use for looking up Pods owned by ProwJobs.
+# The namespace needs to exist and will not be created by prow.
+# Defaults to "default".
+pod_namespace: ' '
+
+
+# ProwJobNamespace is the namespace in the cluster that prow
+# components will use for looking up ProwJobs. The namespace
+# needs to exist and will not be created by prow.
+# Defaults to "default".
+prowjob_namespace: ' '
+
+
+# Pub/Sub Subscriptions that we want to listen to
+pubsub_subscriptions:
+    "": null
+
+
+# PushGateway is a prometheus push gateway.
+push_gateway:
+    # Endpoint is the location of the prometheus pushgateway
+    # where prow will push metrics to.
+    endpoint: ' '
+
+    # Interval specifies how often prow will push metrics
+    # to the pushgateway. Defaults to 1m.
+    interval: 0s
+
+    # ServeMetrics tells if or not the components serve metrics
+    serve_metrics: false
+sinker:
+    # MaxPodAge is how old a Pod can be before it is garbage-collected.
+    # Defaults to one day.
+    max_pod_age: 0s
+
+    # MaxProwJobAge is how old a ProwJob can be before it is garbage-collected.
+    # Defaults to one week.
+    max_prowjob_age: 0s
+
+    # ResyncPeriod is how often the controller will perform a garbage
+    # collection. Defaults to one hour.
+    resync_period: 0s
+
+    # TerminatedPodTTL is how long a Pod can live after termination before it is
+    # garbage collected.
+    # Defaults to matching MaxPodAge.
+    terminated_pod_ttl: 0s
+
+
+# Deprecated: this option will be removed in May 2020.
+slack_reporter:
+    channel: ' '
+    job_states_to_report:
+      - ""
+    job_types_to_report:
+      - ""
+    report_template: ' '
+slack_reporter_configs:
+    "":
+        channel: ' '
+        job_states_to_report:
+          - ""
+        job_types_to_report:
+          - ""
+        report_template: ' '
+
+
+# StatusErrorLink is the url that will be used for jenkins prowJobs that can't be
+# found, or have another generic issue. The default that will be used if this is not set
+# is: https://github.com/kubernetes/test-infra/issues
+status_error_link: ' '
+tide:
+    batch_size_limit:
+        "": 0
+    blocker_label: ' '
+    context_options:
+        from-branch-protection: false
+        optional-contexts:
+          - ""
+        orgs:
+            "":
+                from-branch-protection: false
+                optional-contexts:
+                  - ""
+                repos:
+                    "":
+                        branches:
+                            "":
+                                from-branch-protection: false
+                                optional-contexts:
+                                  - ""
+                                required-contexts:
+                                  - ""
+                                required-if-present-contexts:
+                                  - ""
+                                skip-unknown-contexts: false
+                        from-branch-protection: false
+                        optional-contexts:
+                          - ""
+                        required-contexts:
+                          - ""
+                        required-if-present-contexts:
+                          - ""
+                        skip-unknown-contexts: false
+                required-contexts:
+                  - ""
+                required-if-present-contexts:
+                  - ""
+                skip-unknown-contexts: false
+        required-contexts:
+          - ""
+        required-if-present-contexts:
+          - ""
+        skip-unknown-contexts: false
+    merge_commit_template:
+        "":
+            body: ' '
+            title: ' '
+    merge_label: ' '
+    merge_method:
+        "": ""
+    pr_status_base_url: ' '
+    pr_status_base_urls:
+        "": ""
+    queries:
+      - author: ' '
+        excludedBranches:
+          - ""
+        excludedRepos:
+          - ""
+        includedBranches:
+          - ""
+        labels:
+          - ""
+        milestone: ' '
+        missingLabels:
+          - ""
+        orgs:
+          - ""
+        repos:
+          - ""
+    rebase_label: ' '
+    squash_label: ' '
+    status_update_period: 0s
+    sync_period: 0s
+    target_url: ' '


### PR DESCRIPTION
Currently, genyaml must be fed with a struct whose pointer fields are
manually populated with data, otherwise no documentation will be
generated for them. This is very cumbersome for more complicated types.

This PR adds a PopulateStruct function to genyaml that will do this at
runtime via reflection.

/assign @clarketm 