### PR TITLE
Metrics also collects prow version timestamp

### DIFF
--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -246,7 +246,7 @@ func (c *Controller) Sync() error {
 func (c *Controller) SyncMetrics() {
 	c.pjLock.RLock()
 	defer c.pjLock.RUnlock()
-	kube.GatherProwJobMetrics(c.pjs)
+	kube.GatherProwJobMetrics(c.log, c.pjs)
 }
 
 // getJenkinsJobs returns all the Jenkins jobs for all active

--- a/prow/kube/BUILD.bazel
+++ b/prow/kube/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//prow/apis/prowjobs/v1:go_default_library",
         "//prow/client/clientset/versioned:go_default_library",
         "//prow/client/clientset/versioned/typed/prowjobs/v1:go_default_library",
+        "//prow/version:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -18,6 +18,7 @@ package kube
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
 	"k8s.io/test-infra/prow/version"
@@ -118,7 +119,7 @@ var previousStates map[jobIdentifier]prowapi.ProwJobState
 
 // GatherProwJobMetrics gathers prometheus metrics for prowjobs.
 // Not threadsafe, ensure this is called serially.
-func GatherProwJobMetrics(current []prowapi.ProwJob) {
+func GatherProwJobMetrics(l *logrus.Entry, current []prowapi.ProwJob) {
 	// This may be racing with the prometheus server but we need to remove
 	// stale metrics like triggered or pending jobs that are now complete.
 	prowJobs.Reset()
@@ -127,6 +128,7 @@ func GatherProwJobMetrics(current []prowapi.ProwJob) {
 	version, err := version.VersionTimestamp()
 	if err != nil {
 		// Not worth panicking
+		l.WithError(err).Debug("Failed to get version timestamp")
 		prowVersion.Set(-1)
 	} else {
 		prowVersion.Set(float64(version))

--- a/prow/kube/metrics.go
+++ b/prow/kube/metrics.go
@@ -20,6 +20,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	prowapi "k8s.io/test-infra/prow/apis/prowjobs/v1"
+	"k8s.io/test-infra/prow/version"
 )
 
 var (
@@ -49,6 +50,10 @@ var (
 		Name: "prowjob_state_transitions",
 		Help: "Number of prowjobs transitioning states",
 	}, metricLabels)
+	prowVersion = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "prow_version",
+		Help: "Prow version",
+	})
 )
 
 type jobLabel struct {
@@ -117,6 +122,15 @@ func GatherProwJobMetrics(current []prowapi.ProwJob) {
 	// This may be racing with the prometheus server but we need to remove
 	// stale metrics like triggered or pending jobs that are now complete.
 	prowJobs.Reset()
+
+	// record prow version
+	version, err := version.VersionTimestamp()
+	if err != nil {
+		// Not worth panicking
+		prowVersion.Set(-1)
+	} else {
+		prowVersion.Set(float64(version))
+	}
 
 	// record the current state of ProwJob CRs on the system
 	for jl, count := range getJobLabelMap(current) {

--- a/prow/plank/controller.go
+++ b/prow/plank/controller.go
@@ -263,7 +263,7 @@ func (c *Controller) Sync() error {
 func (c *Controller) SyncMetrics() {
 	c.pjLock.RLock()
 	defer c.pjLock.RUnlock()
-	kube.GatherProwJobMetrics(c.pjs)
+	kube.GatherProwJobMetrics(c.log, c.pjs)
 }
 
 // terminateDupes aborts presubmits that have a newer version. It modifies pjs

--- a/prow/plank/reconciler.go
+++ b/prow/plank/reconciler.go
@@ -160,7 +160,7 @@ func (r *reconciler) syncMetrics(ctx context.Context) error {
 				r.log.WithError(err).Error("failed to list prowjobs for metrics")
 				continue
 			}
-			kube.GatherProwJobMetrics(pjs.Items)
+			kube.GatherProwJobMetrics(r.log, pjs.Items)
 		}
 	}
 }

--- a/prow/version/BUILD.bazel
+++ b/prow/version/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -6,6 +6,12 @@ go_library(
     importpath = "k8s.io/test-infra/prow/version",
     visibility = ["//visibility:public"],
     x_defs = {"Version": "{DOCKER_TAG}"},
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["doc_test.go"],
+    embed = [":go_default_library"],
 )
 
 filegroup(

--- a/prow/version/doc_test.go
+++ b/prow/version/doc_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// version holds variables that identify a Prow binary's name and version
+package version
+
+import "testing"
+
+func TestVersionTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		wantV   int64
+		wantErr bool
+	}{
+		{
+			"base case",
+			"v20200102-a1b2c3",
+			1577923200,
+			false,
+		},
+		{
+			"invlid version",
+			"v20200102a-a1b2c3",
+			0,
+			true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			Version = tc.version
+			got, gotErr := VersionTimestamp()
+			if got != tc.wantV {
+				t.Fatalf("version mismatch, want: %d, got: %d", tc.wantV, got)
+			}
+			if ((gotErr != nil) && tc.wantErr) != ((gotErr != nil) || tc.wantErr) {
+				t.Fatalf("error mismatch, want: %v, got: %v", tc.wantErr, gotErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is useful in prometheus alerting, so that one can set up prometheus rule based on the freshness of the running binary. I.e. if the image is older than 2 weeks, ping oncall to bring their attention