### PR TITLE
[1.20] config/prow: enable code freeze for kubernetes/kubernetes master

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -507,6 +507,30 @@ tide:
     - needs-rebase
   - repos:
     - kubernetes/kubernetes
+    excludedBranches:
+    - master
+    labels:
+    - lgtm
+    - approved
+    - "cncf-cla: yes"
+    missingLabels:
+    - do-not-merge
+    - do-not-merge/blocked-paths
+    - do-not-merge/cherry-pick-not-approved
+    - do-not-merge/contains-merge-commits
+    - do-not-merge/hold
+    - do-not-merge/invalid-commit-message
+    - do-not-merge/invalid-owners-file
+    - do-not-merge/needs-kind
+    - do-not-merge/needs-sig
+    - do-not-merge/release-note-label-needed
+    - do-not-merge/work-in-progress
+    - needs-rebase
+  - repos:
+    - kubernetes/kubernetes
+    milestone: v1.20
+    includedBranches:
+    - master
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
### Enable Code Freeze for the master branch

This PR enables code freeze for `kubernetes/kubernetes` on the master branch.

**AI:** The `release-1.20` branch doesn't exist (the branch creation is scheduled for December 1st), so a follow-up PR for the `release-1.20` branch should be made.

/hold
this PR should be merged only after Tuesday, November 12th, PST EOD.

/sig release
/area release-eng

cc: @kubernetes/release-team-leads @kubernetes/release-engineering 