### PR TITLE
storage migrator e2e: use latest k8s version

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-ci.yaml
@@ -25,6 +25,8 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--focus=\[Disruptive\]
         - --timeout=50m
+        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
+        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true

--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -37,6 +37,8 @@ presubmits:
         - --test=false
         - --test-cmd=../test/e2e/test-cmd.sh
         - --timeout=50m
+        - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
+        - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true
@@ -68,44 +70,6 @@ presubmits:
         - --test-cmd=../test/e2e/test-fully-automated.sh
         - --test-cmd-args=--skip=\[Disruptive\]
         - --timeout=50m
-        # docker-in-docker needs privileged mode
-        securityContext:
-          privileged: true
-    annotations:
-      testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
-      testgrid-tab-name: pr-e2e-fully-automated
-  - name: pull-kube-storage-version-migrator-manually-launched-e2e-optional-custom-build
-    decorate: true
-    extra_refs:
-    - org: roycaihw
-      repo: kubernetes
-      base_ref: storage-version/conditions
-      path_alias: k8s.io/kubernetes
-    optional: true
-    always_run: true
-    labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
-      preset-dind-enabled: "true"
-    spec:
-      containers:
-      - image: gcr.io/k8s-testimages/kubekins-e2e:v20201201-1941b8f-master
-        command:
-        - runner.sh
-        - kubetest
-        args:
-        - --up
-        - --down
-        - --build=quick
-        - --check-leaked-resources
-        - --gcp-master-image=gci
-        - --gcp-node-image=gci
-        - --gcp-nodes=1
-        - --gcp-zone=us-central1-f
-        - --provider=gce
-        - --test=false
-        - --test-cmd=../test/e2e/test-cmd.sh
-        - --timeout=50m
         - --runtime-config=internal.apiserver.k8s.io/v1alpha1=true
         - --env=KUBE_FEATURE_GATES=StorageVersionAPI=true,APIServerIdentity=true
         # docker-in-docker needs privileged mode
@@ -113,4 +77,4 @@ presubmits:
           privileged: true
     annotations:
       testgrid-dashboards: sig-api-machinery-kube-storage-version-migrator
-      testgrid-tab-name: pr-e2e-manually-launched-optional-custom-build
+      testgrid-tab-name: pr-e2e-fully-automated


### PR DESCRIPTION
I couldn't find enough documentation/example about how to pin a custom k8s version. As we discussed offline, let's use the latest k8s version for now. Hopefully the k8s change we need will be merged after the code thaw next week.

/assign @caesarxuchao 