### PR TITLE
Remove reference to master-log-dump.sh

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -740,7 +740,15 @@ func kubemarkGinkgoTest(testArgs []string, dump string) error {
 func kubemarkDown(err *error, wg *sync.WaitGroup, dump string) {
 	defer wg.Done()
 	control.XMLWrap(&suite, "Kubemark MasterLogDump", func() error {
-		return control.FinishRunning(exec.Command("./test/kubemark/master-log-dump.sh", dump))
+		cmd := exec.Command("./cluster/log-dump/log-dump.sh", dump)
+		masterName := os.Getenv("MASTER_NAME")
+		cmd.Env = append(
+			os.Environ(),
+			"KUBEMARK_MASTER_NAME="+masterName,
+			"DUMP_ONLY_MASTER_LOGS=true",
+		)
+		log.Printf("Dumping logs for kubemark master: %s", masterName)
+		return control.FinishRunning(cmd)
 	})
 	*err = control.XMLWrap(&suite, "Kubemark TearDown", func() error {
 		return control.FinishRunning(exec.Command("./test/kubemark/stop-kubemark.sh"))


### PR DESCRIPTION
In https://github.com/kubernetes/test-infra/pull/19747 we established that `log-dump.sh` can easily replace its wrapper script, `master-log-dump.sh`. The latter script does a lot of unnecessary sourcing, exporting env vars and bash functions that are apparently unused when logs from Kubemark masters are being dumped. The only relevant env vars from that script are `KUBEMARK_MASTER_NAME` and `DUMP_ONLY_MASTER_LOGS`.

Next step would be to completely remove [`master-log-dump.sh`](https://github.com/kubernetes/kubernetes/blob/master/test/kubemark/master-log-dump.sh) from k/k altogether.

Ran a simple Kubemark Prow job (bringing Kubemark cluster up, dumping logs and bringing it back down) using a `kubekins-e2e` image based on this change to confirm this works as expected.

/sig scalability
/assign @jkaniuk @wojtek-t 