### PR TITLE
capg: update interval for periodic conformance tests to 12 hours

### DIFF
--- a/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
+++ b/config/jobs/kubernetes-sigs/cluster-api-provider-gcp/cluster-api-provider-gcp-ci.yaml
@@ -51,7 +51,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  interval: 4h
+  interval: 12h
   extra_refs:
   - org: kubernetes-sigs
     repo: cluster-api-provider-gcp
@@ -99,7 +99,7 @@ periodics:
   decorate: true
   decoration_config:
     timeout: 3h
-  interval: 4h
+  interval: 12h
   extra_refs:
     - org: kubernetes-sigs
       repo: cluster-api-provider-gcp


### PR DESCRIPTION
Increase the interval of the periodic conformance tests for CAPG to 12 hours, i think we don't need to run every 4 hours

/assign @detiber 