### PR TITLE
Github v3: Add apps authentication support

### DIFF
--- a/ghproxy/ghcache/coalesce.go
+++ b/ghproxy/ghcache/coalesce.go
@@ -133,7 +133,14 @@ func (r *requestCoalescer) RoundTrip(req *http.Request) (*http.Response, error) 
 		return resp, nil
 	}()
 
-	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), r.hasher.Hash(req))
+	var tokenBudgetName string
+	if val := req.Header.Get(TokenBudgetIdentifierHeader); val != "" {
+		tokenBudgetName = val
+	} else {
+		tokenBudgetName = r.hasher.Hash(req)
+	}
+
+	ghmetrics.CollectCacheRequestMetrics(string(cacheMode), req.URL.Path, req.Header.Get("User-Agent"), tokenBudgetName)
 	if resp != nil {
 		resp.Header.Set(CacheModeHeader, string(cacheMode))
 		if cacheMode == ModeRevalidated && resp.Header.Get(cacheEntryCreationDateHeader) != "" {

--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	github.com/bwmarrin/snowflake v0.0.0
 	github.com/clarketm/json v1.13.4
 	github.com/client9/misspell v0.3.4
+	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
 	github.com/djherbis/atime v1.0.0
 	github.com/docker/docker v1.13.1
 	github.com/evanphx/json-patch v4.9.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -361,6 +361,8 @@ github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mz
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
+github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
 github.com/dgryski/go-gk v0.0.0-20200319235926-a69029f61654/go.mod h1:qm+vckxRlDt0aOla0RYJJVeqHZlWfOm2UIxHaqPB46E=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=

--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//prow/io:go_default_library",
         "//prow/jira:go_default_library",
         "//prow/kube:go_default_library",
+        "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",

--- a/prow/flagutil/github.go
+++ b/prow/flagutil/github.go
@@ -18,12 +18,16 @@ package flagutil
 
 import (
 	"bytes"
+	"crypto/rsa"
+	"errors"
 	"flag"
 	"fmt"
 	"net/url"
 	"strings"
 
+	jwt "github.com/dgrijalva/jwt-go/v4"
 	"github.com/sirupsen/logrus"
+
 	"k8s.io/test-infra/prow/config/secret"
 	"k8s.io/test-infra/prow/git"
 	"k8s.io/test-infra/prow/github"
@@ -40,6 +44,8 @@ type GitHubOptions struct {
 	TokenPath         string
 	AllowAnonymous    bool
 	AllowDirectAccess bool
+	AppID             string
+	AppPrivateKeyPath string
 }
 
 const DefaultGitHubTokenPath = "/etc/github/oauth" // Exported for testing purposes
@@ -51,6 +57,8 @@ func (o *GitHubOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(&o.endpoint, "github-endpoint", "GitHub's API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.graphqlEndpoint, "github-graphql-endpoint", github.DefaultGraphQLEndpoint, "GitHub GraphQL API endpoint (may differ for enterprise).")
 	fs.StringVar(&o.TokenPath, "github-token-path", "", "Path to the file containing the GitHub OAuth secret.")
+	fs.StringVar(&o.AppID, "app-id", "", "ID of the GitHub app. If set, requires --app-private-key path to be set and --github-token-path to be unset.")
+	fs.StringVar(&o.AppPrivateKeyPath, "app-private-key-path", "", "Path to the private key of the github app. If set, requires --app-id to bet set and --github-token-path to be unset")
 }
 
 // Validate validates GitHub options. Note that validate updates the GitHubOptions
@@ -63,6 +71,13 @@ func (o *GitHubOptions) Validate(bool) error {
 		} else if _, err := url.ParseRequestURI(uri); err != nil {
 			return fmt.Errorf("invalid -github-endpoint URI: %q", uri)
 		}
+	}
+
+	if o.TokenPath != "" && (o.AppID != "" || o.AppPrivateKeyPath != "") {
+		return fmt.Errorf("--token-path is mutually exclusive with --app-id and --app-private-key-path")
+	}
+	if o.AppID == "" != (o.AppPrivateKeyPath == "") {
+		return errors.New("--app-id and --app-private-key-path must be set together")
 	}
 
 	if o.TokenPath == "" && !o.AllowAnonymous {
@@ -85,7 +100,7 @@ func (o *GitHubOptions) Validate(bool) error {
 }
 
 // GitHubClientWithLogFields returns a GitHub client with extra logging fields
-func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dryRun bool, fields logrus.Fields) (client github.Client, err error) {
+func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dryRun bool, fields logrus.Fields) (github.Client, error) {
 	var generator *func() []byte
 	if o.TokenPath == "" {
 		logrus.Warn("empty -github-token-path, will use anonymous github client")
@@ -101,14 +116,38 @@ func (o *GitHubOptions) GitHubClientWithLogFields(secretAgent *secret.Agent, dry
 		generator = &generatorFunc
 	}
 
+	var appsGenerator func() *rsa.PrivateKey
+	if o.AppPrivateKeyPath != "" {
+		if secretAgent == nil {
+			return nil, fmt.Errorf("cannot store token from %q without a secret agent", o.AppPrivateKeyPath)
+		}
+		appsGenerator = func() *rsa.PrivateKey {
+			raw := secretAgent.GetTokenGenerator(o.AppPrivateKeyPath)()
+			privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(raw)
+			// TODO alvaroaleman: Add hooks to the SecretAgent
+			if err != nil {
+				panic(fmt.Sprintf("failed to parse private key: %v", err))
+			}
+			return privateKey
+		}
+
+	}
+
 	if dryRun {
+		if o.AppPrivateKeyPath != "" {
+			return github.NewAppsAuthDryRunClientWithFields(fields, secretAgent.Censor, o.AppID, appsGenerator, o.graphqlEndpoint, o.endpoint.Strings()...), nil
+		}
 		return github.NewDryRunClientWithFields(fields, *generator, secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...), nil
+	}
+	if o.AppPrivateKeyPath != "" {
+		return github.NewAppsAuthClientWithFields(fields, secretAgent.Censor, o.AppID, appsGenerator, o.graphqlEndpoint, o.endpoint.Strings()...), nil
+
 	}
 	return github.NewClientWithFields(fields, *generator, secretAgent.Censor, o.graphqlEndpoint, o.endpoint.Strings()...), nil
 }
 
 // GitHubClient returns a GitHub client.
-func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (client github.Client, err error) {
+func (o *GitHubOptions) GitHubClient(secretAgent *secret.Agent, dryRun bool) (github.Client, error) {
 	return o.GitHubClientWithLogFields(secretAgent, dryRun, logrus.Fields{})
 }
 

--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -9,6 +9,8 @@ load(
 go_test(
     name = "go_default_test",
     srcs = [
+        "app_auth_roundtripper_integration_test.go",
+        "app_auth_roundtripper_test.go",
         "client_test.go",
         "helpers_test.go",
         "hmac_test.go",
@@ -18,16 +20,19 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//ghproxy/ghcache:go_default_library",
+        "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_utils//diff:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 
 go_library(
     name = "go_default_library",
     srcs = [
+        "app_auth_roundtripper.go",
         "client.go",
         "helpers.go",
         "hmac.go",
@@ -39,6 +44,7 @@ go_library(
     deps = [
         "//ghproxy/ghcache:go_default_library",
         "//prow/version:go_default_library",
+        "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",

--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	jwt "github.com/dgrijalva/jwt-go/v4"
+
+	"k8s.io/test-infra/ghproxy/ghcache"
+)
+
+const (
+	githubOrgHeaderKey = "X-PROW-GITHUB-ORG"
+)
+
+type appGitHubClient interface {
+	ListAppInstallations() ([]AppInstallation, error)
+	getAppInstallationToken(installationId int64) (*AppInstallationToken, error)
+	GetApp() (*App, error)
+}
+
+type appsRoundTripper struct {
+	appID            string
+	appSlug          string
+	appSlugLock      sync.Mutex
+	privateKey       func() *rsa.PrivateKey
+	installationLock sync.RWMutex
+	installations    map[string]AppInstallation
+	tokenLock        sync.RWMutex
+	tokens           map[int64]*AppInstallationToken
+	upstream         http.RoundTripper
+	githubClient     appGitHubClient
+}
+
+// appsAuthError is returned by the appsRoundTripper if any issues were encountered
+// trying to authorize the request. It signals the client to not retry.
+type appsAuthError struct {
+	error
+}
+
+func (*appsAuthError) Is(target error) bool {
+	_, ok := target.(*appsAuthError)
+	return ok
+}
+
+func (arr *appsRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	if strings.HasPrefix(r.URL.Path, "/app") {
+		if err := arr.addAppAuth(r); err != nil {
+			return nil, err
+		}
+	} else if err := arr.addAppInstallationAuth(r); err != nil {
+		return nil, err
+	}
+
+	return arr.upstream.RoundTrip(r)
+}
+
+func (arr *appsRoundTripper) addAppAuth(r *http.Request) *appsAuthError {
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, &jwt.StandardClaims{
+		IssuedAt:  jwt.NewTime(float64(time.Now().Unix())),
+		ExpiresAt: jwt.NewTime(float64(time.Now().UTC().Add(10 * time.Minute).Unix())),
+		Issuer:    arr.appID,
+	}).SignedString(arr.privateKey())
+	if err != nil {
+		return &appsAuthError{fmt.Errorf("failed to generate jwt: %w", err)}
+	}
+
+	r.Header.Set("Authorization", "Bearer "+token)
+
+	// We call the /app endpoint to resolve the slug, so we can't set it there
+	if r.URL.Path == "/app" {
+		r.Header.Set(ghcache.TokenBudgetIdentifierHeader, arr.appID)
+	} else {
+		slug, err := arr.getSlug()
+		if err != nil {
+			return &appsAuthError{err}
+		}
+		r.Header.Set(ghcache.TokenBudgetIdentifierHeader, slug)
+	}
+	return nil
+}
+
+func (arr *appsRoundTripper) addAppInstallationAuth(r *http.Request) *appsAuthError {
+	org := r.Header.Get(githubOrgHeaderKey)
+	if org == "" {
+		return &appsAuthError{fmt.Errorf("request didn't have %s header set, can not infer org", githubOrgHeaderKey)}
+	}
+
+	installationID, err := arr.installationIDFor(org)
+	if err != nil {
+		return &appsAuthError{fmt.Errorf("failed to get installation id for org %s: %w", org, err)}
+	}
+
+	token, err := arr.getTokenForInstallation(installationID)
+	if err != nil {
+		return &appsAuthError{fmt.Errorf("failed to get an installation token for org %s: %w", org, err)}
+	}
+
+	r.Header.Set("Authorization", "Bearer "+token)
+	slug, err := arr.getSlug()
+	if err != nil {
+		return &appsAuthError{err}
+	}
+
+	// Token budgets are set on organization level, so include it in the identifier
+	// to not mess up metrics.
+	r.Header.Set(ghcache.TokenBudgetIdentifierHeader, slug+" - "+org)
+
+	return nil
+}
+
+// installationIDFor returns the installation id for the given org. Unfortunately,
+// GitHub does not expose what repos in that org the app is installed in, it
+// only tells us if its all repos or a subset via the repository_selection
+// property.
+// Ref: https://docs.github.com/en/free-pro-team@latest/rest/reference/apps#list-installations-for-the-authenticated-app
+func (arr *appsRoundTripper) installationIDFor(org string) (int64, error) {
+	arr.installationLock.RLock()
+	id, found := arr.installations[org]
+	arr.installationLock.RUnlock()
+	if found {
+		return id.ID, nil
+	}
+
+	arr.installationLock.Lock()
+	defer arr.installationLock.Unlock()
+
+	// Check again in case a concurrent routine updated it while we waited for the lock
+	id, found = arr.installations[org]
+	if found {
+		return id.ID, nil
+	}
+
+	installations, err := arr.githubClient.ListAppInstallations()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list app installations: %w", err)
+	}
+
+	installationsMap := make(map[string]AppInstallation, len(installations))
+	for _, installation := range installations {
+		installationsMap[installation.Account.Login] = installation
+	}
+
+	if equal := reflect.DeepEqual(arr.installations, installationsMap); equal {
+		return 0, fmt.Errorf("the github app is not installed in organization %s", org)
+	}
+	arr.installations = installationsMap
+
+	id, found = installationsMap[org]
+	if !found {
+		return 0, fmt.Errorf("the github app is not installed in organization %s", org)
+	}
+
+	return id.ID, nil
+}
+
+func (arr *appsRoundTripper) getTokenForInstallation(installation int64) (string, error) {
+	arr.tokenLock.RLock()
+	token, found := arr.tokens[installation]
+	arr.tokenLock.RUnlock()
+
+	if found && token.ExpiresAt.Add(-time.Minute).After(time.Now()) {
+		return token.Token, nil
+	}
+
+	arr.tokenLock.Lock()
+	defer arr.tokenLock.Unlock()
+
+	// Check again in case a concurrent routine got a token while we waited for the lock
+	token, found = arr.tokens[installation]
+	if found && token.ExpiresAt.Add(-time.Minute).After(time.Now()) {
+		return token.Token, nil
+	}
+
+	token, err := arr.githubClient.getAppInstallationToken(installation)
+	if err != nil {
+		return "", fmt.Errorf("failed to get installation token from GitHub: %w", err)
+	}
+
+	if arr.tokens == nil {
+		arr.tokens = map[int64]*AppInstallationToken{}
+	}
+	arr.tokens[installation] = token
+
+	return token.Token, nil
+}
+
+func (arr *appsRoundTripper) getSlug() (string, error) {
+	arr.appSlugLock.Lock()
+	defer arr.appSlugLock.Unlock()
+
+	if arr.appSlug != "" {
+		return arr.appSlug, nil
+	}
+	response, err := arr.githubClient.GetApp()
+	if err != nil {
+		return "", err
+	}
+
+	arr.appSlug = response.Slug
+	return arr.appSlug, nil
+}

--- a/prow/github/app_auth_roundtripper_integration_test.go
+++ b/prow/github/app_auth_roundtripper_integration_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"crypto/rsa"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	jwt "github.com/dgrijalva/jwt-go/v4"
+	"github.com/sirupsen/logrus"
+)
+
+func TestGetOrg(t *testing.T) {
+	logrus.SetLevel(logrus.TraceLevel)
+	appID := os.Getenv("APP_ID")
+	privateKeyPath := os.Getenv("APP_PRIVATE_KEY_PATH")
+	org := os.Getenv("APP_GITHUB_ORG")
+	if appID == "" || privateKeyPath == "" || org == "" {
+		t.SkipNow()
+	}
+	keyData, err := ioutil.ReadFile(privateKeyPath)
+	if err != nil {
+		t.Fatalf("Failed to read private key: %v", err)
+	}
+	key, err := jwt.ParseRSAPrivateKeyFromPEM(keyData)
+	if err != nil {
+		t.Fatalf("Failed to parse key: %v", err)
+	}
+
+	client := NewAppsAuthClientWithFields(
+		logrus.Fields{},
+		func(b []byte) []byte { return b },
+		appID,
+		func() *rsa.PrivateKey { return key },
+		"https://api.github.com/graphql",
+		"https://api.github.com",
+	)
+
+	if _, err := client.GetOrg(org); err != nil {
+		t.Errorf("Failed to get org: %v", err)
+	}
+}

--- a/prow/github/app_auth_roundtripper_test.go
+++ b/prow/github/app_auth_roundtripper_test.go
@@ -1,0 +1,431 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+
+	utilpointer "k8s.io/utils/pointer"
+)
+
+// *appsAuthError implements the error interface
+var _ error = &appsAuthError{}
+
+// *appsRoundTripper implements the http.RoundTripper interface
+var _ http.RoundTripper = &appsRoundTripper{}
+
+type fakeRoundTripper struct {
+	lock     sync.Mutex
+	requests []*http.Request
+	// path -> response
+	responses map[string]*http.Response
+}
+
+func (frt *fakeRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	frt.lock.Lock()
+	defer frt.lock.Unlock()
+	frt.requests = append(frt.requests, r)
+	if response, found := frt.responses[r.URL.Path]; found {
+		return response, nil
+	}
+	return &http.Response{StatusCode: 400}, nil
+}
+
+func TestAppsAuth(t *testing.T) {
+
+	const appID = "13"
+	testCases := []struct {
+		name                string
+		cachedAppSlug       *string
+		cachedInstallations map[string]AppInstallation
+		cachedTokens        map[int64]*AppInstallationToken
+		doRequest           func(Client) error
+		responses           map[string]*http.Response
+		verifyRequests      func([]*http.Request) error
+	}{
+		{
+			name: "App auth success",
+			doRequest: func(c Client) error {
+				_, err := c.GetApp()
+				return err
+			},
+			responses: map[string]*http.Response{"/app": {
+				StatusCode: 200,
+				Body:       serializeOrDie(App{}),
+			}},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 1 {
+					return fmt.Errorf("expected exactly one request, got %d", n)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != appID {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value %s", val, appID)
+				}
+				return nil
+			},
+		},
+		{
+			name: "App auth failure",
+			doRequest: func(c Client) error {
+				_, err := c.GetApp()
+				if expectedMsg := "status code 401 not one of [200], body: "; err == nil || err.Error() != expectedMsg {
+					return fmt.Errorf("expected error to have message %s, was %v", expectedMsg, err)
+				}
+				return nil
+			},
+			responses: map[string]*http.Response{"/app": {
+				StatusCode: 401,
+				Body:       ioutil.NopCloser(&bytes.Buffer{}),
+			}},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 1 {
+					return fmt.Errorf("expected exactly one request, got %d", n)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != appID {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value %s", val, appID)
+				}
+				return nil
+			},
+		},
+		{
+			name:                "App installation auth success, everything served from cache",
+			cachedAppSlug:       utilpointer.StringPtr("ci-app"),
+			cachedInstallations: map[string]AppInstallation{"org": {ID: 1}},
+			cachedTokens:        map[int64]*AppInstallationToken{1: {Token: "the-token", ExpiresAt: time.Now().Add(time.Hour)}},
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				return err
+			},
+			responses: map[string]*http.Response{"/orgs/org": {
+				StatusCode: 200,
+				Body:       serializeOrDie(Organization{}),
+			}},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 1 {
+					return fmt.Errorf("expected exactly one request, got %d", n)
+				}
+				if val := r[0].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
+		{
+			name:                "App installation auth success, new token is requested",
+			cachedAppSlug:       utilpointer.StringPtr("ci-app"),
+			cachedInstallations: map[string]AppInstallation{"org": {ID: 1}},
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				return err
+			},
+			responses: map[string]*http.Response{
+				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 2 {
+					return fmt.Errorf("expected exactly one request, got %d", n)
+				}
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if r[0].URL.Path != "/app/installations/1/access_tokens" {
+					return fmt.Errorf("expected first request to request a token, but had path %s", r[0].URL.Path)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+				if val := r[1].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
+		{
+			name:          "App installation auth success, installations and token is requsted",
+			cachedAppSlug: utilpointer.StringPtr("ci-app"),
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				return err
+			},
+			responses: map[string]*http.Response{
+				"/app/installations":                 {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
+				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
+				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 3 {
+					return fmt.Errorf("expected exactly three request, got %d", n)
+				}
+				if r[0].URL.Path != "/app/installations" {
+					return fmt.Errorf("expected first request to have path '/app/installations' but had %q", r[0].URL.Path)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				if r[1].URL.Path != "/app/installations/1/access_tokens" {
+					return fmt.Errorf("expected second request to request a token, but had path %s", r[0].URL.Path)
+				}
+				if val := r[1].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if val := r[2].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				if val := r[2].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
+		{
+			name: "App installation auth success, slug, installations and token is requsted",
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("org")
+				return err
+			},
+			responses: map[string]*http.Response{
+				"/app":                               {StatusCode: 200, Body: serializeOrDie(App{Slug: "ci-app"})},
+				"/app/installations":                 {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
+				"/app/installations/1/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-token"})},
+				"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 4 {
+					return fmt.Errorf("expected exactly four request, got %d", n)
+				}
+
+				if r[0].URL.Path != "/app" {
+					return fmt.Errorf("expected first request to have path '/app' but had %q", r[0].URL.Path)
+				}
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "13" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value '13'", val)
+				}
+
+				if r[1].URL.Path != "/app/installations" {
+					return fmt.Errorf("expected first request to have path '/app/installations' but had %q", r[0].URL.Path)
+				}
+				if val := r[1].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[1].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				if r[2].URL.Path != "/app/installations/1/access_tokens" {
+					return fmt.Errorf("expected second request to request a token, but had path %s", r[0].URL.Path)
+				}
+				if val := r[2].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[2].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				expectedGHCacheHeaderValue := "ci-app - org"
+				if val := r[3].Header.Get("Authorization"); val != "Bearer the-token" {
+					return fmt.Errorf("expected the Authorization header %q to be 'Bearer the-token'", val)
+				}
+				if val := r[3].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != expectedGHCacheHeaderValue {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to be %q", val, expectedGHCacheHeaderValue)
+				}
+				return nil
+			},
+		},
+		{
+			name:          "App installation request has no installation, failure",
+			cachedAppSlug: utilpointer.StringPtr("ci-app"),
+			doRequest: func(c Client) error {
+				_, err := c.GetOrg("other-org")
+				expectedErrMsgSubstr := "failed to get installation id for org other-org: the github app is not installed in organization other-org"
+				if err == nil || !strings.Contains(err.Error(), expectedErrMsgSubstr) {
+					return fmt.Errorf("expected error to contain string %s, was %v", expectedErrMsgSubstr, err)
+				}
+				return nil
+			},
+			responses: map[string]*http.Response{
+				"/app/installations": {StatusCode: 200, Body: serializeOrDie([]AppInstallation{{ID: 1, Account: User{Login: "org"}}})},
+			},
+			verifyRequests: func(r []*http.Request) error {
+				if n := len(r); n != 1 {
+					return fmt.Errorf("expected exactly four request, got %d", n)
+				}
+
+				if val := r[0].Header.Get("Authorization"); !strings.HasPrefix(val, "Bearer ") {
+					return fmt.Errorf("expected the Authorization header %q to start with 'Bearer '", val)
+				}
+				if val := r[0].Header.Get("X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER"); val != "ci-app" {
+					return fmt.Errorf("expected X-PROW-GHCACHE-TOKEN-BUDGET-IDENTIFIER header %q to have value ci-app", val)
+				}
+
+				return nil
+			},
+		},
+	}
+
+	// Generate it only once. Can not be smaller, otherwise the JWT signature generation
+	// fails with "message too long for RSA public key size"
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ghClient := NewAppsAuthClientWithFields(logrus.Fields{}, func(b []byte) []byte { return b }, appID, func() *rsa.PrivateKey { return rsaKey }, "", "")
+
+			if _, ok := ghClient.(*client); !ok {
+				t.Fatal("ghclient is not a *client")
+			}
+			if _, ok := ghClient.(*client).client.(*http.Client); !ok {
+				t.Fatal("the ghclients client is not a *http.Client")
+			}
+			if _, ok := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper); !ok {
+				t.Fatal("the ghclients didn't get configured to use the appsRoundTripper")
+			}
+
+			roundTripper := &fakeRoundTripper{
+				responses: tc.responses,
+			}
+
+			appsRoundTripper := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper)
+			appsRoundTripper.upstream = roundTripper
+			if tc.cachedAppSlug != nil {
+				appsRoundTripper.appSlug = *tc.cachedAppSlug
+			}
+			if tc.cachedInstallations != nil {
+				appsRoundTripper.installations = tc.cachedInstallations
+			}
+			if tc.cachedTokens != nil {
+				appsRoundTripper.tokens = tc.cachedTokens
+			}
+
+			if err := tc.doRequest(ghClient); err != nil {
+				t.Fatalf("Failed to do request: %v", err)
+			}
+
+			if err := tc.verifyRequests(roundTripper.requests); err != nil {
+				t.Errorf("Request verification failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestAppsRoundTripperThreadSafety(t *testing.T) {
+	const appID = "13"
+	// Can not be smaller, otherwise the JWT signature generation
+	// fails with "message too long for RSA public key size"
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 512)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	ghClient := NewAppsAuthClientWithFields(logrus.Fields{}, nil, appID, func() *rsa.PrivateKey { return rsaKey }, "", "")
+
+	if _, ok := ghClient.(*client); !ok {
+		t.Fatal("ghclient is not a *client")
+	}
+	if _, ok := ghClient.(*client).client.(*http.Client); !ok {
+		t.Fatal("the ghclients client is not a *http.Client")
+	}
+	if _, ok := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper); !ok {
+		t.Fatal("the ghclients didn't get configured to use the appsRoundTripper")
+	}
+
+	// installation and token for requests to "org" are cached, but need to be fetched for requests
+	// to "other-org"
+	appsRoundTripper := ghClient.(*client).client.(*http.Client).Transport.(*appsRoundTripper)
+	appsRoundTripper.installations = map[string]AppInstallation{"org": {ID: 1}}
+	appsRoundTripper.tokens = map[int64]*AppInstallationToken{1: {Token: "the-token", ExpiresAt: time.Now().Add(time.Hour)}}
+	appsRoundTripper.upstream = &fakeRoundTripper{
+		responses: map[string]*http.Response{
+			"/app": {StatusCode: 200, Body: serializeOrDie(App{Slug: "ci-app"})},
+			"/app/installations": {StatusCode: 200, Body: serializeOrDie([]AppInstallation{
+				{ID: 1, Account: User{Login: "org"}},
+				{ID: 2, Account: User{Login: "other-org"}},
+			})},
+			"/app/installations/2/access_tokens": {StatusCode: 201, Body: serializeOrDie(AppInstallationToken{Token: "the-other-token"})},
+			"/orgs/org":                          {StatusCode: 200, Body: serializeOrDie(Organization{})},
+			"/orgs/other-org":                    {StatusCode: 200, Body: serializeOrDie(Organization{})},
+		},
+	}
+
+	req1Done, req2Done := make(chan struct{}), make(chan struct{})
+
+	go func() {
+		defer close(req1Done)
+		if _, err := ghClient.GetOrg("org"); err != nil {
+			t.Errorf("failed to get org org: %v", err)
+		}
+	}()
+
+	go func() {
+		defer close(req2Done)
+		if _, err := ghClient.GetOrg("other-org"); err != nil {
+			t.Errorf("failed to get org other-org: %v", err)
+		}
+	}()
+
+	<-req1Done
+	<-req2Done
+}
+
+func serializeOrDie(in interface{}) io.ReadCloser {
+	rawData, err := json.Marshal(in)
+	if err != nil {
+		panic(fmt.Sprintf("Serialization failed: %v", err))
+	}
+	return ioutil.NopCloser(bytes.NewBuffer(rawData))
+}

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -19,6 +19,7 @@ package github
 import (
 	"bytes"
 	"context"
+	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
@@ -482,7 +483,21 @@ func (c *client) SetMax404Retries(max int) {
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
 func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor func([]byte) []byte, graphqlEndpoint string, bases ...string) Client {
-	return &client{
+	return newClient(fields, getToken, censor, "", nil, graphqlEndpoint, false, bases)
+}
+
+func NewAppsAuthClientWithFields(fields logrus.Fields, censor func([]byte) []byte, appID string, appPrivateKey func() *rsa.PrivateKey, graphqlEndpoint string, bases ...string) Client {
+	return newClient(fields, nil, censor, appID, appPrivateKey, graphqlEndpoint, false, bases)
+}
+
+func newClient(fields logrus.Fields, getToken func() []byte, censor func([]byte) []byte, appID string, appPrivateKey func() *rsa.PrivateKey, graphqlEndpoint string, dryRun bool, bases []string) Client {
+	// Will be nil if github app authentication is used
+	if getToken == nil {
+		getToken = func() []byte { return nil }
+	}
+	httpClient := &http.Client{Timeout: maxRequestTime}
+	graphQLTransport := newAddHeaderTransport()
+	c := &client{
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		delegate: &delegate{
 			time: &standardTime{},
@@ -492,27 +507,43 @@ func NewClientWithFields(fields logrus.Fields, getToken func() []byte, censor fu
 					Timeout: maxRequestTime,
 					Transport: &oauth2.Transport{
 						Source: newReloadingTokenSource(getToken),
-						Base:   newAddHeaderTransport(),
+						Base:   graphQLTransport,
 					},
 				}),
-			client:        &http.Client{Timeout: maxRequestTime},
+			client:        httpClient,
 			bases:         bases,
 			getToken:      getToken,
 			censor:        censor,
-			dry:           false,
+			dry:           dryRun,
 			maxRetries:    defaultMaxRetries,
 			max404Retries: defaultMax404Retries,
 			initialDelay:  defaultInitialDelay,
 			maxSleepTime:  defaultMaxSleepTime,
 		},
 	}
+	if appID != "" {
+		appsTransport := &appsRoundTripper{
+			appID:        appID,
+			privateKey:   appPrivateKey,
+			upstream:     http.DefaultTransport,
+			githubClient: c,
+		}
+		httpClient.Transport = appsTransport
+		graphQLTransport.upstream = appsTransport
+	}
+
+	return c
 }
 
-func newAddHeaderTransport() http.RoundTripper {
+// addHeaderTransport implements http.RoundTripper
+var _ http.RoundTripper = &addHeaderTransport{}
+
+func newAddHeaderTransport() *addHeaderTransport {
 	return &addHeaderTransport{}
 }
 
 type addHeaderTransport struct {
+	upstream http.RoundTripper
 }
 
 func (s *addHeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) {
@@ -520,6 +551,9 @@ func (s *addHeaderTransport) RoundTrip(r *http.Request) (*http.Response, error) 
 	// https://docs.github.com/en/enterprise-server@2.22/graphql/overview/schema-previews
 	// Any GHE version after 2.22 will enable the Checks types per default
 	r.Header.Add("Accept", "application/vnd.github.antiope-preview+json")
+	if s.upstream != nil {
+		return s.upstream.RoundTrip(r)
+	}
 	return http.DefaultTransport.RoundTrip(r)
 }
 
@@ -537,27 +571,14 @@ func NewClient(getToken func() []byte, censor func([]byte) []byte, graphqlEndpoi
 //   This should be used when using the ghproxy GitHub proxy cache to allow
 //   this client to bypass the cache if it is temporarily unavailable.
 func NewDryRunClientWithFields(fields logrus.Fields, getToken func() []byte, censor func([]byte) []byte, graphqlEndpoint string, bases ...string) Client {
-	return &client{
-		logger: logrus.WithFields(fields).WithField("client", "github"),
-		delegate: &delegate{
-			time: &standardTime{},
-			gqlc: githubql.NewEnterpriseClient(
-				graphqlEndpoint,
-				&http.Client{
-					Timeout:   maxRequestTime,
-					Transport: &oauth2.Transport{Source: newReloadingTokenSource(getToken)},
-				}),
-			client:        &http.Client{Timeout: maxRequestTime},
-			bases:         bases,
-			getToken:      getToken,
-			censor:        censor,
-			dry:           true,
-			maxRetries:    defaultMaxRetries,
-			max404Retries: defaultMax404Retries,
-			initialDelay:  defaultInitialDelay,
-			maxSleepTime:  defaultMaxSleepTime,
-		},
-	}
+	return newClient(fields, getToken, censor, "", nil, graphqlEndpoint, true, bases)
+}
+
+// NewAppsAuthDryRunClientWithFields creates a new client that will not perform mutating actions
+// such as setting statuses or commenting, but it will still query GitHub and
+// use up API tokens. Additional fields are added to the logger.
+func NewAppsAuthDryRunClientWithFields(fields logrus.Fields, censor func([]byte) []byte, appId string, appPrivateKey func() *rsa.PrivateKey, graphqlEndpoint string, bases ...string) Client {
+	return newClient(fields, nil, censor, appId, appPrivateKey, graphqlEndpoint, true, bases)
 }
 
 // NewDryRunClient creates a new client that will not perform mutating actions
@@ -603,6 +624,7 @@ type request struct {
 	method      string
 	path        string
 	accept      string
+	org         string
 	requestBody interface{}
 	exitCodes   []int
 }
@@ -680,7 +702,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 	if c.fake || (c.dry && r.method != http.MethodGet) {
 		return r.exitCodes[0], nil, nil
 	}
-	resp, err := c.requestRetry(r.method, r.path, r.accept, r.requestBody)
+	resp, err := c.requestRetry(r.method, r.path, r.accept, r.org, r.requestBody)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -709,7 +731,7 @@ func (c *client) requestRaw(r *request) (int, []byte, error) {
 // Retry on transport failures. Retries on 500s, retries after sleep on
 // ratelimit exceeded, and retries 404s a couple times.
 // This function closes the response body iff it also returns an error.
-func (c *client) requestRetry(method, path, accept string, body interface{}) (*http.Response, error) {
+func (c *client) requestRetry(method, path, accept, org string, body interface{}) (*http.Response, error) {
 	var hostIndex int
 	var resp *http.Response
 	var err error
@@ -718,7 +740,7 @@ func (c *client) requestRetry(method, path, accept string, body interface{}) (*h
 		if retries > 0 && resp != nil {
 			resp.Body.Close()
 		}
-		resp, err = c.doRequest(method, c.bases[hostIndex]+path, accept, body)
+		resp, err = c.doRequest(method, c.bases[hostIndex]+path, accept, org, body)
 		if err == nil {
 			if resp.StatusCode == 404 && retries < c.max404Retries {
 				// Retry 404s a couple times. Sometimes GitHub is inconsistent in
@@ -791,11 +813,15 @@ func (c *client) requestRetry(method, path, accept string, body interface{}) (*h
 				c.time.Sleep(backoff)
 				backoff *= 2
 			}
+		} else if errors.Is(err, &appsAuthError{}) {
+			c.logger.WithError(err).Error("Stopping retry due to appsAuthError")
+			return resp, err
 		} else {
 			// Connection problem. Try a different host.
 			oldHostIndex := hostIndex
 			hostIndex = (hostIndex + 1) % len(c.bases)
 			c.logger.WithFields(logrus.Fields{
+				"err":          err,
 				"backoff":      backoff.String(),
 				"old-endpoint": c.bases[oldHostIndex],
 				"new-endpoint": c.bases[hostIndex],
@@ -807,7 +833,7 @@ func (c *client) requestRetry(method, path, accept string, body interface{}) (*h
 	return resp, err
 }
 
-func (c *client) doRequest(method, path, accept string, body interface{}) (*http.Response, error) {
+func (c *client) doRequest(method, path, accept, org string, body interface{}) (*http.Response, error) {
 	var buf io.Reader
 	if body != nil {
 		b, err := json.Marshal(body)
@@ -831,6 +857,9 @@ func (c *client) doRequest(method, path, accept string, body interface{}) (*http
 	}
 	if userAgent := c.userAgent(); userAgent != "" {
 		req.Header.Add("User-Agent", userAgent)
+	}
+	if org != "" {
+		req.Header.Set(githubOrgHeaderKey, org)
 	}
 	// Disable keep-alive so that we don't get flakes when GitHub closes the
 	// connection prematurely.
@@ -883,6 +912,9 @@ func maskAuthorizationHeader(key string, value string) string {
 }
 
 func (c *client) authHeader() string {
+	if c.getToken == nil {
+		return ""
+	}
 	token := c.getToken()
 	if len(token) == 0 {
 		return ""
@@ -981,6 +1013,7 @@ func (c *client) IsMember(org, user string) (bool, error) {
 	code, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/orgs/%s/members/%s", org, user),
+		org:       org,
 		exitCodes: []int{204, 404, 302},
 	}, nil)
 	if err != nil {
@@ -1008,6 +1041,7 @@ func (c *client) listHooks(org string, repo *string) ([]Hook, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Hook{}
 		},
@@ -1049,6 +1083,7 @@ func (c *client) editHook(org string, repo *string, id int, req HookRequest) err
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        path,
+		org:         org,
 		exitCodes:   []int{200},
 		requestBody: &req,
 	}, nil)
@@ -1083,6 +1118,7 @@ func (c *client) createHook(org string, repo *string, req HookRequest) (int, err
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        path,
+		org:         org,
 		exitCodes:   []int{201},
 		requestBody: &req,
 	}, &ret)
@@ -1106,7 +1142,7 @@ func (c *client) CreateRepoHook(org, repo string, req HookRequest) (int, error) 
 	return c.createHook(org, &repo, req)
 }
 
-func (c *client) deleteHook(path string) error {
+func (c *client) deleteHook(org, path string) error {
 	if c.dry {
 		return nil
 	}
@@ -1114,6 +1150,7 @@ func (c *client) deleteHook(path string) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      path,
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -1124,7 +1161,7 @@ func (c *client) deleteHook(path string) error {
 func (c *client) DeleteRepoHook(org, repo string, id int, req HookRequest) error {
 	c.log("DeleteRepoHook", org, repo, id)
 	path := fmt.Sprintf("/repos/%s/%s/hooks/%d", org, repo, id)
-	return c.deleteHook(path)
+	return c.deleteHook(org, path)
 }
 
 // DeleteOrgHook deletes and existing org level webhook.
@@ -1132,7 +1169,7 @@ func (c *client) DeleteRepoHook(org, repo string, id int, req HookRequest) error
 func (c *client) DeleteOrgHook(org string, id int, req HookRequest) error {
 	c.log("DeleteOrgHook", org, id)
 	path := fmt.Sprintf("/orgs/%s/hooks/%d", org, id)
-	return c.deleteHook(path)
+	return c.deleteHook(org, path)
 }
 
 // GetOrg returns current metadata for the org
@@ -1144,6 +1181,7 @@ func (c *client) GetOrg(name string) (*Organization, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/orgs/%s", name),
+		org:       name,
 		exitCodes: []int{200},
 	}, &retOrg)
 	if err != nil {
@@ -1164,6 +1202,7 @@ func (c *client) EditOrg(name string, config Organization) (*Organization, error
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/orgs/%s", name),
+		org:         name,
 		exitCodes:   []int{200},
 		requestBody: &config,
 	}, &retOrg)
@@ -1186,6 +1225,7 @@ func (c *client) ListOrgInvitations(org string) ([]OrgInvitation, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]OrgInvitation{}
 		},
@@ -1220,6 +1260,7 @@ func (c *client) ListOrgMembers(org, role string) ([]TeamMember, error) {
 			"role":     []string{role},
 		},
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]TeamMember{}
 		},
@@ -1259,6 +1300,7 @@ func (c *client) GetUserPermission(org, repo, user string) (string, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/collaborators/%s/permission", org, repo, user),
+		org:       org,
 		exitCodes: []int{200},
 	}, &perm)
 	if err != nil {
@@ -1288,6 +1330,7 @@ func (c *client) UpdateOrgMembership(org, user string, admin bool) (*OrgMembersh
 	_, err := c.request(&request{
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/orgs/%s/memberships/%s", org, user),
+		org:         org,
 		requestBody: &om,
 		exitCodes:   []int{200},
 	}, &om)
@@ -1301,6 +1344,7 @@ func (c *client) RemoveOrgMembership(org, user string) error {
 	c.log("RemoveOrgMembership", org, user)
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
+		org:       org,
 		path:      fmt.Sprintf("/orgs/%s/memberships/%s", org, user),
 		exitCodes: []int{204},
 	}, nil)
@@ -1318,6 +1362,7 @@ func (c *client) CreateComment(org, repo string, number int, comment string) err
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/comments", org, repo, number),
+		org:         org,
 		requestBody: &ic,
 		exitCodes:   []int{201},
 	}, nil)
@@ -1332,6 +1377,7 @@ func (c *client) DeleteComment(org, repo string, id int) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/repos/%s/%s/issues/comments/%d", org, repo, id),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -1348,6 +1394,7 @@ func (c *client) EditComment(org, repo string, id int, comment string) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/comments/%d", org, repo, id),
+		org:         org,
 		requestBody: &ic,
 		exitCodes:   []int{200},
 	}, nil)
@@ -1364,6 +1411,7 @@ func (c *client) CreateCommentReaction(org, repo string, id int, reaction string
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/comments/%d/reactions", org, repo, id),
 		accept:      "application/vnd.github.squirrel-girl-preview",
+		org:         org,
 		exitCodes:   []int{201},
 		requestBody: &r,
 	}, nil)
@@ -1401,6 +1449,7 @@ func (c *client) CreateIssue(org, repo, title, body string, milestone int, label
 		accept:      "application/vnd.github.symmetra-preview+json, application/vnd.github.shadow-cat-preview",
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues", org, repo),
+		org:         org,
 		requestBody: &data,
 		exitCodes:   []int{201},
 	}, &resp)
@@ -1420,6 +1469,7 @@ func (c *client) CreateIssueReaction(org, repo string, id int, reaction string) 
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/reactions", org, repo, id),
 		accept:      "application/vnd.github.squirrel-girl-preview",
+		org:         org,
 		requestBody: &r,
 		exitCodes:   []int{200, 201},
 	}, nil)
@@ -1452,21 +1502,21 @@ func (c *client) DeleteStaleComments(org, repo string, number int, comments []Is
 // accumulate() should accept that populated slice for each page of results.
 //
 // Returns an error any call to GitHub or object marshalling fails.
-func (c *client) readPaginatedResults(path, accept string, newObj func() interface{}, accumulate func(interface{})) error {
+func (c *client) readPaginatedResults(path, accept, org string, newObj func() interface{}, accumulate func(interface{})) error {
 	values := url.Values{
 		"per_page": []string{"100"},
 	}
-	return c.readPaginatedResultsWithValues(path, values, accept, newObj, accumulate)
+	return c.readPaginatedResultsWithValues(path, values, accept, org, newObj, accumulate)
 }
 
 // readPaginatedResultsWithValues is an override that allows control over the query string.
-func (c *client) readPaginatedResultsWithValues(path string, values url.Values, accept string, newObj func() interface{}, accumulate func(interface{})) error {
+func (c *client) readPaginatedResultsWithValues(path string, values url.Values, accept, org string, newObj func() interface{}, accumulate func(interface{})) error {
 	pagedPath := path
 	if len(values) > 0 {
 		pagedPath += "?" + values.Encode()
 	}
 	for {
-		resp, err := c.requestRetry(http.MethodGet, pagedPath, accept, nil)
+		resp, err := c.requestRetry(http.MethodGet, pagedPath, accept, org, nil)
 		if err != nil {
 			return err
 		}
@@ -1529,6 +1579,7 @@ func (c *client) ListIssueComments(org, repo string, number int) ([]IssueComment
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]IssueComment{}
 		},
@@ -1557,6 +1608,7 @@ func (c *client) ListOpenIssues(org, repo string) ([]Issue, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Issue{}
 		},
@@ -1586,6 +1638,7 @@ func (c *client) GetPullRequests(org, repo string) ([]PullRequest, error) {
 		// https://developer.github.com/changes/2018-02-22-label-description-search-preview/
 		// https://developer.github.com/changes/2019-02-14-draft-pull-requests/
 		"application/vnd.github.symmetra-preview+json, application/vnd.github.shadow-cat-preview",
+		org,
 		func() interface{} {
 			return &[]PullRequest{}
 		},
@@ -1614,6 +1667,7 @@ func (c *client) GetPullRequest(org, repo string, number int) (*PullRequest, err
 		accept:    "application/vnd.github.symmetra-preview+json, application/vnd.github.shadow-cat-preview",
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:       org,
 		exitCodes: []int{200},
 	}, &pr)
 	return &pr, err
@@ -1642,6 +1696,7 @@ func (c *client) EditPullRequest(org, repo string, number int, pr *PullRequest) 
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:         org,
 		exitCodes:   []int{200},
 		requestBody: &edit,
 	}, &ret)
@@ -1665,6 +1720,7 @@ func (c *client) GetIssue(org, repo string, number int) (*Issue, error) {
 		accept:    "application/vnd.github.symmetra-preview+json",
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, number),
+		org:       org,
 		exitCodes: []int{200},
 	}, &i)
 	return &i, err
@@ -1693,6 +1749,7 @@ func (c *client) EditIssue(org, repo string, number int, issue *Issue) (*Issue, 
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, number),
+		org:         org,
 		exitCodes:   []int{200},
 		requestBody: &edit,
 	}, &ret)
@@ -1713,6 +1770,7 @@ func (c *client) GetPullRequestPatch(org, repo string, number int) ([]byte, erro
 		accept:    "application/vnd.github.VERSION.patch",
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:       org,
 		exitCodes: []int{200},
 	})
 	return patch, err
@@ -1752,6 +1810,7 @@ func (c *client) CreatePullRequest(org, repo, title, body, head, base string, ca
 		accept:      "application/vnd.github.symmetra-preview+json, application/vnd.github.shadow-cat-preview",
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls", org, repo),
+		org:         org,
 		requestBody: &data,
 		exitCodes:   []int{201},
 	}, &resp)
@@ -1794,6 +1853,7 @@ func (c *client) UpdatePullRequest(org, repo string, number int, title, body *st
 		accept:      "application/vnd.github.symmetra-preview+json, application/vnd.github.shadow-cat-preview",
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:         org,
 		requestBody: &data,
 		exitCodes:   []int{200},
 	}, nil)
@@ -1815,6 +1875,7 @@ func (c *client) GetPullRequestChanges(org, repo string, number int) ([]PullRequ
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]PullRequestChange{}
 		},
@@ -1845,6 +1906,7 @@ func (c *client) ListPullRequestComments(org, repo string, number int) ([]Review
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]ReviewComment{}
 		},
@@ -1875,6 +1937,7 @@ func (c *client) ListReviews(org, repo string, number int) ([]Review, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Review{}
 		},
@@ -1898,6 +1961,7 @@ func (c *client) CreateStatus(org, repo, SHA string, s Status) error {
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/statuses/%s", org, repo, SHA),
+		org:         org,
 		requestBody: &s,
 		exitCodes:   []int{201},
 	}, nil)
@@ -1916,6 +1980,7 @@ func (c *client) ListStatuses(org, repo, ref string) ([]Status, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Status{}
 		},
@@ -1937,6 +2002,7 @@ func (c *client) GetRepo(owner, name string) (FullRepo, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s", owner, name),
+		org:       owner,
 		exitCodes: []int{200},
 	}, &repo)
 	return repo, err
@@ -1965,6 +2031,7 @@ func (c *client) CreateRepo(owner string, isUser bool, repo RepoCreateRequest) (
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        path,
+		org:         owner,
 		requestBody: &repo,
 		exitCodes:   []int{201},
 	}, &retRepo)
@@ -1988,6 +2055,7 @@ func (c *client) UpdateRepo(owner, name string, repo RepoUpdateRequest) (*FullRe
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        path,
+		org:         owner,
 		requestBody: &repo,
 		exitCodes:   []int{200},
 	}, &retRepo)
@@ -2018,6 +2086,7 @@ func (c *client) GetRepos(org string, isUser bool) ([]Repo, error) {
 	err := c.readPaginatedResults(
 		nextURL,    // path
 		acceptNone, // accept
+		org,
 		func() interface{} { // newObj
 			return &[]Repo{}
 		},
@@ -2042,6 +2111,7 @@ func (c *client) GetSingleCommit(org, repo, SHA string) (SingleCommit, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/commits/%s", org, repo, SHA),
+		org:       org,
 		exitCodes: []int{200},
 	}, &commit)
 	return commit, err
@@ -2067,6 +2137,7 @@ func (c *client) GetBranches(org, repo string, onlyProtected bool) ([]Branch, er
 			"per_page":  []string{"100"},
 		},
 		acceptNone,
+		org,
 		func() interface{} { // newObj
 			return &[]Branch{}
 		},
@@ -2090,6 +2161,7 @@ func (c *client) GetBranchProtection(org, repo, branch string) (*BranchProtectio
 	code, body, err := c.requestRaw(&request{
 		method: http.MethodGet,
 		path:   fmt.Sprintf("/repos/%s/%s/branches/%s/protection", org, repo, branch),
+		org:    org,
 		// GitHub returns 404 for this call if either:
 		// - The branch is not protected
 		// - The access token used does not have sufficient privileges
@@ -2137,6 +2209,7 @@ func (c *client) RemoveBranchProtection(org, repo, branch string) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/repos/%s/%s/branches/%s/protection", org, repo, branch),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -2153,6 +2226,7 @@ func (c *client) UpdateBranchProtection(org, repo, branch string, config BranchP
 		accept:      "application/vnd.github.luke-cage-preview+json", // for required_approving_review_count
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/repos/%s/%s/branches/%s/protection", org, repo, branch),
+		org:         org,
 		requestBody: config,
 		exitCodes:   []int{200},
 	}, nil)
@@ -2170,6 +2244,7 @@ func (c *client) AddRepoLabel(org, repo, label, description, color string) error
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/labels", org, repo),
 		accept:      "application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
+		org:         org,
 		requestBody: Label{Name: label, Description: description, Color: color},
 		exitCodes:   []int{201},
 	}, nil)
@@ -2187,6 +2262,7 @@ func (c *client) UpdateRepoLabel(org, repo, label, newName, description, color s
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/labels/%s", org, repo, label),
 		accept:      "application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
+		org:         org,
 		requestBody: Label{Name: newName, Description: description, Color: color},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2204,6 +2280,7 @@ func (c *client) DeleteRepoLabel(org, repo, label string) error {
 		method:      http.MethodDelete,
 		accept:      "application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
 		path:        fmt.Sprintf("/repos/%s/%s/labels/%s", org, repo, label),
+		org:         org,
 		requestBody: Label{Name: label},
 		exitCodes:   []int{204},
 	}, nil)
@@ -2221,6 +2298,7 @@ func (c *client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, erro
 	err := c.readPaginatedResults(
 		fmt.Sprintf("/repos/%s/%s/commits/%s/status", org, repo, ref),
 		"",
+		org,
 		func() interface{} {
 			return &CombinedStatus{}
 		},
@@ -2234,7 +2312,7 @@ func (c *client) GetCombinedStatus(org, repo, ref string) (*CombinedStatus, erro
 }
 
 // getLabels is a helper function that retrieves a paginated list of labels from a github URI path.
-func (c *client) getLabels(path string) ([]Label, error) {
+func (c *client) getLabels(path, org string) ([]Label, error) {
 	var labels []Label
 	if c.fake {
 		return labels, nil
@@ -2242,6 +2320,7 @@ func (c *client) getLabels(path string) ([]Label, error) {
 	err := c.readPaginatedResults(
 		path,
 		"application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
+		org,
 		func() interface{} {
 			return &[]Label{}
 		},
@@ -2262,7 +2341,7 @@ func (c *client) GetRepoLabels(org, repo string) ([]Label, error) {
 	durationLogger := c.log("GetRepoLabels", org, repo)
 	defer durationLogger()
 
-	return c.getLabels(fmt.Sprintf("/repos/%s/%s/labels", org, repo))
+	return c.getLabels(fmt.Sprintf("/repos/%s/%s/labels", org, repo), org)
 }
 
 // GetIssueLabels returns the list of labels currently on issue org/repo#number.
@@ -2272,7 +2351,7 @@ func (c *client) GetIssueLabels(org, repo string, number int) ([]Label, error) {
 	durationLogger := c.log("GetIssueLabels", org, repo, number)
 	defer durationLogger()
 
-	return c.getLabels(fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number))
+	return c.getLabels(fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number), org)
 }
 
 // AddLabel adds label to org/repo#number, returning an error on a bad response code.
@@ -2285,6 +2364,7 @@ func (c *client) AddLabel(org, repo string, number int, label string) error {
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/labels", org, repo, number),
+		org:         org,
 		requestBody: []string{label},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2305,6 +2385,7 @@ func (c *client) RemoveLabel(org, repo string, number int, label string) error {
 	code, body, err := c.requestRaw(&request{
 		method: http.MethodDelete,
 		path:   fmt.Sprintf("/repos/%s/%s/issues/%d/labels/%s", org, repo, number, label),
+		org:    org,
 		// GitHub sometimes returns 200 for this call, which is a bug on their end.
 		// Do not expect a 404 exit code and handle it separately because we need
 		// to introspect the request's response body.
@@ -2360,6 +2441,7 @@ func (c *client) AssignIssue(org, repo string, number int, logins []string) erro
 	_, err := c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/assignees", org, repo, number),
+		org:         org,
 		requestBody: map[string][]string{"assignees": logins},
 		exitCodes:   []int{201},
 	}, &i)
@@ -2403,6 +2485,7 @@ func (c *client) UnassignIssue(org, repo string, number int, logins []string) er
 	_, err := c.request(&request{
 		method:      http.MethodDelete,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d/assignees", org, repo, number),
+		org:         org,
 		requestBody: map[string][]string{"assignees": logins},
 		exitCodes:   []int{200},
 	}, &i)
@@ -2435,6 +2518,7 @@ func (c *client) CreateReview(org, repo string, number int, r DraftReview) error
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d/reviews", org, repo, number),
 		accept:      "application/vnd.github.black-cat-preview+json",
+		org:         org,
 		requestBody: r,
 		exitCodes:   []int{200},
 	}, nil)
@@ -2490,6 +2574,7 @@ func (c *client) tryRequestReview(org, repo string, number int, logins []string)
 	return c.request(&request{
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", org, repo, number),
+		org:         org,
 		accept:      "application/vnd.github.symmetra-preview+json",
 		requestBody: body,
 		exitCodes:   []int{http.StatusCreated /*201*/},
@@ -2548,6 +2633,7 @@ func (c *client) UnrequestReview(org, repo string, number int, logins []string) 
 		method:      http.MethodDelete,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d/requested_reviewers", org, repo, number),
 		accept:      "application/vnd.github.symmetra-preview+json",
+		org:         org,
 		requestBody: body,
 		exitCodes:   []int{http.StatusOK /*200*/},
 	}, &pr)
@@ -2583,6 +2669,7 @@ func (c *client) CloseIssue(org, repo string, number int) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, number),
+		org:         org,
 		requestBody: map[string]string{"state": "closed"},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2627,6 +2714,7 @@ func (c *client) ReopenIssue(org, repo string, number int) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/issues/%d", org, repo, number),
+		org:         org,
 		requestBody: map[string]string{"state": "open"},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2644,6 +2732,7 @@ func (c *client) ClosePR(org, repo string, number int) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:         org,
 		requestBody: map[string]string{"state": "closed"},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2661,6 +2750,7 @@ func (c *client) ReopenPR(org, repo string, number int) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d", org, repo, number),
+		org:         org,
 		requestBody: map[string]string{"state": "open"},
 		exitCodes:   []int{200},
 	}, nil)
@@ -2680,6 +2770,7 @@ func (c *client) GetRef(org, repo, ref string) (string, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/git/refs/%s", org, repo, ref),
+		org:       org,
 		exitCodes: []int{200},
 	}, &res)
 	if err != nil {
@@ -2759,6 +2850,7 @@ func (c *client) DeleteRef(org, repo, ref string) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/repos/%s/%s/git/refs/%s", org, repo, ref),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -2818,6 +2910,7 @@ func (c *client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 	code, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      url,
+		org:       org,
 		exitCodes: []int{200, 404},
 	}, &res)
 
@@ -2872,6 +2965,7 @@ func (c *client) CreateTeam(org string, team Team) (*Team, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		accept:      "application/vnd.github.hellcat-preview+json",
+		org:         org,
 		requestBody: &team,
 		exitCodes:   []int{201},
 	}, &retTeam)
@@ -2909,6 +3003,7 @@ func (c *client) EditTeam(org string, t Team) (*Team, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		accept:      "application/vnd.github.hellcat-preview+json",
+		org:         org,
 		requestBody: &team,
 		exitCodes:   []int{200, 201},
 	}, &retTeam)
@@ -2925,6 +3020,7 @@ func (c *client) DeleteTeam(org string, id int) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      path,
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -2947,6 +3043,7 @@ func (c *client) ListTeams(org string) ([]Team, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		"application/vnd.github.hellcat-preview+json",
+		org,
 		func() interface{} {
 			return &[]Team{}
 		},
@@ -2986,6 +3083,7 @@ func (c *client) UpdateTeamMembership(org string, id int, user string, maintaine
 	_, err := c.request(&request{
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/teams/%d/memberships/%s", id, user),
+		org:         org,
 		requestBody: &tm,
 		exitCodes:   []int{200},
 	}, &tm)
@@ -3005,6 +3103,7 @@ func (c *client) RemoveTeamMembership(org string, id int, user string) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/teams/%d/memberships/%s", id, user),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -3033,6 +3132,7 @@ func (c *client) ListTeamMembers(org string, id int, role string) ([]TeamMember,
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		"application/vnd.github.hellcat-preview+json",
+		org,
 		func() interface{} {
 			return &[]TeamMember{}
 		},
@@ -3066,6 +3166,7 @@ func (c *client) ListTeamRepos(org string, id int) ([]Repo, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		"application/vnd.github.hellcat-preview+json",
+		org,
 		func() interface{} {
 			return &[]Repo{}
 		},
@@ -3107,6 +3208,7 @@ func (c *client) UpdateTeamRepo(id int, org, repo string, permission TeamPermiss
 	_, err := c.request(&request{
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo),
+		org:         org,
 		requestBody: &data,
 		exitCodes:   []int{204},
 	}, nil)
@@ -3127,6 +3229,7 @@ func (c *client) RemoveTeamRepo(id int, org, repo string) error {
 	_, err := c.request(&request{
 		method:    http.MethodDelete,
 		path:      fmt.Sprintf("/teams/%d/repos/%s/%s", id, org, repo),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -3148,6 +3251,7 @@ func (c *client) ListTeamInvitations(org string, id int) ([]OrgInvitation, error
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]OrgInvitation{}
 		},
@@ -3211,6 +3315,7 @@ func (c *client) Merge(org, repo string, pr int, details MergeDetails) error {
 	ec, err := c.request(&request{
 		method:      http.MethodPut,
 		path:        fmt.Sprintf("/repos/%s/%s/pulls/%d/merge", org, repo, pr),
+		org:         org,
 		requestBody: &details,
 		exitCodes:   []int{200, 405, 409},
 	}, &ge)
@@ -3275,6 +3380,7 @@ func (c *client) IsCollaborator(org, repo, user string) (bool, error) {
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		accept:    "application/vnd.github.hellcat-preview+json",
 		path:      fmt.Sprintf("/repos/%s/%s/collaborators/%s", org, repo, user),
+		org:       org,
 		exitCodes: []int{204, 404, 302},
 	}, nil)
 	if err != nil {
@@ -3307,6 +3413,7 @@ func (c *client) ListCollaborators(org, repo string) ([]User, error) {
 		// This accept header enables the nested teams preview.
 		// https://developer.github.com/changes/2017-08-30-preview-nested-teams/
 		"application/vnd.github.hellcat-preview+json",
+		org,
 		func() interface{} {
 			return &[]User{}
 		},
@@ -3337,6 +3444,7 @@ func (c *client) CreateFork(owner, repo string) (string, error) {
 	_, err := c.request(&request{
 		method:    http.MethodPost,
 		path:      fmt.Sprintf("/repos/%s/%s/forks", owner, repo),
+		org:       owner,
 		exitCodes: []int{202},
 	}, &resp)
 
@@ -3360,6 +3468,7 @@ func (c *client) ListRepoTeams(org, repo string) ([]Team, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Team{}
 		},
@@ -3390,6 +3499,7 @@ func (c *client) ListIssueEvents(org, repo string, num int) ([]ListedIssueEvent,
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]ListedIssueEvent{}
 		},
@@ -3446,6 +3556,7 @@ func (c *client) ClearMilestone(org, repo string, num int) error {
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%v/%v/issues/%d", org, repo, num),
+		org:         org,
 		requestBody: &issue,
 		exitCodes:   []int{200},
 	}, nil)
@@ -3466,6 +3577,7 @@ func (c *client) SetMilestone(org, repo string, issueNum, milestoneNum int) erro
 	_, err := c.request(&request{
 		method:      http.MethodPatch,
 		path:        fmt.Sprintf("/repos/%v/%v/issues/%d", org, repo, issueNum),
+		org:         org,
 		requestBody: &issue,
 		exitCodes:   []int{200},
 	}, nil)
@@ -3487,6 +3599,7 @@ func (c *client) ListMilestones(org, repo string) ([]Milestone, error) {
 	err := c.readPaginatedResults(
 		path,
 		acceptNone,
+		org,
 		func() interface{} {
 			return &[]Milestone{}
 		},
@@ -3514,6 +3627,7 @@ func (c *client) ListPRCommits(org, repo string, number int) ([]RepositoryCommit
 	err := c.readPaginatedResults(
 		fmt.Sprintf("/repos/%v/%v/pulls/%d/commits", org, repo, number),
 		acceptNone,
+		org,
 		func() interface{} { // newObj returns a pointer to the type of object to create
 			return &[]RepositoryCommit{}
 		},
@@ -3553,6 +3667,7 @@ func (c *client) GetRepoProjects(owner, repo string) ([]Project, error) {
 	err := c.readPaginatedResults(
 		path,
 		"application/vnd.github.inertia-preview+json",
+		owner,
 		func() interface{} {
 			return &[]Project{}
 		},
@@ -3578,6 +3693,7 @@ func (c *client) GetOrgProjects(org string) ([]Project, error) {
 	err := c.readPaginatedResults(
 		path,
 		"application/vnd.github.inertia-preview+json",
+		org,
 		func() interface{} {
 			return &[]Project{}
 		},
@@ -3603,6 +3719,7 @@ func (c *client) GetProjectColumns(org string, projectID int) ([]ProjectColumn, 
 	err := c.readPaginatedResults(
 		path,
 		"application/vnd.github.inertia-preview+json",
+		org,
 		func() interface{} {
 			return &[]ProjectColumn{}
 		},
@@ -3635,6 +3752,7 @@ func (c *client) CreateProjectCard(org string, columnID int, projectCard Project
 		method:      http.MethodPost,
 		path:        path,
 		accept:      "application/vnd.github.inertia-preview+json",
+		org:         org,
 		requestBody: &projectCard,
 		exitCodes:   []int{200},
 	}, &retProjectCard)
@@ -3656,6 +3774,7 @@ func (c *client) GetColumnProjectCards(org string, columnID int) ([]ProjectCard,
 		path,
 		// projects api requies the accept header to be set this way
 		"application/vnd.github.inertia-preview+json",
+		org,
 		func() interface{} {
 			return &[]ProjectCard{}
 		},
@@ -3699,6 +3818,7 @@ func (c *client) MoveProjectCard(org string, projectCardID int, newColumnID int)
 		method:      http.MethodPost,
 		path:        fmt.Sprintf("/projects/columns/cards/%d/moves", projectCardID),
 		accept:      "application/vnd.github.inertia-preview+json",
+		org:         org,
 		requestBody: reqParams,
 		exitCodes:   []int{201},
 	}, nil)
@@ -3716,6 +3836,7 @@ func (c *client) DeleteProjectCard(org string, projectCardID int) error {
 		method:    http.MethodDelete,
 		accept:    "application/vnd.github.symmetra-preview+json", // allow the description field -- https://developer.github.com/changes/2018-02-22-label-description-search-preview/
 		path:      fmt.Sprintf("/projects/columns/cards/:%d", projectCardID),
+		org:       org,
 		exitCodes: []int{204},
 	}, nil)
 	return err
@@ -3752,6 +3873,7 @@ func (c *client) GetTeamBySlug(slug string, org string) (*Team, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/orgs/%s/teams/%s", org, slug),
+		org:       org,
 		exitCodes: []int{200},
 	}, &team)
 	if err != nil {
@@ -3771,6 +3893,7 @@ func (c *client) ListCheckRuns(org, repo, ref string) (*CheckRunList, error) {
 	_, err := c.request(&request{
 		method:    http.MethodGet,
 		path:      fmt.Sprintf("/repos/%s/%s/commits/%s/check-runs", org, repo, ref),
+		org:       org,
 		exitCodes: []int{200},
 	}, &checkRunList)
 	if err != nil {

--- a/repos.bzl
+++ b/repos.bzl
@@ -5258,3 +5258,11 @@ def go_repositories():
         sum = "h1:pMen7vLs8nvgEYhywH3KDWJIJTeEr2ULsVWHWYHQyBs=",
         version = "v3.0.0",
     )
+    go_repository(
+        name = "com_github_dgrijalva_jwt_go_v4",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/dgrijalva/jwt-go/v4",
+        sum = "h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=",
+        version = "v4.0.0-preview1",
+    )


### PR DESCRIPTION
This PR adds github apps authentication to support into the V3 client via a custom http.RoundTripper as described in https://docs.google.com/document/d/1q9NagH0xB2vcuK-TC_X6V_LHc0syBrNrLqiuAQ8zGWY/edit?ts=5fc6fbdf#heading=h.66y4kqbj468a

This PR contains the roundtripper implementation, integration with ghproxy and integration with flagutils.

xref https://github.com/kubernetes/test-infra/issues/10423