### PR TITLE
releng: Teach jobs using latest-fast marker to extract from K8s Infra

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gce-conformance.yaml
@@ -23,6 +23,7 @@ periodics:
       - --scenario=kubernetes_e2e
       - --
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -568,6 +568,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --extract=ci/latest-fast
+          - --extract-ci-bucket=k8s-release-dev
           - --env=KUBE_CONTAINER_RUNTIME=containerd
           - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
@@ -650,6 +651,7 @@ periodics:
       - --env=KUBE_PROXY_DAEMONSET=true
       - --env=ENABLE_POD_PRIORITY=true
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce
@@ -773,6 +775,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=err-e2e
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce

--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gpu/gpu-gce.yaml
@@ -36,6 +36,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project-type=gpu-project
@@ -72,6 +73,7 @@ periodics:
       - --
       - --check-leaked-resources
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --env=KUBE_CONTAINER_RUNTIME=docker
       - --gcp-node-image=gci
       - --gcp-project=k8s-infra-e2e-gpu-project

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -263,6 +263,7 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=asia-southeast1-a
       - --provider=gce
@@ -299,6 +300,7 @@ periodics:
       - --env=GCE_ALPHA_FEATURES=NetworkEndpointGroup
       - --env=KUBE_GCE_ENABLE_IP_ALIASES=true
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-zone=asia-southeast1-a
       - --provider=gce

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -25,6 +25,7 @@ periodics:
       - --env=CONCURRENT_SERVICE_SYNCS=5
       - --env=HEAPSTER_MACHINE_TYPE=e2-standard-32
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-master-image=gci
       - --gcp-node-image=gci
       - --gcp-node-size=e2-small
@@ -80,6 +81,7 @@ periodics:
       # memory usage regression.
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-size=e2-medium
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale
@@ -151,6 +153,7 @@ periodics:
       - --check-leaked-resources
       - --cluster=e2e-big
       - --extract=ci/latest-fast
+      - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project


### PR DESCRIPTION
As we continue to migrate release-blocking jobs to a dedicated K8s Infra
cluster, jobs that use the latest-fast marker need to extract builds
from `gs://k8s-release-dev`, which is the K8s Infra equivalent of
`gs://kubernetes-release-dev`.

A new flag (`--extract-ci-bucket=k8s-release-dev`) was added to support
this transitional use case, so we employ it here.

Exceptions:
Of note, the ci-kubernetes-e2e-gce-master-new-gci-kubectl-skew-serial is
not included in this PR.

This job does two extractions:
- `--extract=ci/k8s-stable1`
- `--extract=ci/latest-fast`

As the generic version markers (like `k8s-stable1`) have not been
migrated to K8s Infra, we cannot take advantage of this flag.

We'll plan to fix this job in a follow-up.

(May mitigate https://github.com/kubernetes/test-infra/issues/19838.)

This is part of migrating release-blocking jobs to K8s Infra (ref: https://github.com/kubernetes/test-infra/issues/19484, https://github.com/kubernetes/test-infra/issues/18549).

---

Previous thought process (https://github.com/kubernetes/test-infra/commit/2b282b3c0a01cb02609ed27ac8f73c5d7e3567a8) is explained here:

~This reverts commit f1fd4142d87e877832be19d89037214d917b76aa. (ref: https://github.com/kubernetes/test-infra/pull/19660).~

~tl;dr of what's happening is that any existing job that extracts the `latest-fast` version marker is extracting the marker from `gs://kubernetes-release-dev/ci/fast` (Google Infra) instead of `gs://k8s-release-dev/ci/fast` (K8s Infra), which means they are using stale builds.~

~We need to make an accompanying change to the extract logic, which will take some time to roll out new images for.
This is the quickest course of action in the meantime.~

/assign @cpanato @saschagrunert @hasheddan 
/priority critical-urgent
cc: @kubernetes/sig-scalability @kubernetes/release-engineering 