### PR TITLE
account for group names which have other group names as prefixes

### DIFF
--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -328,18 +328,17 @@ func TestConfig(t *testing.T) {
 			}
 		}
 
-		// All dashboards must be prefixed with their group.
-		for dashboard := range dashboardmap {
-			assignedGroup, ok := dashboardToGroupMap[dashboard]
-			if !ok {
-				t.Errorf("Dashboard %v did not have an assigned group", dashboard)
-			} else if !strings.HasPrefix(dashboard, assignedGroup+"-") {
-				t.Errorf("Dashboard %v is not prefixed with its assigned group %v", dashboard, assignedGroup)
-			}
-		}
 	}
 
-	// Dashboards
+	// All dashboards must be prefixed with their group.
+	for dashboard := range dashboardmap {
+		assignedGroup, ok := dashboardToGroupMap[dashboard]
+		if !ok {
+			t.Errorf("Dashboard %v did not have an assigned group", dashboard)
+		} else if !strings.HasPrefix(dashboard, assignedGroup+"-") {
+			t.Errorf("Dashboard %v is not prefixed with its assigned group %v", dashboard, assignedGroup)
+		}
+	}
 
 	// All Testgroup should be mapped to one or more tabs
 	missedTestgroups := false

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -319,7 +319,7 @@ func TestConfig(t *testing.T) {
 				dashboardToGroupMap[dashboard] = dashboardGroup.Name
 			}
 
-			if dashboardSet.Has(dashboard) {
+			if !dashboardSet.Has(dashboard) {
 				t.Errorf("Dashboard %v needs to be defined before adding to a dashboard group!", dashboard)
 			}
 

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -344,7 +344,7 @@ func TestConfig(t *testing.T) {
 		}
 	}
 
-	// All Testgroup should be mapped to one or more dashboardToGroupMap
+	// All Testgroup should be mapped to one or more tabs
 	missedTestgroups := false
 	for testgroupname, occurrence := range testgroupMap {
 		if occurrence == 1 {

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -171,7 +171,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// dashboard name set
-	dashboardmap := make(map[string]bool)
+	dashboardSet := sets.NewString()
 
 	for dashboardidx, dashboard := range cfg.Dashboards {
 		// All dashboard must have a name
@@ -196,10 +196,10 @@ func TestConfig(t *testing.T) {
 		}
 
 		// All dashboard must not have duplicated names
-		if dashboardmap[dashboard.Name] {
+		if dashboardSet.Has(dashboard.Name) {
 			t.Errorf("Duplicated dashboard: %v", dashboard.Name)
 		} else {
-			dashboardmap[dashboard.Name] = true
+			dashboardSet.Insert(dashboard.Name)
 		}
 
 		// All dashboard must have at least one tab
@@ -275,7 +275,7 @@ func TestConfig(t *testing.T) {
 	}
 
 	// No dup of dashboard groups, and no dup dashboard in a dashboard group
-	groupSet := make(map[string]bool)
+	groupSet := sets.NewString()
 	dashboardToGroupMap := make(map[string]string)
 
 	for idx, dashboardGroup := range cfg.DashboardGroups {
@@ -301,25 +301,25 @@ func TestConfig(t *testing.T) {
 		}
 
 		// All dashboardgroup must not have duplicated names
-		if _, ok := groupSet[dashboardGroup.Name]; ok {
+		if groupSet.Has(dashboardGroup.Name) {
 			t.Errorf("Duplicated dashboard: %v", dashboardGroup.Name)
 		} else {
-			groupSet[dashboardGroup.Name] = true
+			groupSet.Insert(dashboardGroup.Name)
 		}
 
-		if _, ok := dashboardmap[dashboardGroup.Name]; ok {
+		if dashboardSet.Has(dashboardGroup.Name) {
 			t.Errorf("%v is both a dashboard and dashboard group name.", dashboardGroup.Name)
 		}
 
 		for _, dashboard := range dashboardGroup.DashboardNames {
 			// All dashboard must not have duplicated names
-			if exist, ok := dashboardToGroupMap[dashboard]; ok {
-				t.Errorf("Duplicated dashboard %v in dashboard group %v and %v", dashboard, exist, dashboardGroup.Name)
+			if assignedGroup, ok := dashboardToGroupMap[dashboard]; ok {
+				t.Errorf("Duplicated dashboard %v in dashboard group %v and %v", dashboard, assignedGroup, dashboardGroup.Name)
 			} else {
 				dashboardToGroupMap[dashboard] = dashboardGroup.Name
 			}
 
-			if _, ok := dashboardmap[dashboard]; !ok {
+			if dashboardSet.Has(dashboard) {
 				t.Errorf("Dashboard %v needs to be defined before adding to a dashboard group!", dashboard)
 			}
 
@@ -327,20 +327,24 @@ func TestConfig(t *testing.T) {
 				t.Errorf("Dashboard %v in group %v must have the group name as a prefix", dashboard, dashboardGroup.Name)
 			}
 		}
-
 	}
 
-	// All dashboards must be prefixed with their group.
-	for dashboard := range dashboardmap {
-		assignedGroup, ok := dashboardToGroupMap[dashboard]
-		if !ok {
-			t.Errorf("Dashboard %v did not have an assigned group", dashboard)
-		} else if !strings.HasPrefix(dashboard, assignedGroup+"-") {
-			t.Errorf("Dashboard %v is not prefixed with its assigned group %v", dashboard, assignedGroup)
+	// Dashboards that match this dashboard group's prefix should be a part of it, unless this group is the prefix of the assigned group
+	// (e.g. knative and knative-sandbox).
+	for thisGroup := range groupSet {
+		for dashboard := range dashboardSet {
+			if strings.HasPrefix(dashboard, thisGroup+"-") {
+				assignedGroup, ok := dashboardToGroupMap[dashboard]
+				if !ok {
+					t.Errorf("Dashboard %v should be in dashboard_group %v", dashboard, thisGroup)
+				} else if assignedGroup != thisGroup && !strings.HasPrefix(assignedGroup, thisGroup) {
+					t.Errorf("Dashboard %v should be in dashboard_group %v instead of dashboard_group %v", dashboard, thisGroup, assignedGroup)
+				}
+			}
 		}
 	}
 
-	// All Testgroup should be mapped to one or more tabs
+	// All Testgroup should be mapped to one or more dashboardToGroupMap
 	missedTestgroups := false
 	for testgroupname, occurrence := range testgroupMap {
 		if occurrence == 1 {

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -330,12 +330,17 @@ func TestConfig(t *testing.T) {
 
 		// Dashboards that match this dashboard group's prefix should be a part of it
 		for dashboard := range dashboardmap {
-			if strings.HasPrefix(dashboard, dashboardGroup.Name+"-") {
-				group, ok := tabs[dashboard]
+			thisGroup := dashboardGroup.Name
+			if strings.HasPrefix(dashboard, thisGroup+"-") {
+				assignedGroup, ok := tabs[dashboard]
 				if !ok {
-					t.Errorf("Dashboard %v should be in dashboard_group %v", dashboard, dashboardGroup.Name)
-				} else if group != dashboardGroup.Name {
-					t.Errorf("Dashboard %v should be in dashboard_group %v instead of dashboard_group %v", dashboard, dashboardGroup.Name, group)
+					t.Errorf("Dashboard %v should be in dashboard_group %v", dashboard, thisGroup)
+				} else if assignedGroup != thisGroup {
+					// If the assigned group includes this group name as a prefix (e.g. 'knative-sandbox' and 'knative')
+					// then the arrangment is ok. Otherwise, this group should be the assigned group.
+					if !strings.HasPrefix(dashboard, assignedGroup+"-") {
+						t.Errorf("Dashboard %v should be in dashboard_group %v instead of dashboard_group %v", dashboard, thisGroup, assignedGroup)
+					}
 				}
 			}
 		}

--- a/config/tests/testgrids/config_test.go
+++ b/config/tests/testgrids/config_test.go
@@ -337,7 +337,7 @@ func TestConfig(t *testing.T) {
 					t.Errorf("Dashboard %v should be in dashboard_group %v", dashboard, thisGroup)
 				} else if assignedGroup != thisGroup {
 					// If the assigned group includes this group name as a prefix (e.g. 'knative-sandbox' and 'knative')
-					// then the arrangment is ok. Otherwise, this group should be the assigned group.
+					// then the arrangement is ok. Otherwise, this group should be the assigned group.
 					if !strings.HasPrefix(dashboard, assignedGroup+"-") {
 						t.Errorf("Dashboard %v should be in dashboard_group %v instead of dashboard_group %v", dashboard, thisGroup, assignedGroup)
 					}


### PR DESCRIPTION
If the assigned group for a dashboard includes another group name as a prefix
(e.g. 'knative-sandbox' and 'knative') then the test should not fail.