### PR TITLE
[releng] 1.20: Update kubekins-e2e variants.yaml with 1.20 config

### DIFF
--- a/images/kubekins-e2e/variants.yaml
+++ b/images/kubekins-e2e/variants.yaml
@@ -18,10 +18,16 @@ variants:
     K8S_RELEASE: stable
     BAZEL_VERSION: 3.4.1
     OLD_BAZEL_VERSION: 2.2.0
+  '1.20':
+    CONFIG: '1.20'
+    GO_VERSION: 1.15.5
+    K8S_RELEASE: latest-1.20
+    BAZEL_VERSION: 3.4.1
+    OLD_BAZEL_VERSION: 2.2.0
   '1.19':
     CONFIG: '1.19'
     GO_VERSION: 1.15.5
-    K8S_RELEASE: latest-1.19
+    K8S_RELEASE: stable-1.19
     BAZEL_VERSION: 2.2.0
     OLD_BAZEL_VERSION: 0.23.2
   '1.18':


### PR DESCRIPTION
* Update kubekins-e2e variants.yaml with 1.20 config
* Update 1.19 kubekins-e2e variant to set `K8S_RELEASE` to `stable-1.19`

Pending branch cut:
/hold

/sig release
/area release-eng
/assign @saschagrunert @cpanato
cc: @kubernetes/release-engineering