### PR TITLE
Adding testgrid content for sig-storage container object storage project

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -31,6 +31,7 @@ readonly REPOS=(
     kubernetes-csi/livenessprobe
     kubernetes-csi/node-driver-registrar
     kubernetes-sigs/sig-storage-local-static-provisioner
+    kubernetes-sigs/container-object-storage-interface-api
 )
 
 cat >"${OUTPUT}" <<EOF

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -407,3 +407,32 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/container-object-storage-interface-api:
+    - name: post-container-object-storage-interface-api-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/OWNERS
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - jsafrane
+  - msau42
+  - saad-ali
+  - xing-yang
+  - brahmaroutu
+  - wlan0
+

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-api.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/container-object-storage-interface-api:
+  - name: pull-container-object-storage-interface-api-build
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-api
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-api
+      testgrid-tab-name: build
+      description: Build test in container-object-storage-interface-api repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        # Plain make runs also verify
+        - make
+
+  - name: pull-container-object-storage-interface-api-unit
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-api
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-api
+      testgrid-tab-name: unit
+      description: Unit tests in container-object-storage-interface-api repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        - make
+        args:
+        - test

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -14,6 +14,7 @@ dashboard_groups:
     - sig-storage-csi-node-driver-registrar
     - sig-storage-csi-other
     - sig-storage-image-build
+    - sig-storage-container-object-storage-interface-api
 
 dashboards:
 - name: sig-storage-kubernetes
@@ -115,3 +116,4 @@ dashboards:
 - name: sig-storage-csi-other
 - name: sig-storage-lib-external-provisioner
 - name: sig-storage-image-build
+- name: sig-storage-container-object-storage-interface-api


### PR DESCRIPTION
This PR will enable prow for one of the 4 repos new created for the project implementing container-object-storage-interface under sig-storage. 
The PR is adding a CI and test grid dashboard for container-object-storage-interface-api repository.
Similar configuration will follow for container-object-storage-interface-controller and container-object-storage-interface-provisioner-sidecar and container-object-storage-interface-csi-adapter.

/sig-storage
ping @xing-yang @wlan0 
/release-note-none