### PR TITLE
Run 5k scalability test more frequently

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -47,7 +47,7 @@ periodics:
           memory: "48Gi"
 
 # This is a sig-release-master-blocking job.
-- cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)
+- cron: '1 5,17,23 * * *' # In UTC
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -68,7 +68,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=1080
+      - --timeout=360
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -104,7 +104,7 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/experiments/ignore_known_gce_container_restarts.yaml
       - --test-cmd-args=--testoverrides=./testing/overrides/5000_nodes.yaml
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=1050m
+      - --timeout=330m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20201027-f0200e6-master
       resources:


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/19729 I increased load test throughput to 50 which shortens the test to less than 5h, but makes it harder to pass.

This PR changes the ci-kubernetes-e2e-gce-scale-performance schedule to run two 5k test instead of one. This is a temporary change that aims to have more test runs in shorter period of time to detect potential flakiness of the new test.

I plan to rollback to old schedule after 1-2 weeks of runs or if we see more issues with the test.

The test schedule for kubernetes-scale project before this PR:
* 12:01 - 16:31 UTC: ci-kubernetes-e2e-gce-scale-correctness
* 17:01 - 11:01 UTC (next day): ci-kubernetes-e2e-gce-scale-performance

As the new test finishes in 5h, we can set hard limit to 6h and run three test runs instead of one:
* 12:01 - 16:31 UTC: ci-kubernetes-e2e-gce-scale-correctness
* 17:01 - 23:01 UTC: ci-kubernetes-e2e-gce-scale-performance
* 23:01 - 05:01 UTC: ci-kubernetes-e2e-gce-scale-performance
* 05:01 - 11:01 UTC: ci-kubernetes-e2e-gce-scale-performance

/assign @wojtek-t 
