### PR TITLE
Remove TaintBasedEvictions from master branch tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -38,11 +38,6 @@ presets:
   # Reduce etcd compaction frequency to match production.
   - name: KUBEMARK_ETCD_COMPACTION_INTERVAL_SEC
     value: "150"
-  # Use Taint based evictions to control hollow node recreation in case of
-  # node VM restart.
-  # See https://github.com/kubernetes/kubernetes/issues/67120 for context.
-  - name: KUBE_FEATURE_GATES
-    value: "TaintBasedEvictions=true"
   # Allow one node to not be ready after cluster creation.
   - name: ALLOWED_NOTREADY_NODES
     value: 1


### PR DESCRIPTION
Currently kubemark master-branch tests are failing, because TaintBasedEvictions feature gate was removed. This PR fixes it.