### PR TITLE
Adding preset-kind-volume-mounts label to enable kind in service-apis presubmits

### DIFF
--- a/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
+++ b/config/jobs/kubernetes-sigs/service-apis/service-apis-config.yaml
@@ -5,6 +5,7 @@ presubmits:
       testgrid-dashboards: sig-network-service-apis
       testgrid-tab-name: verify
     labels:
+      preset-kind-volume-mounts: "true"
       preset-dind-enabled: "true"
     decorate: true
     path_alias: sigs.k8s.io/service-apis


### PR DESCRIPTION
I believe this is required to get tests added by https://github.com/kubernetes-sigs/service-apis/pull/428 passing.

/cc @BenTheElder 
/assign @bowei 