### PR TITLE
Add missing comment on an exported function at prow/git

### DIFF
--- a/prow/git/git.go
+++ b/prow/git/git.go
@@ -460,6 +460,8 @@ func retryCmd(l *logrus.Entry, dir, cmd string, arg ...string) ([]byte, error) {
 	return b, err
 }
 
+// Diff runs 'git diff HEAD <sha> --name-only' and returns a list
+// of file names with upcoming changes
 func (r *Repo) Diff(head, sha string) (changes []string, err error) {
 	r.logger.Infof("Diff head with %s'.", sha)
 	output, err := r.gitCommand("diff", head, sha, "--name-only").CombinedOutput()


### PR DESCRIPTION
Add  comment to exported function `git.Repo.Diff` 

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>