### PR TITLE
Configure post-submit test for HNC

### DIFF
--- a/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-postsubmit.yaml
+++ b/config/jobs/kubernetes-sigs/wg-multi-tenancy/hnc-postsubmit.yaml
@@ -1,0 +1,29 @@
+postsubmits:
+  kubernetes-sigs/multi-tenancy:
+  - name: postsubmit-hnc-test
+    always_run: false
+    decorate: true
+    decoration_config:
+      timeout: 1h
+    max_concurrency: 5
+    path_alias: sigs.k8s.io/multi-tenancy
+    run_if_changed: "incubator/hnc/.*"
+    labels:
+      preset-kind-volume-mounts: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: golang:1.14
+        command:
+          - ./incubator/hnc/hack/post-submit-test.sh
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+        env:
+        - name: REPO_INFO
+          value: https://github.com/kubernetes-sigs/multi-tenancy
+        - name: K8S_VERSION
+          value: v1.19.0
+    annotations:
+      testgrid-dashboards: wg-multi-tenancy-hnc
+      testgrid-tab-name: postsubmit-tests


### PR DESCRIPTION
Note: this changed has not been tested, I don't know how to test it. If
this change break then post-submit tests for HNC will simply not run,
but developers can still merge in their changes because it's not
supposed to affect pre-submit tests.

Here's what I referenced for this change: https://github.com/kubernetes/test-infra/blob/9b4e473e58850ac47bcaa4b464cc6f2c4ee20c0b/config/jobs/kubernetes/sig-network/ingress-nginx.yaml#L166-L195