### PR TITLE
releng: Update image promo presubmit/periodic jobs to use v3.0.0 image

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -13,14 +13,12 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
         command:
         - cip
         args:
-        # Pod Utilities already sets pwd to
-        # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
-        # suffice, but it's nice to be explicit.
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - run
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
     annotations:
@@ -36,12 +34,13 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+      - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
         command:
         - cip
         args:
-        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        - -vuln-severity-threshold=1
+        - run
+        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - --vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     annotations:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -46,12 +46,13 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
+    - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
       command:
       - cip
       args:
-      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-      - -dry-run=false
+      - run
+      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+      - --dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io


### PR DESCRIPTION
This commit explicitly leaves out the postsubmit and test-infra job to
give us an opportunity to watch how the presubmit and periodic jobs
behave.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

Promotion PR: https://github.com/kubernetes/k8s.io/pull/1453
v3.0.0 release: https://github.com/kubernetes-sigs/k8s-container-image-promoter/releases/tag/v3.0.0

/assign @hasheddan @dims @spiffxp 
cc: @listx @thockin @justinsb @kubernetes/release-engineering 

/hold for a K8s Infra LGTM as well