### PR TITLE
CAPZ: add "e2e-full" job that includes GPU-based nodes

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -49,6 +49,8 @@ presubmits:
         env:
           - name: GINKGO_FOCUS
             value: "Workload cluster creation"
+          - name: GINKGO_SKIP
+            value: "Creating a GPU-enabled cluster"
           - name: LOCAL_ONLY
             value: "false"
         # docker-in-docker needs privileged mode
@@ -57,6 +59,39 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
       testgrid-tab-name: pr-e2e
+      testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
+  - name: pull-cluster-api-provider-azure-e2e-full
+    path_alias: "sigs.k8s.io/cluster-api-provider-azure"
+    always_run: false
+    optional: true
+    decorate: true
+    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
+    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
+    max_concurrency: 5
+    labels:
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+      preset-azure-cred-only: "true"
+      preset-azure-anonymous-pull: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201027-f0200e6-1.18
+        command:
+        - "runner.sh"
+        - "./scripts/ci-e2e.sh"
+        env:
+          - name: GINKGO_FOCUS
+            value: "Workload cluster creation"
+          - name: GINKGO_SKIP
+            value: ""
+          - name: LOCAL_ONLY
+            value: "false"
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-azure
+      testgrid-tab-name: pr-e2e-full
       testgrid-alert-email: k8s-infra-staging-cluster-api-azure@kubernetes.io
   - name: pull-cluster-api-provider-azure-capi-e2e
     path_alias: "sigs.k8s.io/cluster-api-provider-azure"


### PR DESCRIPTION
kubernetes-sigs/cluster-api-provider-azure#1002 adds a Ginkgo e2e spec to provision and test a GPU-enabled Azure cluster, but skips that test by default. This adds a new `pull-cluster-api-provider-azure-e2e-full` job that can be run on demand to include the GPU-enabled test spec.

cc: @CecileRobertMichon @devigned