### PR TITLE
prow/plank: write prowjob build id correctly onto the test Pod uuid label

### DIFF
--- a/prow/cmd/mkpod/main.go
+++ b/prow/cmd/mkpod/main.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
-	"k8s.io/test-infra/prow/pjutil"
 	"os"
 	"path"
 	"strings"
@@ -32,6 +31,7 @@ import (
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/kube"
+	"k8s.io/test-infra/prow/pjutil"
 	"k8s.io/test-infra/prow/pod-utils/decorate"
 )
 
@@ -121,12 +121,14 @@ func main() {
 		}
 		logrus.WithField("out-dir", outDir).Info("Pod-utils configured for local mode. Instead of uploading to GCS, files will be copied to an output dir on the node.")
 
-		pod, err = makeLocalPod(job, o.buildID, outDir)
+		job.Status.BuildID = o.buildID
+		pod, err = makeLocalPod(job, outDir)
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not decorate PodSpec for local mode.")
 		}
 	} else {
-		pod, err = decorate.ProwJobToPod(job, o.buildID)
+		job.Status.BuildID = o.buildID
+		pod, err = decorate.ProwJobToPod(job)
 		if err != nil {
 			logrus.WithError(err).Fatal("Could not decorate PodSpec.")
 		}
@@ -151,8 +153,8 @@ func main() {
 	fmt.Println(string(podYAML))
 }
 
-func makeLocalPod(pj prowapi.ProwJob, buildID, outDir string) (*v1.Pod, error) {
-	pod, err := decorate.ProwJobToPodLocal(pj, buildID, outDir)
+func makeLocalPod(pj prowapi.ProwJob, outDir string) (*v1.Pod, error) {
+	pod, err := decorate.ProwJobToPodLocal(pj, outDir)
 	if err != nil {
 		return nil, err
 	}

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -573,9 +573,8 @@ func (c *Controller) startPod(pj *prowapi.ProwJob) error {
 		return fmt.Errorf("error getting build ID: %v", err)
 	}
 
-	// TODO: remove buildID from input args to ProwJobToPod
 	pj.Status.BuildID = buildID
-	pod, err := decorate.ProwJobToPod(*pj, buildID)
+	pod, err := decorate.ProwJobToPod(*pj)
 	if err != nil {
 		return err
 	}

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -603,7 +603,8 @@ func (r *reconciler) startPod(pj *prowv1.ProwJob) (string, string, error) {
 		return "", "", fmt.Errorf("error getting build ID: %v", err)
 	}
 
-	pod, err := decorate.ProwJobToPod(*pj, buildID)
+	pj.Status.BuildID = buildID
+	pod, err := decorate.ProwJobToPod(*pj)
 	if err != nil {
 		return "", "", err
 	}

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -158,19 +158,19 @@ func LabelsAndAnnotationsForJob(pj prowapi.ProwJob) (map[string]string, map[stri
 }
 
 // ProwJobToPod converts a ProwJob to a Pod that will run the tests.
-func ProwJobToPod(pj prowapi.ProwJob, buildID string) (*coreapi.Pod, error) {
-	return ProwJobToPodLocal(pj, buildID, "")
+func ProwJobToPod(pj prowapi.ProwJob) (*coreapi.Pod, error) {
+	return ProwJobToPodLocal(pj, "")
 }
 
 // ProwJobToPodLocal converts a ProwJob to a Pod that will run the tests.
 // If an output directory is specified, files are copied to the dir instead of uploading to GCS if
 // decoration is configured.
-func ProwJobToPodLocal(pj prowapi.ProwJob, buildID string, outputDir string) (*coreapi.Pod, error) {
+func ProwJobToPodLocal(pj prowapi.ProwJob, outputDir string) (*coreapi.Pod, error) {
 	if pj.Spec.PodSpec == nil {
 		return nil, fmt.Errorf("prowjob %q lacks a pod spec", pj.Name)
 	}
 
-	rawEnv, err := downwardapi.EnvForSpec(downwardapi.NewJobSpec(pj.Spec, buildID, pj.Name))
+	rawEnv, err := downwardapi.EnvForSpec(downwardapi.NewJobSpec(pj.Spec, pj.Status.BuildID, pj.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/prow/pod-utils/decorate/podspec_test.go
+++ b/prow/pod-utils/decorate/podspec_test.go
@@ -899,7 +899,8 @@ func TestProwJobToPod(t *testing.T) {
 	for i, test := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			pj := prowapi.ProwJob{ObjectMeta: metav1.ObjectMeta{Name: test.podName, Labels: test.labels}, Spec: test.pjSpec, Status: test.pjStatus}
-			got, err := ProwJobToPod(pj, test.buildID)
+			pj.Status.BuildID = test.buildID
+			got, err := ProwJobToPod(pj)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_1.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_2.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_3.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_4.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_5.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/type: periodic

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_6.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name

--- a/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
+++ b/prow/pod-utils/decorate/testdata/TestProwJobToPod_7.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     created-by-prow: "true"
     needstobe: inherited
-    prow.k8s.io/build-id: ""
+    prow.k8s.io/build-id: "blabla"
     prow.k8s.io/id: pod
     prow.k8s.io/job: job-name
     prow.k8s.io/refs.org: org-name


### PR DESCRIPTION
ProwJobToPod previously expected a ProwJob and a buildID as parameter.
The buildID was used for the container env and the
ProwJob.Status.BuildID to write the build-id test pod annotation.

In case of prow/plank/reconciler.go startPod a buildID was handed over,
but the ProwJob.Status.BuildID was empty. This resulted in an empty
build-id label on the Pod. In some cases (in my case for aborted Jobs)
this empty build-id label broke the calculation of the
ProwJob.Status.URL which lead to status URLS on ProwJobs without the build ID
suffix, e.g. `https://prow.io/view/s3/prow-artifacts/pr-logs/pull/org_repo/3031/test` instead of
`https://prow.io/view/s3/prow-artifacts/pr-logs/pull/org_repo/3031/test/<build-id>`