### PR TITLE
Revert "Use 50 load test throughput in 5k scale test" and "Run 5k scalability test more frequently"

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -85,11 +85,8 @@ periodics:
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
       - --provider=gce
-      # TODO(https://github.com/kubernetes/perf-tests/issues/1536): Reenable oom tracker.
-      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=false
+      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --env=CL2_ENABLE_DENSITY_TEST=true
-      - --env=CL2_LOAD_TEST_THROUGHPUT=50
-      - --env=CL2_DELETE_TEST_THROUGHPUT=30
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -47,7 +47,7 @@ periodics:
           memory: "48Gi"
 
 # This is a sig-release-master-blocking job.
-- cron: '1 5,17,23 * * *' # In UTC
+- cron: '1 17 * * *' # Run daily at 9:01PST (17:01 UTC)
   name: ci-kubernetes-e2e-gce-scale-performance
   tags:
   - "perfDashPrefix: gce-5000Nodes"
@@ -68,7 +68,7 @@ periodics:
   spec:
     containers:
     - args:
-      - --timeout=360
+      - --timeout=1080
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
@@ -104,7 +104,7 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/experiments/ignore_known_gce_container_restarts.yaml
       - --test-cmd-args=--testoverrides=./testing/overrides/5000_nodes.yaml
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=330m
+      - --timeout=1050m
       - --use-logexporter
       image: gcr.io/k8s-testimages/kubekins-e2e:v20201030-4553f14-master
       resources:


### PR DESCRIPTION
Reverts https://github.com/kubernetes/test-infra/pull/19729 and https://github.com/kubernetes/test-infra/pull/19749.

It seems to be breaking our tests: https://github.com/kubernetes/kubernetes/issues/96038

/assign @tosi3k 