### PR TITLE
Explicitly enable probing container test for dockershim job

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -31,7 +31,8 @@ presubmits:
         - --node-test-args=--kubelet-flags="--cgroups-per-qos=true --cgroup-root=/"
         - --node-tests=true
         - --provider=gce
-        - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
+        # Explicitly enable probing container test to make sure we run against dockershim (https://github.com/kubernetes/kubernetes/issues/96463)
+        - --test_args=--nodes=8 --focus="\[NodeConformance\]|\[k8s\.io\] Probing container should be restarted startup probe fails" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
         resources:


### PR DESCRIPTION
Explicitly enables `[k8s.io] Probing container should be restarted startup probe
fails` to test against a job using dockershim nodes to guard against
failure see in https://github.com/kubernetes/kubernetes/issues/96463.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

/cc @andrewsykim @justaugustus 
/assign @derekwaynecarr 