### PR TITLE
Disable some of the kubeflow repos' trigger

### DIFF
--- a/config/jobs/kubeflow/kubeflow-postsubmits.yaml
+++ b/config/jobs/kubeflow/kubeflow-postsubmits.yaml
@@ -54,19 +54,7 @@ postsubmits:
       # TODO: use a public email group
       testgrid-alert-email: kubeflow-engineering@google.com
       testgrid-num-failures-to-alert: "3"
-  kubeflow/pytorch-operator:
-  - name: kubeflow-pytorch-operator-postsubmit
-    cluster: kubeflow
-    labels:
-      preset-service-account: "true"
-    spec:
-      containers:
-      - image: gcr.io/kubeflow-ci/test-worker:latest
-        imagePullPolicy: Always
 
-    annotations:
-      testgrid-dashboards: sig-big-data
-      description: Postsubmit kubeflow/pytorch-operator.
   kubeflow/reporting:
   - name: kubeflow-reporting-postsubmit
     cluster: kubeflow

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -699,25 +699,16 @@ plugins:
   kubeflow/internal-acls:
   - trigger
 
-  kubeflow/katib:
-  - trigger
-
   kubeflow/kfp-tekton:
   - trigger
 
   kubeflow/kfp-tekton-backend:
   - trigger
 
-  kubeflow/kfserving:
-  - trigger
-
   kubeflow/kubebench:
   - trigger
 
   kubeflow/kubeflow:
-  - trigger
-
-  kubeflow/manifests:
   - trigger
 
   kubeflow/metadata:
@@ -730,9 +721,6 @@ plugins:
   - trigger
 
   kubeflow/pipelines:
-  - trigger
-
-  kubeflow/pytorch-operator:
   - trigger
 
   kubeflow/reporting:

--- a/config/testgrids/kubeflow/kubeflow.yaml
+++ b/config/testgrids/kubeflow/kubeflow.yaml
@@ -6,8 +6,6 @@ test_groups:
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_examples/kubeflow-examples-postsubmit
 - name: kubeflow-gcp-blueprints-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_gcp-blueprints/kubeflow-gcp-blueprints-postsubmit
-- name: kubeflow-pytorch-operator-postsubmit
-  gcs_prefix: kubernetes-jenkins/logs/kubeflow_pytorch-operator/kubeflow-pytorch-operator-postsubmit
 - name: kubeflow-mxnet-operator-postsubmit
   gcs_prefix: kubernetes-jenkins/logs/kubeflow_mxnet-operator/kubeflow-mxnet-operator-postsubmit
 - name: kubeflow-reporting-postsubmit


### PR DESCRIPTION
Given the fact that some of the kubeflow repos exist two bot respond to `/retest`, `/test all`, etc. This is caused by some of the repos migrated to AWS CI, but still rely on upstream prow/tide managed PR.

E.g, [manifests PR](https://github.com/kubeflow/manifests/pull/1603#issuecomment-722539135)

Thus, disabling some of the kubeflow repos' trigger plugin to avoid two bots multiple response and save developer's confusions

/cc @jlewi @cblecker 
