### PR TITLE
Enable endpointslice updates batching in 5k tests

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -92,6 +92,8 @@ periodics:
       - --env=CL2_ENABLE_DENSITY_TEST=true
       - --env=CL2_LOAD_TEST_THROUGHPUT=50
       - --env=CL2_DELETE_TEST_THROUGHPUT=30
+      # Overrides CONTROLLER_MANAGER_TEST_ARGS from preset-e2e-scalability-periodics.
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=100 --kube-api-burst=100 --endpointslice-updates-batch-period=500ms
       - --test=false
       - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
       - --test-cmd-args=cluster-loader2


### PR DESCRIPTION
This should help with https://github.com/kubernetes/kubernetes/issues/96038

We cannot add this to any existing preset as they are shared between different k8s versions while not all of them supports this flag + we don't want to enable this in one batch.

/assign @wojtek-t 