### PR TITLE
fix bug caused by hardcoded "github.com" for enterprise accounts

### DIFF
--- a/prow/plugins/trigger/push.go
+++ b/prow/plugins/trigger/push.go
@@ -53,6 +53,7 @@ func createRefs(pe github.PushEvent) prowapi.Refs {
 	return prowapi.Refs{
 		Org:      pe.Repo.Owner.Name,
 		Repo:     pe.Repo.Name,
+		RepoLink: pe.Repo.HTMLURL,
 		BaseRef:  pe.Branch(),
 		BaseSHA:  pe.After,
 		BaseLink: pe.Compare,


### PR DESCRIPTION
> https://github.com/kubernetes/test-infra/blob/c69eb89915fca776c67b632049d9b834aaeb74f7/prow/cmd/pipeline/controller.go#L557-L567

As refs.RepoLink doesn't exist for refs in Prow Github hook,  the sourceURL will be assigned to a url started with "github.com" by default, which is not correct for enterprise accounts.

The fix is to add a property of "RepoLink" in the refs of Push Event.