### PR TITLE
add 100-node higher QPS limit scheduler job

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -190,7 +190,7 @@ periodics:
       - --repo=k8s.io/kubernetes=master
       - --repo=k8s.io/perf-tests=master
       - --root=/go/src
-      - --timeout=260
+      - --timeout=170
       - --scenario=kubernetes_e2e
       - --
       - --cluster=kubemark-100
@@ -219,7 +219,7 @@ periodics:
       - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
       - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
       - --test-cmd-name=ClusterLoaderV2
-      - --timeout=240m
+      - --timeout=150m
       - --use-logexporter
       # docker-in-docker needs privileged mode
       securityContext:
@@ -270,10 +270,8 @@ periodics:
       - --kubemark
       - --kubemark-nodes=100
       - --provider=gce
-      - --env=KUBE_SCHEDULER_API_QPS=300
-      - --env=KUBE_SCHEDULER_API_BURST=300
-      - --env=KUBE_CONTROLLER_MANAGER_API_QPS=300
-      - --env=KUBE_CONTROLLER_MANAGER_API_BURST=300
+      - --env=CONTROLLER_MANAGER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
+      - --env=SCHEDULER_TEST_ARGS=--profiling --kube-api-qps=300 --kube-api-burst=300
       - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
       - --test=false
       - --test_args=--ginkgo.focus=xxxx

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-periodic-jobs.yaml
@@ -232,6 +232,74 @@ periodics:
           cpu: 2
           memory: "2Gi"
 
+- name: ci-kubernetes-kubemark-100-gce-scheduler-highqps
+  tags:
+  - "perfDashPrefix: kubemark-100Nodes-scheduler-highqps"
+  - "perfDashJobType: performance"
+  interval: 24h
+  labels:
+    preset-service-account: "true"
+    preset-k8s-ssh: "true"
+    preset-dind-enabled: "true"
+    preset-e2e-kubemark-common: "true"
+    preset-e2e-scalability-periodics: "true"
+    preset-e2e-scalability-periodics-master: "true"
+  annotations:
+    testgrid-dashboards: sig-scalability-kubemark
+    testgrid-tab-name: kubemark-100-scheduler-highqps
+    testgrid-num-failures-to-alert: '1'
+  spec:
+    containers:
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-master
+      args:
+      - --repo=k8s.io/kubernetes=master
+      - --repo=k8s.io/perf-tests=master
+      - --root=/go/src
+      - --timeout=170
+      - --scenario=kubernetes_e2e
+      - --
+      - --cluster=kubemark-100-scheduler-highqps
+      - --build=bazel
+      - --extract=bazel
+      - --gcp-master-size=e2-standard-2
+      - --gcp-node-image=gci
+      - --gcp-node-size=e2-standard-4
+      - --gcp-nodes=4
+      - --gcp-project-type=scalability-project
+      - --gcp-zone=us-east1-b
+      - --kubemark
+      - --kubemark-nodes=100
+      - --provider=gce
+      - --env=KUBE_SCHEDULER_API_QPS=300
+      - --env=KUBE_SCHEDULER_API_BURST=300
+      - --env=KUBE_CONTROLLER_MANAGER_API_QPS=300
+      - --env=KUBE_CONTROLLER_MANAGER_API_BURST=300
+      - --env=CL2_ENABLE_CLUSTER_OOMS_TRACKER=true
+      - --test=false
+      - --test_args=--ginkgo.focus=xxxx
+      - --test-cmd=$GOPATH/src/k8s.io/perf-tests/run-e2e.sh
+      - --test-cmd-args=cluster-loader2
+      - --test-cmd-args=--nodes=100
+      - --test-cmd-args=--prometheus-scrape-node-exporter=true
+      - --test-cmd-args=--provider=kubemark
+      - --test-cmd-args=--report-dir=/workspace/_artifacts
+      - --test-cmd-args=--testsuite=testing/density/scheduler-suite.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/enable_restart_count_check.yaml
+      - --test-cmd-args=--testoverrides=./testing/experiments/use_simple_latency_query.yaml
+      - --test-cmd-name=ClusterLoaderV2
+      - --timeout=150m
+      - --use-logexporter
+      # docker-in-docker needs privileged mode
+      securityContext:
+        privileged: true
+      resources:
+        requests:
+          cpu: 2
+          memory: "2Gi"
+        limits:
+          cpu: 2
+          memory: "2Gi"
+
 - name: ci-kubernetes-kubemark-500-gce
   tags:
   - "perfDashPrefix: kubemark-500Nodes"


### PR DESCRIPTION
/hold until https://github.com/kubernetes/kubernetes/pull/96813 is merged

So sig/scheduling has made numerous improvements to the scheduler over the past few releases, but these improvements have not been realised in practice due to the scheduler's QPS limits. With API priority and fairness being graduated to beta in 1.20 (https://github.com/kubernetes/kubernetes/pull/96527), we now have a path towards safely removing the scheduler's rate limiting in the 1.21+.

Of course, this would need to be done slowly. @ahg-g and I discussed this offline and we believe that increasing the scheduler's QPS limit (not removing) in 1.21 is the first step. Once things are observed to be stable over a couple of releases, the client-side rate limiting will be entirely limit and kube-scheduler will depend on APF to make sure it doesn't overload the API server.

While I have done some preliminary benchmarking of APF with higher scheduler QPS limits (not public yet, will share with everyone in a short while), there would be more confidence in this approach if there were public, periodic benchmarks that run on test-infra. The results could be displayed in perf-dash. These benchmarks should run on the higher QPS limit. The job should be carefully observed for signs of instability. The job would be temporary and is only expected to run for a 3-4 releases; once the scheduler's client-side QPS limits are removed, just the regular job (`ci-kubernetes-kubemark-100-gce`) would be sufficient.

A separate job is needed to do this because all changes happen during cluster creation. As a result, existing jobs cannot be re-used for this.

/sig scheduling
cc @ahg-g 