### PR TITLE
Remove GCP tests for kfctl 0.7 and 1.0

### DIFF
--- a/config/jobs/kubeflow/kubeflow-periodics.yaml
+++ b/config/jobs/kubeflow/kubeflow-periodics.yaml
@@ -23,46 +23,6 @@ periodics:
   annotations:
     testgrid-dashboards: sig-big-data
     description: Periodic testing of Kubeflow on the 1-0 release
-- name: kubeflow-periodic-1-0
-  cluster: kubeflow
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kfctl
-      - name: BRANCH_NAME
-        value: v1.0-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 1-0 release
-- name: kubeflow-periodic-0-7
-  cluster: kubeflow
-  # Might want to increase this after the 0.7 release is done.
-  # Other periodics run at 8h.
-  interval: 4h
-  labels:
-    preset-service-account: "true"
-  spec:
-    containers:
-    - image: gcr.io/kubeflow-ci/test-worker:latest
-      imagePullPolicy: Always
-      env:
-      - name: REPO_OWNER
-        value: kubeflow
-      - name: REPO_NAME
-        value: kfctl
-      - name: BRANCH_NAME
-        value: v0.7-branch
-  annotations:
-    testgrid-dashboards: sig-big-data
-    description: Periodic testing of Kubeflow on the 0-7 release
 #******************************************************************************
 # kubeflow/kubeflow
 #******************************************************************************


### PR DESCRIPTION
* kfctl tests appear to be running and eating up quota in kubeflow-ci-deployment

* We shouldn't need to run these tests anymore so remove them.

* Related to kubeflow/gcp-blueprints#143