### PR TITLE
Remove kfctl presubmit

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -194,20 +194,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmits for kubeflow/manifests.
       testgrid-num-columns-recent: '30'
-  kubeflow/kfctl:
-  - name: kubeflow-kfctl-presubmit
-    cluster: kubeflow
-    always_run: true
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/kfctl.
-      testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-frontend-test
     cluster: kubeflow


### PR DESCRIPTION
kfctl move presubmit jobs to AWS prow.

AWS prow runs presubmit jobs and sig-testing prow tide (kubeflow-ci-bot) merges PR.

Here is the PR to make it work: https://github.com/kubeflow/kfctl/pull/427

/hold
Hold until above PR testing work 

/cc @jlewi @Jeffwan @animeshsingh @yanniszark