### PR TITLE
releng: Use krte wrapper script to execute no-bootstrap build

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -120,8 +120,8 @@ periodics:
     containers:
     - image: gcr.io/k8s-staging-releng/k8s-ci-builder:v1.15.3-1
       command:
+      - wrapper.sh
       - /krel
-      args:
       - ci-build
       - --allow-dup
       - --fast
@@ -142,7 +142,7 @@ periodics:
     github_team_ids:
       - 2241179 # release-managers
   annotations:
-    testgrid-dashboards: sig-release-master-informing, sig-release-releng-informing
+    testgrid-dashboards: sig-release-releng-informing
     testgrid-tab-name: build-master-no-bootstrap
     testgrid-alert-email: release-managers+alerts@kubernetes.io
 


### PR DESCRIPTION
Continued work on the no-bootstrap build job.

ref: 
- https://github.com/kubernetes/release/pull/1700 / https://github.com/kubernetes/release/pull/1700/commits/423b22734d84e0bb4506f00a7b7233ee843b6470
- https://kubernetes.slack.com/archives/CJH2GBF7Y/p1604945713244100?thread_ts=1604682956.212000&cid=CJH2GBF7Y
- https://kubernetes.slack.com/archives/CJH2GBF7Y/p1604942302239500

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/ci-signal 