### PR TITLE
releng: Bump k8s-ci-builder to v20201128-v0.6.0-6-g6313f696-default

### DIFF
--- a/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
+++ b/config/jobs/kubernetes/sig-release/kubernetes-builds.yaml
@@ -118,7 +118,7 @@ periodics:
     preset-dind-enabled: "true"
   spec:
     containers:
-    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:default
+    - image: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201128-v0.6.0-6-g6313f696-default
       command:
       - wrapper.sh
       - /krel


### PR DESCRIPTION
Part of https://github.com/kubernetes/release/issues/1711.

I'm getting closer on the ci-kubernetes-build-no-bootstrap job, but need to solve some of the remaining failures:

![Screenshot from 2020-11-29 06-56-13](https://user-images.githubusercontent.com/567897/100541190-164de000-3210-11eb-9227-6670dc9b1dac.png)

Staring at a few of the build logs ([example](https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-build-no-bootstrap/1333011872948948992)):

<details>

```console
wrapper.sh] [INFO] Wrapping Test Command: `/krel ci-build --allow-dup --fast --bucket=k8s-release-dev --gcs-root=ci-no-bootstrap --registry=gcr.io/k8s-staging-ci-images`
wrapper.sh] [INFO] Running in: gcr.io/k8s-staging-releng/k8s-ci-builder:v20201111-v0.5.0-139-g8206b5d8-default
wrapper.sh] [INFO] See: https://github.com/kubernetes/test-infra/blob/master/images/krte/wrapper.sh
================================================================================
wrapper.sh] [SETUP] Performing pre-test setup ...
wrapper.sh] [SETUP] Docker in Docker enabled, initializing ...
Starting Docker: docker.
wrapper.sh] [SETUP] Waiting for Docker to be ready, sleeping for 1 seconds ...
wrapper.sh] [SETUP] Done setting up Docker in Docker.
wrapper.sh] activating service account from GOOGLE_APPLICATION_CREDENTIALS ...
Activated service account credentials for: [prow-build@k8s-infra-prow-build.iam.gserviceaccount.com]
wrapper.sh] [SETUP] Setting SOURCE_DATE_EPOCH for build reproducibility ...
wrapper.sh] [SETUP] exported SOURCE_DATE_EPOCH=1606600608
================================================================================
wrapper.sh] [TEST] Running Test Command: `/krel ci-build --allow-dup --fast --bucket=k8s-release-dev --gcs-root=ci-no-bootstrap --registry=gcr.io/k8s-staging-ci-images` ...
time="2020-11-29T11:38:18Z" level=fatal msg="unknown flag: --gcs-root"
wrapper.sh] [TEST] Test Command exit code: 1
wrapper.sh] [CLEANUP] Cleaning up after Docker in Docker ...
Stopping Docker: dockerProgram process in pidfile '/var/run/docker-ssd.pid', 1 process(es), refused to die.
wrapper.sh] [CLEANUP] Done cleaning up after Docker in Docker.
================================================================================
wrapper.sh] Exiting 1 
```

</details>

You'll see that the cluster has cached a `k8s-ci-builder` which does not include the correct flags to run the `ci-kubernetes-build-no-bootstrap` job.

This PR updates the Prowjob to use a more recent and explicit flag.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @saschagrunert @cpanato @xmudrii 
cc: @kubernetes/release-engineering 