### PR TITLE
[releng] 1.20: Enable milestone restrictions for release-1.20 branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -521,6 +521,7 @@ tide:
     milestone: v1.20
     includedBranches:
     - master
+    - release-1.20
     labels:
     - lgtm
     - approved


### PR DESCRIPTION
When enabling code freeze for 1.20 in #19930, we only did it for the master branch because release-1.20 didn't exist. The restrictions should also apply to the release branch while the code freeze is in effect.

Pending branch cut:
/hold

/sig release
/area release-eng
/assign @saschagrunert @cpanato
cc: @kubernetes/release-engineering