### PR TITLE
Azure: remove extra CSI driver env variables

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -1224,13 +1224,6 @@ func (c *aksEngineDeployer) TestSetup() error {
 	} else if *testAzureFileCSIDriver || *testAzureDiskCSIDriver || *testBlobCSIDriver || *testSMBCSIDriver || *testNFSCSIDriver {
 		// Set env vars required by CSI driver e2e jobs.
 		// tenantId, subscriptionId, aadClientId, and aadClientSecret will be obtained from AZURE_CREDENTIAL
-		// TODO (CecileRobertMichon): remove RESOURCE_GROUP and LOCATION once image and tests have been updated
-		if err := os.Setenv("RESOURCE_GROUP", c.resourceGroup); err != nil {
-			return err
-		}
-		if err := os.Setenv("LOCATION", c.location); err != nil {
-			return err
-		}
 		if err := os.Setenv("AZURE_RESOURCE_GROUP", c.resourceGroup); err != nil {
 			return err
 		}


### PR DESCRIPTION
fix TODO now that CSI driver updates have merged:

https://github.com/kubernetes-sigs/azurefile-csi-driver/pull/463
kubernetes-sigs/azuredisk-csi-driver#582
kubernetes-sigs/blob-csi-driver#261
kubernetes-csi/csi-driver-smb#139

/assign @andyzhangx @feiskyer @chewong 