### PR TITLE
Add sub stream results to staging

### DIFF
--- a/kettle/update.py
+++ b/kettle/update.py
@@ -70,7 +70,8 @@ def main():
     else:
         call(f'{mj_cmd} | pv | gzip > build_staging.json.gz')
         call(f'{bq_cmd} k8s-gubernator:build.staging build_staging.json.gz schema.json')
-
+        call('python3 stream.py --poll kubernetes-jenkins/gcs-changes/kettle ' \
+            ' --dataset k8s-gubernator:build --tables staging:0 --stop_at=1')
 
 if __name__ == '__main__':
     os.chdir(os.path.dirname(__file__))


### PR DESCRIPTION
Add in the stream.py calls for staging

This is a big step that was left out of staging

I have seen some issue with stream.py in prod, I am not sure how the sub works or if it even still exits today.

I need to look more into what is going on here, issues are related to google-cloud-bigquery versions. However, these are long outdated #19358 and the source has moved/changed. The [Table](https://googleapis.dev/python/bigquery/latest/generated/google.cloud.bigquery.table.Table.html#google.cloud.bigquery.table.Table) no longer has a method we are using and I can't find why/how that changed