### PR TITLE
Make sinker log the number of pods it sees in each cluster.

### DIFF
--- a/prow/cmd/sinker/main.go
+++ b/prow/cmd/sinker/main.go
@@ -379,6 +379,7 @@ func (c *controller) clean() {
 			log.WithError(err).Error("Error listing pods.")
 			continue
 		}
+		log.WithField("pod-count", len(pods.Items)).Debug("Successfully listed pods.")
 		metrics.podsCreated += len(pods.Items)
 		maxPodAge := c.config().Sinker.MaxPodAge.Duration
 		terminatedPodTTL := c.config().Sinker.TerminatedPodTTL.Duration


### PR DESCRIPTION
One of Prow instances stopped cleaning pods, but continues to clean ProwJobs and I can't tell why. I'm hoping to determine if we are successfully listing the pods with this.

/assign @chaodaiG 