### PR TITLE
bump bazel-build-test to v20201028-8000225-kubernetes-master

### DIFF
--- a/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
+++ b/config/jobs/kubernetes/sig-testing/bazel-build-test.yaml
@@ -19,7 +19,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -59,7 +59,7 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -261,7 +261,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
+    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
       command:
       - ../test-infra/hack/bazel.sh
       args:
@@ -302,7 +302,7 @@ periodics:
     repo: test-infra
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:2.2.0-from-0.23.2
+    - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
       command:
       - ../test-infra/hack/bazel.sh
       args:

--- a/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
+++ b/config/jobs/kubernetes/sig-testing/kubetest-canaries.yaml
@@ -16,7 +16,8 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
+        imagePullPolicy: Always
         command:
         - ../test-infra/hack/bazel.sh
         args:
@@ -50,7 +51,8 @@ presubmits:
       repo: test-infra
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
+      - image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:latest-kubernetes-master
+        imagePullPolicy: Always
         command:
         - ../test-infra/hack/bazel.sh
         args:


### PR DESCRIPTION
tested on master:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/96011/pull-kubernetes-bazel-test-canary/1321972735605215232

and with bazel version updated to v3.4.1:

https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/96011/pull-kubernetes-bazel-test-canary/1321911265957777408

/assign @fejta @BenTheElder 