### PR TITLE
Apply milestone applier against k/website release branch

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -354,6 +354,8 @@ milestone_applier:
     master: v0.4
     release-0.4: v0.4
     release-0.3: v0.3
+  kubernetes/website:
+    dev-1.20: 1.20
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Add `k/website` to milestone applier config to apply `1.20` milestone automatically for PR created against `dev-1.20` branch

/hold for review from @kubernetes/sig-docs-leads 

relates to https://github.com/kubernetes/website/pull/24835 and https://github.com/kubernetes/sig-release/pull/1325

Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>