### PR TITLE
Enable new log dumping mechanism for all scalability jobs

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -90,6 +90,10 @@ presets:
     value: 1
   - name: CL2_ENABLE_CLUSTER_OOMS_TRACKER
     value: true
+  # Switch to using log-dump.sh script included in the kubekins-e2e image
+  # instead of relying on the deprecated one from k/k repository.
+  - name: USE_KUBEKINS_LOG_DUMPING
+    value: "true"
 
 ### kubemark-gce-scale
 - labels:
@@ -212,6 +216,10 @@ presets:
       apps/v1/ReplicaSet
       apps/v1/StatefulSet
       extensions/v1beta1/Ingress
+  # Switch to using log-dump.sh script included in the kubekins-e2e image
+  # instead of relying on the deprecated one from k/k repository.
+  - name: USE_KUBEKINS_LOG_DUMPING
+    value: "true"
 
   ###### Scalability Envs
   ### Common env variables for containerd scalability-related suites.
@@ -284,10 +292,6 @@ presets:
 - labels:
     preset-e2e-scalability-periodics: "true"
   env:
-  # Switch to using log-dump.sh script included in the kubekins-e2e image
-  # instead of relying on the deprecated one from k/k repository.
-  - name: USE_KUBEKINS_LOG_DUMPING
-    value: "yes"
 
 - labels:
     preset-e2e-scalability-periodics-master: "true"


### PR DESCRIPTION
Yesterday the mechanism was successfully enabled in https://github.com/kubernetes/test-infra/pull/19710 for 1.16-1.19 periodic jobs (peeked into those jobs - they are green and the logs got exported successfully). This PR additionally turns it on for scalability presubmit jobs.

/sig scalability
/assign @jkaniuk @wojtek-t 