### PR TITLE
capg: add cpanato to the owners file

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/OWNERS
@@ -1,14 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
+- cpanato
 - detiber
-- maisem
-- krousey
 - justinsb
+- krousey
+- maisem
 - vincepri
 approvers:
+- cpanato
 - detiber
-- maisem
-- krousey
 - justinsb
+- krousey
+- maisem
 - vincepri
+
+labels:
+- sig/cluster-lifecycle
+- area/provider/gcp


### PR DESCRIPTION
- add cpanato (myself) to the CAPG owners file.
- order alphabetically
- add labels 

related to https://github.com/kubernetes-sigs/cluster-api-provider-gcp/pull/337

/assign @detiber @vincepri 