### PR TITLE
set gcp-project-type for crio periodic jobs

### DIFF
--- a/config/jobs/kubernetes/sig-node/crio.yaml
+++ b/config/jobs/kubernetes/sig-node/crio.yaml
@@ -15,7 +15,7 @@ periodics:
       - -- # end bootstrap args, scenario args below
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project=node-e2e-project
+      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true
@@ -47,7 +47,7 @@ periodics:
       - -- # end bootstrap args, scenario args below
       - --deployment=node
       - --env=KUBE_SSH_USER=core
-      - --gcp-project=node-e2e-project
+      - --gcp-project-type=node-e2e-project
       - --gcp-zone=us-west1-b
       - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///var/run/crio/crio.sock --container-runtime-process-name=/usr/local/bin/crio --container-runtime-pid-file= --kubelet-flags="--cgroup-driver=systemd --cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/crio.service --non-masquerade-cidr=0.0.0.0/0" --extra-log="{\"name\": \"crio.log\", \"journalctl\": [\"-u\", \"crio\"]}"'
       - --node-tests=true


### PR DESCRIPTION
This PR fixes the current failure to get the correct gcp project for the crio period jobs.

The jobs fail with,

```
W1203 06:21:28.458] 2020/12/03 06:21:28 process.go:153: Running: gcloud compute --project=node-e2e-project project-info describe
W1203 06:21:29.321] ERROR: (gcloud.compute.project-info.describe) Could not fetch resource:
W1203 06:21:29.321]  - Failed to find project node-e2e-project
W1203 06:21:29.321] 
```


Signed-off-by: Harshal Patil <harpatil@redhat.com>