### PR TITLE
releng: Enable image building for k8s-ci-builder

### DIFF
--- a/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
+++ b/config/jobs/image-pushing/releng/k8s-staging-releng.yaml
@@ -71,6 +71,31 @@ periodics:
 
 postsubmits:
   kubernetes/release:
+    - name: post-release-push-image-k8s-ci-builder
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-release-releng-informing, sig-release-image-pushes
+        testgrid-alert-email: release-managers+alerts@kubernetes.io
+      decorate: true
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              - --project=k8s-staging-releng
+              - --scratch-bucket=gs://k8s-staging-releng-gcb
+              - --build-dir=.
+              - images/releng/k8s-ci-builder
+            env:
+              - name: LOG_TO_STDOUT
+                value: "y"
+      rerun_auth_config:
+        github_team_ids:
+          - 2241179 # release-managers
     - name: post-release-push-image-k8s-cloud-builder
       cluster: k8s-infra-prow-build-trusted
       annotations:

--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -118,7 +118,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:v1.15.3-1
+    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:default
       command:
       - wrapper.sh
       - /krel
@@ -127,7 +127,7 @@ periodics:
       - --fast
       - --bucket=k8s-release-dev
       - --gcs-suffix=no-bootstrap
-      - --docker-registry=gcr.io/k8s-staging-ci-images
+      - --registry=gcr.io/k8s-staging-ci-images
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Also, updates job config for the no-bootstrap build job.
Companion PR for https://github.com/kubernetes/release/pull/1710.

/assign @hasheddan
cc: @kubernetes/release-engineering 