### PR TITLE
Fix image for ci-kubernetes-kind-ipv6-e2e-parallel-1-20

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -653,7 +653,7 @@ periodics:
         value: "true"
       - name: BUILD_TYPE
         value: bazel
-      image: gcr.io/k8s-testimages/krte:v20201124-be2d6d8-1.20
+      image: gcr.io/k8s-testimages/krte:v20201201-1941b8f-1.20
       name: ""
       resources:
         limits:


### PR DESCRIPTION
Fix image tag for ci-kubernetes-kind-ipv6-e2e-parallel-1-20

```
Failed to pull image
"gcr.io/k8s-testimages/krte:v20201124-be2d6d8-1.20": rpc error: code
= Unknown desc = failed to resolve image
"gcr.io/k8s-testimages/krte:v20201124-be2d6d8-1.20": no available
registry endpoint: gcr.io/k8s-testimages/krte:v20201124-be2d6d8-1.20 not
found
```

Signed-off-by: Arnaud Meukam <ameukam@gmail.com>