### PR TITLE
Tide: Re-Add checkrun support, paginate query at 37 results

### DIFF
--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//prow/tide/blockers:go_default_library",
         "//prow/tide/history:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",

--- a/prow/tide/search.go
+++ b/prow/tide/search.go
@@ -79,7 +79,12 @@ func search(query querier, log *logrus.Entry, q string, start, end time.Time) ([
 		vars["searchCursor"] = cursor
 		log = log.WithField("searchCursor", *cursor)
 	}
-	log.WithField("duration", time.Since(requestStart).String()).Debugf("Query returned %d PRs and cost %d point(s). %d remaining.", len(ret), totalCost, remaining)
+	log.WithFields(logrus.Fields{
+		"duration":       time.Since(requestStart).String(),
+		"pr_found_count": len(ret),
+		"cost":           totalCost,
+		"remaining":      remaining,
+	}).Debug("Finished query")
 	return ret, nil
 }
 

--- a/prow/tide/status.go
+++ b/prow/tide/status.go
@@ -218,9 +218,10 @@ func requirementDiff(pr *PullRequest, q *config.TideQuery, cc contextChecker) (s
 
 	// fixing label issues takes precedence over status contexts
 	var contexts []string
+	log := logrus.WithFields(pr.logFields())
 	for _, commit := range pr.Commits.Nodes {
 		if commit.Commit.OID == pr.HeadRefOID {
-			for _, ctx := range unsuccessfulContexts(commit.Commit.Status.Contexts, cc, logrus.New().WithFields(pr.logFields())) {
+			for _, ctx := range unsuccessfulContexts(append(commit.Commit.Status.Contexts, checkRunNodesToContexts(log, commit.Commit.StatusCheckRollup.Contexts.Nodes)...), cc, log) {
 				contexts = append(contexts, string(ctx.Context))
 			}
 		}

--- a/prow/tide/status_test.go
+++ b/prow/tide/status_test.go
@@ -53,6 +53,7 @@ func TestExpectedStatus(t *testing.T) {
 		secondQueryAuthor string
 		milestone         string
 		contexts          []Context
+		checkRuns         []CheckRun
 		inPool            bool
 		blocks            []int
 		prowJobs          []runtime.Object
@@ -191,6 +192,136 @@ func TestExpectedStatus(t *testing.T) {
 			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
 		},
 		{
+			name:              "single bad checkrun",
+			labels:            neededLabels,
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)}},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
+		},
+		{
+			name:              "single good checkrun",
+			labels:            neededLabels,
+			checkRuns:         []CheckRun{{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)}},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "multiple good checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "mix of good and bad checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+				{Name: githubql.String("another-job"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job another-job has not succeeded."),
+		},
+		{
+			name:   "mix of good status contexts and checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            true,
+
+			state: github.StatusSuccess,
+			desc:  statusInPool,
+		},
+		{
+			name:   "mix of bad status contexts and checkruns",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
+		},
+		{
+			name:   "good context, bad checkrun",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateSuccess},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job job-name has not succeeded."),
+		},
+		{
+			name:   "bad context, good checkrun",
+			labels: neededLabels,
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateSuccess)},
+			},
+			contexts: []Context{
+				{Context: githubql.String("other-job-name"), State: githubql.StatusStateFailure},
+			},
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			inPool:            false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Job other-job-name has not succeeded."),
+		},
+		{
 			name:              "multiple bad contexts",
 			labels:            neededLabels,
 			author:            "batman",
@@ -200,6 +331,22 @@ func TestExpectedStatus(t *testing.T) {
 			contexts: []Context{
 				{Context: githubql.String("job-name"), State: githubql.StatusStateError},
 				{Context: githubql.String("other-job-name"), State: githubql.StatusStateError},
+			},
+			inPool: false,
+
+			state: github.StatusPending,
+			desc:  fmt.Sprintf(statusNotInPool, " Jobs job-name, other-job-name have not succeeded."),
+		},
+		{
+			name:              "multiple bad checkruns",
+			labels:            neededLabels,
+			author:            "batman",
+			firstQueryAuthor:  "batman",
+			secondQueryAuthor: "batman",
+			milestone:         "v1.0",
+			checkRuns: []CheckRun{
+				{Name: githubql.String("job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
+				{Name: githubql.String("other-job-name"), Status: checkRunStatusCompleted, Conclusion: githubql.String(githubql.StatusStateFailure)},
 			},
 			inPool: false,
 
@@ -517,19 +664,26 @@ func TestExpectedStatus(t *testing.T) {
 				)
 			}
 			pr.HeadRefOID = githubql.String("head")
-			if len(tc.contexts) > 0 {
-				pr.Commits.Nodes = append(
-					pr.Commits.Nodes,
-					struct{ Commit Commit }{
-						Commit: Commit{
-							Status: struct{ Contexts []Context }{
-								Contexts: tc.contexts,
+			var checkRunNodes []CheckRunNode
+			for _, checkRun := range tc.checkRuns {
+				checkRunNodes = append(checkRunNodes, CheckRunNode{CheckRun: checkRun})
+			}
+			pr.Commits.Nodes = append(
+				pr.Commits.Nodes,
+				struct{ Commit Commit }{
+					Commit: Commit{
+						Status: struct{ Contexts []Context }{
+							Contexts: tc.contexts,
+						},
+						OID: githubql.String("head"),
+						StatusCheckRollup: StatusCheckRollup{
+							Contexts: StatusCheckRollupContext{
+								Nodes: checkRunNodes,
 							},
-							OID: githubql.String("head"),
 						},
 					},
-				)
-			}
+				},
+			)
 			pr.Author = struct {
 				Login githubql.String
 			}{githubql.String(tc.author)}

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1716,7 +1716,7 @@ type searchQuery struct {
 			EndCursor   githubql.String
 		}
 		Nodes []PRNode
-	} `graphql:"search(type: ISSUE, first: 100, after: $searchCursor, query: $query)"`
+	} `graphql:"search(type: ISSUE, first: 37, after: $searchCursor, query: $query)"`
 }
 
 func (pr *PullRequest) logFields() logrus.Fields {

--- a/prow/tide/tide.go
+++ b/prow/tide/tide.go
@@ -1672,7 +1672,26 @@ type Commit struct {
 	Status struct {
 		Contexts []Context
 	}
-	OID githubql.String `graphql:"oid"`
+	OID               githubql.String `graphql:"oid"`
+	StatusCheckRollup StatusCheckRollup
+}
+
+type StatusCheckRollup struct {
+	Contexts StatusCheckRollupContext `graphql:"contexts(last: 100)"`
+}
+
+type StatusCheckRollupContext struct {
+	Nodes []CheckRunNode
+}
+
+type CheckRunNode struct {
+	CheckRun CheckRun `graphql:"... on CheckRun"`
+}
+
+type CheckRun struct {
+	Name       githubql.String
+	Conclusion githubql.String
+	Status     githubql.String
 }
 
 // Context holds graphql response data for github contexts.
@@ -1722,7 +1741,7 @@ func (pr *PullRequest) logFields() logrus.Fields {
 func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Context, error) {
 	for _, node := range pr.Commits.Nodes {
 		if node.Commit.OID == pr.HeadRefOID {
-			return node.Commit.Status.Contexts, nil
+			return append(node.Commit.Status.Contexts, checkRunNodesToContexts(log, node.Commit.StatusCheckRollup.Contexts.Nodes)...), nil
 		}
 	}
 	// We didn't get the head commit from the query (the commits must not be
@@ -1731,6 +1750,8 @@ func headContexts(log *logrus.Entry, ghc githubClient, pr *PullRequest) ([]Conte
 	org := string(pr.Repository.Owner.Login)
 	repo := string(pr.Repository.Name)
 	// Log this event so we can tune the number of commits we list to minimize this.
+	// TODO alvaroaleman: Add checkrun support here. Doesn't seem to happen often though,
+	// openshift doesn't have a single occurrence of this in the past seven days.
 	log.Warnf("'last' %d commits didn't contain logical last commit. Querying GitHub...", len(pr.Commits.Nodes))
 	combined, err := ghc.GetCombinedStatus(org, repo, string(pr.HeadRefOID))
 	if err != nil {
@@ -1822,4 +1843,48 @@ func nonFailedBatchByNameBaseAndPullsIndexFunc(obj runtime.Object) []string {
 	}
 
 	return []string{nonFailedBatchByNameBaseAndPullsIndexKey(pj.Spec.Job, pj.Spec.Refs)}
+}
+
+func checkRunNodesToContexts(log *logrus.Entry, nodes []CheckRunNode) []Context {
+	var result []Context
+	for _, node := range nodes {
+		// GitHub gives us an empty checkrun per status context. In theory they could
+		// at some point decide to create a virtual check run per status context.
+		// If that were to happen, we would retrieve redundant data as we get the
+		// status context both directly as a status context and as a checkrun, however
+		// the actual data in there should be identical, hence this isn't a problem.
+		if string(node.CheckRun.Name) == "" {
+			continue
+		}
+		result = append(result, checkRunToContext(node.CheckRun))
+	}
+	if len(result) > 0 {
+		log.WithField("checkruns", len(result)).Debug("Transformed checkruns to contexts")
+	}
+	return result
+}
+
+const (
+	checkRunStatusCompleted   = githubql.String("COMPLETED")
+	checkRunConclusionNeutral = githubql.String("NEUTRAL")
+)
+
+// checkRunToContext translates a checkRun to a classic context
+// ref: https://developer.github.com/v3/checks/runs/#parameters
+func checkRunToContext(checkRun CheckRun) Context {
+	context := Context{
+		Context: checkRun.Name,
+	}
+	if checkRun.Status != checkRunStatusCompleted {
+		context.State = githubql.StatusStatePending
+		return context
+	}
+
+	if checkRun.Conclusion == checkRunConclusionNeutral || checkRun.Conclusion == githubql.String(githubql.StatusStateSuccess) {
+		context.State = githubql.StatusStateSuccess
+		return context
+	}
+
+	context.State = githubql.StatusStateFailure
+	return context
 }


### PR DESCRIPTION
Re-Adds the checkrun support we reverted earlier because it caused our token cost to triple, getting us close to exhaustion. The third commit fixes that issue, its commit message explains this best:


    Tide: Limit query to 37 results
    
    Currently, we paginate at 100 results for the tide search query. This
    always costs two points without querying checkruns and six points when
    querying checkruns. This cost is regardless of the number of results
    returned. However, if the number of results exceeds the pagination
    boundary, another query has to be done which will again cost tokens.
    
    Changing the pagination limit for the search reveals that there are
    boundaries at which the query cost increases. Changing the limits on
    other parts of the query doesn't seem to have an impact on the query
    cost. Neither does changing the search strings, I tried to add both
    the kubernetes and the openshift org to the search string which didn't
    change anything about the cost even though it dramatically increased
    query time.
    
    The boundaries without checkruns are:
    0-99: 1 token
    100:  2 tokens
    
    The boundaries with checkruns are:
    0-37:  1 token
    38-62: 2 tokens
    63-87: 3 tokens
    88-99: 4 tokens
    100:   6 tokens
    
    Thus 37 results is the most token-efficient way when using checkruns.
    Reducing the number of results also has the nice sideffect that it might
    help with the occasional 502 errors the tide status controller is
    getting.
    
    Below the query I used. Remove the `statusCheckRollup` part to get the
    results without checkruns. You can test this out on GitHubs GraphQL
    explorer at https://developer.github.com/v4/explorer/.
    
    {
      rateLimit {
        cost
        remaining
        nodeCount
        limit
        resetAt
        used
      }
      search(type: ISSUE, first: 37, after: null, query: "is:pr state:open archived:false repo:\"openshift/ci-docs\" repo:\"opendatahub-io/manifests\" repo:\"opendatahub-io/odh-manifests\" repo:\"opendatahub-io/opendatahub-operator\"  -label:\"needs-rebase\" -label:\"do-not-merge/hold\" -label:\"do-not-merge/work-in-progress\" -label:\"do-not-merge/invalid-owners-file\"") {
        pageInfo {
          hasNextPage
          endCursor
        }
        nodes {
          ... on PullRequest {
            number
            author {
              login
            }
            baseRef {
              name
              prefix
            }
            headRefName
            headRefOid
            mergeable
            repository {
              name
              nameWithOwner
              owner {
                login
              }
            }
            commits(last: 4) {
              nodes {
                id
                commit {
                  oid
                  status {
                    contexts {
                      context
                      description
                      state
                    }
                  }
                  statusCheckRollup {
                    contexts(last: 100) {
                      nodes {
                        ... on CheckRun {
                          id
                          name
                        }
                      }
                    }
                  }
                }
              }
            }
            labels(first: 100) {
              nodes {
                name
              }
            }
            milestone {
              title
            }
            body
            title
            updatedAt
          }
        }
      }
    }

/assign @stevekuznetsov 
/cc @petr-muller 