### PR TITLE
Move sig-aws-* dashboards to provider-aws-*

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
@@ -4,7 +4,7 @@ postsubmits:
     - name: cloud-provider-aws-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-aws-cloud-provider-aws
+        testgrid-dashboards: provider-aws-cloud-provider-aws
         testgrid-tab-name: cloud-provider-aws-image-pushes
       decorate: true
       branches:
@@ -35,7 +35,7 @@ postsubmits:
     - name: aws-ebs-csi-driver-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
-        testgrid-dashboards: sig-aws-cloud-provider-aws
+        testgrid-dashboards: provider-aws-cloud-provider-aws
         testgrid-tab-name: aws-ebs-csi-driver-image-pushes
       decorate: true
       branches:

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-periodics.yaml
@@ -23,7 +23,7 @@ periodics:
       securityContext:
         privileged: true
   annotations:
-    testgrid-dashboards: sig-aws-ebs-csi-driver
+    testgrid-dashboards: provider-aws-ebs-csi-driver
     testgrid-tab-name: migration-test-latest
     description: aws ebs csi driver migration test on latest kubernetes
     testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: verify
       description: aws ebs csi driver basic code verification
       testgrid-num-columns-recent: '30'
@@ -36,7 +36,7 @@ presubmits:
         - make
         - test
     annotations:
-      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: unit-test
       description: aws ebs csi driver unit test
       testgrid-num-columns-recent: '30'
@@ -60,7 +60,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: e2e-test-single-az
       description: aws ebs csi driver e2e test on single az
       testgrid-num-columns-recent: '30'
@@ -84,7 +84,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: e2e-test-multi-az
       description: aws ebs csi driver e2e test on mutiple AZs
       testgrid-num-columns-recent: '30'
@@ -108,7 +108,7 @@ presubmits:
           securityContext:
             privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-ebs-csi-driver
+      testgrid-dashboards: provider-aws-ebs-csi-driver
       testgrid-tab-name: pull-migration-test-latest
       description: aws ebs csi driver migration test on latest kubernetes
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-efs-csi-driver/aws-efs-csi-driver-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-aws-efs-csi-driver
+      testgrid-dashboards: provider-aws-efs-csi-driver
       testgrid-tab-name: verify
       description: aws efs csi driver basic code verification
       testgrid-num-columns-recent: '30'
@@ -36,7 +36,7 @@ presubmits:
         - make
         - test
     annotations:
-      testgrid-dashboards: sig-aws-efs-csi-driver
+      testgrid-dashboards: provider-aws-efs-csi-driver
       testgrid-tab-name: unit-test
       description: aws efs csi driver unit test
       testgrid-num-columns-recent: '30'
@@ -60,7 +60,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-efs-csi-driver
+      testgrid-dashboards: provider-aws-efs-csi-driver
       testgrid-tab-name: e2e-test
       description: aws efs csi driver e2e test
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-encryption-provider/presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
         - name: GO111MODULE
           value: "on"
     annotations:
-      testgrid-dashboards: sig-aws-encryption-provider
+      testgrid-dashboards: provider-aws-encryption-provider
       testgrid-tab-name: verify
       description: aws-encryption-provider verification
       testgrid-num-columns-recent: '30'
@@ -34,7 +34,7 @@ presubmits:
         - name: GO111MODULE
           value: "on"
     annotations:
-      testgrid-dashboards: sig-aws-encryption-provider
+      testgrid-dashboards: provider-aws-encryption-provider
       testgrid-tab-name: unit-test
       description: aws-encryption-provider unit tests
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-fsx-csi-driver/aws-fsx-csi-driver-presubmits.yaml
@@ -16,7 +16,7 @@ presubmits:
         - make
         - verify
     annotations:
-      testgrid-dashboards: sig-aws-fsx-csi-driver
+      testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: verify
       description: aws fsx csi driver basic code verification
       testgrid-num-columns-recent: '30'
@@ -36,7 +36,7 @@ presubmits:
         - make
         - test
     annotations:
-      testgrid-dashboards: sig-aws-fsx-csi-driver
+      testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: unit-test
       description: aws fsx csi driver unit test
       testgrid-num-columns-recent: '30'
@@ -60,7 +60,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-fsx-csi-driver
+      testgrid-dashboards: provider-aws-fsx-csi-driver
       testgrid-tab-name: e2e-test
       description: aws fsx csi driver e2e test
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/aws-load-balancer-controller/aws-alb-ingress-controller-presubmits.yaml
@@ -14,7 +14,7 @@ presubmits:
         - make
         - lint
     annotations:
-      testgrid-dashboards: sig-aws-load-balancer-controller
+      testgrid-dashboards: provider-aws-load-balancer-controller
       testgrid-tab-name: lint
       description: aws load balancer controller code lint
       testgrid-num-columns-recent: '30'
@@ -40,7 +40,7 @@ presubmits:
         secret:
           secretName: k8s-aws-alb-ingress-coveralls-token
     annotations:
-      testgrid-dashboards: sig-aws-load-balancer-controller
+      testgrid-dashboards: provider-aws-load-balancer-controller
       testgrid-tab-name: unit test
       description: aws load balancer controller unit tests
       testgrid-num-columns-recent: '30'
@@ -63,7 +63,7 @@ presubmits:
         securityContext:
           privileged: true
     annotations:
-      testgrid-dashboards: sig-aws-load-balancer-controller
+      testgrid-dashboards: provider-aws-load-balancer-controller
       testgrid-tab-name: e2e test
       description: aws load balancer controller e2e tests
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
+++ b/config/jobs/kubernetes/cloud-provider-aws/cloud-provider-aws-config.yaml
@@ -17,7 +17,7 @@ presubmits:
         - make
         - check
     annotations:
-      testgrid-dashboards: sig-aws-cloud-provider-aws
+      testgrid-dashboards: provider-aws-cloud-provider-aws
       testgrid-tab-name: check
       description: aws cloud provider checks
       testgrid-num-columns-recent: '30'
@@ -38,7 +38,7 @@ presubmits:
         - make
         - test
     annotations:
-      testgrid-dashboards: sig-aws-cloud-provider-aws
+      testgrid-dashboards: provider-aws-cloud-provider-aws
       testgrid-tab-name: test
       description: aws cloud provider tests
       testgrid-num-columns-recent: '30'

--- a/config/jobs/kubernetes/kops/build_grid.py
+++ b/config/jobs/kubernetes/kops/build_grid.py
@@ -540,7 +540,7 @@ def generate():
                feature_flags=["EnableExternalCloudController,SpecOverrideFlag"],
                extra_flags=['--override=cluster.spec.cloudControllerManager.cloudProvider=aws',
                             '--override=cluster.spec.cloudConfig.awsEBSCSIDriver.enabled=true'],
-               extra_dashboards=['sig-aws-cloud-provider-aws', 'kops-misc'])
+               extra_dashboards=['provider-aws-cloud-provider-aws', 'kops-misc'])
 
     print("")
     print("# %d jobs, total of %d runs per week" % (job_count, runs_per_week))

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -27318,7 +27318,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-latest, kops-misc, sig-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
+    testgrid-dashboards: google-aws, kops-distro-u2004, kops-k8s-1.19, kops-latest, kops-misc, provider-aws-cloud-provider-aws, sig-cluster-lifecycle-kops
     testgrid-days-of-results: '90'
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 

--- a/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/aws/eks/eks-presubmits.yaml
@@ -34,6 +34,6 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-aws-eks-1-13-correctness
         - --timeout=180m
     annotations:
-      testgrid-dashboards: sig-aws-eks-presubmits
+      testgrid-dashboards: provider-aws-eks-presubmits
       testgrid-tab-name: k8s-eks-1-13-correctness
       description: Kubernetes e2e correctness tests against EKS 1.13 build

--- a/config/testgrids/kubernetes/sig-cloud-provider/aws/config.yaml
+++ b/config/testgrids/kubernetes/sig-cloud-provider/aws/config.yaml
@@ -1,19 +1,19 @@
 dashboard_groups:
-- name: sig-aws
+- name: provider-aws
   dashboard_names:
-    - sig-aws-encryption-provider
-    - sig-aws-load-balancer-controller
-    - sig-aws-cloud-provider-aws
-    - sig-aws-ebs-csi-driver
-    - sig-aws-efs-csi-driver
-    - sig-aws-eks-presubmits
-    - sig-aws-fsx-csi-driver
+    - provider-aws-encryption-provider
+    - provider-aws-load-balancer-controller
+    - provider-aws-cloud-provider-aws
+    - provider-aws-ebs-csi-driver
+    - provider-aws-efs-csi-driver
+    - provider-aws-eks-presubmits
+    - provider-aws-fsx-csi-driver
 
 dashboards:
-- name: sig-aws-encryption-provider
-- name: sig-aws-load-balancer-controller
-- name: sig-aws-cloud-provider-aws
-- name: sig-aws-ebs-csi-driver
-- name: sig-aws-efs-csi-driver
-- name: sig-aws-eks-presubmits
-- name: sig-aws-fsx-csi-driver
+- name: provider-aws-encryption-provider
+- name: provider-aws-load-balancer-controller
+- name: provider-aws-cloud-provider-aws
+- name: provider-aws-ebs-csi-driver
+- name: provider-aws-efs-csi-driver
+- name: provider-aws-eks-presubmits
+- name: provider-aws-fsx-csi-driver

--- a/jobs/validOwners.json
+++ b/jobs/validOwners.json
@@ -3,7 +3,6 @@
    "sig-apps",
    "sig-auth",
    "sig-autoscaling",
-   "sig-aws",
    "sig-azure",
    "sig-big-data",
    "sig-cli",


### PR DESCRIPTION
sig-aws is deprecated and is now a subproject under sig-cloud-provider, this naming change will reflect that.  