### PR TITLE
Use a wrapper script for Golang performance job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-golang.yaml
@@ -56,8 +56,8 @@ periodics:
     containers:
     - args:
       - --timeout=210
-      # head of perf-tests' master as of 2020-05-29
-      - --repo=k8s.io/perf-tests=master:c8e93e287413fb0efec4478e2f47f1e7b1a92bfd
+      # head of perf-tests' master as of 2020-11-06
+      - --repo=k8s.io/perf-tests=master:39a6c09ddca620a430d38e5de1400844ea954c2f
       - --root=/go/src
       - --scenario=kubernetes_e2e
       - --
@@ -75,7 +75,7 @@ periodics:
       - --kubemark
       - --kubemark-nodes=2500
       - --test=false
-      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/golang/run-e2e.sh
       - --test-cmd-args=cluster-loader2
       - --test-cmd-args=--experimental-gcp-snapshot-prometheus-disk=true
       - --test-cmd-args=--experimental-prometheus-disk-snapshot-name=${JOB_NAME}-${BUILD_ID}


### PR DESCRIPTION
Leverage https://github.com/kubernetes/perf-tests/pull/1556 to print out the Golang tip's hash in the job's build log.

/sig scalability
/assign @mm4tt