### PR TITLE
releng(gcr-backup): Add canary job for production GCR backups

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1073,7 +1073,8 @@ periodics:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
     testgrid-num-failures-to-alert: '1'
-# TODO: Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
+# TODO(releng): Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
+#               ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269
 - interval: 12h
   cluster: test-infra-trusted
   max_concurrency: 1

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -66,6 +66,46 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
 
+# This job is a canary of 'ci-k8sio-backup' with the following qualities:
+# - Runs in k8s-infra-prow-build-trusted
+# - Jobs renamed to include 'gcr-prod-backup' for clarity
+# - Job names are suffixed with '-canary'
+# - Periodic runs every 2 hours (instead of every 12 hours)
+# - Rerun enabled for Release Managers
+#
+# TODO(releng): Adjust the interval back to 12 hours once we confirm that the
+#               dry-runs complete without issue.
+- interval: 2h
+  cluster: k8s-infra-prow-build-trusted
+  max_concurrency: 1
+  name: ci-k8sio-gcr-prod-backup-canary
+  decorate: true
+  extra_refs:
+  - org: kubernetes
+    repo: k8s.io
+    base_ref: master
+  spec:
+    serviceAccountName: k8s-infra-gcr-promoter-bak
+    containers:
+    # TODO(releng): We should maybe use the k8s-cloud-builder image here
+    #               instead of kubekins.
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.17
+      command:
+      - infra/gcp/backup_tools/backup.sh
+      env:
+      # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
+      # here anyway in case the underlying image changes (the backup.sh script
+      # needs it to be defined).
+      - name: GOPATH
+        value: /go
+  annotations:
+    testgrid-dashboards: sig-release-releng-blocking
+    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
+    testgrid-num-failures-to-alert: '1'
+  rerun_auth_config:
+    github_team_ids:
+      - 2241179 # release-managers
+
 - name: ci-release-vulndash-update
   interval: 2h
   cluster: k8s-infra-prow-build-trusted


### PR DESCRIPTION
This is a step towards running the production GCR backup job on the
k8s-infra-prow-build-trusted instead of test-infra-trusted. (ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269, https://github.com/kubernetes/k8s.io/issues/157)

Differences from the prod jobs:
- Runs in k8s-infra-prow-build-trusted
- Jobs renamed to include 'gcr-prod-backup' for clarity
- Job names are suffixed with '-canary'
- Periodic runs every 2 hours (instead of every 12 hours)
- Rerun enabled for Release Managers

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/hold for @spiffxp or @dims review
/assign @spiffxp @dims 
cc: @listx @thockin @kubernetes/release-engineering 