### PR TITLE
Migrate nodes of scalability release periodic jobs to e2- family

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -211,6 +211,7 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.16
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -278,7 +279,7 @@ periodics:
       - --extract=ci/latest-1.16
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -288,6 +288,7 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.17
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -358,7 +359,7 @@ periodics:
       - --extract=ci/latest-1.17
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -293,7 +293,7 @@ periodics:
       - --extract=ci/latest-1.18
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -359,6 +359,7 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.18
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -250,7 +250,7 @@ periodics:
       - --extract=ci/latest-1.19
       - --gcp-master-size=n1-standard-4
       - --gcp-node-image=gci
-      - --gcp-node-size=n1-standard-8
+      - --gcp-node-size=e2-standard-8
       - --gcp-nodes=8
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -313,6 +313,7 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.19
       - --gcp-node-image=gci
+      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/20043 but changing the release branches periodics this time.

/sig scalability
/assign @wojtek-t 