### PR TITLE
fix: remove run_if_changed line from CAPZ e2e-full job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-presubmits.yaml
@@ -65,8 +65,6 @@ presubmits:
     always_run: false
     optional: true
     decorate: true
-    # please see: https://play.golang.org/p/JJSVylVPd53 for more insights
-    run_if_changed: (^[^d].*$)|(^d$)|(^.[^o].*$)|(^do$)|(^..[^c].*$)|(^doc$)|(^...[^s].*$)|(^docs$)|(^....[^/].*$)|(^[^d][^o][^c][^s]/.*$)
     max_concurrency: 5
     labels:
       preset-dind-enabled: "true"


### PR DESCRIPTION
#19715 mistakenly included a `run_if_changed` line, but was intended to be triggered only manually.

cc: @CecileRobertMichon 