### PR TITLE
Tide: Deduplicate checkrun results and use the best only

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/gomodule/redigo v1.7.0
 	github.com/google/go-cmp v0.5.0
 	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/gofuzz v1.1.0
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/csrf v1.6.2
 	github.com/gorilla/mux v1.7.4

--- a/prow/tide/BUILD.bazel
+++ b/prow/tide/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
         "//prow/tide/history:go_default_library",
         "@com_github_go_test_deep//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/equality:go_default_library",


### PR DESCRIPTION
Checkruns can be restarted, resulting in mulitiple checkruns of the same
name being reported on a given commit with potentially different
results.

This PR makes tide de-duplicate them and use the best, similiar to what
we already do for ProwJobs.