### PR TITLE
Revert "Tide: Add checkrun support"

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -65,7 +65,6 @@ go_test(
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
-        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -218,10 +218,9 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 
 	// fixing label issues takes precedence over status contexts
 	var contexts []string
-	log := logrus.WithFields(pr.logFields())
 	for _, commit := range pr.Commits.Nodes {
 		if commit.Commit.OID == pr.HeadRefOID {
-			for _, ctx := range unsuccessfulContexts(append(commit.Commit.Status.Contexts, checkRunNodesToContexts(log, commit.Commit.StatusCheckRollup.Contexts.Nodes)...), cc, log) {
+			for _, ctx := range unsuccessfulContexts(commit.Commit.Status.Contexts, cc, logrus.New().WithFields(pr.logFields())) {
 				contexts = append(contexts, string(ctx.Context))
 			}
 		}

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -53,7 +53,6 @@ func TestExpectedStatus(t *testing.T) {
 		secondQueryAuthor string
 		milestone         string
 		contexts          []Context
-		checkRuns         []CheckRun
 		inPool            bool
 		blocks            []int
 		prowJobs          []runtime.Object
@@ -192,136 +191,6 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
 		},
 		{
-			name:              "single bad checkrun",
-			labels:            neededLabels,
-			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)}},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
-		},
-		{
-			name:              "single good checkrun",
-			labels:            neededLabels,
-			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            true,
-
-			state: github.StatusSuccess,
-			desc:  statusInPool,
-		},
-		{
-			name:   "multiple good checkruns",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            true,
-
-			state: github.StatusSuccess,
-			desc:  statusInPool,
-		},
-		{
-			name:   "mix of good and bad checkruns",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Job another-job has not succeeded."),
-		},
-		{
-			name:   "mix of good status contexts and checkruns",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-			},
-			contexts: []Context{
-				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            true,
-
-			state: github.StatusSuccess,
-			desc:  statusInPool,
-		},
-		{
-			name:   "mix of bad status contexts and checkruns",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
-			},
-			contexts: []Context{
-				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
-		},
-		{
-			name:   "good context, bad checkrun",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
-			},
-			contexts: []Context{
-				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
-		},
-		{
-			name:   "bad context, good checkrun",
-			labels: neededLabels,
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
-			},
-			contexts: []Context{
-				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
-			},
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			inPool:            false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Job other-job-name has not succeeded."),
-		},
-		{
 			name:              "multiple bad contexts",
 			labels:            neededLabels,
 			author:            "batman",
@@ -331,22 +200,6 @@ func TestExpectedStatus(t *testing.T) {
 			contexts: []Context{
 				{Context: githubql.String("job-name"), State: githubql.StatusStateError},
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateError},
-			},
-			inPool: false,
-
-			state: github.StatusPending,
-			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
-		},
-		{
-			name:              "multiple bad checkruns",
-			labels:            neededLabels,
-			author:            "batman",
-			firstQueryAuthor:  "batman",
-			secondQueryAuthor: "batman",
-			milestone:         "v1.0",
-			checkRuns: []CheckRun{
-				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
-				{Name: githubql.String("other-job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			inPool: false,
 
@@ -664,26 +517,19 @@ func TestExpectedStatus(t *testing.T) {
 				)
 			}
 			pr.HeadRefOID = githubql.String("head")
-			var checkRunNodes []CheckRunNode
-			for _, checkRun := range tc.checkRuns {
-				checkRunNodes = append(checkRunNodes, CheckRunNode{CheckRun: checkRun})
-			}
-			pr.Commits.Nodes = append(
-				pr.Commits.Nodes,
-				struct{ Commit Commit }{
-					Commit: Commit{
-						Status: struct{ Contexts []Context }{
-							Contexts: tc.contexts,
-						},
-						OID: githubql.String("head"),
-						StatusCheckRollup: StatusCheckRollup{
-							Contexts: StatusCheckRollupContext{
-								Nodes: checkRunNodes,
+			if len(tc.contexts) > 0 {
+				pr.Commits.Nodes = append(
+					pr.Commits.Nodes,
+					struct{ Commit Commit }{
+						Commit: Commit{
+							Status: struct{ Contexts []Context }{
+								Contexts: tc.contexts,
 							},
+							OID: githubql.String("head"),
 						},
 					},
-				},
-			)
+				)
+			}
 			pr.Author = struct {
 				Login githubql.String
 			}{githubql.String(tc.author)}

--- a/prow/tide/tide_test.go
+++ b/prow/tide/tide_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/go-test/deep"
-	"github.com/google/go-cmp/cmp"
 	githubql "github.com/shurcooL/githubv4"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -2037,7 +2036,6 @@ func TestFilterSubpool(t *testing.T) {
 		number    int
 		mergeable bool
 		contexts  []Context
-		checkRuns []CheckRun
 	}
 	tcs := []struct {
 		name string
@@ -2068,103 +2066,6 @@ func TestFilterSubpool(t *testing.T) {
 				},
 			},
 			expectedPRs: []int{1},
-		},
-		{
-			name: "one mergeable passing PR (omitting optional context), checkrun is considered",
-			prs: []pr{
-				{
-					number:    1,
-					mergeable: true,
-					contexts: []Context{
-						{
-							Context: githubql.String("pj-a"),
-							State:   githubql.StatusStateSuccess,
-						},
-						{
-							Context: githubql.String("pj-b"),
-							State:   githubql.StatusStateSuccess,
-						},
-					},
-					checkRuns: []CheckRun{{
-						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
-						Conclusion: githubql.String(githubql.StatusStateSuccess),
-					}},
-				},
-			},
-			expectedPRs: []int{1},
-		},
-		{
-			name: "one mergeable passing PR (omitting optional context), neutral checkrun is considered success",
-			prs: []pr{
-				{
-					number:    1,
-					mergeable: true,
-					contexts: []Context{
-						{
-							Context: githubql.String("pj-a"),
-							State:   githubql.StatusStateSuccess,
-						},
-						{
-							Context: githubql.String("pj-b"),
-							State:   githubql.StatusStateSuccess,
-						},
-					},
-					checkRuns: []CheckRun{{
-						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
-						Conclusion: checkRunConclusionNeutral,
-					}},
-				},
-			},
-			expectedPRs: []int{1},
-		},
-		{
-			name: "Incomplete checkrun throws the pr out",
-			prs: []pr{
-				{
-					number:    1,
-					mergeable: true,
-					contexts: []Context{
-						{
-							Context: githubql.String("pj-a"),
-							State:   githubql.StatusStateSuccess,
-						},
-						{
-							Context: githubql.String("pj-b"),
-							State:   githubql.StatusStateSuccess,
-						},
-					},
-					checkRuns: []CheckRun{{
-						Name:       githubql.String("other-a"),
-						Conclusion: githubql.String(githubql.StatusStateSuccess),
-					}},
-				},
-			},
-		},
-		{
-			name: "Failing checkrun throws the pr out",
-			prs: []pr{
-				{
-					number:    1,
-					mergeable: true,
-					contexts: []Context{
-						{
-							Context: githubql.String("pj-a"),
-							State:   githubql.StatusStateSuccess,
-						},
-						{
-							Context: githubql.String("pj-b"),
-							State:   githubql.StatusStateSuccess,
-						},
-					},
-					checkRuns: []CheckRun{{
-						Name:       githubql.String("other-a"),
-						Status:     checkRunStatusCompleted,
-						Conclusion: githubql.String(githubql.StatusStateFailure),
-					}},
-				},
-			},
 		},
 		{
 			name: "one unmergeable passing PR",
@@ -2413,20 +2314,11 @@ func TestFilterSubpool(t *testing.T) {
 				pr := PullRequest{
 					Number: githubql.Int(pull.number),
 				}
-				var checkRunNodes []CheckRunNode
-				for _, checkRun := range pull.checkRuns {
-					checkRunNodes = append(checkRunNodes, CheckRunNode{CheckRun: checkRun})
-				}
 				pr.Commits.Nodes = []struct{ Commit Commit }{
 					{
 						Commit{
 							Status: struct{ Contexts []Context }{
 								Contexts: pull.contexts,
-							},
-							StatusCheckRollup: StatusCheckRollup{
-								Contexts: StatusCheckRollupContext{
-									Nodes: checkRunNodes,
-								},
 							},
 						},
 					},
@@ -3779,62 +3671,5 @@ func TestNonFailedBatchByBaseAndPullsIndexFunc(t *testing.T) {
 		if diff := deep.Equal(result, tc.expected); diff != nil {
 			t.Errorf("Result differs from expected, diff: %v", diff)
 		}
-	}
-}
-
-func TestCheckRunNodesToContexts(t *testing.T) {
-	t.Parallel()
-	testCases := []struct {
-		name      string
-		checkRuns []CheckRun
-		expected  []Context
-	}{
-		{
-			name:      "Empty checkrun is ignored",
-			checkRuns: []CheckRun{{}},
-		},
-		{
-			name:      "Incomplete checkrun is considered pending",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: githubql.String("queued")}},
-			expected:  []Context{{Context: "some-job", State: githubql.StatusStatePending}},
-		},
-		{
-			name:      "Neutral checkrun is considered success",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral}},
-			expected:  []Context{{Context: "some-job", State: githubql.StatusStateSuccess}},
-		},
-		{
-			name:      "Successful checkrun is considered success",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
-			expected:  []Context{{Context: "some-job", State: githubql.StatusStateSuccess}},
-		},
-		{
-			name:      "Other checkrun conclusion is considered failure",
-			checkRuns: []CheckRun{{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: "unclear"}},
-			expected:  []Context{{Context: "some-job", State: githubql.StatusStateFailure}},
-		},
-		{
-			name: "Multiple checkruns are translated correctly",
-			checkRuns: []CheckRun{
-				{Name: githubql.String("some-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral},
-				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: checkRunConclusionNeutral},
-			},
-			expected: []Context{
-				{Context: "some-job", State: githubql.StatusStateSuccess},
-				{Context: "another-job", State: githubql.StatusStateSuccess},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			var checkRunNodes []CheckRunNode
-			for _, checkRun := range tc.checkRuns {
-				checkRunNodes = append(checkRunNodes, CheckRunNode{CheckRun: checkRun})
-			}
-			if diff := cmp.Diff(checkRunNodesToContexts(logrus.New().WithField("test", tc.name), checkRunNodes), tc.expected); diff != "" {
-				t.Errorf("actual result differs from expected: %s", diff)
-			}
-		})
 	}
 }


### PR DESCRIPTION
This reverts commit 1b5f13772461c1200b87c050a91f97f1daa934bd.

This change increases the V4 token usage in Openshift from about 1.7k
tokens per hour to about 4.6k.

Below a graph of the token usage, you can clearly see when we updated tide and when we reverted the update:

<img width="1664" alt="v4" src="https://user-images.githubusercontent.com/6496100/97440239-945f5400-18fd-11eb-9f51-89d88ad98ff1.png">
