### PR TITLE
Remove kfserving from presubmit job

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -180,20 +180,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for kubeflow/metadata.
       testgrid-num-columns-recent: '30'
-  kubeflow/kfserving:
-  - name: kubeflow-kfserving-presubmit
-    cluster: kubeflow
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/kfserving.
-      testgrid-num-columns-recent: '30'
   kubeflow/manifests:
   - name: kubeflow-manifests-presubmit
     cluster: kubeflow


### PR DESCRIPTION
move presubmit jobs to AWS prow.

AWS prow runs presubmit jobs and sig-testing prow tide (kubeflow-ci-bot) merges PR.

Here's the PRs with new bot working.
https://github.com/kubeflow/kfserving/pull/1170

/cc @jlewi @Jeffwan @cliveseldon  @ellistarn @animeshsingh @PatrickXYS