### PR TITLE
[Kettle] Skip jobs with malformed json data

### DIFF
--- a/kettle/model.py
+++ b/kettle/model.py
@@ -62,6 +62,8 @@ class Database:
                 ' and started_json IS NOT NULL and finished_json IS NULL',
                 (jobs_dir + '\x00', jobs_dir + '\x7f')):
             started = json.loads(started_json)
+            if 'timestamp' not in started.keys():
+                continue # malformed started
             if int(started['timestamp']) < time.time() - 60*60*24*5:
                 # over 5 days old, no need to try looking for finished any more.
                 builds_have.add(path_tuple(path))


### PR DESCRIPTION
Some jobs seem to have malformed or non-existent: job data Ex. `<build>.txt`, `started.json`, or `finished.json`. These causes failures in Kettle when attempts are made to pull. These failures causes kettle to completely break 11/11 causing #19961

I have this image running in staging and so far it has not hit the same issue and passed the make_db steps. I will keep watch with this change and make sure there are not jobs we expect to be added getting left out. 

Also changed some loggers back to prints because the loggers are suppressed till failure. 