### PR TITLE
Add deletion annotation handling for job forking

### DIFF
--- a/releng/config-forker/README.md
+++ b/releng/config-forker/README.md
@@ -13,6 +13,7 @@ config-forker forks presubmit, periodic, and postsubmit job configs with the `fo
 
 - `fork-per-release`: only jobs with this set to `"true"` will be forked.
 - `fork-per-release-replacements`: allows replacing values in job `tags` (periodics only) and container `args` (see [Custom replacements](#custom-replacements)).
+- `fork-per-release-deletions`: allows deleting values in job `labels` in periodics (see [Custom deletions](#custom-deletions)).
 - `fork-per-release-periodic-interval`: if set, forked jobs will use this value for `interval`. If multiple space-separated values are provided, the first will be used.
 - `fork-per-release-cron`: if set, forked jobs will use this value for `cron`. If multiple values separated with `, ` are provided, the first will be used.
 
@@ -68,3 +69,15 @@ by the version currently being forked (e.g. `1.15`). For example:
 ```
 fork-per-release-replacements: "--version=stable -> --version={{.Version}"
 ```
+
+## Custom deletions
+
+The `fork-per-release-deletions` annotation can be used for custom deletions in your `labels` (periodic jobs only).
+This is a comma-separated list of keys of labels you would like to remove on forking, for instance:
+
+```
+fork-per-release-deletions: "label-key-to-delete1, label-key-to-delete2"
+```
+
+This is useful for getting rid of a specific preset in the forked job. For instance, one can have a master branch job that
+has a label corresponding to a master-specific preset which is undesired for forked release jobs.

--- a/releng/config-forker/main_test.go
+++ b/releng/config-forker/main_test.go
@@ -180,6 +180,55 @@ func TestPerformArgReplacements(t *testing.T) {
 	}
 }
 
+func TestPerformArgDeletions(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      map[string]string
+		deletions string
+		expected  map[string]string
+	}{
+		{
+			name:      "nil arguments remain nil",
+			args:      nil,
+			deletions: "",
+			expected:  nil,
+		},
+		{
+			name:      "empty arguments remain empty",
+			args:      map[string]string{},
+			deletions: "",
+			expected:  map[string]string{},
+		},
+		{
+			name:      "empty deletions do nothing",
+			args:      map[string]string{"foo": "bar"},
+			deletions: "",
+			expected:  map[string]string{"foo": "bar"},
+		},
+		{
+			name:      "simple deletion works",
+			args:      map[string]string{"foo": "bar", "baz": "baz2"},
+			deletions: "foo",
+			expected:  map[string]string{"baz": "baz2"},
+		},
+		{
+			name:      "multiple deletions work",
+			args:      map[string]string{"foo": "bar", "baz": "baz2", "hello": "world"},
+			deletions: "foo, baz",
+			expected:  map[string]string{"hello": "world"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := performDeletion(tc.args, tc.deletions)
+			if !reflect.DeepEqual(result, tc.expected) {
+				t.Errorf("Expected result %v, but got %v instead", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestFixImage(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -533,6 +582,21 @@ func TestGeneratePeriodics(t *testing.T) {
 			},
 		},
 		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name: "generic-periodic-with-deletions-master",
+				Annotations: map[string]string{
+					forkAnnotation:     "true",
+					deletionAnnotation: "preset-e2e-scalability-periodics-master",
+					suffixAnnotation:   "true",
+				},
+				Labels: map[string]string{
+					"preset-e2e-scalability-periodics":        "true",
+					"preset-e2e-scalability-periodics-master": "true",
+				},
+			},
+		},
+		{
 			Interval: "1h",
 			JobBase: config.JobBase{
 				Name: "periodic-with-replacements",
@@ -586,6 +650,16 @@ func TestGeneratePeriodics(t *testing.T) {
 			JobBase: config.JobBase{
 				Name:        "some-generic-periodic-beta",
 				Annotations: map[string]string{suffixAnnotation: "true", testgridDashboardsAnnotation: "sig-release-job-config-errors"},
+			},
+		},
+		{
+			Cron: "0 * * * *",
+			JobBase: config.JobBase{
+				Name:        "generic-periodic-with-deletions-beta",
+				Annotations: map[string]string{suffixAnnotation: "true", testgridDashboardsAnnotation: "sig-release-job-config-errors"},
+				Labels: map[string]string{
+					"preset-e2e-scalability-periodics": "true",
+				},
 			},
 		},
 		{


### PR DESCRIPTION
This would come in handy when one has a master branch-specific preset that is not desired to be copied when a job is forked to the past releases.

/sig scalability
/assign @jkaniuk 