### PR TITLE
Continue to test stable version of kops

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -354,6 +354,7 @@ k8s_versions = [
 
 kops_versions = [
     None, # maps to latest
+    "1.18",
     "1.19",
 ]
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -44,6 +44,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-ko18-docker
+  cron: '42 12 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-amzn2-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-ko19-docker
   cron: '24 18 * * 0'
@@ -129,6 +172,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k17-ko18-docker
+  cron: '41 2 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k17-ko19-docker
@@ -216,6 +302,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k18-ko18-docker
+  cron: '48 7 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-amzn2-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k18-ko19-docker
   cron: '38 1 * * 6'
@@ -301,6 +430,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k19-ko18-docker
+  cron: '57 18 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k19-ko19-docker
@@ -388,6 +560,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-centos7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-ko18-docker
+  cron: '50 2 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-centos7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-ko19-docker
   cron: '28 20 * * 2'
@@ -473,6 +688,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-centos7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k17-ko18-docker
+  cron: '19 23 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-centos7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k17-ko19-docker
@@ -560,6 +818,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-centos7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k18-ko18-docker
+  cron: '6 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-centos7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k18-ko19-docker
   cron: '12 12 * * 4'
@@ -645,6 +946,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-centos7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k19-ko18-docker
+  cron: '47 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-centos7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k19-ko19-docker
@@ -732,6 +1076,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-ko18-docker
+  cron: '38 20 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-deb9-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-ko19-docker
   cron: '36 10 * * 1'
@@ -817,6 +1204,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k17-ko18-docker
+  cron: '39 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k17-ko19-docker
@@ -904,6 +1334,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k18-ko18-docker
+  cron: '10 11 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-deb9-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k18-ko19-docker
   cron: '20 21 * * 6'
@@ -989,6 +1462,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k19-ko18-docker
+  cron: '39 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k19-ko19-docker
@@ -1076,6 +1592,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-ko18-docker
+  cron: '9 23 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-deb10-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-ko19-docker
   cron: '19 1 * * 5'
@@ -1161,6 +1720,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k17-ko18-docker
+  cron: '18 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k17-ko19-docker
@@ -1248,6 +1850,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k18-ko18-docker
+  cron: '55 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-deb10-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k18-ko19-docker
   cron: '53 14 * * 6'
@@ -1333,6 +1978,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k19-ko18-docker
+  cron: '2 21 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k19-ko19-docker
@@ -1420,6 +2108,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-ko18-docker
+  cron: '33 21 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flatcar-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-ko19-docker
   cron: '31 19 * * 4'
@@ -1505,6 +2236,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k17-ko18-docker
+  cron: '38 10 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k17-ko19-docker
@@ -1592,6 +2366,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k18-ko18-docker
+  cron: '43 23 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flatcar-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k18-ko19-docker
   cron: '1 9 * * 6'
@@ -1677,6 +2494,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k19-ko18-docker
+  cron: '10 2 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k19-ko19-docker
@@ -1764,6 +2624,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-ko18-docker
+  cron: '25 7 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-rhel7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-ko19-docker
   cron: '35 1 * * 6'
@@ -1849,6 +2752,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k17-ko18-docker
+  cron: '34 17 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k17-ko19-docker
@@ -1936,6 +2882,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k18-ko18-docker
+  cron: '51 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-rhel7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k18-ko19-docker
   cron: '49 2 * * 2'
@@ -2021,6 +3010,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k19-ko18-docker
+  cron: '2 9 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k19-ko19-docker
@@ -2108,6 +3140,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-ko18-docker
+  cron: '56 18 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-rhel8-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-ko19-docker
   cron: '50 4 * * 0'
@@ -2193,6 +3268,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k17-ko18-docker
+  cron: '55 4 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k17-ko19-docker
@@ -2280,6 +3398,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k18-ko18-docker
+  cron: '54 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-rhel8-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k18-ko19-docker
   cron: '32 23 * * 5'
@@ -2365,6 +3526,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k19-ko18-docker
+  cron: '19 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k19-ko19-docker
@@ -2452,6 +3656,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1604-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-ko18-docker
+  cron: '57 19 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u1604-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-ko19-docker
   cron: '43 13 * * 5'
@@ -2537,6 +3784,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1604-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k17-ko18-docker
+  cron: '20 19 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u1604-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k17-ko19-docker
@@ -2624,6 +3914,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1604-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k18-ko18-docker
+  cron: '5 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u1604-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k18-ko19-docker
   cron: '35 8 * * 5'
@@ -2709,6 +4042,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1604-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k19-ko18-docker
+  cron: '36 19 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1604-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k19-ko19-docker
@@ -2796,6 +4172,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-ko18-docker
+  cron: '4 14 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u1804-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-ko19-docker
   cron: '22 8 * * 2'
@@ -2881,6 +4300,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k17-ko18-docker
+  cron: '26 13 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k17-ko19-docker
@@ -2968,6 +4430,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k18-ko18-docker
+  cron: '51 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u1804-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k18-ko19-docker
   cron: '41 14 * * 3'
@@ -3053,6 +4558,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k19-ko18-docker
+  cron: '26 13 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k19-ko19-docker
@@ -3140,6 +4688,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-ko18-docker
+  cron: '53 19 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u2004-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-ko19-docker
   cron: '31 21 * * *'
@@ -3225,6 +4816,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k17-ko18-docker
+  cron: '9 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k17-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k17-ko19-docker
@@ -3312,6 +4946,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k18-ko18-docker
+  cron: '0 23 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k18-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u2004-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k18-ko19-docker
   cron: '22 1 * * *'
@@ -3397,6 +5074,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k19-ko18-docker
+  cron: '1 2 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k19-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k19-ko19-docker
@@ -3484,6 +5204,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-ko18-docker
+  cron: '11 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--215fee191e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-amzn2-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-ko19-docker
   cron: '53 10 * * 6'
@@ -3569,6 +5332,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k17-ko18-docker
+  cron: '31 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--e6a59e105f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-ko19-docker
@@ -3656,6 +5462,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k18-ko18-docker
+  cron: '6 13 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--ddf53fe1c0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-ko19-docker
   cron: '40 19 * * 5'
@@ -3741,6 +5590,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k19-ko18-docker
+  cron: '11 8 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--527ed6a019.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-ko19-docker
@@ -3828,6 +5720,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-centos7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-ko18-docker
+  cron: '22 23 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--79fda34cfd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-centos7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-ko19-docker
   cron: '8 17 * * 6'
@@ -3913,6 +5848,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-centos7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k17-ko18-docker
+  cron: '41 13 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--3d1d3d60d6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-centos7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k17-ko19-docker
@@ -4000,6 +5978,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-centos7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k18-ko18-docker
+  cron: '36 8 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--4d27f54d1f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-centos7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k18-ko19-docker
   cron: '58 22 * * 3'
@@ -4085,6 +6106,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-centos7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k19-ko18-docker
+  cron: '5 5 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--80121daa40.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-centos7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k19-ko19-docker
@@ -4172,6 +6236,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-ko18-docker
+  cron: '56 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-deb9-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-ko19-docker
   cron: '46 18 * * 0'
@@ -4257,6 +6364,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k17-ko18-docker
+  cron: '31 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--644672a609.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-ko19-docker
@@ -4344,6 +6494,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k18-ko18-docker
+  cron: '58 22 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--68f646f5d3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-ko19-docker
   cron: '0 0 * * 2'
@@ -4429,6 +6622,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k19-ko18-docker
+  cron: '35 11 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--a6240b802a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-ko19-docker
@@ -4516,6 +6752,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-ko18-docker
+  cron: '12 15 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--491f8a5b2b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-deb10-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-ko19-docker
   cron: '6 9 * * 3'
@@ -4601,6 +6880,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k17-ko18-docker
+  cron: '28 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--8403d1402d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-ko19-docker
@@ -4688,6 +7010,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k18-ko18-docker
+  cron: '5 2 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--8d807a9264.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-ko19-docker
   cron: '55 12 * * 5'
@@ -4773,6 +7138,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k19-ko18-docker
+  cron: '24 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--0782c02af9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-ko19-docker
@@ -4860,6 +7268,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-ko18-docker
+  cron: '41 8 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--ab9262522d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-flatcar-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-ko19-docker
   cron: '35 22 * * 5'
@@ -4945,6 +7396,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k17-ko18-docker
+  cron: '40 16 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--c122e607ac.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-ko19-docker
@@ -5032,6 +7526,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k18-ko18-docker
+  cron: '13 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--58780a85dc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-ko19-docker
   cron: '51 11 * * 6'
@@ -5117,6 +7654,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k19-ko18-docker
+  cron: '20 0 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--9964306e39.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-ko19-docker
@@ -5204,6 +7784,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-ko18-docker
+  cron: '40 15 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--1fee8ff7ec.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-rhel7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-ko19-docker
   cron: '26 1 * * 6'
@@ -5289,6 +7912,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k17-ko18-docker
+  cron: '20 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--86b4319d19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-ko19-docker
@@ -5376,6 +8042,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k18-ko18-docker
+  cron: '57 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--4d064d4de6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-ko19-docker
   cron: '47 8 * * 4'
@@ -5461,6 +8170,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k19-ko18-docker
+  cron: '16 3 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--00a6367c7d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-ko19-docker
@@ -5548,6 +8300,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-ko18-docker
+  cron: '45 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--f5eeba9f58.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-rhel8-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-ko19-docker
   cron: '47 20 * * 3'
@@ -5633,6 +8428,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k17-ko18-docker
+  cron: '21 14 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--4977ff5e99.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-ko19-docker
@@ -5720,6 +8558,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k18-ko18-docker
+  cron: '12 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--03ebbee263.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-ko19-docker
   cron: '42 5 * * 3'
@@ -5805,6 +8686,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k19-ko18-docker
+  cron: '41 6 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--9383d42bb9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-ko19-docker
@@ -5892,6 +8816,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1604-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-ko18-docker
+  cron: '32 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--1c7d24d4f3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u1604-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-ko19-docker
   cron: '14 5 * * 5'
@@ -5977,6 +8944,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1604-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k17-ko18-docker
+  cron: '2 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--240eb833ed.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u1604-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k17-ko19-docker
@@ -6064,6 +9074,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1604-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k18-ko18-docker
+  cron: '27 12 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--aae47920bc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u1604-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k18-ko19-docker
   cron: '33 10 * * 3'
@@ -6149,6 +9202,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1604-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k19-ko18-docker
+  cron: '14 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--3648d4434e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1604-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k19-ko19-docker
@@ -6236,6 +9332,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-ko18-docker
+  cron: '37 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--594200155b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u1804-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-ko19-docker
   cron: '27 0 * * 1'
@@ -6321,6 +9460,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k17-ko18-docker
+  cron: '12 15 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--0224607198.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-ko19-docker
@@ -6408,6 +9590,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k18-ko18-docker
+  cron: '45 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--0c6c6e663e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-ko19-docker
   cron: '3 20 * * 4'
@@ -6493,6 +9718,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k19-ko18-docker
+  cron: '28 23 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--7b56b2aadc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-ko19-docker
@@ -6580,6 +9848,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-ko18-docker
+  cron: '28 3 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--ac1c202665.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u2004-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-ko19-docker
   cron: '26 21 * * *'
@@ -6665,6 +9976,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k17-ko18-docker
+  cron: '31 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--75fe7bfa44.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-ko19-docker
@@ -6752,6 +10106,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k18-ko18-docker
+  cron: '38 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--6dd8c8253a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-ko19-docker
   cron: '20 3 * * *'
@@ -6837,6 +10234,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k19-ko18-docker
+  cron: '31 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--9be591bc9c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-ko19-docker
@@ -6924,6 +10364,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-ko18-docker
+  cron: '4 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--6ccd66cda8.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-amzn2-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-ko19-docker
   cron: '38 13 * * 6'
@@ -7009,6 +10492,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k17-ko18-docker
+  cron: '9 22 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--6f9ae5d702.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-ko19-docker
@@ -7096,6 +10622,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k18-ko18-docker
+  cron: '32 19 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--c2a99a49ce.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-ko19-docker
   cron: '58 13 * * 1'
@@ -7181,6 +10750,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k19-ko18-docker
+  cron: '57 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--97b0cbfb22.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-ko19-docker
@@ -7268,6 +10880,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-centos7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-ko18-docker
+  cron: '45 4 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--8bc6ca950d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-centos7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-ko19-docker
   cron: '23 18 * * 4'
@@ -7353,6 +11008,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-centos7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k17-ko18-docker
+  cron: '27 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--39a0f0df1b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-centos7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k17-ko19-docker
@@ -7440,6 +11138,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-centos7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k18-ko18-docker
+  cron: '42 6 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--c0417b9892.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-centos7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k18-ko19-docker
   cron: '48 0 * * 4'
@@ -7525,6 +11266,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-centos7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k19-ko18-docker
+  cron: '47 11 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--0061768db6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-centos7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k19-ko19-docker
@@ -7612,6 +11396,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-ko18-docker
+  cron: '18 22 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-deb9-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-ko19-docker
   cron: '52 0 * * 3'
@@ -7697,6 +11524,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k17-ko18-docker
+  cron: '17 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--6fd13e3b23.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-ko19-docker
@@ -7784,6 +11654,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k18-ko18-docker
+  cron: '24 12 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--0ca8f69047.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-ko19-docker
   cron: '22 18 * * 4'
@@ -7869,6 +11782,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k19-ko18-docker
+  cron: '37 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--31878455be.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-ko19-docker
@@ -7956,6 +11912,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-ko18-docker
+  cron: '55 16 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--f77ce68f39.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-deb10-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-ko19-docker
   cron: '1 6 * * 6'
@@ -8041,6 +12040,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k17-ko18-docker
+  cron: '42 1 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--021e671328.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-ko19-docker
@@ -8128,6 +12170,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k18-ko18-docker
+  cron: '31 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--d52b3f3dfb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-ko19-docker
   cron: '45 10 * * 4'
@@ -8213,6 +12298,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k19-ko18-docker
+  cron: '46 9 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--16e33a86f5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-ko19-docker
@@ -8300,6 +12428,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-ko18-docker
+  cron: '18 3 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--27bbce400a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-flatcar-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-ko19-docker
   cron: '52 5 * * 6'
@@ -8385,6 +12556,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k17-ko18-docker
+  cron: '30 22 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--41a7ad7b3a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-ko19-docker
@@ -8472,6 +12686,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k18-ko18-docker
+  cron: '11 11 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--6811bcd730.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-ko19-docker
   cron: '29 21 * * 4'
@@ -8557,6 +12814,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k19-ko18-docker
+  cron: '2 22 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--07785eb10e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-ko19-docker
@@ -8644,6 +12944,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-ko18-docker
+  cron: '15 0 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--98ade2c492.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-rhel7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-ko19-docker
   cron: '25 14 * * 2'
@@ -8729,6 +13072,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k17-ko18-docker
+  cron: '42 13 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--0ed897cfd8.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-ko19-docker
@@ -8816,6 +13202,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k18-ko18-docker
+  cron: '15 0 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--9ef84fbd77.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-ko19-docker
   cron: '45 14 * * 2'
@@ -8901,6 +13330,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k19-ko18-docker
+  cron: '46 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--d1e6a9adf5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-ko19-docker
@@ -8988,6 +13460,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-ko18-docker
+  cron: '6 13 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--3484f2b191.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-rhel8-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-ko19-docker
   cron: '40 3 * * 0'
@@ -9073,6 +13588,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k17-ko18-docker
+  cron: '59 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--eea74b7e5f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-ko19-docker
@@ -9160,6 +13718,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k18-ko18-docker
+  cron: '2 21 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--3e50ddea62.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-ko19-docker
   cron: '16 11 * * 1'
@@ -9245,6 +13846,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k19-ko18-docker
+  cron: '47 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--cb03bef825.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-ko19-docker
@@ -9332,6 +13976,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1604-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-ko18-docker
+  cron: '27 4 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--8f827f5b89.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u1604-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-ko19-docker
   cron: '41 18 * * 6'
@@ -9417,6 +14104,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1604-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k17-ko18-docker
+  cron: '12 7 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--ec10f28327.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u1604-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k17-ko19-docker
@@ -9504,6 +14234,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1604-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k18-ko18-docker
+  cron: '41 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--9601dfc980.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u1604-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k18-ko19-docker
   cron: '19 12 * * 5'
@@ -9589,6 +14362,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1604-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k19-ko18-docker
+  cron: '56 23 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--b781e4fced.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1604-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k19-ko19-docker
@@ -9676,6 +14492,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-ko18-docker
+  cron: '18 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--2951f23b45.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u1804-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-ko19-docker
   cron: '32 7 * * 3'
@@ -9761,6 +14620,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k17-ko18-docker
+  cron: '42 17 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--5c1c2bb229.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-ko19-docker
@@ -9848,6 +14750,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k18-ko18-docker
+  cron: '19 4 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--c691c6ea2a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-ko19-docker
   cron: '13 18 * * 4'
@@ -9933,6 +14878,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k19-ko18-docker
+  cron: '42 9 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--a8ec40137f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-ko19-docker
@@ -10020,6 +15008,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-ko18-docker
+  cron: '15 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--afb42cc04c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u2004-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-ko19-docker
   cron: '53 10 * * *'
@@ -10105,6 +15136,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k17-ko18-docker
+  cron: '9 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--f8e8b72609.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-ko19-docker
@@ -10192,6 +15266,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k18-ko18-docker
+  cron: '56 3 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--fa675a97bf.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-ko19-docker
   cron: '38 13 * * *'
@@ -10277,6 +15394,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k19-ko18-docker
+  cron: '17 14 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--b21bfbe3df.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-ko19-docker
@@ -10364,6 +15524,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-ko18-docker
+  cron: '52 22 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--4c379cac0f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-amzn2-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-ko19-docker
   cron: '2 8 * * 2'
@@ -10449,6 +15652,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k17-ko18-docker
+  cron: '7 0 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--80b7130040.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-ko19-docker
@@ -10536,6 +15782,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k18-ko18-docker
+  cron: '26 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--25cf8582bd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-ko19-docker
   cron: '0 3 * * 1'
@@ -10621,6 +15910,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k19-ko18-docker
+  cron: '19 16 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--b2278967c6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-ko19-docker
@@ -10708,6 +16040,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-centos7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-ko18-docker
+  cron: '27 3 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--d3d51ca629.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-centos7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-ko19-docker
   cron: '29 13 * * 3'
@@ -10793,6 +16168,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-centos7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k17-ko18-docker
+  cron: '6 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--767538c26a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-centos7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k17-ko19-docker
@@ -10880,6 +16298,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-centos7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k18-ko18-docker
+  cron: '11 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--5fa634c769.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-centos7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k18-ko19-docker
   cron: '5 1 * * 2'
@@ -10965,6 +16426,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-centos7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k19-ko18-docker
+  cron: '22 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--09d96dc105.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-centos7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k19-ko19-docker
@@ -11052,6 +16556,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-ko18-docker
+  cron: '5 18 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--4d1d386d8f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-deb9-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-ko19-docker
   cron: '43 4 * * 3'
@@ -11137,6 +16684,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k17-ko18-docker
+  cron: '3 0 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--30ed65e9dc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-ko19-docker
@@ -11224,6 +16814,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k18-ko18-docker
+  cron: '26 13 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--0470533c2f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-ko19-docker
   cron: '48 11 * * 0'
@@ -11309,6 +16942,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k19-ko18-docker
+  cron: '3 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--127956d6b7.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-ko19-docker
@@ -11396,6 +17072,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-ko18-docker
+  cron: '27 13 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--897ef504a0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-deb10-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-ko19-docker
   cron: '9 19 * * 4'
@@ -11481,6 +17200,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k17-ko18-docker
+  cron: '48 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--3f01f0fb9f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-ko19-docker
@@ -11568,6 +17330,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k18-ko18-docker
+  cron: '21 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--4ae6a90392.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-ko19-docker
   cron: '35 4 * * 3'
@@ -11653,6 +17458,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k19-ko18-docker
+  cron: '52 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--fa22a065f3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-ko19-docker
@@ -11740,6 +17588,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-ko18-docker
+  cron: '32 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--8cc2b92960.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-flatcar-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-ko19-docker
   cron: '26 10 * * 6'
@@ -11825,6 +17716,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k17-ko18-docker
+  cron: '43 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--c5d9cbca2b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-ko19-docker
@@ -11912,6 +17846,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k18-ko18-docker
+  cron: '6 18 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--a5222aa6e0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-ko19-docker
   cron: '4 12 * * 3'
@@ -11997,6 +17974,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k19-ko18-docker
+  cron: '7 7 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--e98c5fe759.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-ko19-docker
@@ -12084,6 +18104,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-ko18-docker
+  cron: '7 5 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--9325ecb78c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-rhel7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-ko19-docker
   cron: '53 19 * * 1'
@@ -12169,6 +18232,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k17-ko18-docker
+  cron: '12 11 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--11d6f14d18.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-ko19-docker
@@ -12256,6 +18362,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k18-ko18-docker
+  cron: '9 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--7f22496c00.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-ko19-docker
   cron: '31 8 * * 0'
@@ -12341,6 +18490,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k19-ko18-docker
+  cron: '44 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--c165d8a4ce.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-ko19-docker
@@ -12428,6 +18620,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-ko18-docker
+  cron: '26 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--a426658750.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-rhel8-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-ko19-docker
   cron: '24 6 * * 3'
@@ -12513,6 +18748,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k17-ko18-docker
+  cron: '25 14 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--d32d2df897.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-ko19-docker
@@ -12600,6 +18878,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k18-ko18-docker
+  cron: '16 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--f2f59e9ee9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-ko19-docker
   cron: '14 13 * * 0'
@@ -12685,6 +19006,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k19-ko18-docker
+  cron: '57 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--93baaee1cd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-ko19-docker
@@ -12772,6 +19136,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1604-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-ko18-docker
+  cron: '27 17 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--f6898f5da0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u1604-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-ko19-docker
   cron: '1 23 * * 6'
@@ -12857,6 +19264,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1604-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k17-ko18-docker
+  cron: '50 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--e2c15a076d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u1604-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k17-ko19-docker
@@ -12944,6 +19394,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1604-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k18-ko18-docker
+  cron: '35 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--a936f9db73.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u1604-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k18-ko19-docker
   cron: '41 18 * * 3'
@@ -13029,6 +19522,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1604-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k19-ko18-docker
+  cron: '22 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--4abee426cb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1604-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k19-ko19-docker
@@ -13116,6 +19652,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-ko18-docker
+  cron: '22 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--3eed4b7313.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u1804-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-ko19-docker
   cron: '44 18 * * 1'
@@ -13201,6 +19780,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k17-ko18-docker
+  cron: '56 7 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--70f297e628.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-ko19-docker
@@ -13288,6 +19910,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k18-ko18-docker
+  cron: '25 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--a488bf8883.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-ko19-docker
   cron: '7 20 * * 3'
@@ -13373,6 +20038,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k19-ko18-docker
+  cron: '16 15 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--cbfd2dd907.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-ko19-docker
@@ -13460,6 +20168,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-ko18-docker
+  cron: '11 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--09a92ac883.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u2004-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-ko19-docker
   cron: '9 7 * * *'
@@ -13545,6 +20296,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k17-ko18-docker
+  cron: '47 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--880b10f52a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-ko19-docker
@@ -13632,6 +20426,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k18-ko18-docker
+  cron: '30 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--9408176b04.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-ko19-docker
   cron: '40 19 * * *'
@@ -13717,6 +20554,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k19-ko18-docker
+  cron: '15 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--90901fd101.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-ko19-docker
@@ -13804,6 +20684,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-ko18-docker
+  cron: '35 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--43d2e40b1c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-amzn2-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-ko19-docker
   cron: '41 10 * * 4'
@@ -13889,6 +20812,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k17-ko18-docker
+  cron: '49 18 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--eff93ec454.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-ko19-docker
@@ -13976,6 +20942,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k18-ko18-docker
+  cron: '8 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--335be34bdc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-ko19-docker
   cron: '58 1 * * 2'
@@ -14061,6 +21070,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k19-ko18-docker
+  cron: '9 2 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--b965a2f88d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-ko19-docker
@@ -14148,6 +21200,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-centos7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-ko18-docker
+  cron: '14 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--706aba8ed4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-centos7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-ko19-docker
   cron: '16 21 * * 5'
@@ -14233,6 +21328,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-centos7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k17-ko18-docker
+  cron: '47 23 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--b7ba5534bb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-centos7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k17-ko19-docker
@@ -14320,6 +21458,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-centos7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k18-ko18-docker
+  cron: '58 18 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--a65f538792.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-centos7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k18-ko19-docker
   cron: '0 4 * * 1'
@@ -14405,6 +21586,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-centos7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k19-ko18-docker
+  cron: '47 7 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--fb1e2aaceb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-centos7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k19-ko19-docker
@@ -14492,6 +21716,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-ko18-docker
+  cron: '40 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9-ko18-docker.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-deb9-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-ko19-docker
   cron: '14 2 * * 5'
@@ -14577,6 +21844,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k17-ko18-docker
+  cron: '48 0 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--8f39e2e93e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-ko19-docker
@@ -14664,6 +21974,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k18-ko18-docker
+  cron: '41 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--65224fa5b6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-ko19-docker
   cron: '55 11 * * 5'
@@ -14749,6 +22102,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k19-ko18-docker
+  cron: '48 8 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--f9995b48b5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-ko19-docker
@@ -14836,6 +22232,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-ko18-docker
+  cron: '36 15 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--529c562a61.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-deb10-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-ko19-docker
   cron: '54 9 * * 3'
@@ -14921,6 +22360,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k17-ko18-docker
+  cron: '2 5 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--a17b51dde8.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-ko19-docker
@@ -15008,6 +22490,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k18-ko18-docker
+  cron: '19 16 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--b70a7e1d75.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-ko19-docker
   cron: '41 6 * * 2'
@@ -15093,6 +22618,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k19-ko18-docker
+  cron: '26 21 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--9da3711b79.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-ko19-docker
@@ -15180,6 +22748,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-ko18-docker
+  cron: '33 4 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--5cebd705ba.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-flatcar-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-ko19-docker
   cron: '43 2 * * 1'
@@ -15265,6 +22876,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k17-ko18-docker
+  cron: '10 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--2c4ffd37a6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-ko19-docker
@@ -15352,6 +23006,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k18-ko18-docker
+  cron: '51 7 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--02f194f5b1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-ko19-docker
   cron: '41 1 * * 4'
@@ -15437,6 +23134,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k19-ko18-docker
+  cron: '6 2 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--8b97a9f7b3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-ko19-docker
@@ -15524,6 +23264,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-ko18-docker
+  cron: '0 23 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--f81b208325.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-rhel7-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-ko19-docker
   cron: '18 17 * * 4'
@@ -15609,6 +23392,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k17-ko18-docker
+  cron: '22 9 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--2a060e8e0b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-ko19-docker
@@ -15696,6 +23522,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k18-ko18-docker
+  cron: '47 12 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--8309a447b2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-ko19-docker
   cron: '9 18 * * 1'
@@ -15781,6 +23650,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k19-ko18-docker
+  cron: '54 1 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--1f38950c7a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-ko19-docker
@@ -15868,6 +23780,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-ko18-docker
+  cron: '21 2 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--0e084d9548.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-rhel8-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-ko19-docker
   cron: '51 4 * * 2'
@@ -15953,6 +23908,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k17-ko18-docker
+  cron: '23 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--97db836b11.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-ko19-docker
@@ -16040,6 +24038,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k18-ko18-docker
+  cron: '54 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--c2a0a4bcb1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-ko19-docker
   cron: '48 15 * * 6'
@@ -16125,6 +24166,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k19-ko18-docker
+  cron: '3 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--4c92da291c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-ko19-docker
@@ -16212,6 +24296,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1604-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-ko18-docker
+  cron: '16 11 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--4956aec85d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u1604-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-ko19-docker
   cron: '22 21 * * 4'
@@ -16297,6 +24424,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1604-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k17-ko18-docker
+  cron: '16 11 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--65e52d3b50.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u1604-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k17-ko19-docker
@@ -16384,6 +24554,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1604-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k18-ko18-docker
+  cron: '25 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--5ac5e8457b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u1604-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k18-ko19-docker
   cron: '55 16 * * 2'
@@ -16469,6 +24682,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1604-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k19-ko18-docker
+  cron: '20 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--3bd1d61ea1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1604-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k19-ko19-docker
@@ -16556,6 +24812,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-ko18-docker
+  cron: '21 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--c6c2f80c7a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u1804-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-ko19-docker
   cron: '47 0 * * 5'
@@ -16641,6 +24940,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k17-ko18-docker
+  cron: '18 5 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--7b1664b3a1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-ko19-docker
@@ -16728,6 +25070,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k18-ko18-docker
+  cron: '39 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--82fa66b867.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-ko19-docker
   cron: '41 14 * * 4'
@@ -16813,6 +25198,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k19-ko18-docker
+  cron: '22 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--6805be8384.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-ko19-docker
@@ -16900,6 +25328,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-ko18-docker
+  cron: '56 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--fb77fa6c03.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u2004-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-ko19-docker
   cron: '26 13 * * *'
@@ -16985,6 +25456,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k17-ko18-docker
+  cron: '25 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--87dbbabd63.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-ko19-docker
@@ -17072,6 +25586,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-docker
 
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k18-ko18-docker
+  cron: '20 15 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--d5621cc20d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-docker
+
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-ko19-docker
   cron: '26 1 * * *'
@@ -17157,6 +25714,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-docker
+
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k19-ko18-docker
+  cron: '13 18 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--65c637a53e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=docker
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-docker
 
 # {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-ko19-docker
@@ -17244,6 +25844,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-ko18-containerd
+  cron: '45 14 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-amzn2-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-ko19-containerd
   cron: '22 1 * * 0'
@@ -17329,6 +25972,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k17-ko18-containerd
+  cron: '57 11 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k17-k--0bc79dc8c1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k17-ko19-containerd
@@ -17416,6 +26102,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k18-ko18-containerd
+  cron: '36 6 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k18-k--053700ea34.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-amzn2-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k18-ko19-containerd
   cron: '43 17 * * 5'
@@ -17501,6 +26230,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-amzn2-k19-ko18-containerd
+  cron: '19 13 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-amzn2-k19-k--050ac736bc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-amzn2-k19-ko19-containerd
@@ -17588,6 +26360,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-centos7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-ko18-containerd
+  cron: '39 11 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-centos7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-ko19-containerd
   cron: '16 4 * * 5'
@@ -17673,6 +26488,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-centos7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k17-ko18-containerd
+  cron: '24 20 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k17--bba68505b4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-centos7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k17-ko19-containerd
@@ -17760,6 +26618,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-centos7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k18-ko18-containerd
+  cron: '45 17 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k18--b61ca10572.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-centos7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k18-ko19-containerd
   cron: '2 6 * * 3'
@@ -17845,6 +26746,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-centos7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-centos7-k19-ko18-containerd
+  cron: '42 10 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-centos7-k19--788ccc33bf.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-centos7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-centos7-k19-ko19-containerd
@@ -17932,6 +26876,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-ko18-containerd
+  cron: '59 2 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-deb9-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-ko19-containerd
   cron: '32 21 * * 4'
@@ -18017,6 +27004,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k17-ko18-containerd
+  cron: '3 4 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k17-ko--36a93e8e3c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k17-ko19-containerd
@@ -18104,6 +27134,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k18-ko18-containerd
+  cron: '14 17 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k18-ko--cbf329241c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-deb9-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k18-ko19-containerd
   cron: '45 14 * * 2'
@@ -18189,6 +27262,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb9-k19-ko18-containerd
+  cron: '25 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb9-k19-ko--0d544d83e7.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb9-k19-ko19-containerd
@@ -18276,6 +27392,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-ko18-containerd
+  cron: '14 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-deb10-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-ko19-containerd
   cron: '45 14 * * 1'
@@ -18361,6 +27520,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k17-ko18-containerd
+  cron: '43 17 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k17-k--a21f91516d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k17-ko19-containerd
@@ -18448,6 +27650,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k18-ko18-containerd
+  cron: '42 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k18-k--ea6ce893d3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-deb10-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k18-ko19-containerd
   cron: '49 3 * * 2'
@@ -18533,6 +27778,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-deb10-k19-ko18-containerd
+  cron: '9 15 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-deb10-k19-k--6715c141b0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-deb10-k19-ko19-containerd
@@ -18620,6 +27908,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-ko18-containerd
+  cron: '50 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flatcar-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-ko19-containerd
   cron: '57 1 * * 4'
@@ -18705,6 +28036,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k17-ko18-containerd
+  cron: '48 4 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k17--1648117534.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k17-ko19-containerd
@@ -18792,6 +28166,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k18-ko18-containerd
+  cron: '9 1 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k18--08c7d68883.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flatcar-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k18-ko19-containerd
   cron: '58 14 * * 5'
@@ -18877,6 +28294,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-flatcar-k19-ko18-containerd
+  cron: '2 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flatcar-k19--4ec16a413d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-flatcar-k19-ko19-containerd
@@ -18964,6 +28424,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-ko18-containerd
+  cron: '58 21 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-rhel7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-ko19-containerd
   cron: '57 2 * * 4'
@@ -19049,6 +28552,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k17-ko18-containerd
+  cron: '29 7 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k17-k--66ef72894c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k17-ko19-containerd
@@ -19136,6 +28682,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k18-ko18-containerd
+  cron: '32 2 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k18-k--691ccbb923.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-rhel7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k18-ko19-containerd
   cron: '43 21 * * 2'
@@ -19221,6 +28810,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel7-k19-ko18-containerd
+  cron: '31 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel7-k19-k--fad5eda7f6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel7-k19-ko19-containerd
@@ -19308,6 +28940,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-ko18-containerd
+  cron: '59 16 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-rhel8-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-ko19-containerd
   cron: '36 7 * * 4'
@@ -19393,6 +29068,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k17-ko18-containerd
+  cron: '19 9 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k17-k--8f46292ef7.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k17-ko19-containerd
@@ -19480,6 +29198,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k18-ko18-containerd
+  cron: '54 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k18-k--da16bb8864.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-rhel8-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k18-ko19-containerd
   cron: '45 11 * * 5'
@@ -19565,6 +29326,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-rhel8-k19-ko18-containerd
+  cron: '25 15 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-rhel8-k19-k--3ceed265ea.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-rhel8-k19-ko19-containerd
@@ -19652,6 +29456,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1604-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-ko18-containerd
+  cron: '44 23 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u1604-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-ko19-containerd
   cron: '43 16 * * 1'
@@ -19737,6 +29584,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1604-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k17-ko18-containerd
+  cron: '20 18 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k17-k--965f8dce19.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u1604-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k17-ko19-containerd
@@ -19824,6 +29714,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1604-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k18-ko18-containerd
+  cron: '13 23 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k18-k--a83bf3fafb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u1604-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k18-ko19-containerd
   cron: '54 16 * * 1'
@@ -19909,6 +29842,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1604-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1604-k19-ko18-containerd
+  cron: '22 20 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1604-k19-k--e5ca42e3a4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1604-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1604-k19-ko19-containerd
@@ -19996,6 +29972,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-ko18-containerd
+  cron: '26 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u1804-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-ko19-containerd
   cron: '9 14 * * 4'
@@ -20081,6 +30100,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k17-ko18-containerd
+  cron: '44 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k17-k--f6d16f94f5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k17-ko19-containerd
@@ -20168,6 +30230,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k18-ko18-containerd
+  cron: '53 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k18-k--005b62bb10.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u1804-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k18-ko19-containerd
   cron: '22 12 * * 3'
@@ -20253,6 +30358,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u1804-k19-ko18-containerd
+  cron: '18 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u1804-k19-k--7c56bbbeeb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u1804-k19-ko19-containerd
@@ -20340,6 +30488,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-ko18-containerd
+  cron: '17 14 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-ko18-containerd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-u2004-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-ko19-containerd
   cron: '2 17 * * *'
@@ -20425,6 +30616,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k17-ko18-containerd
+  cron: '34 8 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k17-k--0cc985ccb5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k17-ko19-containerd
@@ -20512,6 +30746,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k18-ko18-containerd
+  cron: '55 13 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k18-k--a5f1ad2deb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-u2004-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k18-ko19-containerd
   cron: '8 2 * * *'
@@ -20597,6 +30874,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": null}
+- name: e2e-kops-grid-u2004-k19-ko18-containerd
+  cron: '48 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-u2004-k19-k--c9208a4841.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": null}
 - name: e2e-kops-grid-u2004-k19-ko19-containerd
@@ -20684,6 +31004,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-ko18-containerd
+  cron: '47 12 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--3812da828a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-amzn2-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-ko19-containerd
   cron: '12 19 * * 2'
@@ -20769,6 +31132,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k17-ko18-containerd
+  cron: '24 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--90553a72ff.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k17-ko19-containerd
@@ -20856,6 +31262,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k18-ko18-containerd
+  cron: '53 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--81a085601c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k18-ko19-containerd
   cron: '26 12 * * 2'
@@ -20941,6 +31390,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-amzn2-k19-ko18-containerd
+  cron: '14 16 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-amzn--c6c0e4a90e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-amzn2-k19-ko19-containerd
@@ -21028,6 +31520,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-centos7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-ko18-containerd
+  cron: '25 1 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--2e391f7a48.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-centos7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-ko19-containerd
   cron: '2 14 * * 6'
@@ -21113,6 +31648,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-centos7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k17-ko18-containerd
+  cron: '43 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--1ab66ba1fa.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-centos7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k17-ko19-containerd
@@ -21200,6 +31778,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-centos7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k18-ko18-containerd
+  cron: '26 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--07e40d5713.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-centos7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k18-ko19-containerd
   cron: '5 4 * * 6'
@@ -21285,6 +31906,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-centos7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-centos7-k19-ko18-containerd
+  cron: '13 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-cent--30bd13f851.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-centos7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-centos7-k19-ko19-containerd
@@ -21372,6 +32036,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-ko18-containerd
+  cron: '31 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--0f445f8162.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-deb9-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-ko19-containerd
   cron: '20 0 * * 6'
@@ -21457,6 +32164,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k17-ko18-containerd
+  cron: '25 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--5865f868d5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k17-ko19-containerd
@@ -21544,6 +32294,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k18-ko18-containerd
+  cron: '4 20 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--50b08641d7.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k18-ko19-containerd
   cron: '7 11 * * 1'
@@ -21629,6 +32422,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb9-k19-ko18-containerd
+  cron: '19 15 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb9--e6b0dc74ab.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb9-k19-ko19-containerd
@@ -21716,6 +32552,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-ko18-containerd
+  cron: '8 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--0544aff31c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-deb10-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-ko19-containerd
   cron: '31 4 * * 1'
@@ -21801,6 +32680,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k17-ko18-containerd
+  cron: '46 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--3d43734dba.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k17-ko19-containerd
@@ -21888,6 +32810,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k18-ko18-containerd
+  cron: '23 17 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--b9ea7bd8ce.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k18-ko19-containerd
   cron: '56 14 * * 2'
@@ -21973,6 +32938,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-deb10-k19-ko18-containerd
+  cron: '28 18 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-deb1--ac816894bd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-deb10-k19-ko19-containerd
@@ -22060,6 +33068,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-ko18-containerd
+  cron: '32 4 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--2fefc6c966.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-flatcar-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-ko19-containerd
   cron: '3 11 * * 6'
@@ -22145,6 +33196,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k17-ko18-containerd
+  cron: '31 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--863e94b3b3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k17-ko19-containerd
@@ -22232,6 +33326,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k18-ko18-containerd
+  cron: '30 3 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--e14130cddf.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k18-ko19-containerd
   cron: '37 12 * * 0'
@@ -22317,6 +33454,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-flatcar-k19-ko18-containerd
+  cron: '13 0 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-flat--61f1e672eb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-flatcar-k19-ko19-containerd
@@ -22404,6 +33584,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-ko18-containerd
+  cron: '20 7 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--e2a7652d37.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-rhel7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-ko19-containerd
   cron: '27 8 * * 2'
@@ -22489,6 +33712,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k17-ko18-containerd
+  cron: '16 10 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--e3e1e9ed02.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k17-ko19-containerd
@@ -22576,6 +33842,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k18-ko18-containerd
+  cron: '45 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--d4b3588f70.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k18-ko19-containerd
   cron: '50 0 * * 6'
@@ -22661,6 +33970,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel7-k19-ko18-containerd
+  cron: '42 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--8d9af34066.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel7-k19-ko19-containerd
@@ -22748,6 +34100,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-ko18-containerd
+  cron: '45 2 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--a0cc93e8b9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-rhel8-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-ko19-containerd
   cron: '38 13 * * 0'
@@ -22833,6 +34228,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k17-ko18-containerd
+  cron: '34 4 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--68768f7454.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k17-ko19-containerd
@@ -22920,6 +34358,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k18-ko18-containerd
+  cron: '19 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--8850176442.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k18-ko19-containerd
   cron: '24 22 * * 4'
@@ -23005,6 +34486,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-rhel8-k19-ko18-containerd
+  cron: '0 10 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-rhel--2ad48ce066.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-rhel8-k19-ko19-containerd
@@ -23092,6 +34616,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1604-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-ko18-containerd
+  cron: '42 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--6083629df5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u1604-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-ko19-containerd
   cron: '41 10 * * 3'
@@ -23177,6 +34744,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1604-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k17-ko18-containerd
+  cron: '9 7 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--9c6d33e4cc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u1604-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k17-ko19-containerd
@@ -23264,6 +34874,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1604-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k18-ko18-containerd
+  cron: '12 18 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--3f5b3c3174.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u1604-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k18-ko19-containerd
   cron: '47 13 * * 1'
@@ -23349,6 +35002,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1604-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1604-k19-ko18-containerd
+  cron: '47 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u160--1b4625d4f1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1604-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1604-k19-ko19-containerd
@@ -23436,6 +35132,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-ko18-containerd
+  cron: '0 19 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--590757ee96.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u1804-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-ko19-containerd
   cron: '59 4 * * 2'
@@ -23521,6 +35260,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k17-ko18-containerd
+  cron: '1 11 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--baddcbc4ce.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k17-ko19-containerd
@@ -23608,6 +35390,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k18-ko18-containerd
+  cron: '56 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--80782ca9d3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k18-ko19-containerd
   cron: '23 17 * * 6'
@@ -23693,6 +35518,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u1804-k19-ko18-containerd
+  cron: '23 13 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u180--ae75c5a522.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u1804-k19-ko19-containerd
@@ -23780,6 +35648,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-ko18-containerd
+  cron: '47 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--e07687fb6d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-calico-u2004-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-ko19-containerd
   cron: '12 11 * * *'
@@ -23865,6 +35776,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k17-ko18-containerd
+  cron: '27 21 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--428da53f72.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k17-ko19-containerd
@@ -23952,6 +35906,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k18-ko18-containerd
+  cron: '38 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--d9f470ef49.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k18-ko19-containerd
   cron: '5 7 * * *'
@@ -24037,6 +36034,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "calico"}
+- name: e2e-kops-grid-calico-u2004-k19-ko18-containerd
+  cron: '17 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-calico-u200--8ca2cdc6c8.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=calico --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "calico"}
 - name: e2e-kops-grid-calico-u2004-k19-ko19-containerd
@@ -24124,6 +36164,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-ko18-containerd
+  cron: '49 10 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--d78defe41c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-amzn2-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-ko19-containerd
   cron: '14 5 * * 5'
@@ -24209,6 +36292,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k17-ko18-containerd
+  cron: '4 18 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--a0f43fe7eb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k17-ko19-containerd
@@ -24296,6 +36422,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k18-ko18-containerd
+  cron: '57 23 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--51c31337b5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k18-ko19-containerd
   cron: '22 8 * * 6'
@@ -24381,6 +36550,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-amzn2-k19-ko18-containerd
+  cron: '6 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-amzn--f9f139e6bf.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-amzn2-k19-ko19-containerd
@@ -24468,6 +36680,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-centos7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-ko18-containerd
+  cron: '59 15 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--1ed99ca0dc.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-centos7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-ko19-containerd
   cron: '8 8 * * 6'
@@ -24553,6 +36808,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-centos7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k17-ko18-containerd
+  cron: '36 5 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--98c498ff4a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-centos7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k17-ko19-containerd
@@ -24640,6 +36938,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-centos7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k18-ko18-containerd
+  cron: '33 0 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--c22e0a4725.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-centos7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k18-ko19-containerd
   cron: '14 7 * * 3'
@@ -24725,6 +37066,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-centos7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-centos7-k19-ko18-containerd
+  cron: '34 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-cent--3842421a48.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-centos7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-centos7-k19-ko19-containerd
@@ -24812,6 +37196,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-ko18-containerd
+  cron: '21 5 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--3cff49fd16.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-deb9-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-ko19-containerd
   cron: '58 2 * * 6'
@@ -24897,6 +37324,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k17-ko18-containerd
+  cron: '13 5 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--8825cf314a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k17-ko19-containerd
@@ -24984,6 +37454,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k18-ko18-containerd
+  cron: '24 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--a60f2a3b20.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k18-ko19-containerd
   cron: '51 23 * * 3'
@@ -25069,6 +37582,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb9-k19-ko18-containerd
+  cron: '59 11 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb9--c0d875a245.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb9-k19-ko19-containerd
@@ -25156,6 +37712,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-ko18-containerd
+  cron: '58 5 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--d686610468.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-deb10-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-ko19-containerd
   cron: '21 2 * * 3'
@@ -25241,6 +37840,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k17-ko18-containerd
+  cron: '22 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--5f422d9851.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k17-ko19-containerd
@@ -25328,6 +37970,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k18-ko18-containerd
+  cron: '11 13 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--c449d41212.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k18-ko19-containerd
   cron: '24 10 * * 6'
@@ -25413,6 +38098,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-deb10-k19-ko18-containerd
+  cron: '0 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-deb1--d330105937.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-deb10-k19-ko19-containerd
@@ -25500,6 +38228,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-ko18-containerd
+  cron: '14 10 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--446ed2d4b1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-flatcar-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-ko19-containerd
   cron: '45 13 * * 1'
@@ -25585,6 +38356,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k17-ko18-containerd
+  cron: '4 5 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--61f4168c90.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k17-ko19-containerd
@@ -25672,6 +38486,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k18-ko18-containerd
+  cron: '45 8 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--1abe5a17f2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k18-ko19-containerd
   cron: '6 15 * * 3'
@@ -25757,6 +38614,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-flatcar-k19-ko18-containerd
+  cron: '42 11 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-flat--4663da95af.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-flatcar-k19-ko19-containerd
@@ -25844,6 +38744,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-ko18-containerd
+  cron: '2 9 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--7ec86d23f5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-rhel7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-ko19-containerd
   cron: '25 14 * * 3'
@@ -25929,6 +38872,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k17-ko18-containerd
+  cron: '8 6 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--9c15bc1564.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k17-ko19-containerd
@@ -26016,6 +39002,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k18-ko18-containerd
+  cron: '21 11 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--14c5e0918f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k18-ko19-containerd
   cron: '34 4 * * 6'
@@ -26101,6 +39130,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel7-k19-ko18-containerd
+  cron: '6 8 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--e1115cdab4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel7-k19-ko19-containerd
@@ -26188,6 +39260,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-ko18-containerd
+  cron: '27 20 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--6c8089b923.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-rhel8-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-ko19-containerd
   cron: '52 11 * * 2'
@@ -26273,6 +39388,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k17-ko18-containerd
+  cron: '2 8 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--8be8d5f517.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k17-ko19-containerd
@@ -26360,6 +39518,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k18-ko18-containerd
+  cron: '43 21 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--0a9b46e689.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k18-ko19-containerd
   cron: '44 18 * * 5'
@@ -26445,6 +39646,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-rhel8-k19-ko18-containerd
+  cron: '36 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-rhel--5c3ce6ce17.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-rhel8-k19-ko19-containerd
@@ -26532,6 +39776,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1604-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-ko18-containerd
+  cron: '20 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--5dbcdba0d9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u1604-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-ko19-containerd
   cron: '15 12 * * 0'
@@ -26617,6 +39904,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1604-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k17-ko18-containerd
+  cron: '37 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--a04f52c8b7.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u1604-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k17-ko19-containerd
@@ -26704,6 +40034,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1604-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k18-ko18-containerd
+  cron: '36 14 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--8ea8793145.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u1604-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k18-ko19-containerd
   cron: '23 1 * * 6'
@@ -26789,6 +40162,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1604-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1604-k19-ko18-containerd
+  cron: '51 5 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u160--e313026257.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1604-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1604-k19-ko19-containerd
@@ -26876,6 +40292,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-ko18-containerd
+  cron: '42 21 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--f0fb8f3b28.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u1804-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-ko19-containerd
   cron: '45 2 * * 4'
@@ -26961,6 +40420,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k17-ko18-containerd
+  cron: '33 7 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--28d7a863ee.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k17-ko19-containerd
@@ -27048,6 +40550,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k18-ko18-containerd
+  cron: '24 10 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--10bf10c608.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k18-ko19-containerd
   cron: '47 5 * * 6'
@@ -27133,6 +40678,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u1804-k19-ko18-containerd
+  cron: '11 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u180--373cd8bafb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u1804-k19-ko19-containerd
@@ -27220,6 +40808,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-ko18-containerd
+  cron: '13 10 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--1f1e95884e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-cilium-u2004-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-ko19-containerd
   cron: '6 13 * * *'
@@ -27305,6 +40936,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k17-ko18-containerd
+  cron: '39 17 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--a3823f3434.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k17-ko19-containerd
@@ -27392,6 +41066,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k18-ko18-containerd
+  cron: '50 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--563e65b087.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k18-ko19-containerd
   cron: '33 19 * * *'
@@ -27477,6 +41194,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "cilium"}
+- name: e2e-kops-grid-cilium-u2004-k19-ko18-containerd
+  cron: '49 7 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-cilium-u200--51b5abb1ae.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=cilium --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "cilium"}
 - name: e2e-kops-grid-cilium-u2004-k19-ko19-containerd
@@ -27564,6 +41324,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-ko18-containerd
+  cron: '51 12 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--cbfc45bb46.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-amzn2-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-ko19-containerd
   cron: '24 11 * * 2'
@@ -27649,6 +41452,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k17-ko18-containerd
+  cron: '39 21 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--a1a7cd5917.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k17-ko19-containerd
@@ -27736,6 +41582,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k18-ko18-containerd
+  cron: '34 0 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--691de50f8e.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k18-ko19-containerd
   cron: '25 23 * * 4'
@@ -27821,6 +41710,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-amzn2-k19-ko18-containerd
+  cron: '1 19 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-amz--1233576a1a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-amzn2-k19-ko19-containerd
@@ -27908,6 +41840,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-centos7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-ko18-containerd
+  cron: '10 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--15d7679d59.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-centos7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-ko19-containerd
   cron: '25 1 * * 2'
@@ -27993,6 +41968,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-centos7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k17-ko18-containerd
+  cron: '33 12 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--550248d361.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-centos7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k17-ko19-containerd
@@ -28080,6 +42098,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-centos7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k18-ko18-containerd
+  cron: '8 9 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--32d7b604e6.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-centos7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k18-ko19-containerd
   cron: '55 22 * * 1'
@@ -28165,6 +42226,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-centos7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-centos7-k19-ko18-containerd
+  cron: '23 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-cen--c076346725.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-centos7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-centos7-k19-ko19-containerd
@@ -28252,6 +42356,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-ko18-containerd
+  cron: '7 20 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--ada27e4403.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-deb9-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-ko19-containerd
   cron: '24 19 * * 2'
@@ -28337,6 +42484,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k17-ko18-containerd
+  cron: '53 23 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--cf9d75f48c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k17-ko19-containerd
@@ -28424,6 +42614,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k18-ko18-containerd
+  cron: '36 18 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--a31c24b611.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k18-ko19-containerd
   cron: '39 13 * * 2'
@@ -28509,6 +42742,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb9-k19-ko18-containerd
+  cron: '3 1 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--a08350feb0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb9-k19-ko19-containerd
@@ -28596,6 +42872,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-ko18-containerd
+  cron: '0 19 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--e41c395181.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-deb10-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-ko19-containerd
   cron: '55 4 * * 4'
@@ -28681,6 +43000,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k17-ko18-containerd
+  cron: '41 7 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--201ee4523a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k17-ko19-containerd
@@ -28768,6 +43130,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k18-ko18-containerd
+  cron: '56 10 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--1b48f0852d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k18-ko19-containerd
   cron: '11 13 * * 6'
@@ -28853,6 +43258,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-deb10-k19-ko18-containerd
+  cron: '31 1 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-deb--0621bcb366.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-deb10-k19-ko19-containerd
@@ -28940,6 +43388,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-ko18-containerd
+  cron: '3 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--501dab48ec.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-flatcar-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-ko19-containerd
   cron: '32 4 * * 4'
@@ -29025,6 +43516,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k17-ko18-containerd
+  cron: '21 4 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--dab9aaa9bb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k17-ko19-containerd
@@ -29112,6 +43646,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k18-ko18-containerd
+  cron: '20 9 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--1b629a88ab.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k18-ko19-containerd
   cron: '19 14 * * 4'
@@ -29197,6 +43774,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-flatcar-k19-ko18-containerd
+  cron: '19 18 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-fla--0d2ab6f86c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-flatcar-k19-ko19-containerd
@@ -29284,6 +43904,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-ko18-containerd
+  cron: '44 23 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--8ffb4f1325.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-rhel7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-ko19-containerd
   cron: '7 16 * * 5'
@@ -29369,6 +44032,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k17-ko18-containerd
+  cron: '19 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--5ba61f7554.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k17-ko19-containerd
@@ -29456,6 +44162,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k18-ko18-containerd
+  cron: '46 12 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--248cf4eea9.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k18-ko19-containerd
   cron: '45 3 * * 6'
@@ -29541,6 +44290,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel7-k19-ko18-containerd
+  cron: '17 23 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--f56022f575.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel7-k19-ko19-containerd
@@ -29628,6 +44420,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-ko18-containerd
+  cron: '33 10 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--10c81082a4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-rhel8-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-ko19-containerd
   cron: '14 5 * * 4'
@@ -29713,6 +44548,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k17-ko18-containerd
+  cron: '41 15 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--3d549a2339.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k17-ko19-containerd
@@ -29800,6 +44678,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k18-ko18-containerd
+  cron: '48 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--35f71790f3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k18-ko19-containerd
   cron: '3 5 * * 2'
@@ -29885,6 +44806,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-rhel8-k19-ko18-containerd
+  cron: '7 9 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-rhe--7b7250e9aa.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-rhel8-k19-ko19-containerd
@@ -29972,6 +44936,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1604-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-ko18-containerd
+  cron: '6 21 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--9adf6632bd.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u1604-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-ko19-containerd
   cron: '41 10 * * 6'
@@ -30057,6 +45064,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1604-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k17-ko18-containerd
+  cron: '26 4 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--8b3e991a67.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u1604-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k17-ko19-containerd
@@ -30144,6 +45194,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1604-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k18-ko18-containerd
+  cron: '47 9 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--c87f06b3e5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u1604-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k18-ko19-containerd
   cron: '12 6 * * 4'
@@ -30229,6 +45322,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1604-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1604-k19-ko18-containerd
+  cron: '32 10 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u16--2978e7475c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1604-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1604-k19-ko19-containerd
@@ -30316,6 +45452,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-ko18-containerd
+  cron: '36 11 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--d7e9a756a2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u1804-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-ko19-containerd
   cron: '47 12 * * 0'
@@ -30401,6 +45580,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k17-ko18-containerd
+  cron: '30 0 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--3d1be6b986.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k17-ko19-containerd
@@ -30488,6 +45710,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k18-ko18-containerd
+  cron: '35 13 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--f1b89d57cf.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k18-ko19-containerd
   cron: '40 2 * * 3'
@@ -30573,6 +45838,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u1804-k19-ko18-containerd
+  cron: '36 6 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u18--652705b05c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u1804-k19-ko19-containerd
@@ -30660,6 +45968,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-ko18-containerd
+  cron: '31 4 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--8fe9ca4715.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-flannel-u2004-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-ko19-containerd
   cron: '24 19 * * *'
@@ -30745,6 +46096,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k17-ko18-containerd
+  cron: '4 6 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--d9dcd83700.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k17-ko19-containerd
@@ -30832,6 +46226,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k18-ko18-containerd
+  cron: '21 11 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--07854d912c.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k18-ko19-containerd
   cron: '58 20 * * *'
@@ -30917,6 +46354,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "flannel"}
+- name: e2e-kops-grid-flannel-u2004-k19-ko18-containerd
+  cron: '38 16 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-flannel-u20--aba20a23c0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=flannel --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "flannel"}
 - name: e2e-kops-grid-flannel-u2004-k19-ko19-containerd
@@ -31004,6 +46484,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-ko18-containerd
+  cron: '1 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--ecbc9cbaf3.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-amzn2-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-ko19-containerd
   cron: '18 9 * * 0'
@@ -31089,6 +46612,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k17-ko18-containerd
+  cron: '44 14 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--a78e310559.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k17-ko19-containerd
@@ -31176,6 +46742,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k18-ko18-containerd
+  cron: '29 3 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--4c96d1d969.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k18-ko19-containerd
   cron: '58 12 * * 0'
@@ -31261,6 +46870,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-amzn2-k19-ko18-containerd
+  cron: '38 0 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-amzn--56e022ec84.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=137112412989/amzn2-ami-hvm-2.0.20200406.0-x86_64-gp2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "amzn2", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-amzn2-k19-ko19-containerd
@@ -31348,6 +47000,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-centos7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-ko18-containerd
+  cron: '47 19 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--91dd17f375.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-centos7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-ko19-containerd
   cron: '36 4 * * 5'
@@ -31433,6 +47128,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-centos7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k17-ko18-containerd
+  cron: '27 22 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--4d3696ce9a.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-centos7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k17-ko19-containerd
@@ -31520,6 +47258,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-centos7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k18-ko18-containerd
+  cron: '46 19 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--bfab576752.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-centos7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k18-ko19-containerd
   cron: '37 4 * * 2'
@@ -31605,6 +47386,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-centos7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-centos7-k19-ko18-containerd
+  cron: '33 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-cent--65655e01a5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=centos
+      - --env=KUBE_SSH_USER=centos
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=679593333241/CentOS Linux 7 x86_64 HVM EBS ENA 2002_01-b7ee8a69-ee97-4a49-9e68-afaee216db2e-ami-0042af67f8e4dcc20.4
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-centos7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-centos7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "centos7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-centos7-k19-ko19-containerd
@@ -31692,6 +47516,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-ko18-containerd
+  cron: '8 12 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--1e774312df.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-deb9-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-ko19-containerd
   cron: '51 3 * * 6'
@@ -31777,6 +47644,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k17-ko18-containerd
+  cron: '30 2 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--ebd3823192.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k17-ko19-containerd
@@ -31864,6 +47774,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k18-ko18-containerd
+  cron: '19 15 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--16e464c740.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k18-ko19-containerd
   cron: '40 0 * * 1'
@@ -31949,6 +47902,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb9-k19-ko18-containerd
+  cron: '40 12 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb9--d49ebc12eb.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=379101102735/debian-stretch-hvm-x86_64-gp2-2020-02-10-73984
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb9", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb9-k19-ko19-containerd
@@ -32036,6 +48032,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-ko18-containerd
+  cron: '22 17 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--a1886f2bb2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-deb10-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-ko19-containerd
   cron: '41 22 * * 6'
@@ -32121,6 +48160,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k17-ko18-containerd
+  cron: '54 12 * * 5'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--775d99af83.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k17-ko19-containerd
@@ -32208,6 +48290,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k18-ko18-containerd
+  cron: '15 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--410948ad38.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k18-ko19-containerd
   cron: '4 14 * * 3'
@@ -32293,6 +48418,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-deb10-k19-ko18-containerd
+  cron: '4 2 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-deb1--a18312e6b5.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=admin
+      - --env=KUBE_SSH_USER=admin
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=136693071363/debian-10-amd64-20200511-260
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "deb10", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-deb10-k19-ko19-containerd
@@ -32380,6 +48548,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-ko18-containerd
+  cron: '10 6 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--acaf98e586.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-flatcar-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-ko19-containerd
   cron: '21 17 * * 6'
@@ -32465,6 +48676,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k17-ko18-containerd
+  cron: '3 14 * * 4'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--fe293db897.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k17-ko19-containerd
@@ -32552,6 +48806,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k18-ko18-containerd
+  cron: '2 3 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--d4d95a2e1f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k18-ko19-containerd
   cron: '41 4 * * 5'
@@ -32637,6 +48934,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-flatcar-k19-ko18-containerd
+  cron: '9 8 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-flat--26915c6415.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=core
+      - --env=KUBE_SSH_USER=core
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=075585003325/Flatcar-stable-2605.6.0-hvm
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "flatcar", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-flatcar-k19-ko19-containerd
@@ -32724,6 +49064,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-ko18-containerd
+  cron: '58 13 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--6b816b5857.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-rhel7-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-ko19-containerd
   cron: '13 18 * * 0'
@@ -32809,6 +49192,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k17-ko18-containerd
+  cron: '4 2 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--794b43d004.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k17-ko19-containerd
@@ -32896,6 +49322,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k18-ko18-containerd
+  cron: '25 23 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--3159c41116.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k18-ko19-containerd
   cron: '50 0 * * 6'
@@ -32981,6 +49450,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel7-k19-ko18-containerd
+  cron: '42 20 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--8cacb6969f.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-7.8_HVM_GA-20200225-x86_64-1-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel7", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel7-k19-ko19-containerd
@@ -33068,6 +49580,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-ko18-containerd
+  cron: '39 8 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--5cc1775266.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-rhel8-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-ko19-containerd
   cron: '16 23 * * 6'
@@ -33153,6 +49708,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k17-ko18-containerd
+  cron: '50 4 * * 3'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--4c541ab908.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k17-ko19-containerd
@@ -33240,6 +49838,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k18-ko18-containerd
+  cron: '39 1 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--7c289a8316.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k18-ko19-containerd
   cron: '0 6 * * 6'
@@ -33325,6 +49966,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-rhel8-k19-ko18-containerd
+  cron: '32 2 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-rhel--1f1b4570ad.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ec2-user
+      - --env=KUBE_SSH_USER=ec2-user
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=309956199498/RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "rhel8", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-rhel8-k19-ko19-containerd
@@ -33412,6 +50096,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1604-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-ko18-containerd
+  cron: '52 7 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--f4359c06a4.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u1604-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-ko19-containerd
   cron: '15 16 * * 2'
@@ -33497,6 +50224,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1604-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k17-ko18-containerd
+  cron: '41 23 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--1072ea1553.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u1604-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k17-ko19-containerd
@@ -33584,6 +50354,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1604-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k18-ko18-containerd
+  cron: '24 10 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--8f53facbe2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u1604-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k18-ko19-containerd
   cron: '7 5 * * 6'
@@ -33669,6 +50482,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1604-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1604-k19-ko18-containerd
+  cron: '7 1 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u160--37af53ced1.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20200429
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1604, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1604-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1604", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1604-k19-ko19-containerd
@@ -33756,6 +50612,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-ko18-containerd
+  cron: '6 1 * * 0'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--1d388c5a34.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u1804-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-ko19-containerd
   cron: '21 6 * * 3'
@@ -33841,6 +50740,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k17-ko18-containerd
+  cron: '25 3 * * 1'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--9b9434f514.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k17-ko19-containerd
@@ -33928,6 +50870,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k18-ko18-containerd
+  cron: '4 6 * * 6'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--3a7391e644.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k18-ko19-containerd
   cron: '7 17 * * 6'
@@ -34013,6 +50998,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u1804-k19-ko18-containerd
+  cron: '19 21 * * 2'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u180--d996707180.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200430
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u1804", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u1804-k19-ko19-containerd
@@ -34100,6 +51128,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-ko18-containerd
+  cron: '17 14 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--df5d43ab0b.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/latest
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-tab-name: kops-grid-kopeio-u2004-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": null, "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-ko19-containerd
   cron: '30 9 * * *'
@@ -34185,6 +51256,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k17-ko18-containerd
+  cron: '35 5 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--c017b60ac0.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.17.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.17
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.17
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
+    testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.17", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k17-ko19-containerd
@@ -34272,6 +51386,49 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-containerd
 
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k18-ko18-containerd
+  cron: '54 0 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--09b89e21c2.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.18.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.18
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.18
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
+    testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-containerd
+
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.18", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k18-ko19-containerd
   cron: '5 15 * * *'
@@ -34357,6 +51514,49 @@ periodics:
   annotations:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-containerd
+
+# {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.18", "networking": "kopeio"}
+- name: e2e-kops-grid-kopeio-u2004-k19-ko18-containerd
+  cron: '25 3 * * *'
+  labels:
+    preset-service-account: "true"
+    preset-aws-ssh: "true"
+    preset-aws-credential: "true"
+  decorate: true
+  decoration_config:
+    timeout: 90m
+  spec:
+    containers:
+    - command:
+      - runner.sh
+      - /workspace/scenarios/kubernetes_e2e.py
+      args:
+      - --cluster=e2e-kops-kopeio-u200--80ed6fd70d.test-cncf-aws.k8s.io
+      - --deployment=kops
+      - --kops-ssh-user=ubuntu
+      - --env=KUBE_SSH_USER=ubuntu
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
+      - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
+      - --extract=release/stable-1.19
+      - --ginkgo-parallel
+      - --kops-args=--networking=kopeio --container-runtime=containerd
+      - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200528
+      - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
+      - --kops-version=https://storage.googleapis.com/kops-ci/markers/release-1.18/latest-ci-updown-green.txt
+      - --provider=aws
+      - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
+      - --timeout=60m
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-1.19
+      resources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi
+  annotations:
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-containerd
 
 # {"cloud": "aws", "container_runtime": "containerd", "distro": "u2004", "k8s_version": "1.19", "kops_version": "1.19", "networking": "kopeio"}
 - name: e2e-kops-grid-kopeio-u2004-k19-ko19-containerd
@@ -34488,4 +51688,4 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
-# 802 jobs, total of 1288 runs per week
+# 1202 jobs, total of 1928 runs per week


### PR DESCRIPTION
We can continue to test older versions of kops that are still in
widespread use, to catch regressions.

Can also give signal about when problems were introduced.