### PR TITLE
releng: Update Release Managers' alert emails

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-artifact-promoter.yaml
@@ -4,7 +4,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
       decorate: true
       run_if_changed: '^cmd\/vulndash\/'
@@ -32,7 +32,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-blocking
-        testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+        testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
         testgrid-num-failures-to-alert: '1'
       decorate: true
       branches:

--- a/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-build-image.yaml
@@ -4,7 +4,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/debian-base\/'
       branches:
@@ -36,7 +36,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/debian-hyperkube-base\/'
       branches:
@@ -62,7 +62,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/debian-iptables\/'
       branches:
@@ -88,7 +88,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/go-runner\/'
       branches:
@@ -114,7 +114,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/build\/cross\/'
       branches:

--- a/config/jobs/image-pushing/releng/k8s-staging-kubernetes.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-kubernetes.yaml
@@ -4,7 +4,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^cluster\/images\/etcd\/'
       branches:
@@ -30,7 +30,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-master-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^build\/pause\/'
       branches:

--- a/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
@@ -32,7 +32,7 @@ periodics:
     # TODO(justaugustus): Enable forking for prototype GCB-based build jobs.
     testgrid-dashboards: sig-release-prototype-master-blocking
     testgrid-tab-name: build-master
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
 
 # TODO(justaugustus): Decrease interval to 5m once we cut build over to k8s-infra.
 #                     ref: https://github.com/kubernetes/release/issues/911
@@ -66,7 +66,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-prototype-master-blocking
     testgrid-tab-name: build-master-fast
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
     description: 'Ends up running: make quick-release'
 
 postsubmits:
@@ -75,7 +75,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/'
       branches:
@@ -101,7 +101,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       run_if_changed: '^images\/'
       branches:
@@ -128,7 +128,7 @@ postsubmits:
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
-        testgrid-alert-email: release-managers@kubernetes.io
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
       decorate: true
       branches:
         - ^master$

--- a/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/mdtoc/mdtoc-presubmits.yaml
@@ -13,7 +13,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: mdtoc-test
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-mdtoc-verify
     always_run: true
@@ -28,5 +28,5 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: mdtoc-verify
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/release/release-config.yaml
+++ b/config/jobs/kubernetes/release/release-config.yaml
@@ -36,7 +36,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-cluster-up
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-test
     always_run: true
@@ -51,7 +51,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-test
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-integration-test
     always_run: true
@@ -66,7 +66,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-integration-test
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
   - name: pull-release-verify
     always_run: true
@@ -81,14 +81,14 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-tab-name: release-verify
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
       testgrid-num-columns-recent: '30'
 periodics:
 # package tests
 - name: periodic-release-verify-packages-debs
   interval: 6h
   annotations:
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-packages-debs
   decorate: true
@@ -110,7 +110,7 @@ periodics:
 - name: periodic-release-verify-packages-rpms
   interval: 6h
   annotations:
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: verify-packages-rpms
   decorate: true

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -95,7 +95,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
   - name: pull-cip-auditor-e2e
     decorate: true
     path_alias: "sigs.k8s.io/k8s-container-image-promoter"
@@ -125,7 +125,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
   # Build all binaries and also run unit tests.
   - name: pull-cip-unit-tests
     decorate: true
@@ -144,7 +144,7 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
   # Run linter.
   - name: pull-cip-verify
     decorate: true
@@ -162,4 +162,4 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-release-releng-presubmits
       testgrid-num-columns-recent: '30'
-      testgrid-alert-email: release-managers@kubernetes.io
+      testgrid-alert-email: release-managers+alerts@kubernetes.io

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -65,7 +65,7 @@ periodics:
     fork-per-release-replacements: "k8s-master -> k8s-beta"
     testgrid-dashboards: sig-release-master-blocking
     testgrid-tab-name: build-master
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
 - interval: 1h
   name: ci-kubernetes-build-canary
@@ -103,7 +103,7 @@ periodics:
   annotations:
     testgrid-dashboards: sig-release-master-informing, sig-testing-canaries
     testgrid-tab-name: build-master-canary
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
 
 - interval: 5m
   name: ci-kubernetes-build-fast
@@ -162,7 +162,7 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
   annotations:
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-debs
 
@@ -185,6 +185,6 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
   annotations:
-    testgrid-alert-email: release-managers@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-packages-rpms

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -151,7 +151,7 @@ periodics:
           memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.16-blocking
     testgrid-tab-name: build-1.16
   interval: 1h
@@ -438,7 +438,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: ""
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
-      release-managers@kubernetes.io
+      release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-1.16-blocking, google-unit
     testgrid-tab-name: verify-1.16
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -193,7 +193,7 @@ periodics:
           memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.17-blocking
     testgrid-tab-name: build-1.17
   interval: 1h
@@ -482,7 +482,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
-      release-managers@kubernetes.io
+      release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-1.17-blocking, google-unit
     testgrid-tab-name: verify-1.17
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -194,7 +194,7 @@ periodics:
           memory: 6Gi
 - annotations:
     fork-per-release-generic-suffix: "true"
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.18-blocking
     testgrid-tab-name: build-1.18
   interval: 1h
@@ -487,7 +487,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
-      release-managers@kubernetes.io
+      release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-1.18-blocking, google-unit
     testgrid-tab-name: verify-1.18
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -152,7 +152,7 @@ periodics:
           cpu: 6
           memory: 6Gi
 - annotations:
-    testgrid-alert-email: release-managers@kubernetes.io, release-team@kubernetes.io
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
     testgrid-dashboards: sig-release-1.19-blocking
     testgrid-tab-name: build-1.19
   interval: 1h
@@ -437,7 +437,7 @@ periodics:
     fork-per-release-generic-suffix: "true"
     fork-per-release-periodic-interval: 2h 6h 24h
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com,
-      release-managers@kubernetes.io
+      release-managers+alerts@kubernetes.io
     testgrid-dashboards: sig-release-1.19-blocking, google-unit
     testgrid-tab-name: verify-1.19
   cluster: k8s-infra-prow-build

--- a/config/jobs/kubernetes/sig-testing/verify.yaml
+++ b/config/jobs/kubernetes/sig-testing/verify.yaml
@@ -59,7 +59,7 @@ periodics:
     fork-per-release-periodic-interval: 2h 2h 6h 24h
     testgrid-dashboards: sig-release-master-blocking, google-unit
     testgrid-tab-name: verify-master
-    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers@kubernetes.io
+    testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com, release-managers+alerts@kubernetes.io
     description: "Ends up running: make verify"
   decorate: true
   extra_refs:

--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -755,7 +755,7 @@ postsubmits:
         - -dry-run=false
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
-      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
   kubernetes/community:
   - name: post-community-tempelis-apply
@@ -1090,7 +1090,7 @@ periodics:
       - -dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
     testgrid-num-failures-to-alert: '1'
 # TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
 - interval: 12h
@@ -1116,7 +1116,7 @@ periodics:
         value: /go
   annotations:
     testgrid-dashboards: sig-release-releng-blocking
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
     testgrid-num-failures-to-alert: '1'
 
 # This job is used as a heartbeat health check of the Prow instance's ability to run jobs.

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -28,7 +28,7 @@ periodics:
           memory: "8Gi"
   annotations:
     testgrid-dashboards: sig-release-releng-informing, wg-k8s-infra-k8sio
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers@kubernetes.io
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
     testgrid-num-failures-to-alert: '1'
   rerun_auth_config:
     github_team_ids:


### PR DESCRIPTION
release-managers@kubernetes.io --> release-managers+alerts@kubernetes.io

This is a convenience to be able to filter/tag Testgrid emails to @kubernetes/release-engineering.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @dims @saschagrunert @hasheddan 