### PR TITLE
releng/vuln-dashboard: fix dashboard path

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -41,7 +41,7 @@ periodics:
       args:
         - --project=k8s-artifacts-prod
         - --bucket=gs://k8s-artifacts-prod-vuln-dashboard
-        - --dashboard-file-path=/home/prow/go/src/k8s.io/release/cmd/vulndash/
+        - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
   annotations:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io


### PR DESCRIPTION
Fix path for the arg `dashboard-file-path` when we clone the repo it puts in the path `/home/prow/go/src/github.com/kubernetes/release` and not in `/home/prow/go/src/k8s.io/release/`

ref: https://github.com/kubernetes/release/issues/1665

/assign @justaugustus 
cc: @kubernetes/release-engineering
