### PR TITLE
github/graphql: implement checks scheme preview support for GHE

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -486,8 +486,11 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 			gqlc: githubql.NewEnterpriseClient(
 				graphqlEndpoint,
 				&http.Client{
-					Timeout:   maxRequestTime,
-					Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
+					Timeout: maxRequestTime,
+					Transport: &oauth2.Transport{
+						Source: newReloadingTokenSource(getToken),
+						Base:   newAddHeaderTransport(),
+					},
 				}),
 			client:        &http.Client{Timeout: maxRequestTime},
 			bases:         bases,
@@ -500,6 +503,21 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 			maxSleepTime:  defaultMaxSleepTime,
 		},
 	}
+}
+
+func newAddHeaderTransport() http.RoundTripper {
+	return &addHeaderTransport{}
+}
+
+type addHeaderTransport struct {
+}
+
+func (s *addHeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// We have to add this header to enable the Checks scheme preview:
+	// https://docs.github.com/en/enterprise-server@2.22/graphql/overview/schema-previews
+	// Any GHE version after 2.22 will enable the Checks types per default
+	r.Header.Add("Accept", "application/vnd.github.antiope-preview+json")
+	return http.DefaultTransport.RoundTrip(r)
 }
 
 // NewClient creates a new fully operational GitHub client.


### PR DESCRIPTION
For more context see: https://github.com/kubernetes/test-infra/pull/19520#issuecomment-719938941

In the latest GHE version the Checks types are not enabled per default: https://docs.github.com/en/enterprise-server@2.22/graphql/reference/objects#checkrun

This PR enables the Checks scheme Preview for all GraphQL requests as documented here:
https://docs.github.com/en/free-pro-team@latest/graphql/overview/schema-previews#checks-preview