### PR TITLE
Fix security-profiles-operator image pushing bucket

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-seccomp-operator.yaml
@@ -13,8 +13,8 @@ postsubmits:
             command:
               - /run.sh
             args:
-              - --project=k8s-staging-security-profiles-operator
-              - --scratch-bucket=gs://k8s-staging-security-profiles-operator-gcb
+              - --project=k8s-staging-sp-operator
+              - --scratch-bucket=gs://k8s-staging-sp-operator-gcb
               - .
             env:
               - name: LOG_TO_STDOUT


### PR DESCRIPTION
We changed the bucket name to shorthand `security-profile` to `sp` to
fix the name length limitation. This is now reflected here, too.

cc @pjbgf @hasheddan 