### PR TITLE
Trigger: Abort jobs on pushes

### DIFF
--- a/prow/plugins/trigger/pull-request_test.go
+++ b/prow/plugins/trigger/pull-request_test.go
@@ -389,6 +389,15 @@ func TestHandlePullRequest(t *testing.T) {
 			ShouldBuild: false,
 			jobToAbort:  jobToAbort,
 		},
+		{
+			name: "Abort old jobs and build on push",
+
+			Author:      "t",
+			HasOkToTest: true,
+			prAction:    github.PullRequestActionSynchronize,
+			ShouldBuild: true,
+			jobToAbort:  jobToAbort,
+		},
 	}
 	for _, tc := range testcases {
 		t.Logf("running scenario %q", tc.name)


### PR DESCRIPTION
Plank already has logic to abort older jobs, which causes it to
terminate all older instances of a given job after a push. This won't
work if the new revision doesn't trigger this job (e.G. due to
`run_if_changed`). This change makes trigger abort all jobs for a given
PR on a push event prior to creating new ones.