### PR TITLE
kubeadm jobs: update manifests.yaml to not use latest-master

### DIFF
--- a/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
+++ b/config/jobs/kubernetes/sig-cluster-lifecycle/manifests.yaml
@@ -13,8 +13,7 @@ periodics:
       - --scenario=execute
       - --
       - ./tests/e2e/manifests/verify_manifest_lists.sh
-      image: gcr.io/k8s-testimages/kubekins-e2e:latest-master
-      imagePullPolicy: Always
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-all
     testgrid-tab-name: periodic-manifest-lists


### PR DESCRIPTION
update manifests.yaml to use the latest kubekins tag instead of `latest-x` and to not always pulling the image.
