### PR TITLE
config/tests/jobs: add check for use of k8s-release-dev bucket

### DIFF
--- a/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
+++ b/config/jobs/kubernetes/sig-cli/sig-cli-config.yaml
@@ -200,7 +200,7 @@ periodics:
       - --check-leaked-resources
       - --check-version-skew=false
       - --extract=ci/k8s-stable1
-      - --extract=ci/latest-fast
+      - --extract=ci/latest
       - --gcp-node-image=gci
       - --gcp-zone=us-west1-b
       - --provider=gce


### PR DESCRIPTION
enforce that anything extracting from ci/latest-fast should be
using the k8s-release-dev bucket

drop ci/latest-fast from skew job; I would prefer it use latest-fast,
but ci/stable1 hasn't migrated over yet, and extract-ci-bucket applies
to all extracts

This should close out https://github.com/kubernetes/test-infra/issues/19484
but I'll do that manually after looking things over