### PR TITLE
releng: Enable image building for vulndash and reconfigure ci-k8sio-vuln-dashboard-update

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/k8s-staging-artifact-promoter.yaml
@@ -1,4 +1,32 @@
 postsubmits:
+  kubernetes/release:
+    - name: post-release-push-image-vulndash
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-num-failures-to-alert: '1'
+      decorate: true
+      run_if_changed: '^cmd\/vulndash\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-artifact-promoter
+              - --scratch-bucket=gs://k8s-staging-artifact-promoter-gcb
+              - --build-dir=.
+              - cmd/vulndash
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
   kubernetes-sigs/k8s-container-image-promoter:
     - name: cip-postsubmit-push-to-staging
       cluster: k8s-infra-prow-build-trusted

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -29,7 +29,7 @@ periodics:
   decorate: true
   extra_refs:
   - org: kubernetes
-    repo: k8s.io
+    repo: release
     base_ref: master
   spec:
     serviceAccountName: k8s-infra-gcr-vuln-dashboard
@@ -37,11 +37,11 @@ periodics:
     # TODO(releng): Point to promoted image once this job is fixed
     - image: gcr.io/k8s-staging-artifact-promoter/vulndash:latest
       command:
-      - dashboard
+      - vulndash
       args:
-        - -dashboard-file-path=/home/prow/go/src/github.com/kubernetes-sigs/k8s-container-image-promoter/dashboard/
-        - -vuln-target-project=k8s-artifacts-prod
-        - -dashboard-bucket=gs://k8s-artifacts-prod-vuln-dashboard
+        - --project=k8s-artifacts-prod
+        - --bucket=gs://k8s-artifacts-prod-vuln-dashboard
+        - --dashboard-file-path=/home/prow/go/src/k8s.io/release/cmd/vulndash/
   annotations:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -34,7 +34,8 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-vuln-dashboard
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+    # TODO(releng): Point to promoted image once this job is fixed
+    - image: gcr.io/k8s-staging-artifact-promoter/vulndash:latest
       command:
       - dashboard
       args:


### PR DESCRIPTION
Continuation of https://github.com/kubernetes/release/pull/1662, https://github.com/kubernetes/release/pull/1657, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/274

- releng(vulndash): Enable image building
- releng(vulndash): Temporarily use a debug version for update job
  
  `ci-k8sio-vuln-dashboard-update` is currently broken.
  While I'm debugging this, I'm setting this image to:
  
  `gcr.io/k8s-staging-artifact-promoter/vulndash:latest`

  to enable a faster feedback loop. This will be set to a promoted image
  tag once the job is confirmed as fixed.

- releng(vulndash): Correct command, args, and extra_refs
  
  The vulnerability dashboard has:
  
  - been migrated to k/release
  - been renamed from 'dashboard' to 'vulndash'
  - is now built with cobra, so the flags have changed
  
  This updates all of the appropriate references.

/assign @dims @spiffxp @listx @hasheddan 
cc: @kubernetes/release-engineering 