### PR TITLE
Remove kubeflow manifests kfctl postsubmits

### DIFF
--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -54,32 +54,6 @@ postsubmits:
       # TODO: use a public email group
       testgrid-alert-email: kubeflow-engineering@google.com
       testgrid-num-failures-to-alert: "3"
-  kubeflow/kfctl:
-  - name: kubeflow-kfctl-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/kfctl.
-  kubeflow/manifests:
-  - name: kubeflow-manifests-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
-
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit tests for kubeflow/manifests.
   kubeflow/pytorch-operator:
   - name: kubeflow-pytorch-operator-postsubmit
     cluster: kubeflow

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -6,10 +6,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_examples/kubeflow-examples-postsubmit
 - name: kubeflow-gcp-blueprints-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
-- name: kubeflow-kfctl-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_kfctl/kubeflow-kfctl-postsubmit
-- name: kubeflow-manifests-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_manifests/kubeflow-manifests-postsubmit
 - name: kubeflow-pytorch-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_pytorch-operator/kubeflow-pytorch-operator-postsubmit
 - name: kubeflow-mxnet-operator-postsubmit


### PR DESCRIPTION
Since now kfctl and manifests tests are using AWS CI, removing manifests + kfctl postsubmits since they are not in use.

/cc @jlewi 