### PR TITLE
capg: add e2e-test presubmit job and set some missing resources, also rename the conformance script name

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -73,7 +73,7 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
         command:
           - "runner.sh"
-          - "./scripts/ci-e2e.sh"
+          - "./scripts/ci-conformance.sh"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -218,7 +218,7 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
         command:
           - "runner.sh"
-          - "./scripts/ci-e2e.sh"
+          - "./scripts/ci-conformance.sh"
           - "--use-ci-artifacts"
         # we need privileged mode in order to do docker in docker
         securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -10,6 +10,10 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
         command:
         - "./scripts/ci-test.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-test
@@ -23,6 +27,10 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
         command:
         - "./scripts/ci-build.sh"
+        resources:
+          requests:
+            memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-build
@@ -46,9 +54,50 @@ presubmits:
         resources:
           requests:
             memory: "6Gi"
+            cpu: "2"
     annotations:
       testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
       testgrid-tab-name: pr-make
+  - name: pull-cluster-api-provider-gcp-e2e-test
+    labels:
+      preset-service-account: "true"
+      preset-bazel-scratch-dir: "true"
+      preset-bazel-remote-cache-enabled: "true"
+      preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
+    path_alias: "sigs.k8s.io/cluster-api-provider-gcp"
+    always_run: true
+    optional: true
+    decorate: true
+    decoration_config:
+      timeout: 3h
+    extra_refs:
+    - org: kubernetes-sigs
+      repo: image-builder
+      base_ref: master
+      path_alias: "sigs.k8s.io/image-builder"
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+          env:
+            - name: "BOSKOS_HOST"
+              value: "boskos.test-pods.svc.cluster.local"
+          command:
+            - "runner.sh"
+            - "./scripts/ci-e2e.sh"
+          # we need privileged mode in order to do docker in docker
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              # these are both a bit below peak usage during build
+              # this is mostly for building kubernetes
+              memory: "9000Mi"
+              # during the tests more like 3-20m is used
+              cpu: 2000m
+    annotations:
+      testgrid-dashboards: sig-cluster-lifecycle-cluster-api-provider-gcp
+      testgrid-tab-name: pr-e2e-test
   # conformance test against kubernetes master branch with `kind` + cluster-api-provider-gcp
   - name: pull-cluster-api-provider-gcp-make-conformance
     labels:
@@ -80,7 +129,7 @@ presubmits:
               value: "boskos.test-pods.svc.cluster.local"
           command:
             - "runner.sh"
-            - "./scripts/ci-e2e.sh"
+            - "./scripts/ci-conformance.sh"
             - "--use-ci-artifacts"
           # we need privileged mode in order to do docker in docker
           securityContext:


### PR DESCRIPTION
- Add e2e test presubmit job to CAPG, for now is not mandatory, but will set this as required after the canary phase :)
- rename the conformance script
- set missing resources requests (will set the limits in another pr)

Needed for: https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/334

/assign @detiber @rsmitty
