### PR TITLE
releng: Manual kubekins-e2e bump to v20201124-be2d6d8-**

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -27,7 +27,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       resources:
         requests:
           cpu: 1000m
@@ -66,7 +66,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       resources:
         requests:
           cpu: 1000m
@@ -105,7 +105,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       resources:
         requests:
           cpu: 1000m
@@ -144,7 +144,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       resources:
         requests:
           cpu: 1000m
@@ -183,7 +183,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       resources:
         requests:
           cpu: 1000m
@@ -222,7 +222,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       resources:
         requests:
           cpu: 1000m
@@ -261,7 +261,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       resources:
         requests:
           cpu: 1000m
@@ -300,7 +300,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       resources:
         requests:
           cpu: 1000m
@@ -339,7 +339,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       resources:
         requests:
           cpu: 1000m
@@ -378,7 +378,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       resources:
         requests:
           cpu: 1000m
@@ -417,7 +417,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       resources:
         requests:
           cpu: 1000m
@@ -456,7 +456,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       resources:
         requests:
           cpu: 1000m
@@ -495,7 +495,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       resources:
         requests:
           cpu: 1000m
@@ -534,7 +534,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       resources:
         requests:
           cpu: 1000m
@@ -573,7 +573,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       resources:
         requests:
           cpu: 1000m
@@ -612,7 +612,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       resources:
         requests:
           cpu: 1000m

--- a/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
+++ b/config/jobs/kubernetes/sig-release/cip/container-image-promoter.yaml
@@ -55,7 +55,7 @@ presubmits:
     spec:
       serviceAccountName: k8s-infra-gcr-promoter-test
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         command:
         - infra/gcp/backup_tools/backup_test.sh
         env:
@@ -78,7 +78,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
         command:
         - "./test-e2e/cip/e2e-entrypoint-from-container.sh"
         env:
@@ -108,7 +108,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
         command:
         - "./test-e2e/cip-auditor/entrypoint-from-container.sh"
         env:
@@ -136,7 +136,7 @@ presubmits:
     - ^master$
     spec:
       containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
         command:
         - "make"
         args:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.17.yaml
@@ -31,7 +31,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -106,7 +106,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -145,7 +145,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -182,7 +182,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -317,7 +317,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -386,7 +386,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=100m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources: {}
       securityContext:
@@ -429,7 +429,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -501,7 +501,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -543,7 +543,7 @@ periodics:
         value: release-1.17
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       imagePullPolicy: Always
       name: ""
       resources:
@@ -594,7 +594,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-1.17.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources: {}
 - annotations:
@@ -628,7 +628,7 @@ periodics:
       env:
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -674,7 +674,7 @@ periodics:
         value: ipv6
       - name: PARALLEL
         value: "true"
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
       name: ""
       resources:
         limits:
@@ -713,7 +713,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           requests:
@@ -790,7 +790,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           requests:
@@ -832,7 +832,7 @@ presubmits:
         env:
         - name: GINKGO_TOLERATE_FLAKES
           value: "y"
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           limits:
@@ -880,7 +880,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources: {}
   - always_run: false
@@ -920,7 +920,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           requests:
@@ -953,7 +953,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           limits:
@@ -997,7 +997,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           requests:
@@ -1057,7 +1057,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
         name: ""
         resources:
           limits:
@@ -1129,7 +1129,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           limits:
@@ -1223,7 +1223,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: main
         resources:
           limits:
@@ -1250,7 +1250,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           limits:
@@ -1277,7 +1277,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: main
         resources:
           limits:
@@ -1311,7 +1311,7 @@ presubmits:
           value: release-1.17
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         imagePullPolicy: Always
         name: ""
         resources:
@@ -1359,7 +1359,7 @@ presubmits:
         command:
         - runner.sh
         - kubetest
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
         name: ""
         resources:
           limits:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.18.yaml
@@ -31,7 +31,7 @@ periodics:
       - --skew
       - --test_args=--ginkgo.focus=Kubectl --ginkgo.skip=\[Serial\] --minStartupPods=8
       - --timeout=120m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -107,7 +107,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -146,7 +146,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -183,7 +183,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -322,7 +322,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=100m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources: {}
       securityContext:
@@ -389,7 +389,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -437,7 +437,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -509,7 +509,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources:
         limits:
@@ -551,7 +551,7 @@ periodics:
         value: release-1.18
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       imagePullPolicy: Always
       name: ""
       resources:
@@ -602,7 +602,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources: {}
 - annotations:
@@ -644,7 +644,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
       name: ""
       resources: {}
 - annotations:
@@ -777,7 +777,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -854,7 +854,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -893,7 +893,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -935,7 +935,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -981,7 +981,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -1032,7 +1032,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -1080,7 +1080,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources: {}
   - always_run: false
@@ -1120,7 +1120,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -1153,7 +1153,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -1197,7 +1197,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           requests:
@@ -1258,7 +1258,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -1330,7 +1330,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -1424,7 +1424,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: main
         resources:
           limits:
@@ -1451,7 +1451,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: ""
         resources:
           limits:
@@ -1519,7 +1519,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         name: main
         resources:
           limits:
@@ -1553,7 +1553,7 @@ presubmits:
           value: release-1.18
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.19.yaml
@@ -26,7 +26,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -66,7 +66,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -105,7 +105,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -142,7 +142,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -275,7 +275,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=100m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources: {}
       securityContext:
@@ -338,7 +338,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -386,7 +386,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -458,7 +458,7 @@ periodics:
       - ./hack/jenkins/test-dockerized.sh
       command:
       - runner.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources:
         limits:
@@ -500,7 +500,7 @@ periodics:
         value: release-1.19
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       imagePullPolicy: Always
       name: ""
       resources:
@@ -551,7 +551,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources: {}
 - annotations:
@@ -593,7 +593,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
       name: ""
       resources: {}
 - annotations:
@@ -726,7 +726,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -805,7 +805,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -844,7 +844,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -886,7 +886,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -932,7 +932,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -982,7 +982,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -1030,7 +1030,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources: {}
   - always_run: false
@@ -1070,7 +1070,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -1103,7 +1103,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -1147,7 +1147,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           requests:
@@ -1203,7 +1203,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -1271,7 +1271,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -1365,7 +1365,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: main
         resources:
           limits:
@@ -1393,7 +1393,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: main
         resources:
           limits:
@@ -1418,7 +1418,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: ""
         resources:
           limits:
@@ -1487,7 +1487,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         name: main
         resources:
           limits:
@@ -1523,7 +1523,7 @@ presubmits:
           value: release-1.19
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
         imagePullPolicy: Always
         name: ""
         resources:

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -27,7 +27,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Conformance\]
       - --timeout=200m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -67,7 +67,7 @@ periodics:
       - --provider=gce
       - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
       - --timeout=180m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -106,7 +106,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -143,7 +143,7 @@ periodics:
       env:
       - name: GOPATH
         value: /go
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -235,7 +235,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=100m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -301,7 +301,7 @@ periodics:
       - --test-cmd-name=ClusterLoaderV2
       - --timeout=120m
       - --use-logexporter
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -349,7 +349,7 @@ periodics:
             --version-suffix=-bazel
       command:
       - bash
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -423,7 +423,7 @@ periodics:
       env:
       - name: SHORT
         value: --short=false
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:
@@ -464,7 +464,7 @@ periodics:
         value: release-1.20
       - name: REPO_DIR
         value: /workspace/k8s.io/kubernetes
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       imagePullPolicy: Always
       name: ""
       resources:
@@ -516,7 +516,7 @@ periodics:
         value: win2019
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources: {}
 - annotations:
@@ -559,7 +559,7 @@ periodics:
         value: win1909
       - name: PREPULL_YAML
         value: prepull-head.yaml
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
       name: ""
       resources: {}
 - annotations:
@@ -692,7 +692,7 @@ postsubmits:
         - --release=//build/release-tars
         - --gcs=gs://kubernetes-release-dev/ci
         - --version-suffix=-bazel
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           requests:
@@ -743,7 +743,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-kops-aws
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort
         - --timeout=55m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           requests:
@@ -782,7 +782,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -824,7 +824,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -874,7 +874,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           requests:
@@ -924,7 +924,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -978,7 +978,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-ubuntu-containerd-canary
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1026,7 +1026,7 @@ presubmits:
         - --timeout=80m
         command:
         - ../test-infra/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources: {}
   - always_run: false
@@ -1066,7 +1066,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-gce-device-plugin-gpu
         - --test_args=--ginkgo.focus=\[Feature:GPUDevicePlugin\] --minStartupPods=8
         - --timeout=60m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           requests:
@@ -1099,7 +1099,7 @@ presubmits:
         - --test_args=--nodes=8 --focus="\[NodeConformance\]" --skip="\[Flaky\]|\[Slow\]|\[Serial\]"
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/image-config.yaml
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1143,7 +1143,7 @@ presubmits:
         command:
         - runner.sh
         - /workspace/scenarios/kubernetes_e2e.py
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1187,7 +1187,7 @@ presubmits:
         - --stage=gs://kubernetes-release-pull/ci/pull-kubernetes-e2e-containerd-gce
         - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[NodeFeature:RuntimeHandler\] --minStartupPods=8
         - --timeout=80m
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           requests:
@@ -1240,7 +1240,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1306,7 +1306,7 @@ presubmits:
         - --test-cmd-name=ClusterLoaderV2
         - --timeout=100m
         - --use-logexporter
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1403,7 +1403,7 @@ presubmits:
         env:
         - name: WHAT
           value: external-dependencies-version vendor vendor-licenses
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: main
         resources:
           limits:
@@ -1431,7 +1431,7 @@ presubmits:
         env:
         - name: WHAT
           value: generated-files-remake
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: main
         resources:
           limits:
@@ -1456,7 +1456,7 @@ presubmits:
         - ./hack/jenkins/test-dockerized.sh
         command:
         - runner.sh
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: ""
         resources:
           limits:
@@ -1525,7 +1525,7 @@ presubmits:
         env:
         - name: WHAT
           value: typecheck typecheck-providerless typecheck-dockerless
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         name: main
         resources:
           limits:
@@ -1561,7 +1561,7 @@ presubmits:
           value: release-1.20
         - name: REPO_DIR
           value: /workspace/k8s.io/kubernetes
-        image: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+        image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
         imagePullPolicy: Always
         name: ""
         resources:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -658,23 +658,23 @@ nodeK8sVersions:
   dev:
     args:
     - --repo=k8s.io/kubernetes=master
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-master
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
   beta:
     args:
     - --repo=k8s.io/kubernetes=release-1.20
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.20
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.20
   stable1:
     args:
     - --repo=k8s.io/kubernetes=release-1.19
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.19
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.19
   stable2:
     args:
     - --repo=k8s.io/kubernetes=release-1.18
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.18
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.18
   stable3:
     args:
     - --repo=k8s.io/kubernetes=release-1.17
-    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201124-be2d6d8-1.17
+    prowImage: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-1.17
 
 nodeTestSuites:
   default:


### PR DESCRIPTION
Follow-up to https://github.com/kubernetes/test-infra/pull/20079.
Bump to pick up the images built today: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-test-infra-push-kubekins-e2e/1333749970951475200.

Only bumping the release branch and generated jobs here, as everything else will get picked up in https://github.com/kubernetes/test-infra/pull/20064.

/assign @hasheddan @saschagrunert 
cc: @kubernetes/release-engineering 