### PR TITLE
Fix panic issues when OrchestratorProfile is not set in aks-engine manifest

### DIFF
--- a/kubetest/aksengine.go
+++ b/kubetest/aksengine.go
@@ -477,6 +477,9 @@ func (c *aksEngineDeployer) populateAPIModelTemplate() error {
 	if c.name != "" {
 		v.Name = c.name
 	}
+	if v.Properties.OrchestratorProfile == nil {
+		v.Properties.OrchestratorProfile = &OrchestratorProfile{}
+	}
 	if c.k8sVersion != "" {
 		v.Properties.OrchestratorProfile.OrchestratorRelease = c.k8sVersion
 	}


### PR DESCRIPTION
Related test job failure [here](https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/96740/pull-kubernetes-e2e-aks-engine-azure/1333252518112661504):

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x19e6f84]
goroutine 1 [running]:
main.(*aksEngineDeployer).populateAPIModelTemplate(0xc0002238c0, 0x52, 0xc00075c1b0)
	/workspace/kubetest/aksengine.go:481 +0x2e4
main.(*aksEngineDeployer).Up(0xc0002238c0, 0xc01511e2d4, 0xe1c43a608d481)
	/workspace/kubetest/aksengine.go:1023 +0x5e
k8s.io/test-infra/kubetest/process.(*Control).XMLWrap(0xc0001b0080, 0x33ff060, 0x1fb636c, 0x2, 0xc00078d3f8, 0x0, 0x0)
	/workspace/kubetest/process/process.go:103 +0x7b
main.run(0x2429ac0, 0xc0002238c0, 0x7fffb7f8a8f0, 0x5, 0x10000, 0x0, 0x0, 0x0, 0x0, 0x7fffb7f8a92e, ...)
	/workspace/kubetest/e2e.go:115 +0x491
main.complete(0xc000327180, 0x0, 0x0)
	/workspace/kubetest/main.go:398 +0x461
main.main()
	/workspace/kubetest/main.go:307 +0x3ef
+ EXIT_VALUE=2
```