### PR TITLE
Migrate nodes of scalability presubmit jobs to e2- family

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.16.yaml
@@ -211,7 +211,6 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.16
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -1026,7 +1025,7 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -288,7 +288,6 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.17
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -1107,7 +1106,7 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -359,7 +359,6 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.18
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -1312,7 +1311,7 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -313,7 +313,6 @@ periodics:
       - --cluster=e2e-big
       - --extract=ci/latest-1.19
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b
@@ -1257,7 +1256,7 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-experimental-periodic-jobs.yaml
@@ -75,7 +75,6 @@ periodics:
       - --cluster=e2e-scalability-calico
       - --env=CL2_ENABLE_NETWORKPOLICIES=true
       - --extract=ci/latest
-      - --gcp-node-size=e2-medium
       - --gcp-node-image=gci
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
@@ -123,7 +122,6 @@ periodics:
           - --check-leaked-resources
           - --cluster=e2e-big
           - --extract=ci/latest
-          - --gcp-node-size=e2-medium
           - --gcp-node-image=gci
           - --gcp-nodes=100
           - --gcp-project-type=scalability-project

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -116,7 +116,7 @@ presets:
   env:
   # Override GCE defaults.
   - name: NODE_SIZE
-    value: "n1-standard-1"
+    value: "e2-medium"
   - name: NODE_DISK_SIZE
     value: "50GB"
   - name: REGISTER_MASTER

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presubmit-jobs.yaml
@@ -88,7 +88,7 @@ presubmits:
         - --
         - --build=bazel
         - --cluster=
-        - --env=HEAPSTER_MACHINE_TYPE=n1-standard-4
+        - --env=HEAPSTER_MACHINE_TYPE=e2-standard-4
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-nodes=500
@@ -145,11 +145,11 @@ presubmits:
         - --build=bazel
         - --cluster=gce-cluster
         - --env=CONCURRENT_SERVICE_SYNCS=5
-        - --env=HEAPSTER_MACHINE_TYPE=n1-standard-2
+        - --env=HEAPSTER_MACHINE_TYPE=e2-standard-2
         - --extract=local
         - --gcp-master-image=gci
         - --gcp-node-image=gci
-        - --gcp-node-size=g1-small
+        - --gcp-node-size=e2-small
         - --gcp-nodes=100
         - --gcp-project-type=scalability-project
         - --gcp-ssh-proxy-instance-name=gce-cluster-master
@@ -194,7 +194,7 @@ presubmits:
         - --
         - --build=bazel
         - --cluster=
-        - --env=HEAPSTER_MACHINE_TYPE=n1-standard-8
+        - --env=HEAPSTER_MACHINE_TYPE=e2-standard-8
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-nodes=2000
@@ -262,7 +262,7 @@ presubmits:
         - --extract=local
         - --flush-mem-after-build=true
         - --gcp-master-size=n1-standard-4
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=7
         - --gcp-project-type=scalability-project
         - --gcp-zone=us-east1-b
@@ -333,7 +333,7 @@ presubmits:
         - --cluster=
         - --extract=local
         - --flush-mem-after-build=true
-        - --gcp-node-size=n1-standard-8
+        - --gcp-node-size=e2-standard-8
         - --gcp-nodes=84
         - --gcp-project=k8s-presubmit-scale
         - --gcp-zone=us-east1-b
@@ -492,7 +492,7 @@ presubmits:
             - --cluster=
             - --extract=ci/latest
             - --gcp-master-size=n1-standard-2
-            - --gcp-node-size=n1-standard-4
+            - --gcp-node-size=e2-standard-4
             - --gcp-nodes=4
             - --gcp-project-type=scalability-presubmit-project
             - --gcp-zone=us-east1-b

--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-release-blocking-jobs.yaml
@@ -82,7 +82,6 @@ periodics:
       - --env=KUBE_DNS_MEMORY_LIMIT=300Mi
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=5000
       - --gcp-project=kubernetes-scale
       - --gcp-zone=us-east1-b
@@ -157,7 +156,6 @@ periodics:
       - --extract=ci/latest-fast
       - --extract-ci-bucket=k8s-release-dev
       - --gcp-node-image=gci
-      - --gcp-node-size=e2-medium
       - --gcp-nodes=100
       - --gcp-project-type=scalability-project
       - --gcp-zone=us-east1-b


### PR DESCRIPTION
Finish what we did in https://github.com/kubernetes/test-infra/pull/20047 and https://github.com/kubernetes/test-infra/pull/20043.

/sig scalability