### PR TITLE
Add canary job for ci-ingress-gce-e2e

### DIFF
--- a/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
+++ b/config/jobs/kubernetes/sig-network/ingress-gce-e2e.yaml
@@ -165,6 +165,43 @@ periodics:
     testgrid-dashboards: sig-network-ingress-gce-e2e
     testgrid-tab-name: ingress-gce-e2e
     testgrid-alert-email: kubernetes-sig-network-test-failures@googlegroups.com
+- name: ci-ingress-gce-e2e-canary
+  cluster: k8s-infra-prow-build
+  interval: 60m
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-ingress-master-yaml: "true"
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201028-8000225-master
+      args:
+      - --timeout=340
+      - --bare
+      - --scenario=kubernetes_e2e
+      - --
+      - --check-leaked-resources
+      - --cluster=
+      - --env=GCE_GLBC_IMAGE=gcr.io/k8s-ingress-image-push/ingress-gce-glbc-amd64:master
+      - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
+      - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
+      - --extract=ci/latest
+      - --gcp-zone=asia-southeast1-a
+      - --ginkgo-parallel=1
+      - --provider=gce
+      - --test_args=--ginkgo.focus=\[Feature:Ingress\]|\[Feature:NEG\]
+      - --timeout=320m
+      resources:
+        limits:
+          cpu: 2
+          memory: 4Gi
+        requests:
+          cpu: 2
+          memory: 4Gi
+  annotations:
+    testgrid-dashboards: sig-testing-canaries
+    testgrid-tab-name: ingress-gce-e2e-canary
+    description: Duplicate of ci-ingress-gce-e2e pinned to a k8s-infra community-owned project
 - name: ci-ingress-gce-e2e-multi-zone
   interval: 3h
   labels:


### PR DESCRIPTION
Duplicate of `ci-ingress-gce-e2e` that validates the job can run on
k8s-infra-prow-build.

Ref: https://github.com/kubernetes/k8s.io/issues/1093
Part of : https://github.com/kubernetes/test-infra/issues/18549

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>