### PR TITLE
vulndash: adding cpu/mem requests

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -19,6 +19,13 @@ periodics:
         - --project=k8s-artifacts-prod
         - --bucket=k8s-artifacts-prod-vuln-dashboard
         - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
+      resources:
+        requests:
+          cpu: 2
+          memory: "8Gi"
+        limits:
+          cpu: 2
+          memory: "8Gi"
   annotations:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io


### PR DESCRIPTION
defining cpu/mem requests for the job, because this execution timeout: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-release-vulndash-update/1322405073002696704

and running locally in my machine took around 1:30 minute (2,3 GHz Quad-Core Intel Core i7 / 32 GB )


/assing @justaugustus 