### PR TITLE
Fix testgrid prefix problem for knative

### DIFF
--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -46,6 +46,7 @@ var (
 		"istio",
 		"googleoss",
 		"google",
+		"knative", // This allows both "knative" and "knative-sandbox", as well as "knative-google"
 		"kopeio",
 		"redhat",
 		"vmware",


### PR DESCRIPTION
Transfigure requires explicit allowed prefix for a dashboard group name, adding knative here so that we can add new dashboard group names for knative

@joshua-bone 

/cc @chases2 @michelle192837 