### PR TITLE
releng(kubekins, krte): Update Golang versions to go1.15.5

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -1,26 +1,26 @@
 variants:
   experimental:
     CONFIG: experimental
-    GO_VERSION: 1.15.2
+    GO_VERSION: 1.15.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
     UPGRADE_DOCKER: 'true'
   go-canary:
     CONFIG: go-canary
-    GO_VERSION: 1.15.2
+    GO_VERSION: 1.15.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   master:
     CONFIG: master
-    GO_VERSION: 1.15.2
+    GO_VERSION: 1.15.5
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
   '1.19':
     CONFIG: '1.19'
-    GO_VERSION: 1.15.2
+    GO_VERSION: 1.15.5
     K8S_RELEASE: latest-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/1651.
Ready to land, now that the k/k go1.15.5 PR has merged https://github.com/kubernetes/kubernetes/pull/95776.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 

FYI @BenTheElder on krte.