### PR TITLE
Switch kubernetes 1.20 bazel jobs to an image that exists

### DIFF
--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -388,7 +388,7 @@ periodics:
       - -//vendor/...
       command:
       - ../test-infra/hack/bazel.sh
-      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-1.20
+      image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
       name: ""
       resources:
         limits:
@@ -1341,7 +1341,7 @@ presubmits:
         - //build/release-tars
         command:
         - ../test-infra/hack/bazel.sh
-        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-1.20
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
         name: ""
         resources:
           limits:
@@ -1374,7 +1374,7 @@ presubmits:
         - -//vendor/...
         command:
         - ../test-infra/hack/bazel.sh
-        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-1.20
+        image: gcr.io/k8s-testimages/launcher.gcr.io/google/bazel:v20201028-8000225-kubernetes-master
         name: ""
         resources:
           limits:


### PR DESCRIPTION
This is intended to be a temporary workaround until a proper 1.20
variant exists, if that is the direction we intend to head

ref: https://github.com/kubernetes/kubernetes/issues/97025#issuecomment-737530281