### PR TITLE
Remove kubeproxy log level

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -250,7 +250,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
       - --extract=ci/latest-1.17
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -318,7 +318,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
       - --extract=ci/latest-1.18
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -273,7 +273,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
       - --extract=ci/latest-1.19
       - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -122,8 +122,6 @@ periodics:
           - --scenario=kubernetes_e2e
           - --
           - --check-leaked-resources
-          # TODO(oxddr): remove once debugging is finished
-          - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
           - --cluster=e2e-big
           - --extract=ci/latest
           - --gcp-node-image=gci

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -146,8 +146,6 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --check-leaked-resources
-      # TODO(oxddr): remove once debugging is finished
-      - --env=KUBEPROXY_TEST_LOG_LEVEL=--v=4
       - --cluster=e2e-big
       - --extract=ci/latest-fast
       - --gcp-node-image=gci


### PR DESCRIPTION
This has already been understood and fixed in https://github.com/kubernetes/kubernetes/pull/95363

http://perf-dash.k8s.io/#/?jobname=gce-100Nodes-master&metriccategoryname=Network&metricname=Load_NetworkProgrammingLatency&Metric=NetworkProgrammingLatency

/assign @mborsz @jkaniuk 

