### PR TITLE
wg-k8s-infra: Enable Release Managers to approve their trusted jobs

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/OWNERS
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/OWNERS
@@ -1,0 +1,13 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+
+# As RelEng trusted jobs have the potential to broadly disrupt community
+# operations, reviewers are explicitly constrained to the RelEng approvers.
+reviewers:
+- release-engineering-approvers
+
+labels:
+- sig/release
+- area/release-eng

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -1,5 +1,5 @@
 periodics:
-- name: ci-k8sio-vuln-dashboard-update
+- name: ci-release-vulndash-update
   interval: 2h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
@@ -23,3 +23,6 @@ periodics:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
     testgrid-num-failures-to-alert: '1'
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -1,0 +1,25 @@
+periodics:
+- name: ci-k8sio-vuln-dashboard-update
+  interval: 2h
+  cluster: k8s-infra-prow-build-trusted
+  max_concurrency: 1
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: release
+    base_ref: master
+  spec:
+    serviceAccountName: k8s-infra-gcr-vuln-dashboard
+    containers:
+    # TODO(releng): Point to promoted image once this job is fixed
+    - image: gcr.io/k8s-staging-artifact-promoter/vulndash-amd64:latest
+      command:
+      - /vulndash
+      args:
+        - --project=k8s-artifacts-prod
+        - --bucket=gs://k8s-artifacts-prod-vuln-dashboard
+        - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
+  annotations:
+    testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-num-failures-to-alert: '1'

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/wg-k8s-infra-trusted.yaml
@@ -22,30 +22,6 @@ periodics:
       args:
       - -c
       - "cd groups && make run -- --confirm"
-- name: ci-k8sio-vuln-dashboard-update
-  interval: 2h
-  cluster: k8s-infra-prow-build-trusted
-  max_concurrency: 1
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: release
-    base_ref: master
-  spec:
-    serviceAccountName: k8s-infra-gcr-vuln-dashboard
-    containers:
-    # TODO(releng): Point to promoted image once this job is fixed
-    - image: gcr.io/k8s-staging-artifact-promoter/vulndash-amd64:latest
-      command:
-      - /vulndash
-      args:
-        - --project=k8s-artifacts-prod
-        - --bucket=gs://k8s-artifacts-prod-vuln-dashboard
-        - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
-  annotations:
-    testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
 
 postsubmits:
   kubernetes/k8s.io:

--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -339,10 +339,10 @@ func TestTrustedJobs(t *testing.T) {
 	}
 }
 
-// Enforce conventions for jobs that run in k8s-infra-prow-build-trused cluster
+// Enforce conventions for jobs that run in k8s-infra-prow-build-trusted cluster
 func TestK8sInfraTrusted(t *testing.T) {
 	const trusted = "k8s-infra-prow-build-trusted"
-	trustedPath := path.Join(*jobConfigPath, "kubernetes", "wg-k8s-infra", "trusted", "wg-k8s-infra-trusted.yaml")
+	trustedPath := path.Join(*jobConfigPath, "kubernetes", "wg-k8s-infra", "trusted") + "/"
 	imagePushingDir := path.Join(*jobConfigPath, "image-pushing") + "/"
 
 	// Presubmits may not use this cluster
@@ -370,7 +370,7 @@ func TestK8sInfraTrusted(t *testing.T) {
 			if err := validateImagePushingImage(job.Spec); err != nil {
 				t.Errorf("%s defined in %s %s", job.Name, job.SourcePath, err)
 			}
-		} else if job.SourcePath != trustedPath {
+		} else if !strings.HasPrefix(job.SourcePath, trustedPath) {
 			t.Errorf("%s defined in %s may not run in cluster: %s", job.Name, job.SourcePath, trusted)
 		}
 	}


### PR DESCRIPTION
Similar to https://github.com/kubernetes/test-infra/pull/19738, this enables @kubernetes/release-engineering to approve their own trusted jobs.

- wg-k8s-infra/trusted: Add subdirectory to scope RelEng approvals
- releng(trusted): Move RelEng jobs to a RelEng-approved subdir
- releng(trusted): Rename `ci-k8sio-vuln-dashboard-update` to `ci-release-vulndash-update` and enable rerun (@cpanato -- note the new job name while looking results related to https://github.com/kubernetes/release/issues/1665)

/assign @dims 
cc: @kubernetes/release-engineering 