### PR TITLE
Revert explicit bumps of master sizes

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -34,8 +34,6 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-nodes=100
-        # TODO(k/k#94098): Remove the line below once we get enough data.
-        - --gcp-master-size=n1-standard-8
         - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
         - --provider=gce

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -150,8 +150,6 @@ periodics:
       - --extract=ci/latest-fast
       - --gcp-node-image=gci
       - --gcp-nodes=100
-      # TODO(k/k#94098): Remove the line below once we get enough data.
-      - --gcp-master-size=n1-standard-8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
       - --provider=gce


### PR DESCRIPTION
This is no longer needed after https://github.com/kubernetes/kubernetes/pull/95947

Fix https://github.com/kubernetes/kubernetes/issues/94098

/assign @jkaniuk 