### PR TITLE
Bump containerd version to 1.4.3

### DIFF
--- a/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
+++ b/config/jobs/kubernetes/sig-cloud-provider/gcp/gcp-gce.yaml
@@ -291,7 +291,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -352,7 +352,7 @@ presubmits:
             - --build=bazel
             - --cluster=
             - --env=KUBE_CONTAINER_RUNTIME=containerd
-            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+            - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
             - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
             - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
             - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -569,7 +569,7 @@ periodics:
           - --
           - --check-leaked-resources
           - --env=KUBE_CONTAINER_RUNTIME=containerd
-          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+          - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
           - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
           - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
           - --env=ENABLE_POD_SECURITY_POLICY=true

--- a/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
+++ b/config/jobs/kubernetes/sig-network/sig-network-misc.yaml
@@ -513,7 +513,7 @@ periodics:
       - --env=ALLOW_PRIVILEGED=true
       - --env=NET_PLUGIN=kubenet
       - --env=KUBE_CONTAINER_RUNTIME=containerd
-      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+      - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
       - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
       - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
       - --env=CONTAINER_RUNTIME_TEST_HANDLER=true

--- a/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
+++ b/config/jobs/kubernetes/sig-release/release-branch-jobs/1.20.yaml
@@ -904,7 +904,7 @@ presubmits:
         - --build=bazel
         - --cluster=
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=ENABLE_POD_SECURITY_POLICY=true
@@ -958,7 +958,7 @@ presubmits:
         - --build=bazel
         - --cluster=
         - --env=KUBE_CONTAINER_RUNTIME=containerd
-        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.0
+        - --env=KUBE_UBUNTU_INSTALL_CONTAINERD_VERSION=v1.4.3
         - --env=KUBE_UBUNTU_INSTALL_RUNC_VERSION=v1.0.0-rc92
         - --env=LOG_DUMP_SYSTEMD_SERVICES=containerd
         - --env=ENABLE_POD_SECURITY_POLICY=true


### PR DESCRIPTION
Link to the new release: https://github.com/containerd/containerd/releases/tag/v1.4.3

1.4.3 has fixes for CVE-2020-15257. Details are here -https://github.com/containerd/containerd/security/advisories/GHSA-36xw-fx78-c5r4

Signed-off-by: Davanum Srinivas <davanum@gmail.com>