### PR TITLE
Storage migrator presubmit: add an optional presubmit that pins a custom build

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -74,8 +74,14 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-fully-automated
-  - name: pull-kube-storage-version-migrator-manually-launched-e2e
+  - name: pull-kube-storage-version-migrator-manually-launched-e2e-optional-custom-build
     decorate: true
+    extra_refs:
+    - org: roycaihw
+      repo: kubernetes
+      base_ref: storage-version/conditions
+      path_alias: k8s.io/kubernetes
+    optional: true
     always_run: true
     labels:
       preset-service-account: "true"
@@ -88,8 +94,10 @@ presubmits:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
         args:
+        - --up
+        - --down
+        - --build=quick
         - --check-leaked-resources
-        - --extract=ci/latest
         - --gcp-master-image=gci
         - --gcp-node-image=gci
         - --gcp-nodes=1
@@ -98,9 +106,11 @@ presubmits:
         - --test=false
         - --test-cmd=../test/e2e/test-cmd.sh
         - --timeout=50m
+        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
+        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
-      testgrid-tab-name: pr-e2e-manually-launched
+      testgrid-tab-name: pr-e2e-manually-launched-optional-custom-build

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -74,3 +74,33 @@ presubmits:
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
       testgrid-tab-name: pr-e2e-fully-automated
+  - name: pull-kube-storage-version-migrator-manually-launched-e2e
+    decorate: true
+    always_run: true
+    labels:
+      preset-service-account: "true"
+      preset-k8s-ssh: "true"
+      preset-dind-enabled: "true"
+    spec:
+      containers:
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-master
+        command:
+        - runner.sh
+        - /workspace/scenarios/kubernetes_e2e.py
+        args:
+        - --check-leaked-resources
+        - --extract=ci/latest
+        - --gcp-master-image=gci
+        - --gcp-node-image=gci
+        - --gcp-nodes=1
+        - --gcp-zone=us-central1-f
+        - --provider=gce
+        - --test=false
+        - --test-cmd=../test/e2e/test-cmd.sh
+        - --timeout=50m
+        # docker-in-docker needs privileged mode
+        securityContext:
+          privileged: true
+    annotations:
+      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
+      testgrid-tab-name: pr-e2e-manually-launched


### PR DESCRIPTION
Taking [this config](https://github.com/kubernetes/test-infra/blob/107eb8136065977533374560bfb94ba97793eadd/config/jobs/kubernetes/sig-network/dualstack-e2e.yaml#L11-L15) as an example. Using a custom build so that we can start early testing the StorageVersionAPI feature.

/assign @caesarxuchao 