### PR TITLE
Handle "Assignee has already been taken"

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -672,28 +672,6 @@ func (c *client) request(r *request, ret interface{}) (int, error) {
 	return statusCode, nil
 }
 
-// Make a request with retries. If ret is not nil, unmarshal the response body
-// into it. Returns an error if the exit code is not one of the provided codes.
-// Returns githubError if HTTP Status Code is not 2xx.
-func (c *client) requestWithGitHubError(r *request, ret interface{}) (int, githubError, error) {
-	statusCode, b, err := c.requestRaw(r)
-	if err != nil {
-		return statusCode, githubError{}, err
-	}
-	if ret != nil && statusCode > 199 && statusCode < 300 {
-		if err := json.Unmarshal(b, ret); err != nil {
-			return statusCode, githubError{}, err
-		}
-		return statusCode, githubError{}, nil
-	}
-
-	ghe := githubError{}
-	if err := json.Unmarshal(b, &ghe); err != nil {
-		return statusCode, githubError{}, err
-	}
-	return statusCode, ghe, nil
-}
-
 // requestRaw makes a request with retries and returns the response body.
 // Returns an error if the exit code is not one of the provided codes.
 func (c *client) requestRaw(r *request) (int, []byte, error) {
@@ -2312,8 +2290,7 @@ func (c *client) AddLabel(org, repo string, number int, label string) error {
 }
 
 type githubError struct {
-	Message string   `json:"message,omitempty"`
-	Errors  []string `json:"errors,omitempty"`
+	Message string `json:"message,omitempty"`
 }
 
 // RemoveLabel removes label from org/repo#number, returning an error on any failure.
@@ -2378,27 +2355,24 @@ func (c *client) AssignIssue(org, repo string, number int, logins []string) erro
 
 	assigned := make(map[string]bool)
 	var i Issue
-	httpStatusCode, githubError, err := c.requestWithGitHubError(&request{
+	httpStatusCode, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/assignees", org, repo, number),
 		requestBody: map[string][]string{"assignees": logins},
-		exitCodes: []int{
-			http.StatusCreated,             //201
-			http.StatusUnprocessableEntity, //422
-		},
+		exitCodes:   []int{http.StatusCreated}, //201
 	}, &i)
 	if err != nil {
-		return err
-	}
-	if httpStatusCode == http.StatusUnprocessableEntity {
-		if githubError.Message == "Validation Failed" && githubError.Errors != nil && len(githubError.Errors) == 1 &&
-			githubError.Errors[0] == "Could not add assignees: Validation failed: Assignee has already been taken" {
-			c.logger.WithFields(logrus.Fields{
-				"org": org, "repo": repo, "number": number, "users": logins, "httpStatusCode": httpStatusCode, "githubError": githubError,
-			}).Debug("User was already assigned")
-			return nil
+		if reqErr, isReqErr := err.(requestError); isReqErr && (httpStatusCode == http.StatusUnprocessableEntity) {
+			if altClientErr, isAltClientErr := reqErr.ClientError.(AlternativeClientError); isAltClientErr &&
+				altClientErr.Message == "Validation Failed" && altClientErr.Errors != nil && len(altClientErr.Errors) == 1 &&
+				altClientErr.Errors[0] == "Could not add assignees: Validation failed: Assignee has already been taken" {
+				c.logger.WithFields(logrus.Fields{
+					"org": org, "repo": repo, "number": number, "users": logins, "httpStatusCode": httpStatusCode, "altClientErr": altClientErr,
+				}).Debug("User was already assigned")
+				return nil
+			}
 		}
-		return fmt.Errorf("AssignIssue(%v,%v, %v, %v) failed with status: %v, response: %#v", org, repo, number, logins, httpStatusCode, githubError)
+		return err
 	}
 	for _, assignee := range i.Assignees {
 		assigned[NormLogin(assignee.Login)] = true

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -846,11 +846,11 @@ func TestAssignIssue422Other(t *testing.T) {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 
-		ge := &githubError{
+		altClientErr := &AlternativeClientError{
 			Message: "Some Other failure",
 			Errors:  []string{"error 1"},
 		}
-		b, err := json.Marshal(&ge)
+		b, err := json.Marshal(&altClientErr)
 		if err != nil {
 			t.Fatalf("Didn't expect error: %v", err)
 		}
@@ -872,11 +872,12 @@ func TestAssignIssue422AlreadyAssigned(t *testing.T) {
 			t.Errorf("Bad request path: %s", r.URL.Path)
 		}
 
-		ge := &githubError{
-			Message: "Validation Failed",
-			Errors:  []string{"Could not add assignees: Validation failed: Assignee has already been taken"},
+		altClientErr := &AlternativeClientError{
+			Message:          "Validation Failed",
+			Errors:           []string{"Could not add assignees: Validation failed: Assignee has already been taken"},
+			DocumentationURL: "https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue",
 		}
-		b, err := json.Marshal(&ge)
+		b, err := json.Marshal(&altClientErr)
 		if err != nil {
 			t.Fatalf("Didn't expect error: %v", err)
 		}
@@ -885,7 +886,7 @@ func TestAssignIssue422AlreadyAssigned(t *testing.T) {
 	defer ts.Close()
 	c := getClient(ts.URL)
 	if err := c.AssignIssue("k8s", "kuber", 5, []string{"george", "jungle"}); err != nil {
-		t.Errorf("Got unexpected error %v", err)
+		t.Errorf("Got unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
Handle the following response...
https://docs.github.com/en/free-pro-team@latest/rest/reference/issues#add-assignees-to-an-issue
HTTP Status Code: 422

```
{
	"message":"Validation Failed",
	"errors":["Could not add assignees: Validation failed: Assignee has already been taken"],
	"documentation_url":"https://developer.github.com/v3/issues/assignees/#add-assignees-to-an-issue"
}
```
Fixes #16145 