### PR TITLE
Revert "Fix config file stopping autobumper from working"

### DIFF
--- a/config/jobs/kubernetes/test-infra/autobump-config.yaml
+++ b/config/jobs/kubernetes/test-infra/autobump-config.yaml
@@ -16,8 +16,7 @@ excludedConfigPaths:
 extraFiles:
   - "config/jobs/kubernetes/kops/build-grid.py"
   - "config/jobs/kubernetes/kops/build-pipeline.py"
-  - "releng/generate_tests.py"
-  - "images/kubekins-e2e/Dockerfile"
+  - "releng/generate_tests.py,images/kubekins-e2e/Dockerfile"
 targetVersion: "latest"
 prefixes:
   - name: "Prow"


### PR DESCRIPTION
Reverts kubernetes/test-infra#20000

Reverting this so we can revert larger autobumper change: https://github.com/kubernetes/test-infra/pull/19913