### PR TITLE
added secondary github-graphql-endpoint

### DIFF
--- a/config/prow/cluster/starter-gcs.yaml
+++ b/config/prow/cluster/starter-gcs.yaml
@@ -371,6 +371,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --github-graphql-endpoint=https://api.github.com/graphql
         - --plugin-config=/etc/plugins/plugins.yaml
         - --spyglass=true
         ports:
@@ -495,6 +496,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --github-graphql-endpoint=https://api.github.com/graphql
         - --gcs-credentials-file=/etc/gcs-credentials/service-account.json
         - --status-path=gs://tide/tide-status
         - --history-uri=gs://tide/tide-history.json

--- a/config/prow/cluster/starter-s3.yaml
+++ b/config/prow/cluster/starter-s3.yaml
@@ -369,6 +369,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --github-graphql-endpoint=https://api.github.com/graphql
         - --plugin-config=/etc/plugins/plugins.yaml
         - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --spyglass=true
@@ -493,6 +494,7 @@ spec:
         - --github-endpoint=http://ghproxy
         - --github-endpoint=https://api.github.com
         - --github-graphql-endpoint=http://ghproxy/graphql
+        - --github-graphql-endpoint=https://api.github.com/graphql
         - --s3-credentials-file=/etc/s3-credentials/service-account.json
         - --status-path=s3://tide/tide-status
         - --history-uri=s3://tide/tide-history.json


### PR DESCRIPTION
If ghproxy is down tide/deck should target the github endpoint.