### PR TITLE
Post-test-infra-push-prow: Don't get triggered by prow bump

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -162,7 +162,7 @@ postsubmits:
   - name: post-test-infra-push-prow
     cluster: test-infra-trusted
     # Runs on more than just the Prow dir to include some additional images that we publish to gcr.io/k8s-prow.
-    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|prow|ghproxy|label_sync|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)/'
+    run_if_changed: '^(WORKSPACE|load.bzl|repos.bzl|containers.bzl|prow|ghproxy|label_sync/.+\.go|robots/commenter|robots/pr-creator|robots/issue-creator|testgrid/cmd|gcsweb)'
     decorate: true
     branches:
     - ^master$


### PR DESCRIPTION
Currently, a prow bump triggers a prow push because it changes files in
`label_sync/cluster/` which gets matched by the regex. This PR fixes the
regex to:
* Only include go files in label_sync
* Not require a trailing slash, because the matchgroup also contains
  files

/assign @chaodaiG 