### PR TITLE
releng: Update image promoter jobs to use v2.4.1 prod image

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -13,7 +13,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
@@ -36,7 +36,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -693,7 +693,7 @@ postsubmits:
     spec:
       serviceAccountName: pusher
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
@@ -720,7 +720,7 @@ postsubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
@@ -1055,7 +1055,7 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
       command:
       - cip
       args:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -34,7 +34,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-vuln-dashboard
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:20200807-v2.3.1-258-gc35b3a0
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
       command:
       - dashboard
       args:


### PR DESCRIPTION
[CIP v2.4.1](https://github.com/kubernetes-sigs/k8s-container-image-promoter/releases/tag/v2.4.1) (release commit: https://github.com/kubernetes-sigs/k8s-container-image-promoter/commit/f131ef2f9638605c2afd65f945a190199da7f483).

Promotion PR: https://github.com/kubernetes/k8s.io/pull/1362

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @listx @dims @saschagrunert @hasheddan 
cc: @kubernetes/release-engineering 