### PR TITLE
Remove useless minio PersistentVolumeClaim

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -1269,15 +1269,3 @@ subjects:
 - kind: ServiceAccount
   name: crier
   namespace: prow
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: minio
-  namespace: prow
-spec:
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 100Gi


### PR DESCRIPTION
It seems that we are not using this `minio` PersistentVolumeClaim. So I deleted it.

