### PR TITLE
Adding COSI controller to testgrid

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -38,7 +38,7 @@ readonly BROKEN_REPOS=(
     kubernetes-csi/csi-driver-iscsi
     kubernetes-csi/csi-driver-nfs
     kubernetes-csi/csi-proxy
-    kubernetes-sigs/container-object-storage-interface-api
+    kubernetes-sigs/container-object-storage-interface-controller
 )
 
 cat >"${OUTPUT}" <<EOF

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -407,8 +407,8 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
-  kubernetes-sigs/container-object-storage-interface-api:
-    - name: post-container-object-storage-interface-api-push-images
+  kubernetes-sigs/container-object-storage-interface-controller:
+    - name: post-container-object-storage-interface-controller-push-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
         testgrid-dashboards: sig-storage-image-build

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-controller.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/container-object-storage-interface-controller:
+  - name: pull-container-object-storage-interface-controller-build
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-controller
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-controller
+      testgrid-tab-name: build
+      description: Build test in container-object-storage-interface-controller repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        # Plain make runs also verify
+        - make
+
+  - name: pull-container-object-storage-interface-controller-unit
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-controller
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-controller
+      testgrid-tab-name: unit
+      description: Unit tests in container-object-storage-interface-controller repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        - make
+        args:
+        - test

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -15,6 +15,7 @@ dashboard_groups:
     - sig-storage-csi-other
     - sig-storage-image-build
     - sig-storage-container-object-storage-interface-api
+    - sig-storage-container-object-storage-interface-controller
 
 dashboards:
 - name: sig-storage-kubernetes
@@ -117,3 +118,4 @@ dashboards:
 - name: sig-storage-lib-external-provisioner
 - name: sig-storage-image-build
 - name: sig-storage-container-object-storage-interface-api
+- name: sig-storage-container-object-storage-interface-controller


### PR DESCRIPTION
This PR adds Container Object Storage component 'controller' to the CI process.
<continuation of work for COSI : https://github.com/kubernetes/test-infra/pull/19831>
/sig-storage
ping @xing-yang @wlan0 
/release-note-none