### PR TITLE
[Kettle] Extend error message with information on unfound path

### DIFF
--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -71,7 +71,7 @@ class GCSClient:
     @staticmethod
     def _parse_uri(path):
         if not path.startswith('gs://'):
-            raise ValueError("Bad GCS path")
+            raise ValueError("Bad path: %s, should start with 'gs://" % path)
         bucket, prefix = path[5:].split('/', 1)
         return bucket, prefix
 

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -71,7 +71,7 @@ class GCSClient:
     @staticmethod
     def _parse_uri(path):
         if not path.startswith('gs://'):
-            raise ValueError("Bad path: %s, should start with 'gs://" % path)
+            raise ValueError("Bad path: %s, should start with 'gs://'" % path)
         bucket, prefix = path[5:].split('/', 1)
         return bucket, prefix
 


### PR DESCRIPTION
#19961 is causing failures in Kettle. There is little context around the path it was trying.