### PR TITLE
Update kubekins-e2e image for cluster-api-provider-aws

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -17,7 +17,7 @@ periodics:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+    - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
       command:
         - "runner.sh"
         - "./scripts/ci-e2e.sh"
@@ -57,7 +57,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
           - "runner.sh"
           - "./scripts/ci-e2e.sh"
@@ -95,7 +95,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
           - "runner.sh"
           - "./scripts/ci-conformance.sh"
@@ -133,7 +133,7 @@ periodics:
       path_alias: "sigs.k8s.io/cluster-api-provider-aws"
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
           - "runner.sh"
           - "./scripts/ci-e2e-conformance.sh"
@@ -182,7 +182,7 @@ periodics:
     path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         env:
           - name: CAPI_BRANCH
             value: "stable"
@@ -238,7 +238,7 @@ periodics:
       path_alias: k8s.io/kubernetes
   spec:
     containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         env:
           - name: BOSKOS_HOST
             value: "boskos.test-pods.svc.cluster.local"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-periodics.yaml
@@ -260,7 +260,7 @@ periodics:
             # during the tests more like 3-20m is used
             cpu: 2000m
   annotations:
-    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws, sig-release-master-informing
+    testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-aws
     testgrid-tab-name: capa-conformance-v1alpha3-k8s-master
     testgrid-num-columns-recent: '20'
-    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com, release-team@kubernetes.io
+    testgrid-alert-email: kubernetes-sig-cluster-lifecycle-cluster-api-alerts@googlegroups.com

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-postsubmits.yaml
@@ -14,7 +14,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
             command:
               - "runner.sh"
               - "./scripts/ci-e2e.sh"
@@ -50,7 +50,7 @@ postsubmits:
         preset-aws-credential: "true"
       spec:
         containers:
-          - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+          - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
             command:
               - "runner.sh"
               - "./scripts/ci-conformance.sh"

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-aws/cluster-api-provider-aws-presubmits.yaml
@@ -7,7 +7,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
         - "./scripts/ci-test.sh"
     annotations:
@@ -20,7 +20,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
         - "./scripts/ci-build.sh"
     annotations:
@@ -33,7 +33,7 @@ presubmits:
     path_alias: "sigs.k8s.io/cluster-api-provider-aws"
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
         command:
         - "make"
         - "verify"
@@ -68,7 +68,7 @@ presubmits:
       path_alias: k8s.io/kubernetes
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -108,7 +108,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-conformance.sh"
@@ -145,7 +145,7 @@ presubmits:
       preset-aws-credential: "true"
     spec:
       containers:
-        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.18
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-1.19
           command:
             - "runner.sh"
             - "./scripts/ci-e2e.sh"


### PR DESCRIPTION
This PR updates the kubekins-e2e version from 1.18 to 1.19, which uses go v1.15.x.


/hold
until we are close to merge https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2121

cc @randomvariable 