### PR TITLE
Revert "Revert "Increase memory for pull-kubernetes-node-e2e""

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -37,10 +37,10 @@ presubmits:
         resources:
           limits:
             cpu: 4
-            memory: 3Gi
+            memory: 6Gi
           requests:
             cpu: 4
-            memory: 3Gi
+            memory: 6Gi
   - name: pull-kubernetes-e2e-containerd-gce
     always_run: false
     optional: true


### PR DESCRIPTION
Further analysis by @spiffxp found that the increase in memory consumption is
most likely related to https://github.com/kubernetes/kubernetes/pull/95239. It
is not immediately clear how to trim down usage here so bumping the resource
limit is the agreed approach.

ref: https://github.com/kubernetes/test-infra/pull/19615#issuecomment-720615200