### PR TITLE
sig-storage images: fix canary rebuild job

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage-periodic.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage-periodic.yaml
@@ -24,6 +24,11 @@ periodics:
       - image: gcr.io/k8s-testimages/image-builder:v20200612-cd781f9
         command:
           - /run.sh
+        env:
+        # We need to emulate a pull job for the cloud build to work the same
+        # way as it usually does.
+        - name: PULL_BASE_REF
+          value: master
         args:
           # this is the project GCB will run in, which is the same as the GCR
           # images are pushed to.


### PR DESCRIPTION
The build rules rely on PULL_BASE_REF for determining what the
tag name should be, so it has to be set also for the periodic job.