### PR TITLE
Github: Plug through org information for teams endpoints

### DIFF
--- a/prow/apis/prowjobs/v1/types.go
+++ b/prow/apis/prowjobs/v1/types.go
@@ -203,7 +203,7 @@ type RerunAuthConfig struct {
 
 // IsSpecifiedUser returns true if AllowAnyone is set to true or if the given user is
 // specified as a permitted GitHubUser
-func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient) (bool, error) {
+func (rac *RerunAuthConfig) IsAuthorized(org, user string, cli prowgithub.RerunClient) (bool, error) {
 	if rac == nil {
 		return false, nil
 	}
@@ -229,7 +229,7 @@ func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient
 		}
 	}
 	for _, ght := range rac.GitHubTeamIDs {
-		member, err := cli.TeamHasMember(ght, user)
+		member, err := cli.TeamHasMember(org, ght, user)
 		if err != nil {
 			return false, fmt.Errorf("GitHub failed to fetch members of team %v, verify that you have the correct team number and access token: %v", ght, err)
 		}
@@ -242,7 +242,7 @@ func (rac *RerunAuthConfig) IsAuthorized(user string, cli prowgithub.RerunClient
 		if err != nil {
 			return false, fmt.Errorf("GitHub failed to fetch team with slug %s and org %s: %v", ghts.Slug, ghts.Org, err)
 		}
-		member, err := cli.TeamHasMember(team.ID, user)
+		member, err := cli.TeamHasMember(org, team.ID, user)
 		if err != nil {
 			return false, fmt.Errorf("GitHub failed to fetch members of team %v: %v", team, err)
 		}

--- a/prow/apis/prowjobs/v1/types_test.go
+++ b/prow/apis/prowjobs/v1/types_test.go
@@ -372,7 +372,7 @@ func TestRerunAuthConfigIsAuthorized(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			if actual, _ := tc.config.IsAuthorized(tc.user, nil); actual != tc.authorized {
+			if actual, _ := tc.config.IsAuthorized("", tc.user, nil); actual != tc.authorized {
 				t.Errorf("Expected %v, got %v", tc.authorized, actual)
 			}
 		})

--- a/prow/cmd/peribolos/main_test.go
+++ b/prow/cmd/peribolos/main_test.go
@@ -282,7 +282,7 @@ func (c *fakeClient) UpdateOrgMembership(org, user string, admin bool) (*github.
 	}, nil
 }
 
-func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team 66 supported, not %d", id)
 	}
@@ -296,7 +296,7 @@ func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, 
 	}
 }
 
-func (c *fakeClient) ListTeamInvitations(id int) ([]github.OrgInvitation, error) {
+func (c *fakeClient) ListTeamInvitations(org string, id int) ([]github.OrgInvitation, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team 66 supported, not %d", id)
 	}
@@ -316,7 +316,7 @@ func (c *fakeClient) ListTeamInvitations(id int) ([]github.OrgInvitation, error)
 
 const teamID = 66
 
-func (c *fakeClient) UpdateTeamMembership(id int, user string, maintainer bool) (*github.TeamMembership, error) {
+func (c *fakeClient) UpdateTeamMembership(org string, id int, user string, maintainer bool) (*github.TeamMembership, error) {
 	if id != teamID {
 		return nil, fmt.Errorf("only team %d supported, not %d", teamID, id)
 	}
@@ -347,7 +347,7 @@ func (c *fakeClient) UpdateTeamMembership(id int, user string, maintainer bool) 
 	}, nil
 }
 
-func (c *fakeClient) RemoveTeamMembership(id int, user string) error {
+func (c *fakeClient) RemoveTeamMembership(org string, id int, user string) error {
 	if id != teamID {
 		return fmt.Errorf("only team %d supported, not %d", teamID, id)
 	}
@@ -758,7 +758,7 @@ func (c *fakeTeamClient) ListTeams(name string) ([]github.Team, error) {
 	return teams, nil
 }
 
-func (c *fakeTeamClient) DeleteTeam(id int) error {
+func (c *fakeTeamClient) DeleteTeam(org string, id int) error {
 	switch _, ok := c.teams[id]; {
 	case !ok:
 		return fmt.Errorf("not found %d", id)
@@ -769,7 +769,7 @@ func (c *fakeTeamClient) DeleteTeam(id int) error {
 	return nil
 }
 
-func (c *fakeTeamClient) EditTeam(team github.Team) (*github.Team, error) {
+func (c *fakeTeamClient) EditTeam(org string, team github.Team) (*github.Team, error) {
 	id := team.ID
 	t, ok := c.teams[id]
 	if !ok {
@@ -1357,7 +1357,7 @@ func TestConfigureTeamMembers(t *testing.T) {
 				newAdmins:  sets.String{},
 				newMembers: sets.String{},
 			}
-			err := configureTeamMembers(fc, gt, tc.team)
+			err := configureTeamMembers(fc, "", gt, tc.team)
 			switch {
 			case err != nil:
 				if !tc.err {
@@ -2122,7 +2122,7 @@ func (c fakeDumpClient) ListTeams(name string) ([]github.Team, error) {
 	return c.teams, nil
 }
 
-func (c fakeDumpClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c fakeDumpClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	var mapping map[int][]string
 	switch {
 	case id < 0:
@@ -2141,7 +2141,7 @@ func (c fakeDumpClient) ListTeamMembers(id int, role string) ([]github.TeamMembe
 	return c.makeMembers(people)
 }
 
-func (c fakeDumpClient) ListTeamRepos(id int) ([]github.Repo, error) {
+func (c fakeDumpClient) ListTeamRepos(org string, id int) ([]github.Repo, error) {
 	if id < 0 {
 		return nil, errors.New("injected ListTeamRepos error")
 	}
@@ -2266,7 +2266,7 @@ type fakeTeamRepoClient struct {
 	failList, failUpdate, failRemove bool
 }
 
-func (c *fakeTeamRepoClient) ListTeamRepos(id int) ([]github.Repo, error) {
+func (c *fakeTeamRepoClient) ListTeamRepos(org string, id int) ([]github.Repo, error) {
 	if c.failList {
 		return nil, errors.New("injected failure to ListTeamRepos")
 	}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -170,17 +170,17 @@ type RepositoryClient interface {
 // TeamClient interface for team related API actions
 type TeamClient interface {
 	CreateTeam(org string, team Team) (*Team, error)
-	EditTeam(t Team) (*Team, error)
-	DeleteTeam(id int) error
+	EditTeam(org string, t Team) (*Team, error)
+	DeleteTeam(org string, id int) error
 	ListTeams(org string) ([]Team, error)
-	UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error)
-	RemoveTeamMembership(id int, user string) error
-	ListTeamMembers(id int, role string) ([]TeamMember, error)
-	ListTeamRepos(id int) ([]Repo, error)
+	UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error)
+	RemoveTeamMembership(org string, id int, user string) error
+	ListTeamMembers(org string, id int, role string) ([]TeamMember, error)
+	ListTeamRepos(org string, id int) ([]Repo, error)
 	UpdateTeamRepo(id int, org, repo string, permission TeamPermission) error
 	RemoveTeamRepo(id int, org, repo string) error
-	ListTeamInvitations(id int) ([]OrgInvitation, error)
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	ListTeamInvitations(org string, id int) ([]OrgInvitation, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 	GetTeamBySlug(slug string, org string) (*Team, error)
 }
 
@@ -212,7 +212,7 @@ type MilestoneClient interface {
 
 // RerunClient interface for job rerun access check related API actions
 type RerunClient interface {
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 	GetTeamBySlug(slug string, org string) (*Team, error)
 	IsCollaborator(org, repo, user string) (bool, error)
 	IsMember(org, user string) (bool, error)
@@ -2879,7 +2879,7 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 // EditTeam patches team.ID to contain the specified other values.
 //
 // See https://developer.github.com/v3/teams/#edit-team
-func (c *client) EditTeam(t Team) (*Team, error) {
+func (c *client) EditTeam(org string, t Team) (*Team, error) {
 	durationLogger := c.log("EditTeam", t)
 	defer durationLogger()
 
@@ -2916,7 +2916,7 @@ func (c *client) EditTeam(t Team) (*Team, error) {
 // DeleteTeam removes team.ID from GitHub.
 //
 // See https://developer.github.com/v3/teams/#delete-team
-func (c *client) DeleteTeam(id int) error {
+func (c *client) DeleteTeam(org string, id int) error {
 	durationLogger := c.log("DeleteTeam", id)
 	defer durationLogger()
 	path := fmt.Sprintf("/teams/%d", id)
@@ -2963,7 +2963,7 @@ func (c *client) ListTeams(org string) ([]Team, error) {
 // If the user is not a member of the org, GitHub will invite them to become an outside collaborator, setting their status to pending.
 //
 // https://developer.github.com/v3/teams/members/#add-or-update-team-membership
-func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*TeamMembership, error) {
+func (c *client) UpdateTeamMembership(org string, id int, user string, maintainer bool) (*TeamMembership, error) {
 	durationLogger := c.log("UpdateTeamMembership", id, user, maintainer)
 	defer durationLogger()
 
@@ -2993,7 +2993,7 @@ func (c *client) UpdateTeamMembership(id int, user string, maintainer bool) (*Te
 // RemoveTeamMembership removes the user from the team (but not the org).
 //
 // https://developer.github.com/v3/teams/members/#remove-team-member
-func (c *client) RemoveTeamMembership(id int, user string) error {
+func (c *client) RemoveTeamMembership(org string, id int, user string) error {
 	durationLogger := c.log("RemoveTeamMembership", id, user)
 	defer durationLogger()
 
@@ -3013,7 +3013,7 @@ func (c *client) RemoveTeamMembership(id int, user string) error {
 // Role options are "all", "maintainer" and "member"
 //
 // https://developer.github.com/v3/teams/members/#list-team-members
-func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
+func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember, error) {
 	durationLogger := c.log("ListTeamMembers", id, role)
 	defer durationLogger()
 
@@ -3047,7 +3047,7 @@ func (c *client) ListTeamMembers(id int, role string) ([]TeamMember, error) {
 // ListTeamRepos gets a list of team repos for the given team id
 //
 // https://developer.github.com/v3/teams/#list-team-repos
-func (c *client) ListTeamRepos(id int) ([]Repo, error) {
+func (c *client) ListTeamRepos(org string, id int) ([]Repo, error) {
 	durationLogger := c.log("ListTeamRepos", id)
 	defer durationLogger()
 
@@ -3134,7 +3134,7 @@ func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 // given team id
 //
 // https://developer.github.com/v3/teams/members/#list-pending-team-invitations
-func (c *client) ListTeamInvitations(id int) ([]OrgInvitation, error) {
+func (c *client) ListTeamInvitations(org string, id int) ([]OrgInvitation, error) {
 	durationLogger := c.log("ListTeamInvites", id)
 	defer durationLogger()
 
@@ -3720,11 +3720,11 @@ func (c *client) DeleteProjectCard(org string, projectCardID int) error {
 }
 
 // TeamHasMember checks if a user belongs to a team
-func (c *client) TeamHasMember(teamID int, memberLogin string) (bool, error) {
+func (c *client) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
 	durationLogger := c.log("TeamHasMember", teamID, memberLogin)
 	defer durationLogger()
 
-	projectMaintainers, err := c.ListTeamMembers(teamID, RoleAll)
+	projectMaintainers, err := c.ListTeamMembers(org, teamID, RoleAll)
 	if err != nil {
 		return false, err
 	}

--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -1598,10 +1598,10 @@ func TestEditTeam(t *testing.T) {
 	}))
 	defer ts.Close()
 	c := getClient(ts.URL)
-	if _, err := c.EditTeam(Team{ID: 0, Name: "frobber"}); err == nil {
+	if _, err := c.EditTeam("", Team{ID: 0, Name: "frobber"}); err == nil {
 		t.Errorf("client should reject id 0")
 	}
-	switch team, err := c.EditTeam(Team{ID: 63, Name: "frobber"}); {
+	switch team, err := c.EditTeam("", Team{ID: 63, Name: "frobber"}); {
 	case err != nil:
 		t.Errorf("unexpected error: %v", err)
 	case team.Name != "hello":
@@ -1617,7 +1617,7 @@ func TestListTeamMembers(t *testing.T) {
 	ts := simpleTestServer(t, "/teams/1/members", []TeamMember{{Login: "foo"}})
 	defer ts.Close()
 	c := getClient(ts.URL)
-	teamMembers, err := c.ListTeamMembers(1, RoleAll)
+	teamMembers, err := c.ListTeamMembers("", 1, RoleAll)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	} else if len(teamMembers) != 1 {
@@ -2451,7 +2451,7 @@ func TestListTeamRepos(t *testing.T) {
 	)
 	defer ts.Close()
 	c := getClient(ts.URL)
-	repos, err := c.ListTeamRepos(1)
+	repos, err := c.ListTeamRepos("", 1)
 	if err != nil {
 		t.Errorf("Didn't expect error: %v", err)
 	} else if len(repos) != 1 {

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -439,7 +439,7 @@ func (f *FakeClient) ListTeams(org string) ([]github.Team, error) {
 }
 
 // ListTeamMembers return a fake team with a single "sig-lead" GitHub teammember
-func (f *FakeClient) ListTeamMembers(teamID int, role string) ([]github.TeamMember, error) {
+func (f *FakeClient) ListTeamMembers(org string, teamID int, role string) ([]github.TeamMember, error) {
 	if role != github.RoleAll {
 		return nil, fmt.Errorf("unsupported role %v (only all supported)", role)
 	}
@@ -687,8 +687,8 @@ func (f *FakeClient) MoveProjectCard(org string, projectCardID int, newColumnID 
 }
 
 // TeamHasMember checks if a user belongs to a team
-func (f *FakeClient) TeamHasMember(teamID int, memberLogin string) (bool, error) {
-	teamMembers, _ := f.ListTeamMembers(teamID, github.RoleAll)
+func (f *FakeClient) TeamHasMember(org string, teamID int, memberLogin string) (bool, error) {
+	teamMembers, _ := f.ListTeamMembers(org, teamID, github.RoleAll)
 	for _, member := range teamMembers {
 		if member.Login == memberLogin {
 			return true, nil

--- a/prow/plugins/lgtm/lgtm.go
+++ b/prow/plugins/lgtm/lgtm.go
@@ -135,7 +135,7 @@ type githubClient interface {
 	GetSingleCommit(org, repo, SHA string) (github.SingleCommit, error)
 	IsMember(org, user string) (bool, error)
 	ListTeams(org string) ([]github.Team, error)
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 // reviewCtx contains information about each review event
@@ -378,7 +378,7 @@ func stickyLgtm(log *logrus.Entry, gc githubClient, _ *plugins.Configuration, lg
 		if teams, err := gc.ListTeams(org); err == nil {
 			for _, teamInOrg := range teams {
 				if strings.Compare(teamInOrg.Name, lgtm.StickyLgtmTeam) == 0 {
-					if members, err := gc.ListTeamMembers(teamInOrg.ID, github.RoleAll); err == nil {
+					if members, err := gc.ListTeamMembers(org, teamInOrg.ID, github.RoleAll); err == nil {
 						for _, member := range members {
 							if strings.Compare(member.Login, author) == 0 {
 								// The author is in a trusted team

--- a/prow/plugins/milestone/milestone.go
+++ b/prow/plugins/milestone/milestone.go
@@ -46,7 +46,7 @@ type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	ClearMilestone(org, repo string, num int) error
 	SetMilestone(org, repo string, issueNum, milestoneNum int) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 	ListMilestones(org, repo string) ([]github.Milestone, error)
 }
 
@@ -113,7 +113,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		milestone = repoMilestone[""]
 	}
 
-	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, github.RoleAll)
+	milestoneMaintainers, err := gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/milestonestatus/milestonestatus.go
+++ b/prow/plugins/milestonestatus/milestonestatus.go
@@ -47,7 +47,7 @@ var (
 type githubClient interface {
 	CreateComment(owner, repo string, number int, comment string) error
 	AddLabel(owner, repo string, number int, label string) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 func init() {
@@ -106,7 +106,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, r
 		milestone = repoMilestone[""]
 	}
 
-	milestoneMaintainers, err := gc.ListTeamMembers(milestone.MaintainersID, github.RoleAll)
+	milestoneMaintainers, err := gc.ListTeamMembers(org, milestone.MaintainersID, github.RoleAll)
 	if err != nil {
 		return err
 	}

--- a/prow/plugins/override/override.go
+++ b/prow/plugins/override/override.go
@@ -51,7 +51,7 @@ type githubClient interface {
 	HasPermission(org, repo, user string, role ...string) (bool, error)
 	ListStatuses(org, repo, ref string) ([]github.Status, error)
 	ListTeams(org string) ([]github.Team, error)
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 }
 
 type prowJobClient interface {
@@ -100,8 +100,8 @@ func (c client) HasPermission(org, repo, user string, role ...string) (bool, err
 func (c client) ListTeams(org string) ([]github.Team, error) {
 	return c.ghc.ListTeams(org)
 }
-func (c client) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
-	return c.ghc.ListTeamMembers(id, role)
+func (c client) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
+	return c.ghc.ListTeamMembers(org, id, role)
 }
 
 func (c client) Create(ctx context.Context, pj *prowapi.ProwJob, o metav1.CreateOptions) (*prowapi.ProwJob, error) {
@@ -247,7 +247,7 @@ func authorizedGitHubTeamMember(gc githubClient, log *logrus.Entry, teamSlugs ma
 	for _, slug := range teamSlugs[fmt.Sprintf("%s/%s", org, repo)] {
 		for _, team := range teams {
 			if team.Slug == slug {
-				members, err := gc.ListTeamMembers(team.ID, github.RoleAll)
+				members, err := gc.ListTeamMembers(org, team.ID, github.RoleAll)
 				if err != nil {
 					log.WithError(err).Warnf("cannot find members of team %s in org %s", slug, org)
 					continue

--- a/prow/plugins/override/override_test.go
+++ b/prow/plugins/override/override_test.go
@@ -220,7 +220,7 @@ func (c *fakeClient) ListTeams(org string) ([]github.Team, error) {
 	return []github.Team{}, nil
 }
 
-func (c *fakeClient) ListTeamMembers(id int, role string) ([]github.TeamMember, error) {
+func (c *fakeClient) ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error) {
 	if id == 1 {
 		return []github.TeamMember{
 			{Login: "user1"},

--- a/prow/plugins/project/project.go
+++ b/prow/plugins/project/project.go
@@ -56,7 +56,7 @@ var (
 type githubClient interface {
 	BotName() (string, error)
 	CreateComment(owner, repo string, number int, comment string) error
-	ListTeamMembers(id int, role string) ([]github.TeamMember, error)
+	ListTeamMembers(org string, id int, role string) ([]github.TeamMember, error)
 	GetRepos(org string, isUser bool) ([]github.Repo, error)
 	GetRepoProjects(owner, repo string) ([]github.Project, error)
 	GetOrgProjects(org string) ([]github.Project, error)
@@ -65,7 +65,7 @@ type githubClient interface {
 	GetColumnProjectCard(org string, columnID int, contentURL string) (*github.ProjectCard, error)
 	MoveProjectCard(org string, projectCardID int, newColumnID int) error
 	DeleteProjectCard(org string, projectCardID int) error
-	TeamHasMember(teamID int, memberLogin string) (bool, error)
+	TeamHasMember(org string, teamID int, memberLogin string) (bool, error)
 }
 
 func init() {
@@ -212,7 +212,7 @@ func handle(gc githubClient, log *logrus.Entry, e *github.GenericCommentEvent, p
 	if maintainerTeamID == -1 {
 		return gc.CreateComment(org, repo, e.Number, plugins.FormatResponseRaw(e.Body, e.HTMLURL, e.User.Login, notTeamConfigMsg))
 	}
-	isAMember, err := gc.TeamHasMember(maintainerTeamID, e.User.Login)
+	isAMember, err := gc.TeamHasMember(org, maintainerTeamID, e.User.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is needed for github app auth to work. Furthermore, all the
endpoints to manage teams by ID are deprecatd, so we will have to deprecate
and eventually remove the support for this as well.