### PR TITLE
Remove Kubeflow Katib from post-submit jobs

### DIFF
--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -145,19 +145,6 @@ postsubmits:
     annotations:
       testgrid-dashboards: sig-big-data
       description: Postsubmit kubeflow/tf-operator.
-  kubeflow/katib:
-  - name: kubeflow-katib-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/katib.
   kubeflow/experimental-seldon:
   - name: kubeflow-experimental-seldon-postsubmit
     cluster: kubeflow

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -20,8 +20,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_testing/kubeflow-testing-postsubmit
 - name: kubeflow-tf-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_tf-operator/kubeflow-tf-operator-postsubmit
-- name: kubeflow-katib-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_katib/kubeflow-katib-postsubmit
 - name: kubeflow-experimental-seldon-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_experimental-seldon/kubeflow-experimental-seldon-postsubmit
 - name: kubeflow-caffe2-operator-postsubmit


### PR DESCRIPTION
We can remove Kubeflow Katib from post-submit jobs.
We will use AWS infra for our release/post-submits process, corresponding issues: https://github.com/kubeflow/katib/issues/1332 and https://github.com/kubeflow/katib/issues/1367.

Here is the PR to switch pre-submits to AWS infra: https://github.com/kubeflow/katib/pull/1356.

/assign @jlewi @Jeffwan @PatrickXYS
/cc @gaocegege @johnugeorge