### PR TITLE
prow/bugzilla: allow specifying the tracker id

### DIFF
--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -23,7 +23,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -105,8 +104,8 @@ func TestGetBug(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, but got one: %v", err)
 	}
-	if !reflect.DeepEqual(bug, bugStruct) {
-		t.Errorf("got incorrect bug: %v", diff.ObjectReflectDiff(bug, bugStruct))
+	if diff := cmp.Diff(bug, bugStruct); diff != "" {
+		t.Errorf("got incorrect bug: %v", diff)
 	}
 
 	// this should 404
@@ -301,8 +300,8 @@ func TestGetComments(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected no error, but got one: %v", err)
 	}
-	if !reflect.DeepEqual(comments, commentsStruct) {
-		t.Errorf("got incorrect comments: %v", diff.ObjectReflectDiff(comments, commentsStruct))
+	if diff := cmp.Diff(comments, commentsStruct); diff != "" {
+		t.Errorf("got incorrect comments: %v", diff)
 	}
 
 	// this should 404
@@ -443,8 +442,8 @@ This is another comment.`,
 	}}
 	for _, testCase := range testCases {
 		newBug := cloneBugStruct(&testCase.bug, nil, testCase.comments)
-		if !reflect.DeepEqual(*newBug, testCase.expected) {
-			t.Errorf("%s: Difference in expected BugCreate and actual: %s", testCase.name, cmp.Diff(testCase.expected, *newBug))
+		if diff := cmp.Diff(*newBug, testCase.expected); diff != "" {
+			t.Errorf("%s: Difference in expected BugCreate and actual: %s", testCase.name, diff)
 		}
 	}
 	// test max length truncation
@@ -636,8 +635,8 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 		}
 		for _, testCase := range testCases {
 			if payload.Parameters[0].BugIDs[0] == testCase.id {
-				if actual, expected := string(raw), testCase.expectedPayload; actual != expected {
-					t.Errorf("%s: got incorrect JSONRPC payload: %v", testCase.name, diff.ObjectReflectDiff(expected, actual))
+				if diff := cmp.Diff(string(raw), testCase.expectedPayload); diff != "" {
+					t.Errorf("%s: got incorrect JSONRPC payload: %v", testCase.name, diff)
 				}
 				if _, err := w.Write([]byte(testCase.response)); err != nil {
 					t.Fatalf("%s: failed to send JSONRPC response: %v", testCase.name, err)
@@ -994,8 +993,8 @@ func TestGetExternalBugPRsOnBug(t *testing.T) {
 			if testCase.expectedError && err == nil {
 				t.Errorf("%s: expected an error, but got none", testCase.name)
 			}
-			if actual, expected := prs, testCase.expectedPRs; !reflect.DeepEqual(actual, expected) {
-				t.Errorf("%s: got incorrect prs: %v", testCase.name, diff.ObjectReflectDiff(actual, expected))
+			if diff := cmp.Diff(prs, testCase.expectedPRs); diff != "" {
+				t.Errorf("%s: got incorrect prs: %v", testCase.name, diff)
 			}
 		})
 	}

--- a/prow/bugzilla/client_test.go
+++ b/prow/bugzilla/client_test.go
@@ -541,6 +541,7 @@ func TestUpdateBug(t *testing.T) {
 func TestAddPullRequestAsExternalBug(t *testing.T) {
 	var testCases = []struct {
 		name            string
+		trackerId       uint
 		id              int
 		expectedPayload string
 		response        string
@@ -552,6 +553,15 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 			id:              1705243,
 			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[1705243],"external_bugs":[{"ext_type_url":"https://github.com/","ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
 			response:        `{"error":null,"id":"identifier","result":{"bugs":[{"alias":[],"changes":{"ext_bz_bug_map.ext_bz_bug_id":{"added":"Github org/repo/pull/1","removed":""}},"id":1705243}]}}`,
+			expectedError:   false,
+			expectedChanged: true,
+		},
+		{
+			name:            "explicit tracker ID is used, update succeeds, makes a change",
+			trackerId:       123,
+			id:              17052430,
+			expectedPayload: `{"jsonrpc":"1.0","method":"ExternalBugs.add_external_bug","params":[{"api_key":"api-key","bug_ids":[17052430],"external_bugs":[{"ext_type_id":123,"ext_bz_bug_id":"org/repo/pull/1"}]}],"id":"identifier"}`,
+			response:        `{"error":null,"id":"identifier","result":{"bugs":[{"alias":[],"changes":{"ext_bz_bug_map.ext_bz_bug_id":{"added":"Github org/repo/pull/1","removed":""}},"id":17052430}]}}`,
 			expectedError:   false,
 			expectedChanged: true,
 		},
@@ -651,6 +661,7 @@ func TestAddPullRequestAsExternalBug(t *testing.T) {
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
+			client.githubExternalTrackerId = testCase.trackerId
 			changed, err := client.AddPullRequestAsExternalBug(testCase.id, "org", "repo", 1)
 			if !testCase.expectedError && err != nil {
 				t.Errorf("%s: expected no error, but got one: %v", testCase.name, err)

--- a/prow/bugzilla/types.go
+++ b/prow/bugzilla/types.go
@@ -284,7 +284,11 @@ type AddExternalBugParameters struct {
 type ExternalBugIdentifier struct {
 	// Type is the URL prefix that identifies the external bug tracker type.
 	// For GitHub, this is commonly https://github.com/
-	Type string `json:"ext_type_url"`
+	Type string `json:"ext_type_url,omitempty"`
+	// TrackerID is the internal identifier for the external bug tracker type.
+	// This should be passed instead of the ext_type_url when there is more
+	// than one external tracker for https://github.com/
+	TrackerID int `json:"ext_type_id,omitempty"`
 	// ID is the identifier of the external bug within the bug tracker type.
 	// For GitHub issues and pull requests, this ID is commonly the path
 	// like `org/repo/pull/number` or `org/repo/issue/number`.

--- a/prow/flagutil/bugzilla.go
+++ b/prow/flagutil/bugzilla.go
@@ -29,13 +29,15 @@ import (
 
 // BugzillaOptions holds options for interacting with Bugzilla.
 type BugzillaOptions struct {
-	endpoint   string
-	ApiKeyPath string
+	endpoint                string
+	githubExternalTrackerId uint
+	ApiKeyPath              string
 }
 
 // AddFlags injects Bugzilla options into the given FlagSet.
 func (o *BugzillaOptions) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&o.endpoint, "bugzilla-endpoint", "", "Bugzilla's API endpoint.")
+	fs.UintVar(&o.githubExternalTrackerId, "--bugzilla-github-external-tracker-id", 0, "The ext_type_id for GitHub external bugs, optional.")
 	fs.StringVar(&o.ApiKeyPath, "bugzilla-api-key-path", "", "Path to the file containing the Bugzilla API key.")
 }
 
@@ -77,5 +79,5 @@ func (o *BugzillaOptions) BugzillaClient(secretAgent *secret.Agent) (bugzilla.Cl
 		generator = &generatorFunc
 	}
 
-	return bugzilla.NewClient(*generator, o.endpoint), nil
+	return bugzilla.NewClient(*generator, o.endpoint, o.githubExternalTrackerId), nil
 }


### PR DESCRIPTION
prow/bugzilla: use cmp.Diff in tests

The previous diff library is deprecated and this one creates better
output anyway.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

prow/bugzilla: allow specifying the tracker id

While the URL of the external tracker is meant to be a convenient,
unique identifier for adding external bugs, it may be the case that more
than one external tracker bug types are configured on the Bugzilla
server that track against one server. In this case, the URL is no longer
unique and the internal unique identifier must be used. Normal API keys
may not have the privileges necessary to list all possible trackers, so
we expect the user to simply provide the identifier at startup.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

/assign @alvaroaleman 
