### PR TITLE
ci-k8sio-vuln-dashboard-update: Use absolute path for vulndash binary

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -37,7 +37,7 @@ periodics:
     # TODO(releng): Point to promoted image once this job is fixed
     - image: gcr.io/k8s-staging-artifact-promoter/vulndash-amd64:latest
       command:
-      - vulndash
+      - /vulndash
       args:
         - --project=k8s-artifacts-prod
         - --bucket=gs://k8s-artifacts-prod-vuln-dashboard


### PR DESCRIPTION
:facepalm: :facepalm: :facepalm: :facepalm: :facepalm: :facepalm:

Distroless containers do not seed a $PATH.

Should fix:

```console
could not start the process: exec: "vulndash": executable file not found
in $PATH
```

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

ref: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-vuln-dashboard-update/1321609773078024192
Continuation of https://github.com/kubernetes/test-infra/pull/19737, https://github.com/kubernetes/test-infra/pull/19725, https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/274

/assign @dims @spiffxp
cc: @kubernetes/release-engineering