### PR TITLE
config: remove branch protection for nfd gh-pages branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -407,6 +407,10 @@ branch-protection:
           required_status_checks:
             contexts:
             - Kubespray CI Pipeline
+        node-feature-discovery:
+          branches:
+            gh-pages:
+              protect: false
     kubeflow:
       protect: true
       required_status_checks:


### PR DESCRIPTION
This branch is being automatically updated by Github actions.