### PR TITLE
Return stderr output in kubernetes_build called subprocesses

### DIFF
--- a/scenarios/kubernetes_build.py
+++ b/scenarios/kubernetes_build.py
@@ -40,7 +40,7 @@ def check_no_stdout(*cmd):
 def check_output(*cmd):
     """Log and run the command, raising on errors, return output"""
     print >>sys.stderr, 'Run:', cmd
-    return subprocess.check_output(cmd)
+    return subprocess.check_output(cmd, stderr=subprocess.STDOUT)
 
 def check_build_exists(gcs, suffix, fast):
     """ check if a k8s build with same version


### PR DESCRIPTION
Redirects stderr to stdout such that it will be included in the output
of a subprocess that is executed in kubernetes_build. This can be useful
for troubleshooting errors.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

See [subprocess docs](https://docs.python.org/2/library/subprocess.html) for info.

xref: https://github.com/kubernetes/release/issues/1693

/cc @justaugustus @ameukam 
/assign @dims (for his python wisdom)