### PR TITLE
Run master-informing capg against release-1.19

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -208,7 +208,7 @@ periodics:
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes
-      base_ref: master
+      base_ref: release-1.19
       path_alias: k8s.io/kubernetes
   spec:
     containers:


### PR DESCRIPTION
This is a temporary fix to make the capg master-informing job run
against the release-1.19 conformance tests while it is using the latest
stable kubernetes version from 1.19.

This should be followed by investigating whether CAPI jobs should be on
any master dashboards for testgrid when they are running against older
branches.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

Follow up to https://github.com/kubernetes/test-infra/pull/19752

Fixes https://github.com/kubernetes/kubernetes/issues/96055

/assign @cpanato @detiber 