### PR TITLE
Revert "Update image promo presubmit/periodic jobs to use v3.0.0 image"

### DIFF
--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -13,12 +13,14 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
-        - run
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        # Pod Utilities already sets pwd to
+        # /home/prow/go/src/github.com/{{.Org}}/{{.Repo}}, so just '.' should
+        # suffice, but it's nice to be explicit.
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
   # Check that images to be promoted are free of fixable vulnerabilities
   - name: pull-k8sio-cip-vuln
     annotations:
@@ -34,13 +36,12 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-vuln-scanning
       containers:
-      - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
+      - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
         command:
         - cip
         args:
-        - run
-        - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-        - --vuln-severity-threshold=1
+        - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+        - -vuln-severity-threshold=1
   # Check that changes to backup scripts are valid.
   - name: pull-k8sio-backup
     annotations:

--- a/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
+++ b/config/jobs/kubernetes/wg-k8s-infra/trusted/releng/releng-trusted.yaml
@@ -46,13 +46,12 @@ periodics:
     # https://github.com/kubernetes/k8s.io/pull/695.
     serviceAccountName: k8s-infra-gcr-promoter
     containers:
-    - image: k8s.gcr.io/artifact-promoter/cip:v3.0.0
+    - image: us.gcr.io/k8s-artifacts-prod/artifact-promoter/cip:v2.4.1
       command:
       - cip
       args:
-      - run
-      - --thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
-      - --dry-run=false
+      - -thin-manifest-dir=/home/prow/go/src/github.com/kubernetes/k8s.io/k8s.gcr.io
+      - -dry-run=false
   annotations:
     testgrid-dashboards: sig-release-releng-blocking, wg-k8s-infra-k8sio
     testgrid-alert-email: k8s-infra-alerts@kubernetes.io, release-managers+alerts@kubernetes.io


### PR DESCRIPTION
This reverts commit 0a2236341fb5852629def1c52ec8065cfef06928.

Working on a fixup [here](https://github.com/kubernetes-sigs/k8s-container-image-promoter/pull/285), but it's taking longer than expected, so let's revert this for now.

/assign @hasheddan 
cc: @kubernetes/release-engineering  