### PR TITLE
Allow Kubemark master log dumping without k/k

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -232,7 +232,7 @@ func run(deploy deployer, o options) error {
 	var kubemarkDownErr error
 	if o.down && o.kubemark {
 		kubemarkWg.Add(1)
-		go kubemarkDown(&kubemarkDownErr, &kubemarkWg, dump)
+		go kubemarkDown(&kubemarkDownErr, &kubemarkWg, o.provider, dump)
 	}
 
 	if o.charts {
@@ -737,10 +737,11 @@ func kubemarkGinkgoTest(testArgs []string, dump string) error {
 }
 
 // Brings down the kubemark cluster.
-func kubemarkDown(err *error, wg *sync.WaitGroup, dump string) {
+func kubemarkDown(err *error, wg *sync.WaitGroup, provider, dump string) {
 	defer wg.Done()
 	control.XMLWrap(&suite, "Kubemark MasterLogDump", func() error {
-		cmd := exec.Command("./cluster/log-dump/log-dump.sh", dump)
+		logDumpPath := logDumpPath(provider)
+		cmd := exec.Command(logDumpPath, dump)
 		masterName := os.Getenv("MASTER_NAME")
 		cmd.Env = append(
 			os.Environ(),


### PR DESCRIPTION
When the new log dumping mechanism was enabled for Kubemark test jobs, it only used it for dumping logs of nodes - masters were still getting log dumped using a script from k/k (namely `k/k/test/kubemark/master-log-dump.sh` that was wrapping `k/k/cluster/log-dump/log-dump.sh`).

I ran a Prow job using a `kubekins-e2e` image based on this PR to confirm that it works as expected for Kubemark jobs.

/sig scalability
/assign @jkaniuk @wojtek-t 