### PR TITLE
Skip adding results for malformed test data

### DIFF
--- a/kettle/model.py
+++ b/kettle/model.py
@@ -166,9 +166,13 @@ class Database:
         for dataz, in self.db.execute(
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
-            data = zlib.decompress(dataz).decode('utf-8')
-            if data:
-                results.append(data)
+            try:
+                data = zlib.decompress(dataz).decode('utf-8', 'replace')
+                if data:
+                    results.append(data)
+            except UnicodeDecodeError:
+                print(f'Failed to decode data for {path}')
+                break
         return results
 
     def get_oldest_emitted(self, incremental_table):


### PR DESCRIPTION
/area kettle

#19732 fix (the malformed jobs only exist in the Prod DB so I can't test in staging without injecting bad data)

The malformed data is with good data so I try to run a replace on the bad characters to get what we can.

All of these jobs seem extremely old and I can not find them in prow history. 