### PR TITLE
Add job to push aws-ebs-csi-driver images

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cloud-provider-aws.yaml
@@ -30,3 +30,34 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-provider-aws-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  # This is the github repo we'll build from. This block needs to be repeated for each repo.
+  kubernetes-sigs/aws-ebs-csi-driver:
+    - name: aws-ebs-csi-driver-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-aws-cloud-provider-aws
+        testgrid-tab-name: aws-ebs-csi-driver-image-pushes
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-provider-aws
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-provider-aws-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .


### PR DESCRIPTION
I want the next release to be on GCR.

cloudbuild.yaml: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/cloudbuild.yaml

I followed READMEs at https://github.com/kubernetes/k8s.io/tree/master/k8s.gcr.io and
https://github.com/kubernetes/test-infra/tree/master/config/jobs/image-pushing.