### PR TITLE
Configure kubekins dockerd to use mirror.gcr.io

### DIFF
--- a/images/kubekins-e2e/Dockerfile
+++ b/images/kubekins-e2e/Dockerfile
@@ -90,6 +90,13 @@ RUN [ "${UPGRADE_DOCKER_ARG}" = "true" ] && \
     rm -rf /var/lib/apt/lists/* && \
     sed -i 's/cgroupfs_mount$/#cgroupfs_mount\n/' /etc/init.d/docker || true
 
+# configure dockerd to use mirror.gcr.io
+# per instructions at https://cloud.google.com/container-registry/docs/pulling-cached-images
+ARG DOCKER_REGISTRY_MIRROR_URL=https://mirror.gcr.io
+RUN [ -n "${DOCKER_REGISTRY_MIRROR_URL}" ] && \
+    echo "DOCKER_OPTS=\"\${DOCKER_OPTS} --registry-mirror=${DOCKER_REGISTRY_MIRROR_URL}\"" | \
+    tee --append /etc/default/docker
+
 # add env we can debug with the image name:tag
 ARG IMAGE_ARG
 ENV IMAGE=${IMAGE_ARG}


### PR DESCRIPTION
Follow instructions from https://cloud.google.com/container-registry/docs/pulling-cached-images

This is intended for jobs that use docker-in-docker via the `preset-dind-enabled` preset and also use the kubekins image

ref: https://github.com/kubernetes/test-infra/issues/19477