### PR TITLE
storage-migrator presubmit: use kubetest instead of kubernetes_e2e.py

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -92,7 +92,7 @@ presubmits:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201111-a263fd7-master
         command:
         - runner.sh
-        - /workspace/scenarios/kubernetes_e2e.py
+        - kubetest
         args:
         - --up
         - --down


### PR DESCRIPTION
Copying https://github.com/kubernetes/test-infra/blob/e6b167bfb46895d2a8d5641a780e843162b3f9d3/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml#L25-L81. 

Trying to fix: 

```
+ /workspace/scenarios/kubernetes_e2e.py --up --down --build=quick --check-leaked-resources --gcp-master-image=gci --gcp-node-image=gci --gcp-nodes=1 --gcp-zone=us-central1-f --provider=gce --test=false --test-cmd=../test/e2e/test-cmd.sh --timeout=50m --runtime-config=internal.apiserver.k8s.io/v1alpha1=true --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
usage: kubernetes_e2e.py [-h] [--env-file ENV_FILE] [--env ENV]
                         [--gce-ssh GCE_SSH] [--gce-pub GCE_PUB]
                         [--service-account SERVICE_ACCOUNT] [--build [BUILD]]
                         [--inject-bazelrc INJECT_BAZELRC]
                         [--build-federation [BUILD_FEDERATION]]
                         [--use-shared-build [USE_SHARED_BUILD]]
                         [--gcs-shared GCS_SHARED] [--cluster CLUSTER]
                         [--stage STAGE] [--test TEST] [--down DOWN] [--up UP]
                         [--tear-down-previous] [--use-logexporter]
                         [--kubetest_args KUBETEST_ARGS]
                         [--dump-before-and-after] [--aws]
                         [--aws-profile AWS_PROFILE]
                         [--aws-role-arn AWS_ROLE_ARN] [--aws-ssh AWS_SSH]
                         [--aws-pub AWS_PUB] [--aws-cred AWS_CRED]
                         [--aws-cluster-domain AWS_CLUSTER_DOMAIN]
                         [--kops-nodes KOPS_NODES]
                         [--kops-ssh-user KOPS_SSH_USER]
                         [--kops-state KOPS_STATE]
                         [--kops-state-gce KOPS_STATE_GCE]
                         [--kops-zones KOPS_ZONES] [--kops-build]
                         [--kops-multiple-zones] [--provider PROVIDER]
                         [--deployment DEPLOYMENT]
kubernetes_e2e.py: error: argument --up: expected one argument
```

/assign @caesarxuchao 