### PR TITLE
Use 50 load test throughput in 5k scale test

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -85,8 +85,11 @@ periodics:
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
       - --provider=gce
-      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
+      # TODO(https://github.com/kubernetes/perf-tests/issues/1536): Reenable oom tracker.
+      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=false
       - --env=CL2_ENABLE_DENSITY_TEST=true
+      - --env=CL2_LOAD_TEST_THROUGHPUT=50
+      - --env=CL2_DELETE_TEST_THROUGHPUT=30
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2


### PR DESCRIPTION
This change starts using 50 load test throughput (5x increase) and 30 deletion test throughput (3x increase) in our 5k master load test.

The expected latency growth is approx. 2x on simple metrics which is still within our SLO.

Ref https://github.com/kubernetes/perf-tests/issues/561

/assign @wojtek-t 