### PR TITLE
Tide: Degrade error writing http response to debug

### DIFF
--- a/prow/tide/history/history.go
+++ b/prow/tide/history/history.go
@@ -180,7 +180,7 @@ func (h *History) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		b = []byte("{}")
 	}
 	if _, err = w.Write(b); err != nil {
-		logrus.WithError(err).Error("Writing JSON history response.")
+		logrus.WithError(err).Debug("Writing JSON history response.")
 	}
 }
 


### PR DESCRIPTION
This is expected to happen if the client vanishes, e.G. because we are
currently updating Prow so an old Deck instance gets removed.

Fixes https://github.com/kubernetes/test-infra/issues/19981