### PR TITLE
set minimum aks-engine version as 1.16

### DIFF
--- a/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azuredisk-csi-driver/azuredisk-csi-driver-config.yaml
@@ -127,7 +127,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.15
+        - --aksengine-orchestratorRelease=1.16
         - --aksengine-location=eastus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/single-az.json

--- a/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/azurefile-csi-driver/azurefile-csi-driver-config.yaml
@@ -127,7 +127,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.15
+        - --aksengine-orchestratorRelease=1.16
         - --aksengine-location=eastus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azurefile-csi-driver/master/test/e2e/manifest/linux.json

--- a/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/blob-csi-driver/blob-csi-driver-config.yaml
@@ -127,7 +127,7 @@ presubmits:
         - --deployment=aksengine
         - --aksengine-admin-username=azureuser
         - --aksengine-creds=$(AZURE_CREDENTIALS)
-        - --aksengine-orchestratorRelease=1.15
+        - --aksengine-orchestratorRelease=1.16
         - --aksengine-location=eastus2
         - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
         - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/blob-csi-driver/master/test/manifest/linux.json


### PR DESCRIPTION
/assign @mayankshah1607 
```
2020/11/10 14:34:08 process.go:153: Running: /tmp/aks-engine generate /root/tmp182822394/kubernetes.json --output-directory /root/tmp182822394
Error: loading API model in generateCmd: error parsing the api model: the following OrchestratorProfile configuration is not supported: OrchestratorType: "Kubernetes", OrchestratorRelease: "1.15", OrchestratorVersion: "". Please use one of the following versions: [1.6.9 1.16.14 1.16.15 1.17.12 1.17.13 1.18.9 1.18.10 1.19.2 1.19.3 1.20.0-alpha.3 1.20.0-beta.0 1.20.0-beta.1]
Usage:
  aks-engine generate [flags]

Flags:
  -m, --api-model string             path to your cluster definition file
      --ca-certificate-path string   path to the CA certificate to use for Kubernetes PKI assets
      --ca-private-key-path string   path to the CA private key to use for Kubernetes PKI assets
      --client-id string             client id
      --client-secret string         client secret
  -h, --help                         help for generate
      --no-pretty-print              skip pretty printing the output
  -o, --output-directory string      output directory (derived from FQDN if absent)
      --parameters-only              only output parameters files
      --set stringArray              set values on the command line (can specify multiple or separate values with commas: key1=val1,key2=val2)

Global Flags:
      --debug   enable verbose debug logs
```