### PR TITLE
CAPZ: set LOCAL_ONLY to false for periodic capi-e2e job

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-azure/cluster-api-provider-azure-periodics.yaml
@@ -57,6 +57,8 @@ periodics:
       env:
         - name: GINKGO_FOCUS
           value: "Cluster API E2E tests"
+        - name: LOCAL_ONLY
+          value: "false"
       # docker-in-docker needs privileged mode
       securityContext:
         privileged: true


### PR DESCRIPTION
Realized we never set `LOCAL_ONLY` to `false` for the periodic capi-e2e job so it wasn't running the self hosted cluster spec. It already has the right presets.

/assign @devigned @nader-ziada 