### PR TITLE
capg: use k/k master branch since we are using the ci artifacts

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -70,7 +70,7 @@ presubmits:
       path_alias: "sigs.k8s.io/image-builder"
     - org: kubernetes
       repo: kubernetes
-      base_ref: release-1.19
+      base_ref: master
       path_alias: k8s.io/kubernetes
     spec:
       containers:


### PR DESCRIPTION
here: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/blob/master/hack/ci/e2e-conformance.sh#L464 we are pointing to use master branch so we need to use the master branch in the job config as well

/assign @detiber 