### PR TITLE
prow: Preserve exclude_defaults in bugzilla plugin

### DIFF
--- a/prow/plugins/config.go
+++ b/prow/plugins/config.go
@@ -1492,6 +1492,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 
 	if child.ExcludeDefaults == nil || !*child.ExcludeDefaults {
 		// populate with the parent
+		if parent.ExcludeDefaults != nil {
+			output.ExcludeDefaults = parent.ExcludeDefaults
+		}
 		if parent.ValidateByDefault != nil {
 			output.ValidateByDefault = parent.ValidateByDefault
 		}
@@ -1553,6 +1556,9 @@ func ResolveBugzillaOptions(parent, child BugzillaBranchOptions) BugzillaBranchO
 	}
 
 	// override with the child
+	if child.ExcludeDefaults != nil {
+		output.ExcludeDefaults = child.ExcludeDefaults
+	}
 	if child.ValidateByDefault != nil {
 		output.ValidateByDefault = child.ValidateByDefault
 	}


### PR DESCRIPTION
This may be a naive PR, but I'm running into problems with the Bugzilla plugin with the dependent bug configurations not being overridden.

Signed-off-by: Jose A. Rivera <jarrpa@redhat.com>