### PR TITLE
images(kubekins-e2e,krte): Stop building 1.16 images

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -36,9 +36,3 @@ variants:
     K8S_RELEASE: stable-1.17
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
-  '1.16':
-    CONFIG: '1.16'
-    GO_VERSION: 1.13.15
-    K8S_RELEASE: stable-1.16
-    BAZEL_VERSION: 2.2.0
-    OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Kubernetes 1.16 is out of support, so we stop building the kubekins-e2e and krte 1.16 images.

The 1.16 cleanup PR (https://github.com/kubernetes/test-infra/pull/19850) is quickly becoming a rebase magnet, so I'm pulling this out to get it merged first.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cpanato @saschagrunert @hasheddan 
cc: @kubernetes/release-engineering 