### PR TITLE
capg: use ci-e2e.sh until new script is ready

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -73,7 +73,7 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
         command:
           - "runner.sh"
-          - "./scripts/ci-conformance.sh"
+          - "./scripts/ci-e2e.sh"
         # we need privileged mode in order to do docker in docker
         securityContext:
           privileged: true
@@ -121,7 +121,7 @@ periodics:
             value: "boskos.test-pods.svc.cluster.local"
         command:
           - "runner.sh"
-          - "./scripts/ci-conformance.sh"
+          - "./scripts/ci-e2e.sh"
           - "--use-ci-artifacts"
         # we need privileged mode in order to do docker in docker
         securityContext:

--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-presubmits.yaml
@@ -129,7 +129,7 @@ presubmits:
               value: "boskos.test-pods.svc.cluster.local"
           command:
             - "runner.sh"
-            - "./scripts/ci-conformance.sh"
+            - "./scripts/ci-e2e.sh"
             - "--use-ci-artifacts"
           # we need privileged mode in order to do docker in docker
           securityContext:


### PR DESCRIPTION
Switches capg back to using ci-e2e.sh until ci-conformance.sh is ready
and tested.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/334

/assign @cpanato 
/cc @RobertKielty 