### PR TITLE
releng: Lower requests/limits for ci-kubernetes-build-no-bootstrap

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -133,11 +133,11 @@ periodics:
         privileged: true
       resources:
         limits:
-          cpu: 7300m
-          memory: "34Gi"
+          cpu: 6
+          memory: "20Gi"
         requests:
-          cpu: 7300m
-          memory: "34Gi"
+          cpu: 6
+          memory: "20Gi"
   rerun_auth_config:
     github_team_ids:
       - 2241179 # release-managers


### PR DESCRIPTION
This job is having scheduling issues, so let's lower the resource requirements while I'm testing things.

ref: https://kubernetes.slack.com/archives/CJH2GBF7Y/p1604942302239500

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/ci-signal @kubernetes/release-engineering 