### PR TITLE
releng: Migrate image promotion jobs to k8s-infra-prow-build-trusted

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -714,30 +714,6 @@ postsubmits:
       testgrid-num-failures-to-alert: '1'
       description: Uses the Container Image Promoter to promote images from gcr.io/k8s-prow-edge to gcr.io/k8s-prow.
 
-  kubernetes/k8s.io:
-  - name: post-k8sio-cip
-    cluster: test-infra-trusted
-    decorate: true
-    run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
-    # Never run more than 1 job at a time. This is because we don't want to run
-    # into a case where an older manifest PR merge gets run last (after a newer
-    # one).
-    max_concurrency: 1
-    branches:
-    - ^master$
-    spec:
-      serviceAccountName: k8s-infra-gcr-promoter
-      containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
-        command:
-        - cip
-        args:
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        - -dry-run=false
-    annotations:
-      testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
-      testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-      testgrid-num-failures-to-alert: '1'
   kubernetes/community:
   - name: post-community-tempelis-apply
     cluster: test-infra-trusted
@@ -1043,36 +1019,7 @@ periodics:
     testgrid-tab-name: label_sync
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
-# ci-k8sio-cip runs daily, to make sure that the destination GCRs do not deviate
-# away from the intent of the manifest.
-- interval: 4h
-  cluster: test-infra-trusted
-  max_concurrency: 1
-  # This name is the "job name", passed in as "--job=NAME" for mkpj.
-  name: ci-k8sio-cip
-  # Enable Pod Utilities. See https://github.com/kubernetes/test-infra/blob/master/prow/pod-utilities.md.
-  decorate: true
-  extra_refs:
-  # Because of Pod Utilities, we clone the below repo automatically, and, get
-  # dropped into /home/prow/go/src/github.com/kubernetes/k8s.io.
-  - org: kubernetes
-    repo: k8s.io
-    base_ref: master
-  spec:
-    # The k8s-artifacts-prod name was chosen in
-    # https://github.com/kubernetes/k8s.io/pull/695.
-    serviceAccountName: k8s-infra-gcr-promoter
-    containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
-      command:
-      - cip
-      args:
-      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-      - -dry-run=false
-  annotations:
-    testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
+
 # TODO(releng): Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
 #               ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269
 - interval: 12h

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -1,6 +1,6 @@
 postsubmits:
   kubernetes/k8s.io:
-  - name: post-k8sio-image-promo-canary
+  - name: post-k8sio-image-promo
     cluster: k8s-infra-prow-build-trusted
     decorate: true
     run_if_changed: 'k8s.gcr.io/((images/.*/images\.yaml)|(manifests/.*/promoter-manifest\.yaml))'
@@ -18,24 +18,20 @@ postsubmits:
         - cip
         args:
         - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        # TODO(releng): Set -dry-run=false once we confirm there is nothing wrong
-        #               with service accounts and the jobs succeed.
-        - -dry-run=true
+        - -dry-run=false
     annotations:
       testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
       testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
       testgrid-num-failures-to-alert: '1'
 
 periodics:
-# TODO(releng): Adjust the interval back to 4 hours once we confirm that the
-#               dry-runs complete without issue.
-# ci-k8sio-image-promo-canary runs every 2 hours, to make sure that the
-# destination GCRs do not deviate away from the intent of the manifest.
-- interval: 2h
+# ci-k8sio-image-promo runs every 4 hours, to make sure that the destination
+# GCRs do not deviate away from the intent of the manifest.
+- interval: 4h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   # This name is the "job name", passed in as "--job=NAME" for mkpj.
-  name: ci-k8sio-image-promo-canary
+  name: ci-k8sio-image-promo
   # Enable Pod Utilities.
   # See https://git.k8s.io/test-infra/prow/pod-utilities.md.
   decorate: true
@@ -55,9 +51,7 @@ periodics:
       - cip
       args:
       - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-      # TODO(releng): Set -dry-run=false once we confirm there is nothing wrong
-      #               with service accounts and the jobs succeed.
-      - -dry-run=true
+      - -dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269.

With some optimism in seeing [`ci-k8sio-image-promo-canary` pass](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-image-promo-canary/1323357772196089856) ([job history](https://prow.k8s.io/job-history/gs/kubernetes-jenkins/logs/ci-k8sio-image-promo-canary)), I'm opening this as a follow-up to https://github.com/kubernetes/test-infra/pull/19789 to officially move image promotion jobs to K8s Infra.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold for a few more job runs, just to make sure. I'll also find an image to promote to test the postsubmit.

/assign @spiffxp @dims 
cc: @listx @thockin @kubernetes/release-engineering 