### PR TITLE
releng: Migrate production GCR backup to k8s-infra-prow-build-trusted

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -1020,34 +1020,6 @@ periodics:
     testgrid-alert-email: kubernetes-sig-testing-alerts@googlegroups.com, k8s-infra-oncall@google.com
     description: Runs label_sync to synchronize GitHub repo labels with the label config defined in label_sync/labels.yaml.
 
-# TODO(releng): Move this job to a K8s cluster owned by kubernetes-wg-k8s-infra@googlegroups.com.
-#               ref: https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269
-- interval: 12h
-  cluster: test-infra-trusted
-  max_concurrency: 1
-  name: ci-k8sio-backup
-  decorate: true
-  extra_refs:
-  - org: kubernetes
-    repo: k8s.io
-    base_ref: master
-  spec:
-    serviceAccountName: k8s-infra-gcr-promoter-bak
-    containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.17
-      command:
-      - infra/gcp/backup_tools/backup.sh
-      env:
-      # Even though GOPATH is set to /go in the kubekins-e2e image, we set it
-      # here anyway in case the underlying image changes (the backup.sh script
-      # needs it to be defined).
-      - name: GOPATH
-        value: /go
-  annotations:
-    testgrid-dashboards: sig-release-releng-blocking
-    testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io
-    testgrid-num-failures-to-alert: '1'
-
 # This job is used as a heartbeat health check of the Prow instance's ability to run jobs.
 # Alerts expect it to run every 5 mins and will fire after 20 mins without a successful run.
 # Please keep this in sync with the `pull-test-infra-prow-checkconfig` job

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -60,19 +60,10 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
 
-# This job is a canary of 'ci-k8sio-backup' with the following qualities:
-# - Runs in k8s-infra-prow-build-trusted
-# - Jobs renamed to include 'gcr-prod-backup' for clarity
-# - Job names are suffixed with '-canary'
-# - Periodic runs every 2 hours (instead of every 12 hours)
-# - Rerun enabled for Release Managers
-#
-# TODO(releng): Adjust the interval back to 12 hours once we confirm that the
-#               dry-runs complete without issue.
-- interval: 2h
+- interval: 4h
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
-  name: ci-k8sio-gcr-prod-backup-canary
+  name: ci-k8sio-gcr-prod-backup
   decorate: true
   extra_refs:
   - org: kubernetes


### PR DESCRIPTION
Part of https://github.com/kubernetes-sigs/k8s-container-image-promoter/issues/269.

- Several runs of the canary job have succeeded since we've turned it on (ref: https://github.com/kubernetes/test-infra/pull/19811)
  - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-gcr-prod-backup-canary/1323662038446116864
  - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-gcr-prod-backup-canary/1323631586154909696
  - https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-gcr-prod-backup-canary/1323601135512064000
- The image was updated to a lightweight one that Release Managers have
  control over and the canary job continues to succeed (ref: https://github.com/kubernetes/test-infra/pull/19822, https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-k8sio-gcr-prod-backup-canary/1323692357429760000)

Here I've opted to go with a 4-hr backup interval (instead of the
previously-set 12-hr interval) to give Release Managers a better
opportunity to react to and remediate issues within "business hours".

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @spiffxp @dims 
/hold for any discussion
cc: @listx @thockin @kubernetes/release-engineering 
