### PR TITLE
CAPG: use kubernetes branch 1.19 instead of master

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -63,7 +63,7 @@ periodics:
     path_alias: "sigs.k8s.io/image-builder"
   - org: kubernetes
     repo: kubernetes
-    base_ref: master
+    base_ref: release-1.19
     path_alias: k8s.io/kubernetes
   spec:
     containers:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes
-      base_ref: master
+      base_ref: release-1.19
       path_alias: k8s.io/kubernetes
     spec:
       containers:


### PR DESCRIPTION
Instead, clone the main branch of k/k lets use the release 1.19 branch, similar other cluster-api providers use


will also change the conformance in the CAPG side

maybe fix: https://kubernetes.slack.com/archives/C8TSNPY4T/p1603896882143400

/assign @detiber @rsmitty 