### PR TITLE
Sinker supports excluding build cluster

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -372,7 +372,7 @@ func (c *controller) clean() {
 		}
 		if isClusterExcluded {
 			log.Debugf("Cluster %q is excluded, skipping pods deletion.", cluster)
-			break
+			continue
 		}
 		var pods corev1api.PodList
 		if err := client.List(c.ctx, &pods, ctrlruntimeclient.MatchingLabels{kube.CreatedByProw: "true"}, ctrlruntimeclient.InNamespace(c.config().PodNamespace)); err != nil {

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -751,7 +751,7 @@ func TestClean(t *testing.T) {
 
 func TestNotClean(t *testing.T) {
 
-	pods := []runtime.Object{
+	pods := []ctrlruntimeclient.Object{
 		&corev1api.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "job-complete-pod-succeeded",
@@ -767,7 +767,7 @@ func TestNotClean(t *testing.T) {
 			},
 		},
 	}
-	podsExcluded := []runtime.Object{
+	podsExcluded := []ctrlruntimeclient.Object{
 		&corev1api.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "job-complete-pod-succeeded-on-excluded-cluster",
@@ -787,7 +787,7 @@ func TestNotClean(t *testing.T) {
 		completed := metav1.NewTime(time.Now().Add(d))
 		return &completed
 	}
-	prowJobs := []runtime.Object{
+	prowJobs := []ctrlruntimeclient.Object{
 		&prowv1.ProwJob{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "job-complete",

--- a/prow/cmd/sinker/main_test.go
+++ b/prow/cmd/sinker/main_test.go
@@ -46,21 +46,25 @@ const (
 	terminatedPodTTL = 30 * time.Minute // must be less than maxPodAge
 )
 
+func newDefaultFakeSinkerConfig() config.Sinker {
+	return config.Sinker{
+		MaxProwJobAge:    &metav1.Duration{Duration: maxProwJobAge},
+		MaxPodAge:        &metav1.Duration{Duration: maxPodAge},
+		TerminatedPodTTL: &metav1.Duration{Duration: terminatedPodTTL},
+	}
+}
+
 type fca struct {
 	c *config.Config
 }
 
-func newFakeConfigAgent() *fca {
+func newFakeConfigAgent(s config.Sinker) *fca {
 	return &fca{
 		c: &config.Config{
 			ProwConfig: config.ProwConfig{
 				ProwJobNamespace: "ns",
 				PodNamespace:     "ns",
-				Sinker: config.Sinker{
-					MaxProwJobAge:    &metav1.Duration{Duration: maxProwJobAge},
-					MaxPodAge:        &metav1.Duration{Duration: maxPodAge},
-					TerminatedPodTTL: &metav1.Duration{Duration: terminatedPodTTL},
-				},
+				Sinker:           s,
 			},
 			JobConfig: config.JobConfig{
 				Periodics: []config.Periodic{
@@ -725,7 +729,7 @@ func TestClean(t *testing.T) {
 		logger:        logrus.WithField("component", "sinker"),
 		prowJobClient: fpjc,
 		podClients:    fpc,
-		config:        newFakeConfigAgent().Config,
+		config:        newFakeConfigAgent(newDefaultFakeSinkerConfig()).Config,
 	}
 	c.clean()
 	assertSetsEqual(deletedPods, fkc[0].deletedPods, t, "did not delete correct Pods")
@@ -743,6 +747,90 @@ func TestClean(t *testing.T) {
 		actuallyDeletedProwJobs.Delete(remainingProwJob.Name)
 	}
 	assertSetsEqual(deletedProwJobs, actuallyDeletedProwJobs, t, "did not delete correct ProwJobs")
+}
+
+func TestNotClean(t *testing.T) {
+
+	pods := []runtime.Object{
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-complete-pod-succeeded",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw:  "true",
+					kube.ProwJobIDLabel: "job-complete",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodSucceeded,
+				StartTime: startTime(time.Now().Add(-maxPodAge).Add(-time.Second)),
+			},
+		},
+	}
+	podsExcluded := []runtime.Object{
+		&corev1api.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-complete-pod-succeeded-on-excluded-cluster",
+				Namespace: "ns",
+				Labels: map[string]string{
+					kube.CreatedByProw:  "true",
+					kube.ProwJobIDLabel: "job-complete",
+				},
+			},
+			Status: corev1api.PodStatus{
+				Phase:     corev1api.PodSucceeded,
+				StartTime: startTime(time.Now().Add(-maxPodAge).Add(-time.Second)),
+			},
+		},
+	}
+	setComplete := func(d time.Duration) *metav1.Time {
+		completed := metav1.NewTime(time.Now().Add(d))
+		return &completed
+	}
+	prowJobs := []runtime.Object{
+		&prowv1.ProwJob{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-complete",
+				Namespace: "ns",
+			},
+			Status: prowv1.ProwJobStatus{
+				StartTime:      metav1.NewTime(time.Now().Add(-maxProwJobAge).Add(-time.Second)),
+				CompletionTime: setComplete(-60 * time.Second),
+			},
+		},
+	}
+
+	deletedPods := sets.NewString(
+		"job-complete-pod-succeeded",
+	)
+
+	fpjc := &clientWrapper{
+		Client:          fakectrlruntimeclient.NewFakeClient(prowJobs...),
+		getOnlyProwJobs: map[string]*prowv1.ProwJob{"ns/get-only-prowjob": {}},
+	}
+	podClientValid := podClientWrapper{
+		t: t, Client: fakectrlruntimeclient.NewFakeClient(pods...),
+	}
+	podClientExcluded := podClientWrapper{
+		t: t, Client: fakectrlruntimeclient.NewFakeClient(podsExcluded...),
+	}
+	fpc := map[string]ctrlruntimeclient.Client{
+		"build-cluster-valid":    &podClientValid,
+		"build-cluster-excluded": &podClientExcluded,
+	}
+	// Run
+	fakeSinkerConfig := newDefaultFakeSinkerConfig()
+	fakeSinkerConfig.ExcludeClusters = []string{"build-cluster-excluded"}
+	fakeConfigAgent := newFakeConfigAgent(fakeSinkerConfig).Config
+	c := controller{
+		logger:        logrus.WithField("component", "sinker"),
+		prowJobClient: fpjc,
+		podClients:    fpc,
+		config:        fakeConfigAgent,
+	}
+	c.clean()
+	assertSetsEqual(deletedPods, podClientValid.deletedPods, t, "did not delete correct Pods")
+	assertSetsEqual(sets.String{}, podClientExcluded.deletedPods, t, "did not delete correct Pods")
 }
 
 func assertSetsEqual(expected, actual sets.String, t *testing.T, prefix string) {
@@ -872,7 +960,7 @@ func TestDeletePodToleratesNotFound(t *testing.T) {
 		podsRemoved:      map[string]int{},
 		podRemovalErrors: map[string]int{},
 	}
-	c := &controller{config: newFakeConfigAgent().Config}
+	c := &controller{config: newFakeConfigAgent(newDefaultFakeSinkerConfig()).Config}
 	l := logrus.NewEntry(logrus.New())
 	pod := &corev1api.Pod{
 		ObjectMeta: metav1.ObjectMeta{

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -576,6 +576,8 @@ type Sinker struct {
 	// garbage collected.
 	// Defaults to matching MaxPodAge.
 	TerminatedPodTTL *metav1.Duration `json:"terminated_pod_ttl,omitempty"`
+	// ExcludeClusters are build clusters that don't want to be managed by sinker
+	ExcludeClusters []string `json:"exclude_clusters,omitempty"`
 }
 
 // LensConfig names a specific lens, and optionally provides some configuration for it.

--- a/prow/config/prow-config-documented.yaml
+++ b/prow/config/prow-config-documented.yaml
@@ -655,6 +655,10 @@ push_gateway:
     # ServeMetrics tells if or not the components serve metrics
     serve_metrics: false
 sinker:
+    # ExcludeClusters are build clusters that don't want to be managed by sinker
+    exclude_clusters:
+      - ""
+
     # MaxPodAge is how old a Pod can be before it is garbage-collected.
     # Defaults to one day.
     max_pod_age: 0s


### PR DESCRIPTION
Sinker treats all build clusters stored in kubeconfig secret as managed, majority of times this is valid assumption. But it could be handy to allow sinker ignore certain build clusters. For example,  migrating workloads from prow instance A to prow instance B, to achieve seemless transition (aka no down time), there will be certain amount of time that sinker instances of prow A and prow B both are working, which will cause sinker A delete pods scheduled by prow B, vice versa.

This PR provides a solution to this problem, so that the build cluster can be temporarily ignored by sinker A and sinker B, thus prow A and prow B can both work at the same time.

/cc @spiffxp @amwat @alvaroaleman 