### PR TITLE
Replace SingleCommit with RepositoryCommit

### DIFF
--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -137,7 +137,7 @@ type PullRequestClient interface {
 type CommitClient interface {
 	CreateStatus(org, repo, SHA string, s Status) error
 	ListStatuses(org, repo, ref string) ([]Status, error)
-	GetSingleCommit(org, repo, SHA string) (SingleCommit, error)
+	GetSingleCommit(org, repo, SHA string) (RepositoryCommit, error)
 	GetCombinedStatus(org, repo, ref string) (*CombinedStatus, error)
 	ListCheckRuns(org, repo, ref string) (*CheckRunList, error)
 	GetRef(org, repo, ref string) (string, error)
@@ -2032,11 +2032,11 @@ func (c *client) GetRepos(org string, isUser bool) ([]Repo, error) {
 // GetSingleCommit returns a single commit.
 //
 // See https://developer.github.com/v3/repos/#get
-func (c *client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
+func (c *client) GetSingleCommit(org, repo, SHA string) (RepositoryCommit, error) {
 	durationLogger := c.log("GetSingleCommit", org, repo, SHA)
 	defer durationLogger()
 
-	var commit SingleCommit
+	var commit RepositoryCommit
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/commits/%s", org, repo, SHA),

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -51,7 +51,7 @@ type FakeClient struct {
 	CombinedStatuses    map[string]*github.CombinedStatus
 	CreatedStatuses     map[string][]github.Status
 	IssueEvents         map[int][]github.ListedIssueEvent
-	Commits             map[string]github.SingleCommit
+	Commits             map[string]github.RepositoryCommit
 
 	// All Labels That Exist In The Repo
 	RepoLabelsExisting []string
@@ -281,7 +281,7 @@ func (f *FakeClient) DeleteRef(owner, repo, ref string) error {
 }
 
 // GetSingleCommit returns a single commit.
-func (f *FakeClient) GetSingleCommit(org, repo, SHA string) (github.SingleCommit, error) {
+func (f *FakeClient) GetSingleCommit(org, repo, SHA string) (github.RepositoryCommit, error) {
 	return f.Commits[SHA], nil
 }
 

--- a/prow/github/types.go
+++ b/prow/github/types.go
@@ -822,14 +822,6 @@ type Commit struct {
 	Modified []string `json:"modified"`
 }
 
-// SingleCommit is the commit part received when requesting a single commit
-// https://developer.github.com/v3/repos/commits/#get-a-single-commit
-type SingleCommit struct {
-	Commit struct {
-		Tree Tree `json:"tree"`
-	} `json:"commit"`
-}
-
 // Tree represents a GitHub tree.
 type Tree struct {
 	SHA string `json:"sha,omitempty"`
@@ -1092,6 +1084,7 @@ type Milestone struct {
 // RepositoryCommit represents a commit in a repo.
 // Note that it's wrapping a GitCommit, so author/committer information is in two places,
 // but contain different details about them: in RepositoryCommit "github details", in GitCommit - "git details".
+// Get single commit also use it, see: https://developer.github.com/v3/repos/commits/#get-a-single-commit.
 type RepositoryCommit struct {
 	NodeID      string      `json:"node_id,omitempty"`
 	SHA         string      `json:"sha,omitempty"`

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -132,7 +132,7 @@ type githubClient interface {
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	DeleteComment(org, repo string, ID int) error
 	BotName() (string, error)
-	GetSingleCommit(org, repo, SHA string) (github.SingleCommit, error)
+	GetSingleCommit(org, repo, SHA string) (github.RepositoryCommit, error)
 	IsMember(org, user string) (bool, error)
 	ListTeams(org string) ([]github.Team, error)
 	ListTeamMembers(id int, role string) ([]github.TeamMember, error)

--- a/prow/plugins/lgtm/lgtm_test.go
+++ b/prow/plugins/lgtm/lgtm_test.go
@@ -995,12 +995,12 @@ func TestHandlePullRequest(t *testing.T) {
 						},
 					},
 				},
-				Commits:          make(map[string]github.SingleCommit),
+				Commits:          make(map[string]github.RepositoryCommit),
 				Collaborators:    []string{"collab"},
 				IssueLabelsAdded: c.IssueLabelsAdded,
 			}
 			fakeGitHub.IssueLabelsAdded = append(fakeGitHub.IssueLabelsAdded, "kubernetes/kubernetes#101:lgtm")
-			commit := github.SingleCommit{}
+			commit := github.RepositoryCommit{}
 			commit.Commit.Tree.SHA = treeSHA
 			fakeGitHub.Commits[SHA] = commit
 			pc := &plugins.Configuration{}
@@ -1095,7 +1095,7 @@ func TestAddTreeHashComment(t *testing.T) {
 				body:   "/lgtm",
 			}
 			fc := &fakegithub.FakeClient{
-				Commits:       make(map[string]github.SingleCommit),
+				Commits:       make(map[string]github.RepositoryCommit),
 				IssueComments: map[int][]github.IssueComment{},
 				PullRequests: map[int]*github.PullRequest{
 					101: {
@@ -1109,7 +1109,7 @@ func TestAddTreeHashComment(t *testing.T) {
 				},
 				Collaborators: []string{"collab1", "collab2"},
 			}
-			commit := github.SingleCommit{}
+			commit := github.RepositoryCommit{}
 			commit.Commit.Tree.SHA = treeSHA
 			fc.Commits[SHA] = commit
 			handle(true, pc, &fakeOwnersClient{}, rc, fc, logrus.WithField("plugin", PluginName), &fakePruner{})


### PR DESCRIPTION
Because `RepositoryCommit` also meets the structural requirements in the https://developer.github.com/v3/repos/commits/#get-a-single-commit link.  So I think we should replace it with  RepositoryCommit.