### PR TITLE
releng/vulndash: increase job timeout for debugging

### DIFF
--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -94,6 +94,8 @@ periodics:
   cluster: k8s-infra-prow-build-trusted
   max_concurrency: 1
   decorate: true
+  decoration_config:
+    timeout: 6h
   extra_refs:
   - org: kubernetes
     repo: release
@@ -109,6 +111,7 @@ periodics:
         - --project=k8s-artifacts-prod
         - --bucket=k8s-artifacts-prod-vuln-dashboard
         - --dashboard-file-path=/home/prow/go/src/github.com/kubernetes/release/cmd/vulndash/
+        - --log-level=debug
       resources:
         requests:
           cpu: 2


### PR DESCRIPTION
Increasing the job timeout for debugging purposes since the job is failing due timeout and adding debug level

Will add more debug logs in the service


Discussion here: https://github.com/kubernetes/release/issues/1665#issuecomment-730526470

/assign @spiffxp 