### PR TITLE
Remove kubeflow/manifests presubmit

### DIFF
--- a/config/jobs/kubeflow/kubeflow-presubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-presubmits.yaml
@@ -180,20 +180,6 @@ presubmits:
       testgrid-dashboards: sig-big-data
       description: Presubmit tests for kubeflow/metadata.
       testgrid-num-columns-recent: '30'
-  kubeflow/manifests:
-  - name: kubeflow-manifests-presubmit
-    cluster: kubeflow
-    always_run: true         # Run for every PR, or only when requested.
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Presubmits for kubeflow/manifests.
-      testgrid-num-columns-recent: '30'
   kubeflow/pipelines:
   - name: kubeflow-pipeline-frontend-test
     cluster: kubeflow


### PR DESCRIPTION
kubeflow/manifests move presubmit jobs to AWS prow.

AWS prow runs presubmit jobs and sig-testing prow tide (kubeflow-ci-bot) merges PR.

Here is the PR to make it work: https://github.com/kubeflow/manifests/pull/1601

/hold
Hold until above PR testing work 

/cc @jlewi @Jeffwan @yanniszark