### PR TITLE
Enable density in load for 5000kubemark nodes

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -349,6 +349,7 @@ periodics:
       - --test-cmd-args=--nodes=5000
       - --test-cmd-args=--provider=kubemark
       - --env=CL2_ENABLE_PVS=false # TODO(https://github.com/kubernetes/perf-tests/issues/803): Fix me
+      - --env=CL2_ENABLE_DENSITY_TEST=true
       - --test-cmd-args=--report-dir=/workspace/_artifacts
       - --test-cmd-args=--testconfig=testing/density/config.yaml
       - --test-cmd-args=--testconfig=testing/load/config.yaml


### PR DESCRIPTION
Enable density in load test for 5000 kubemark nodes