### PR TITLE
Kops - kubetest2 directory troubleshooting

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -128,6 +128,8 @@ presubmits:
           set -o nounset;
           set -o pipefail;
           set -o xtrace;
+          pwd;
+          cd /home/prow/go/src/k8s.io/kops/tests/e2e;
           export GO111MODULE=on;
           go get sigs.k8s.io/kubetest2@latest;
           go install ./kubetest2-kops;


### PR DESCRIPTION
this seems like its not running in the tests/e2e subdirectory as specified by workingDir. troubleshooting this to confirm.

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/kops/10113/pull-kops-e2e-kubernetes-aws-kubetest2/1321087393746391040