### PR TITLE
Kops kubetest2 - fix binary path for running kops commands

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -128,14 +128,17 @@ presubmits:
           set -o nounset;
           set -o pipefail;
           set -o xtrace;
-          pwd;
           cd /home/prow/go/src/k8s.io/kops/tests/e2e;
           export GO111MODULE=on;
           go get sigs.k8s.io/kubetest2@latest;
           go install ./kubetest2-kops;
           env;
-          kubetest2 kops -v 2 --build --up --down --cloud-provider=aws --kops-binary-path=/home/prow/go/src/k8s.io/kops/kubernetes/platforms/linux/amd64;
-        workingDir: /home/prow/go/src/k8s.io/kops/tests/e2e
+          kubetest2 kops
+            -v 2
+            --build --up --down
+            --cloud-provider=aws
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux_amd64_pure_stripped/kops
+          ;
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
this will only be temporary since this path will only exist for presubmit jobs where kops is built in the same job. Eventually we'll download kops from the artifact storage.