### PR TITLE
Decoration config: Fix defaulting

### DIFF
--- a/prow/apis/prowjobs/v1/BUILD.bazel
+++ b/prow/apis/prowjobs/v1/BUILD.bazel
@@ -43,5 +43,6 @@ go_test(
     deps = [
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_google_go_cmp//cmp/cmpopts:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
     ],
 )

--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -437,6 +437,9 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 	if merged.GCSCredentialsSecret == "" {
 		merged.GCSCredentialsSecret = def.GCSCredentialsSecret
 	}
+	if merged.S3CredentialsSecret == "" {
+		merged.S3CredentialsSecret = def.S3CredentialsSecret
+	}
 	if len(merged.SSHKeySecrets) == 0 {
 		merged.SSHKeySecrets = def.SSHKeySecrets
 	}
@@ -448,6 +451,9 @@ func (d *DecorationConfig) ApplyDefault(def *DecorationConfig) *DecorationConfig
 	}
 	if merged.CookiefileSecret == "" {
 		merged.CookiefileSecret = def.CookiefileSecret
+	}
+	if merged.OauthTokenSecret == nil {
+		merged.OauthTokenSecret = def.OauthTokenSecret
 	}
 
 	return &merged


### PR DESCRIPTION
Related to https://github.com/kubernetes/test-infra/issues/19835

Fixes the defaulting to default all fields and adds a simple fuzz test that will prevent this kind of regression from happening again.