### PR TITLE
Fix rbac after controller-runtime update

### DIFF
--- a/config/prow/cluster/prow_controller_manager_rbac.yaml
+++ b/config/prow/cluster/prow_controller_manager_rbac.yaml
@@ -25,6 +25,21 @@ metadata:
   name: "prow-controller-manager"
 rules:
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - prow-controller-manager-leader-lock
+  verbs:
+  - get
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/config/prow/cluster/sinker_rbac.yaml
+++ b/config/prow/cluster/sinker_rbac.yaml
@@ -11,30 +11,45 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - delete
-      - list
-      - watch
-      - get
+    - delete
+    - list
+    - watch
+    - get
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-sinker-leaderlock
+    - prow-sinker-leaderlock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -741,30 +741,45 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - delete
-      - list
-      - watch
-      - get
+    - delete
+    - list
+    - watch
+    - get
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-sinker-leaderlock
+    - prow-sinker-leaderlock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -1047,31 +1062,46 @@ metadata:
   name: prow-controller-manager
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
+    - get
+    - list
+    - watch
+    - update
+    - patch
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-controller-manager-leader-lock
+    - prow-controller-manager-leader-lock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-controller-manager-leader-lock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -738,30 +738,45 @@ metadata:
   name: "sinker"
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - delete
-      - list
-      - watch
-      - get
+    - delete
+    - list
+    - watch
+    - get
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-sinker-leaderlock
+    - prow-sinker-leaderlock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-sinker-leaderlock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -1044,31 +1059,46 @@ metadata:
   name: prow-controller-manager
 rules:
   - apiGroups:
-      - "prow.k8s.io"
+    - "prow.k8s.io"
     resources:
-      - prowjobs
+    - prowjobs
     verbs:
-      - get
-      - list
-      - watch
-      - update
-      - patch
+    - get
+    - list
+    - watch
+    - update
+    - patch
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
+    - leases
     resourceNames:
-      - prow-controller-manager-leader-lock
+    - prow-controller-manager-leader-lock
     verbs:
-      - get
-      - update
+    - get
+    - update
   - apiGroups:
-      - ""
+    - coordination.k8s.io
     resources:
-      - configmaps
-      - events
+    - leases
     verbs:
-      - create
+    - create
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    resourceNames:
+    - prow-controller-manager-leader-lock
+    verbs:
+    - get
+    - update
+  - apiGroups:
+    - ""
+    resources:
+    - configmaps
+    - events
+    verbs:
+    - create
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/prow/ANNOUNCEMENTS.md
+++ b/prow/ANNOUNCEMENTS.md
@@ -127,7 +127,9 @@ Note: versions specified in these announcements may not include bug fixes made
 in more recent versions so it is recommended that the most recent versions are
 used when updating deployments.
 
+ - *November 11th, 2020* The prow-controller-manager and sinker now require RBAC to be set up to manage their leader lock in the `coordination.k8s.io` group. See [here](https://github.com/kubernetes/test-infra/pull/19906/files?diff=split&w=1)
  - *November, 2020* The deprecated `namespace` and `additional_namespaces` properties have been removed from the config updater plugin
+                       for more details.
  - *November, 2020* The `blacklist` flag in status reconciler has been deprecated in favor of `denylist`. The support of `blacklist` will be stopped in February 2021.
  - *October, 2020*  The `plank` binary has been deprecated in favor of the more modern implementation in the prow-controller-manager that provides the same functionality. Check out
                   its [README](/prow//prow-controller-manager/README.md) or check out its [deployment](config/prow/cluster/prow_controller_manager_deployment.yaml) and


### PR DESCRIPTION
In #19440 controller-runtime was updated, changing its default for the
leader election to be both a configmap (which were never intended to be
used for this) and the lease resource. The latter requires additional
rbac which is added here.

The reason for using two apigroups for this in parallel is to allow safe
transitions. We should after some grace period start using the lease
resource only.