### PR TITLE
Remove `needs-kind` and `needs-sig` from tide and fejta-bot queries

### DIFF
--- a/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
+++ b/config/jobs/kubernetes/test-infra/fejta-bot-periodics.yaml
@@ -155,8 +155,6 @@ periodics:
         label:approved
         label:"cncf-cla: yes"
         status:failure
-        -label:needs-sig
-        -label:needs-kind
         -label:needs-rebase
         -label:needs-ok-to-test
         -label:"cncf-cla: no"

--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -523,9 +523,7 @@ tide:
     - do-not-merge/needs-sig
     - do-not-merge/release-note-label-needed
     - do-not-merge/work-in-progress
-    - needs-kind
     - needs-rebase
-    - needs-sig
   - repos:
     - GoogleCloudPlatform/netd
     labels:


### PR DESCRIPTION
They have been removed from kubernetes/kubernetes PRs, and the new
labels `do-not-merge/needs-kind` and `do-not-merge/needs-sig` will
be used instead

Fixes: https://github.com/kubernetes/test-infra/issues/19805