### PR TITLE
capdo: use the same image as the presubmit job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-digitalocean/cluster-api-provider-digitalocean-periodics.yaml
@@ -15,7 +15,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-digitalocean"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201031-122dc79-master
       command:
         - "runner.sh"
         - "./scripts/ci-conformance.sh"


### PR DESCRIPTION
the only difference for the presubmit job is the image

/assign @MorrisLaw @xmudrii @prksu 