### PR TITLE
cloud-provider-openstack: set ignore_review_state to true

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -99,6 +99,10 @@ approve:
   - helm/charts
   require_self_approval: false
   lgtm_acts_as_approve: true
+- repos:
+  - kubernetes/cloud-provider-openstack
+  require_self_approval: false
+  ignore_review_state: true
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:


### PR DESCRIPTION
Sets ignore_review_state to true for kubernetes/cloud-provider-openstack to avoid the auto approval for the PRs submitted by the person with 'approve' permission.