### PR TITLE
releng(gcr-backup): Use k8s.gcr.io/releng/releng-ci:v0.1.1

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -81,9 +81,7 @@ periodics:
   spec:
     serviceAccountName: k8s-infra-gcr-promoter-bak
     containers:
-    # TODO(releng): We should maybe use the k8s-cloud-builder image here
-    #               instead of kubekins.
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.17
+    - image: k8s.gcr.io/releng/releng-ci:v0.1.1
       command:
       - infra/gcp/backup_tools/backup.sh
       env:


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269.

The canary job mimics 'ci-k8sio-backup', which is using the following
image:

`gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.17`

A few things wrong with this:
- kubekins is a bit more bloated than we need for this use case
- the kubekins 1.17 image variant is being used, which is incorrect

This switches to using a versioned and promoted lightweight image, which
is maintained by @kubernetes/release-engineering.

An additional advantage here is that we (Release Managers) are in full
control of the image and can turn around any required changes faster
than the kubekins-e2e image.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
ref: https://github.com/kubernetes/test-infra/pull/19811, https://github.com/kubernetes/release/pull/1679, https://github.com/kubernetes/k8s.io/pull/1391