### PR TITLE
Kops - update kubetest2's binary path with new rules_go location

### DIFF
--- a/config/jobs/kubernetes/kops/kops-presubmits.yaml
+++ b/config/jobs/kubernetes/kops/kops-presubmits.yaml
@@ -137,7 +137,7 @@ presubmits:
             -v 2
             --build --up --down
             --cloud-provider=aws
-            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux_amd64_pure_stripped/kops
+            --kops-binary-path=/home/prow/go/src/k8s.io/kops/bazel-bin/cmd/kops/linux-amd64/kops
           ;
         # docker-in-docker needs privileged mode
         securityContext:


### PR DESCRIPTION
ref: https://github.com/kubernetes/kops/pull/10240/files#diff-93c44391a39b06027e002731a3641a607d8a2016fdbf0324bc81026b58f6804bR129-R134

/cc @hakman