### PR TITLE
ci-k8sio-vuln-dashboard-update: Set -amd64 arch on image reference

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -35,7 +35,7 @@ periodics:
     serviceAccountName: k8s-infra-gcr-vuln-dashboard
     containers:
     # TODO(releng): Point to promoted image once this job is fixed
-    - image: gcr.io/k8s-staging-artifact-promoter/vulndash:latest
+    - image: gcr.io/k8s-staging-artifact-promoter/vulndash-amd64:latest
       command:
       - vulndash
       args:


### PR DESCRIPTION
Continuation of https://github.com/kubernetes/test-infra/pull/19725, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/274.

'vulndash' is a manifest list which does not tag 'latest'.
'vulndash-amd64' is an image which does tag 'latest'.

Causes a pod timeout w/ `ErrImagePull` (ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-vuln-dashboard-update/1321488027800834048)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @spiffxp 
cc: @kubernetes/release-engineering 