### PR TITLE
Use instances with more memory for the memory manager tests

### DIFF
--- a/config/jobs/kubernetes/sig-node/node-kubelet.yaml
+++ b/config/jobs/kubernetes/sig-node/node-kubelet.yaml
@@ -344,7 +344,7 @@ periodics:
           - --deployment=node
           - --gcp-project-type=node-e2e-project
           - --gcp-zone=us-west1-b
-          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+          - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
           - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
           - --node-tests=true
           - --provider=gce

--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -360,7 +360,7 @@ presubmits:
             - --deployment=node
             - --gcp-project=k8s-jkns-pr-node-e2e
             - --gcp-zone=us-west1-b
-            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
+            - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config-serial-cpu-manager.yaml
             - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
             - --node-tests=true
             - --provider=gce


### PR DESCRIPTION
Under the memory manager tests, we need to allocate hugepages and also
have some reserved memory. The amount of memory under the
n1-standard-1(3.75GB) is not enough for it.

To fix the problem, we will use the CPU manager image profile that has more than enough memory.
It possible that n1-standard-4 will have more memory than the test will need, but
I want to have some flexibility to avoid memory issues once we will add multi
NUMA tests that will need to allocate 1Gb hugepages.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>