### PR TITLE
Added new entries in testgrid dashboard to refer and publish s390x conformance results  (v1.18, v1.19)

### DIFF
--- a/config/testgrids/conformance/conformance-all.yaml
+++ b/config/testgrids/conformance/conformance-all.yaml
@@ -257,6 +257,12 @@ dashboards:
     - name: Periodic s390x conformance test on local cluster
       test_group_name: s390x-conformance
       description: Runs conformance tests by using kubetest against latest master version of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.19
+      test_group_name: s390x-conformance-v1.19
+      description: Runs conformance tests by using kubetest against latest v1.19 branch HEAD of kubernetes on local s390x cluster
+    - name: Periodic s390x conformance test on local cluster , v1.18
+      test_group_name: s390x-conformance-v1.18
+      description: Runs conformance tests by using kubetest against latest v1.18 branch HEAD of kubernetes on local s390x cluster
 
 test_groups:
 # cloud-provider-openstack e2e conformance tests
@@ -351,6 +357,10 @@ test_groups:
 #IBM s390x test results
 - name: s390x-conformance
   gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x
+- name: s390x-conformance-v1.19
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.19
+- name: s390x-conformance-v1.18
+  gcs_prefix: k8s-conform-s390x-k8s/logs/ci-k8s-conformance-s390x-v1.18
 
 # google-gce-compute-image-tools
 - name: ci-daisy-e2e


### PR DESCRIPTION
Added new entries in testgrid dashboard to refer and publish s390x conformance results  (v1.18, v1.19) periodically.