### PR TITLE
Add canary jobs for ci-kubernetes-build job variants.

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -200,6 +200,41 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
+  name: ci-kubernetes-build-1-17-canary
+  cluster: k8s-infra-prow-build
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.17
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=240
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-release-dev
+      - --allow-dup
+      - --extra-version-markers=k8s-stable2
+      - --registry=gcr.io/k8s-staging-ci-images
+      image: gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+      name: ""
+      resources:
+        limits:
+          cpu: 7300m
+          memory: "34Gi"
+        requests:
+          cpu: 7300m
+          memory: "34Gi"
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.17-blocking, sig-testing-canaries
+    testgrid-tab-name: build-1.17-canary
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
   name: ci-kubernetes-build-stable2
   spec:
     containers:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -201,6 +201,44 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
+  name: ci-kubernetes-build-1-18-canary
+  cluster: k8s-infra-prow-build
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.18
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=240
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-release-dev
+      - --allow-dup
+      - --extra-version-markers=k8s-stable1
+      - --registry=gcr.io/k8s-staging-ci-images
+      image: gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+      name: ""
+      resources:
+        limits:
+          cpu: 7300m
+          memory: "34Gi"
+        requests:
+          cpu: 7300m
+          memory: "34Gi"
+      securityContext:
+        privileged: true
+- annotations:
+    fork-per-release-generic-suffix: "true"
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.18-blocking, sig-testing-canaries
+    testgrid-tab-name: build-1.18-canary
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
   name: ci-kubernetes-build-stable1
   rerun_auth_config:
     github_team_ids:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -159,6 +159,43 @@ periodics:
   labels:
     preset-dind-enabled: "true"
     preset-service-account: "true"
+  name: ci-kubernetes-build-1-19-canary
+  cluster: k8s-infra-prow-build
+  rerun_auth_config:
+    github_team_ids:
+    - 2241179
+  spec:
+    containers:
+    - args:
+      - --repo=k8s.io/kubernetes=release-1.19
+      - --repo=k8s.io/release
+      - --root=/go/src
+      - --timeout=240
+      - --scenario=kubernetes_build
+      - --
+      - --release=k8s-release-dev
+      - --allow-dup
+      - --extra-version-markers=k8s-beta
+      - --registry=gcr.io/k8s-staging-ci-images
+      image: gcr.io/k8s-testimages/bootstrap:v20201106-b01d6e7
+      name: ""
+      resources:
+        limits:
+          cpu: 7300m
+          memory: "34Gi"
+        requests:
+          cpu: 7300m
+          memory: "34Gi"
+      securityContext:
+        privileged: true
+- annotations:
+    testgrid-alert-email: release-managers+alerts@kubernetes.io, release-team@kubernetes.io
+    testgrid-dashboards: sig-release-1.19-blocking, sig-testing-canaries
+    testgrid-tab-name: build-1.19-canary
+  interval: 1h
+  labels:
+    preset-dind-enabled: "true"
+    preset-service-account: "true"
   name: ci-kubernetes-build-1-19
   rerun_auth_config:
     github_team_ids:


### PR DESCRIPTION
Ensure the job variants of ci-kubernetes-build are successful on `k8s-infra-prow-build` cluster.
Ref : https://github.com/kubernetes/test-infra/issues/19483
Part of: https://github.com/kubernetes/test-infra/issues/18549

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>