### PR TITLE
capg: update release branch to release-0.3

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cluster-api.yaml
@@ -105,7 +105,7 @@ postsubmits:
       decorate: true
       branches:
         - ^master$
-        - ^release-0.2$
+        - ^release-.*
         # this is a regex for semver, from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
         - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:


### PR DESCRIPTION
update `post-cluster-api-provider-gcp-push-images` to build image for the release-0.3 branch and not more for 0.2