### PR TITLE
Add test for testrgrid alert emails on release-blocking jobs

### DIFF
--- a/config/tests/jobs/jobs_test.go
+++ b/config/tests/jobs/jobs_test.go
@@ -969,6 +969,13 @@ func verifyPodQOSGuaranteed(spec *coreapi.PodSpec) (errs []error) {
 	return errs
 }
 
+func hasAlertEmails(job cfg.JobBase) bool {
+	if _, ok := job.Annotations["testgrid-alert-email"]; !ok {
+		return false
+	}
+	return true
+}
+
 // A job is merge-blocking if it:
 // - is not optional
 // - reports (aka does not skip reporting)
@@ -1014,6 +1021,19 @@ func TestKubernetesReleaseBlockingJobsMustHavePodQOSGuaranteed(t *testing.T) {
 		errs := verifyPodQOSGuaranteed(job.Spec)
 		for _, err := range errs {
 			t.Errorf("%v: %v", job.Name, err)
+		}
+	}
+}
+
+// TODO: s/Should/Must and s/Logf/Errorf when all jobs pass
+func TestKubernetesReleaseBlockingJobsMustHaveContactInformation(t *testing.T) {
+	for _, job := range allStaticJobs() {
+		// Only consider Pods that are release-blocking
+		if job.Spec == nil || !isKubernetesReleaseBlocking(job) {
+			continue
+		}
+		if !hasAlertEmails(job) {
+			t.Logf("%v: should have testgrid-alert-email(s)", job.Name)
 		}
 	}
 }


### PR DESCRIPTION
Adds a check that release-blocking jobs have testgrid alert emails. Logs
violations for now, but should be updated to error on violations when
all jobs pass.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref: https://github.com/kubernetes/sig-release/issues/1216 https://github.com/kubernetes/test-infra/pull/19844#issuecomment-721867705

/assign @justaugustus @cpanato 