### PR TITLE
kops-grid: add metadata annotations to our test jobs

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -297,9 +297,9 @@ def build_test(cloud='aws',
         'container_runtime': container_runtime,
     }
     if feature_flags:
-        spec['feature_flags'] = feature_flags
+        spec['feature_flags'] = ','.join(feature_flags)
     if extra_flags:
-        spec['extra_flags'] = extra_flags
+        spec['extra_flags'] = ' '.join(extra_flags)
     jsonspec = json.dumps(spec, sort_keys=True)
 
     dashboards = [
@@ -322,6 +322,8 @@ def build_test(cloud='aws',
         'testgrid-dashboards': ', '.join(dashboards),
         'testgrid-tab-name': tab,
     }
+    for (k, v) in spec.items():
+        annotations['test.kops.k8s.io/' + k] = v if v else ""
 
     extra = yaml.dump({'annotations': annotations}, width=9999, default_flow_style=False)
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -41,6 +41,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-docker
 
@@ -84,6 +90,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko18-docker
 
@@ -127,6 +139,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko19-docker
 
@@ -170,6 +188,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-docker
 
@@ -213,6 +237,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-docker
 
@@ -256,6 +286,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-docker
 
@@ -299,6 +335,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-docker
 
@@ -342,6 +384,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-docker
 
@@ -385,6 +433,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-docker
 
@@ -428,6 +482,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-docker
 
@@ -471,6 +531,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko18-docker
 
@@ -514,6 +580,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-docker
 
@@ -557,6 +629,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-docker
 
@@ -600,6 +678,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko18-docker
 
@@ -643,6 +727,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko19-docker
 
@@ -686,6 +776,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-docker
 
@@ -729,6 +825,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-ko18-docker
 
@@ -772,6 +874,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-ko19-docker
 
@@ -815,6 +923,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-docker
 
@@ -858,6 +972,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18-docker
 
@@ -901,6 +1021,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko19-docker
 
@@ -944,6 +1070,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-docker
 
@@ -987,6 +1119,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko18-docker
 
@@ -1030,6 +1168,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko19-docker
 
@@ -1073,6 +1217,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-docker
 
@@ -1116,6 +1266,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko18-docker
 
@@ -1159,6 +1315,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko19-docker
 
@@ -1202,6 +1364,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-docker
 
@@ -1245,6 +1413,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-ko18-docker
 
@@ -1288,6 +1462,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-ko19-docker
 
@@ -1331,6 +1511,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-docker
 
@@ -1374,6 +1560,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18-docker
 
@@ -1417,6 +1609,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko19-docker
 
@@ -1460,6 +1658,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-docker
 
@@ -1503,6 +1707,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko18-docker
 
@@ -1546,6 +1756,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko19-docker
 
@@ -1589,6 +1805,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-docker
 
@@ -1632,6 +1854,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko18-docker
 
@@ -1675,6 +1903,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko19-docker
 
@@ -1718,6 +1952,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-docker
 
@@ -1761,6 +2001,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-docker
 
@@ -1804,6 +2050,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-docker
 
@@ -1847,6 +2099,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-docker
 
@@ -1890,6 +2148,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-docker
 
@@ -1933,6 +2197,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-docker
 
@@ -1976,6 +2246,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-docker
 
@@ -2019,6 +2295,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko18-docker
 
@@ -2062,6 +2344,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-docker
 
@@ -2105,6 +2393,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-docker
 
@@ -2148,6 +2442,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko18-docker
 
@@ -2191,6 +2491,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko19-docker
 
@@ -2234,6 +2540,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-docker
 
@@ -2277,6 +2589,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-docker
 
@@ -2320,6 +2638,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-docker
 
@@ -2363,6 +2687,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-docker
 
@@ -2406,6 +2736,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-docker
 
@@ -2449,6 +2785,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-docker
 
@@ -2492,6 +2834,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-docker
 
@@ -2535,6 +2883,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko18-docker
 
@@ -2578,6 +2932,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-docker
 
@@ -2621,6 +2981,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-docker
 
@@ -2664,6 +3030,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko18-docker
 
@@ -2707,6 +3079,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko19-docker
 
@@ -2750,6 +3128,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-docker
 
@@ -2793,6 +3177,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-docker
 
@@ -2836,6 +3226,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-docker
 
@@ -2879,6 +3275,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-docker
 
@@ -2922,6 +3324,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-docker
 
@@ -2965,6 +3373,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-docker
 
@@ -3008,6 +3422,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-docker
 
@@ -3051,6 +3471,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko18-docker
 
@@ -3094,6 +3520,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-docker
 
@@ -3137,6 +3569,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-docker
 
@@ -3180,6 +3618,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko18-docker
 
@@ -3223,6 +3667,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko19-docker
 
@@ -3266,6 +3716,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-docker
 
@@ -3309,6 +3765,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-ko18-docker
 
@@ -3352,6 +3814,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-ko19-docker
 
@@ -3395,6 +3863,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-docker
 
@@ -3438,6 +3912,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18-docker
 
@@ -3481,6 +3961,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko19-docker
 
@@ -3524,6 +4010,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-docker
 
@@ -3567,6 +4059,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko18-docker
 
@@ -3610,6 +4108,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko19-docker
 
@@ -3653,6 +4157,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-docker
 
@@ -3696,6 +4206,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko18-docker
 
@@ -3739,6 +4255,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko19-docker
 
@@ -3782,6 +4304,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-docker
 
@@ -3825,6 +4353,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-ko18-docker
 
@@ -3868,6 +4402,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-ko19-docker
 
@@ -3911,6 +4451,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-docker
 
@@ -3954,6 +4500,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18-docker
 
@@ -3997,6 +4549,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko19-docker
 
@@ -4040,6 +4598,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-docker
 
@@ -4083,6 +4647,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko18-docker
 
@@ -4126,6 +4696,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko19-docker
 
@@ -4169,6 +4745,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-docker
 
@@ -4212,6 +4794,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko18-docker
 
@@ -4255,6 +4843,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko19-docker
 
@@ -4298,6 +4892,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-docker
 
@@ -4341,6 +4941,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-docker
 
@@ -4384,6 +4990,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-docker
 
@@ -4427,6 +5039,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-docker
 
@@ -4470,6 +5088,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-docker
 
@@ -4513,6 +5137,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-docker
 
@@ -4556,6 +5186,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-docker
 
@@ -4599,6 +5235,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-docker
 
@@ -4642,6 +5284,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-docker
 
@@ -4685,6 +5333,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-docker
 
@@ -4728,6 +5382,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko18-docker
 
@@ -4771,6 +5431,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko19-docker
 
@@ -4814,6 +5480,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-docker
 
@@ -4857,6 +5529,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-docker
 
@@ -4900,6 +5578,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-docker
 
@@ -4943,6 +5627,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-docker
 
@@ -4986,6 +5676,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-docker
 
@@ -5029,6 +5725,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-docker
 
@@ -5072,6 +5774,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-docker
 
@@ -5115,6 +5823,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-docker
 
@@ -5158,6 +5872,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-docker
 
@@ -5201,6 +5921,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-docker
 
@@ -5244,6 +5970,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko18-docker
 
@@ -5287,6 +6019,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko19-docker
 
@@ -5330,6 +6068,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-docker
 
@@ -5373,6 +6117,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-docker
 
@@ -5416,6 +6166,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-docker
 
@@ -5459,6 +6215,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-docker
 
@@ -5502,6 +6264,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-docker
 
@@ -5545,6 +6313,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-docker
 
@@ -5588,6 +6362,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-docker
 
@@ -5631,6 +6411,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-docker
 
@@ -5674,6 +6460,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-docker
 
@@ -5717,6 +6509,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-docker
 
@@ -5760,6 +6558,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko18-docker
 
@@ -5803,6 +6607,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko19-docker
 
@@ -5846,6 +6656,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-docker
 
@@ -5889,6 +6705,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-docker
 
@@ -5932,6 +6754,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-docker
 
@@ -5975,6 +6803,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-docker
 
@@ -6018,6 +6852,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-docker
 
@@ -6061,6 +6901,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-docker
 
@@ -6104,6 +6950,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-docker
 
@@ -6147,6 +6999,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-docker
 
@@ -6190,6 +7048,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-docker
 
@@ -6233,6 +7097,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-docker
 
@@ -6276,6 +7146,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko18-docker
 
@@ -6319,6 +7195,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko19-docker
 
@@ -6362,6 +7244,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-docker
 
@@ -6405,6 +7293,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-docker
 
@@ -6448,6 +7342,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-docker
 
@@ -6491,6 +7391,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-docker
 
@@ -6534,6 +7440,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-docker
 
@@ -6577,6 +7489,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-docker
 
@@ -6620,6 +7538,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-docker
 
@@ -6663,6 +7587,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-docker
 
@@ -6706,6 +7636,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-docker
 
@@ -6749,6 +7685,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-docker
 
@@ -6792,6 +7734,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko18-docker
 
@@ -6835,6 +7783,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko19-docker
 
@@ -6878,6 +7832,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-docker
 
@@ -6921,6 +7881,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-docker
 
@@ -6964,6 +7930,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-docker
 
@@ -7007,6 +7979,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-docker
 
@@ -7050,6 +8028,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-docker
 
@@ -7093,6 +8077,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-docker
 
@@ -7136,6 +8126,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-docker
 
@@ -7179,6 +8175,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-docker
 
@@ -7222,6 +8224,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-docker
 
@@ -7265,6 +8273,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-docker
 
@@ -7308,6 +8322,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko18-docker
 
@@ -7351,6 +8371,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko19-docker
 
@@ -7394,6 +8420,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-docker
 
@@ -7437,6 +8469,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-docker
 
@@ -7480,6 +8518,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-docker
 
@@ -7523,6 +8567,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-docker
 
@@ -7566,6 +8616,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-docker
 
@@ -7609,6 +8665,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-docker
 
@@ -7652,6 +8714,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-docker
 
@@ -7695,6 +8763,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-docker
 
@@ -7738,6 +8812,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-docker
 
@@ -7781,6 +8861,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-docker
 
@@ -7824,6 +8910,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko18-docker
 
@@ -7867,6 +8959,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko19-docker
 
@@ -7910,6 +9008,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-docker
 
@@ -7953,6 +9057,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-docker
 
@@ -7996,6 +9106,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-docker
 
@@ -8039,6 +9155,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-docker
 
@@ -8082,6 +9204,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-docker
 
@@ -8125,6 +9253,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-docker
 
@@ -8168,6 +9302,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-docker
 
@@ -8211,6 +9351,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-docker
 
@@ -8254,6 +9400,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-docker
 
@@ -8297,6 +9449,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-docker
 
@@ -8340,6 +9498,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko18-docker
 
@@ -8383,6 +9547,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko19-docker
 
@@ -8426,6 +9596,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-docker
 
@@ -8469,6 +9645,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-docker
 
@@ -8512,6 +9694,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-docker
 
@@ -8555,6 +9743,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-docker
 
@@ -8598,6 +9792,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-docker
 
@@ -8641,6 +9841,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-docker
 
@@ -8684,6 +9890,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-docker
 
@@ -8727,6 +9939,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-docker
 
@@ -8770,6 +9988,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-docker
 
@@ -8813,6 +10037,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-docker
 
@@ -8856,6 +10086,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko18-docker
 
@@ -8899,6 +10135,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko19-docker
 
@@ -8942,6 +10184,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-docker
 
@@ -8985,6 +10233,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-docker
 
@@ -9028,6 +10282,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-docker
 
@@ -9071,6 +10331,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-docker
 
@@ -9114,6 +10380,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-docker
 
@@ -9157,6 +10429,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-docker
 
@@ -9200,6 +10478,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-docker
 
@@ -9243,6 +10527,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-docker
 
@@ -9286,6 +10576,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-docker
 
@@ -9329,6 +10625,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-docker
 
@@ -9372,6 +10674,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko18-docker
 
@@ -9415,6 +10723,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko19-docker
 
@@ -9458,6 +10772,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-docker
 
@@ -9501,6 +10821,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-docker
 
@@ -9544,6 +10870,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-docker
 
@@ -9587,6 +10919,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-docker
 
@@ -9630,6 +10968,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-docker
 
@@ -9673,6 +11017,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-docker
 
@@ -9716,6 +11066,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-docker
 
@@ -9759,6 +11115,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-docker
 
@@ -9802,6 +11164,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-docker
 
@@ -9845,6 +11213,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-docker
 
@@ -9888,6 +11262,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko18-docker
 
@@ -9931,6 +11311,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko19-docker
 
@@ -9974,6 +11360,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-docker
 
@@ -10017,6 +11409,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-docker
 
@@ -10060,6 +11458,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-docker
 
@@ -10103,6 +11507,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-docker
 
@@ -10146,6 +11556,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-docker
 
@@ -10189,6 +11605,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-docker
 
@@ -10232,6 +11654,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-docker
 
@@ -10275,6 +11703,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-docker
 
@@ -10318,6 +11752,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-docker
 
@@ -10361,6 +11801,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-docker
 
@@ -10404,6 +11850,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-ko18-docker
 
@@ -10447,6 +11899,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-ko19-docker
 
@@ -10490,6 +11948,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-docker
 
@@ -10533,6 +11997,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-docker
 
@@ -10576,6 +12046,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-docker
 
@@ -10619,6 +12095,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-docker
 
@@ -10662,6 +12144,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-docker
 
@@ -10705,6 +12193,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-docker
 
@@ -10748,6 +12242,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-docker
 
@@ -10791,6 +12291,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-docker
 
@@ -10834,6 +12340,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-docker
 
@@ -10877,6 +12389,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-docker
 
@@ -10920,6 +12438,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko18-docker
 
@@ -10963,6 +12487,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko19-docker
 
@@ -11006,6 +12536,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-docker
 
@@ -11049,6 +12585,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-docker
 
@@ -11092,6 +12634,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-docker
 
@@ -11135,6 +12683,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-docker
 
@@ -11178,6 +12732,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-docker
 
@@ -11221,6 +12781,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-docker
 
@@ -11264,6 +12830,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-docker
 
@@ -11307,6 +12879,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-docker
 
@@ -11350,6 +12928,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-docker
 
@@ -11393,6 +12977,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-docker
 
@@ -11436,6 +13026,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko18-docker
 
@@ -11479,6 +13075,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko19-docker
 
@@ -11522,6 +13124,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-docker
 
@@ -11565,6 +13173,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-docker
 
@@ -11608,6 +13222,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-docker
 
@@ -11651,6 +13271,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-docker
 
@@ -11694,6 +13320,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-docker
 
@@ -11737,6 +13369,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-docker
 
@@ -11780,6 +13418,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-docker
 
@@ -11823,6 +13467,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-docker
 
@@ -11866,6 +13516,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-docker
 
@@ -11909,6 +13565,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-docker
 
@@ -11952,6 +13614,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko18-docker
 
@@ -11995,6 +13663,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko19-docker
 
@@ -12038,6 +13712,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-docker
 
@@ -12081,6 +13761,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-docker
 
@@ -12124,6 +13810,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-docker
 
@@ -12167,6 +13859,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-docker
 
@@ -12210,6 +13908,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-docker
 
@@ -12253,6 +13957,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-docker
 
@@ -12296,6 +14006,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-docker
 
@@ -12339,6 +14055,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-docker
 
@@ -12382,6 +14104,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-docker
 
@@ -12425,6 +14153,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-docker
 
@@ -12468,6 +14202,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko18-docker
 
@@ -12511,6 +14251,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko19-docker
 
@@ -12554,6 +14300,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-docker
 
@@ -12597,6 +14349,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-docker
 
@@ -12640,6 +14398,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-docker
 
@@ -12683,6 +14447,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-docker
 
@@ -12726,6 +14496,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-docker
 
@@ -12769,6 +14545,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-docker
 
@@ -12812,6 +14594,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-docker
 
@@ -12855,6 +14643,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-docker
 
@@ -12898,6 +14692,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-docker
 
@@ -12941,6 +14741,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-docker
 
@@ -12984,6 +14790,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko18-docker
 
@@ -13027,6 +14839,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko19-docker
 
@@ -13070,6 +14888,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-docker
 
@@ -13113,6 +14937,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-docker
 
@@ -13156,6 +14986,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-docker
 
@@ -13199,6 +15035,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-docker
 
@@ -13242,6 +15084,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-docker
 
@@ -13285,6 +15133,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-docker
 
@@ -13328,6 +15182,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-docker
 
@@ -13371,6 +15231,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-docker
 
@@ -13414,6 +15280,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-docker
 
@@ -13457,6 +15329,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-docker
 
@@ -13500,6 +15378,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko18-docker
 
@@ -13543,6 +15427,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko19-docker
 
@@ -13586,6 +15476,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-docker
 
@@ -13629,6 +15525,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-docker
 
@@ -13672,6 +15574,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-docker
 
@@ -13715,6 +15623,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-docker
 
@@ -13758,6 +15672,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-docker
 
@@ -13801,6 +15721,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-docker
 
@@ -13844,6 +15770,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-docker
 
@@ -13887,6 +15819,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-docker
 
@@ -13930,6 +15868,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-docker
 
@@ -13973,6 +15917,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-docker
 
@@ -14016,6 +15966,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko18-docker
 
@@ -14059,6 +16015,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko19-docker
 
@@ -14102,6 +16064,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-docker
 
@@ -14145,6 +16113,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-docker
 
@@ -14188,6 +16162,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-docker
 
@@ -14231,6 +16211,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-docker
 
@@ -14274,6 +16260,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-docker
 
@@ -14317,6 +16309,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-docker
 
@@ -14360,6 +16358,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-docker
 
@@ -14403,6 +16407,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-docker
 
@@ -14446,6 +16456,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-docker
 
@@ -14489,6 +16505,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-docker
 
@@ -14532,6 +16554,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko18-docker
 
@@ -14575,6 +16603,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko19-docker
 
@@ -14618,6 +16652,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-docker
 
@@ -14661,6 +16701,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-docker
 
@@ -14704,6 +16750,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-docker
 
@@ -14747,6 +16799,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-docker
 
@@ -14790,6 +16848,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-docker
 
@@ -14833,6 +16897,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-docker
 
@@ -14876,6 +16946,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-docker
 
@@ -14919,6 +16995,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-docker
 
@@ -14962,6 +17044,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-docker
 
@@ -15005,6 +17093,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-docker
 
@@ -15048,6 +17142,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko18-docker
 
@@ -15091,6 +17191,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko19-docker
 
@@ -15134,6 +17240,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-docker
 
@@ -15177,6 +17289,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-docker
 
@@ -15220,6 +17338,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-docker
 
@@ -15263,6 +17387,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-docker
 
@@ -15306,6 +17436,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-docker
 
@@ -15349,6 +17485,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-docker
 
@@ -15392,6 +17534,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-docker
 
@@ -15435,6 +17583,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-docker
 
@@ -15478,6 +17632,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-docker
 
@@ -15521,6 +17681,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-docker
 
@@ -15564,6 +17730,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko18-docker
 
@@ -15607,6 +17779,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko19-docker
 
@@ -15650,6 +17828,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-docker
 
@@ -15693,6 +17877,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-docker
 
@@ -15736,6 +17926,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-docker
 
@@ -15779,6 +17975,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-docker
 
@@ -15822,6 +18024,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-docker
 
@@ -15865,6 +18073,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-docker
 
@@ -15908,6 +18122,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-docker
 
@@ -15951,6 +18171,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-docker
 
@@ -15994,6 +18220,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-docker
 
@@ -16037,6 +18269,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-docker
 
@@ -16080,6 +18318,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko18-docker
 
@@ -16123,6 +18367,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko19-docker
 
@@ -16166,6 +18416,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-docker
 
@@ -16209,6 +18465,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-docker
 
@@ -16252,6 +18514,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-docker
 
@@ -16295,6 +18563,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-docker
 
@@ -16338,6 +18612,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-docker
 
@@ -16381,6 +18661,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-docker
 
@@ -16424,6 +18710,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-docker
 
@@ -16467,6 +18759,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-docker
 
@@ -16510,6 +18808,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-docker
 
@@ -16553,6 +18857,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-docker
 
@@ -16596,6 +18906,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko18-docker
 
@@ -16639,6 +18955,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko19-docker
 
@@ -16682,6 +19004,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-docker
 
@@ -16725,6 +19053,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-docker
 
@@ -16768,6 +19102,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-docker
 
@@ -16811,6 +19151,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-docker
 
@@ -16854,6 +19200,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-docker
 
@@ -16897,6 +19249,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-docker
 
@@ -16940,6 +19298,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-docker
 
@@ -16983,6 +19347,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-docker
 
@@ -17026,6 +19396,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-docker
 
@@ -17069,6 +19445,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-docker
 
@@ -17112,6 +19494,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko18-docker
 
@@ -17155,6 +19543,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko19-docker
 
@@ -17198,6 +19592,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-docker
 
@@ -17241,6 +19641,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-docker
 
@@ -17284,6 +19690,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-docker
 
@@ -17327,6 +19739,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-docker
 
@@ -17370,6 +19788,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-docker
 
@@ -17413,6 +19837,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-docker
 
@@ -17456,6 +19886,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-docker
 
@@ -17499,6 +19935,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-docker
 
@@ -17542,6 +19984,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-docker
 
@@ -17585,6 +20033,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-docker
 
@@ -17628,6 +20082,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko18-docker
 
@@ -17671,6 +20131,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko19-docker
 
@@ -17714,6 +20180,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-docker
 
@@ -17757,6 +20229,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-docker
 
@@ -17800,6 +20278,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-docker
 
@@ -17843,6 +20327,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-docker
 
@@ -17886,6 +20376,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-docker
 
@@ -17929,6 +20425,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-docker
 
@@ -17972,6 +20474,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-docker
 
@@ -18015,6 +20523,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-docker
 
@@ -18058,6 +20572,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-docker
 
@@ -18101,6 +20621,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-docker
 
@@ -18144,6 +20670,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko18-docker
 
@@ -18187,6 +20719,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko19-docker
 
@@ -18230,6 +20768,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-docker
 
@@ -18273,6 +20817,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-docker
 
@@ -18316,6 +20866,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-docker
 
@@ -18359,6 +20915,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-docker
 
@@ -18402,6 +20964,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-docker
 
@@ -18445,6 +21013,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-docker
 
@@ -18488,6 +21062,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-docker
 
@@ -18531,6 +21111,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-docker
 
@@ -18574,6 +21160,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-docker
 
@@ -18617,6 +21209,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-docker
 
@@ -18660,6 +21258,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko18-docker
 
@@ -18703,6 +21307,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko19-docker
 
@@ -18746,6 +21356,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-docker
 
@@ -18789,6 +21405,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-docker
 
@@ -18832,6 +21454,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-docker
 
@@ -18875,6 +21503,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-docker
 
@@ -18918,6 +21552,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-docker
 
@@ -18961,6 +21601,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-docker
 
@@ -19004,6 +21650,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-docker
 
@@ -19047,6 +21699,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-docker
 
@@ -19090,6 +21748,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-docker
 
@@ -19133,6 +21797,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-docker
 
@@ -19176,6 +21846,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko18-docker
 
@@ -19219,6 +21895,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko19-docker
 
@@ -19262,6 +21944,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-docker
 
@@ -19305,6 +21993,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-docker
 
@@ -19348,6 +22042,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-docker
 
@@ -19391,6 +22091,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-docker
 
@@ -19434,6 +22140,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-docker
 
@@ -19477,6 +22189,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-docker
 
@@ -19520,6 +22238,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-docker
 
@@ -19563,6 +22287,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-docker
 
@@ -19606,6 +22336,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-docker
 
@@ -19649,6 +22385,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-docker
 
@@ -19692,6 +22434,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko18-docker
 
@@ -19735,6 +22483,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko19-docker
 
@@ -19778,6 +22532,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-docker
 
@@ -19821,6 +22581,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-docker
 
@@ -19864,6 +22630,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-docker
 
@@ -19907,6 +22679,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-docker
 
@@ -19950,6 +22728,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-docker
 
@@ -19993,6 +22777,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-docker
 
@@ -20036,6 +22826,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-docker
 
@@ -20079,6 +22875,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-docker
 
@@ -20122,6 +22924,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-docker
 
@@ -20165,6 +22973,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-docker
 
@@ -20208,6 +23022,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko18-docker
 
@@ -20251,6 +23071,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko19-docker
 
@@ -20294,6 +23120,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-docker
 
@@ -20337,6 +23169,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-docker
 
@@ -20380,6 +23218,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-docker
 
@@ -20423,6 +23267,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-docker
 
@@ -20466,6 +23316,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-docker
 
@@ -20509,6 +23365,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-docker
 
@@ -20552,6 +23414,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-docker
 
@@ -20595,6 +23463,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-docker
 
@@ -20638,6 +23512,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-docker
 
@@ -20681,6 +23561,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-containerd
 
@@ -20724,6 +23610,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko18-containerd
 
@@ -20767,6 +23659,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-amzn2-ko19-containerd
 
@@ -20810,6 +23708,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-containerd
 
@@ -20853,6 +23757,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-ko18-containerd
 
@@ -20896,6 +23806,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-amzn2-k17-ko19-containerd
 
@@ -20939,6 +23855,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-containerd
 
@@ -20982,6 +23904,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko18-containerd
 
@@ -21025,6 +23953,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-amzn2-k18-ko19-containerd
 
@@ -21068,6 +24002,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-containerd
 
@@ -21111,6 +24051,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko18-containerd
 
@@ -21154,6 +24100,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-amzn2-k19-ko19-containerd
 
@@ -21197,6 +24149,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-containerd
 
@@ -21240,6 +24198,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko18-containerd
 
@@ -21283,6 +24247,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb9-ko19-containerd
 
@@ -21326,6 +24296,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-containerd
 
@@ -21369,6 +24345,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-ko18-containerd
 
@@ -21412,6 +24394,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb9-k17-ko19-containerd
 
@@ -21455,6 +24443,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-containerd
 
@@ -21498,6 +24492,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko18-containerd
 
@@ -21541,6 +24541,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb9-k18-ko19-containerd
 
@@ -21584,6 +24590,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-containerd
 
@@ -21627,6 +24639,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko18-containerd
 
@@ -21670,6 +24688,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb9-k19-ko19-containerd
 
@@ -21713,6 +24737,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-containerd
 
@@ -21756,6 +24786,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko18-containerd
 
@@ -21799,6 +24835,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-deb10-ko19-containerd
 
@@ -21842,6 +24884,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-containerd
 
@@ -21885,6 +24933,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-ko18-containerd
 
@@ -21928,6 +24982,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-deb10-k17-ko19-containerd
 
@@ -21971,6 +25031,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-containerd
 
@@ -22014,6 +25080,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko18-containerd
 
@@ -22057,6 +25129,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-deb10-k18-ko19-containerd
 
@@ -22100,6 +25178,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-containerd
 
@@ -22143,6 +25227,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko18-containerd
 
@@ -22186,6 +25276,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-deb10-k19-ko19-containerd
 
@@ -22229,6 +25325,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-containerd
 
@@ -22272,6 +25374,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko18-containerd
 
@@ -22315,6 +25423,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flatcar-ko19-containerd
 
@@ -22358,6 +25472,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-containerd
 
@@ -22401,6 +25521,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-ko18-containerd
 
@@ -22444,6 +25570,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flatcar-k17-ko19-containerd
 
@@ -22487,6 +25619,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-containerd
 
@@ -22530,6 +25668,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko18-containerd
 
@@ -22573,6 +25717,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flatcar-k18-ko19-containerd
 
@@ -22616,6 +25766,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-containerd
 
@@ -22659,6 +25815,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko18-containerd
 
@@ -22702,6 +25864,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flatcar-k19-ko19-containerd
 
@@ -22745,6 +25913,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-containerd
 
@@ -22788,6 +25962,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko18-containerd
 
@@ -22831,6 +26011,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel7-ko19-containerd
 
@@ -22874,6 +26060,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-containerd
 
@@ -22917,6 +26109,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-ko18-containerd
 
@@ -22960,6 +26158,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel7-k17-ko19-containerd
 
@@ -23003,6 +26207,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-containerd
 
@@ -23046,6 +26256,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko18-containerd
 
@@ -23089,6 +26305,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel7-k18-ko19-containerd
 
@@ -23132,6 +26354,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-containerd
 
@@ -23175,6 +26403,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko18-containerd
 
@@ -23218,6 +26452,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel7-k19-ko19-containerd
 
@@ -23261,6 +26501,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-containerd
 
@@ -23304,6 +26550,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko18-containerd
 
@@ -23347,6 +26599,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-rhel8-ko19-containerd
 
@@ -23390,6 +26648,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-containerd
 
@@ -23433,6 +26697,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-ko18-containerd
 
@@ -23476,6 +26746,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-rhel8-k17-ko19-containerd
 
@@ -23519,6 +26795,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-containerd
 
@@ -23562,6 +26844,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko18-containerd
 
@@ -23605,6 +26893,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-rhel8-k18-ko19-containerd
 
@@ -23648,6 +26942,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-containerd
 
@@ -23691,6 +26991,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko18-containerd
 
@@ -23734,6 +27040,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-rhel8-k19-ko19-containerd
 
@@ -23777,6 +27089,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-containerd
 
@@ -23820,6 +27138,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko18-containerd
 
@@ -23863,6 +27187,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-u1804-ko19-containerd
 
@@ -23906,6 +27236,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-containerd
 
@@ -23949,6 +27285,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-ko18-containerd
 
@@ -23992,6 +27334,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u1804-k17-ko19-containerd
 
@@ -24035,6 +27383,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-containerd
 
@@ -24078,6 +27432,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko18-containerd
 
@@ -24121,6 +27481,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u1804-k18-ko19-containerd
 
@@ -24164,6 +27530,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-containerd
 
@@ -24207,6 +27579,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko18-containerd
 
@@ -24250,6 +27628,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u1804-k19-ko19-containerd
 
@@ -24293,6 +27677,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-containerd
 
@@ -24336,6 +27726,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko18-containerd
 
@@ -24379,6 +27775,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-u2004-ko19-containerd
 
@@ -24422,6 +27824,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-containerd
 
@@ -24465,6 +27873,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-ko18-containerd
 
@@ -24508,6 +27922,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-u2004-k17-ko19-containerd
 
@@ -24551,6 +27971,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-containerd
 
@@ -24594,6 +28020,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko18-containerd
 
@@ -24637,6 +28069,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-u2004-k18-ko19-containerd
 
@@ -24680,6 +28118,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-containerd
 
@@ -24723,6 +28167,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko18-containerd
 
@@ -24766,6 +28216,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-u2004-k19-ko19-containerd
 
@@ -24809,6 +28265,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-containerd
 
@@ -24852,6 +28314,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko18-containerd
 
@@ -24895,6 +28363,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-amzn2-ko19-containerd
 
@@ -24938,6 +28412,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-containerd
 
@@ -24981,6 +28461,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko18-containerd
 
@@ -25024,6 +28510,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-amzn2-k17-ko19-containerd
 
@@ -25067,6 +28559,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-containerd
 
@@ -25110,6 +28608,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko18-containerd
 
@@ -25153,6 +28657,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-amzn2-k18-ko19-containerd
 
@@ -25196,6 +28706,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-containerd
 
@@ -25239,6 +28755,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko18-containerd
 
@@ -25282,6 +28804,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-amzn2-k19-ko19-containerd
 
@@ -25325,6 +28853,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-containerd
 
@@ -25368,6 +28902,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko18-containerd
 
@@ -25411,6 +28951,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb9-ko19-containerd
 
@@ -25454,6 +29000,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-containerd
 
@@ -25497,6 +29049,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko18-containerd
 
@@ -25540,6 +29098,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb9-k17-ko19-containerd
 
@@ -25583,6 +29147,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-containerd
 
@@ -25626,6 +29196,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko18-containerd
 
@@ -25669,6 +29245,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb9-k18-ko19-containerd
 
@@ -25712,6 +29294,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-containerd
 
@@ -25755,6 +29343,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko18-containerd
 
@@ -25798,6 +29392,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb9-k19-ko19-containerd
 
@@ -25841,6 +29441,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-containerd
 
@@ -25884,6 +29490,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko18-containerd
 
@@ -25927,6 +29539,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-deb10-ko19-containerd
 
@@ -25970,6 +29588,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-containerd
 
@@ -26013,6 +29637,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko18-containerd
 
@@ -26056,6 +29686,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-deb10-k17-ko19-containerd
 
@@ -26099,6 +29735,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-containerd
 
@@ -26142,6 +29784,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko18-containerd
 
@@ -26185,6 +29833,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-deb10-k18-ko19-containerd
 
@@ -26228,6 +29882,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-containerd
 
@@ -26271,6 +29931,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko18-containerd
 
@@ -26314,6 +29980,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-deb10-k19-ko19-containerd
 
@@ -26357,6 +30029,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-containerd
 
@@ -26400,6 +30078,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko18-containerd
 
@@ -26443,6 +30127,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-flatcar-ko19-containerd
 
@@ -26486,6 +30176,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-containerd
 
@@ -26529,6 +30225,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko18-containerd
 
@@ -26572,6 +30274,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-flatcar-k17-ko19-containerd
 
@@ -26615,6 +30323,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-containerd
 
@@ -26658,6 +30372,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko18-containerd
 
@@ -26701,6 +30421,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-flatcar-k18-ko19-containerd
 
@@ -26744,6 +30470,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-containerd
 
@@ -26787,6 +30519,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko18-containerd
 
@@ -26830,6 +30568,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-flatcar-k19-ko19-containerd
 
@@ -26873,6 +30617,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-containerd
 
@@ -26916,6 +30666,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko18-containerd
 
@@ -26959,6 +30715,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel7-ko19-containerd
 
@@ -27002,6 +30764,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-containerd
 
@@ -27045,6 +30813,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko18-containerd
 
@@ -27088,6 +30862,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel7-k17-ko19-containerd
 
@@ -27131,6 +30911,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-containerd
 
@@ -27174,6 +30960,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko18-containerd
 
@@ -27217,6 +31009,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel7-k18-ko19-containerd
 
@@ -27260,6 +31058,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-containerd
 
@@ -27303,6 +31107,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko18-containerd
 
@@ -27346,6 +31156,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel7-k19-ko19-containerd
 
@@ -27389,6 +31205,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-containerd
 
@@ -27432,6 +31254,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko18-containerd
 
@@ -27475,6 +31303,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-rhel8-ko19-containerd
 
@@ -27518,6 +31352,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-containerd
 
@@ -27561,6 +31401,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko18-containerd
 
@@ -27604,6 +31450,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-rhel8-k17-ko19-containerd
 
@@ -27647,6 +31499,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-containerd
 
@@ -27690,6 +31548,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko18-containerd
 
@@ -27733,6 +31597,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-rhel8-k18-ko19-containerd
 
@@ -27776,6 +31646,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-containerd
 
@@ -27819,6 +31695,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko18-containerd
 
@@ -27862,6 +31744,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-rhel8-k19-ko19-containerd
 
@@ -27905,6 +31793,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-containerd
 
@@ -27948,6 +31842,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko18-containerd
 
@@ -27991,6 +31891,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u1804-ko19-containerd
 
@@ -28034,6 +31940,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-containerd
 
@@ -28077,6 +31989,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko18-containerd
 
@@ -28120,6 +32038,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u1804-k17-ko19-containerd
 
@@ -28163,6 +32087,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-containerd
 
@@ -28206,6 +32136,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko18-containerd
 
@@ -28249,6 +32185,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u1804-k18-ko19-containerd
 
@@ -28292,6 +32234,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-containerd
 
@@ -28335,6 +32283,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko18-containerd
 
@@ -28378,6 +32332,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u1804-k19-ko19-containerd
 
@@ -28421,6 +32381,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-containerd
 
@@ -28464,6 +32430,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko18-containerd
 
@@ -28507,6 +32479,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-calico-u2004-ko19-containerd
 
@@ -28550,6 +32528,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-containerd
 
@@ -28593,6 +32577,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko18-containerd
 
@@ -28636,6 +32626,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-calico-u2004-k17-ko19-containerd
 
@@ -28679,6 +32675,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-containerd
 
@@ -28722,6 +32724,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko18-containerd
 
@@ -28765,6 +32773,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-calico-u2004-k18-ko19-containerd
 
@@ -28808,6 +32822,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-containerd
 
@@ -28851,6 +32871,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko18-containerd
 
@@ -28894,6 +32920,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: calico
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-calico-u2004-k19-ko19-containerd
 
@@ -28937,6 +32969,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-containerd
 
@@ -28980,6 +33018,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko18-containerd
 
@@ -29023,6 +33067,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-amzn2-ko19-containerd
 
@@ -29066,6 +33116,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-containerd
 
@@ -29109,6 +33165,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko18-containerd
 
@@ -29152,6 +33214,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-amzn2-k17-ko19-containerd
 
@@ -29195,6 +33263,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-containerd
 
@@ -29238,6 +33312,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko18-containerd
 
@@ -29281,6 +33361,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-amzn2-k18-ko19-containerd
 
@@ -29324,6 +33410,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-containerd
 
@@ -29367,6 +33459,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko18-containerd
 
@@ -29410,6 +33508,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-amzn2-k19-ko19-containerd
 
@@ -29453,6 +33557,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-containerd
 
@@ -29496,6 +33606,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko18-containerd
 
@@ -29539,6 +33655,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb9-ko19-containerd
 
@@ -29582,6 +33704,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-containerd
 
@@ -29625,6 +33753,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko18-containerd
 
@@ -29668,6 +33802,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb9-k17-ko19-containerd
 
@@ -29711,6 +33851,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-containerd
 
@@ -29754,6 +33900,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko18-containerd
 
@@ -29797,6 +33949,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb9-k18-ko19-containerd
 
@@ -29840,6 +33998,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-containerd
 
@@ -29883,6 +34047,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko18-containerd
 
@@ -29926,6 +34096,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb9-k19-ko19-containerd
 
@@ -29969,6 +34145,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-containerd
 
@@ -30012,6 +34194,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko18-containerd
 
@@ -30055,6 +34243,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-deb10-ko19-containerd
 
@@ -30098,6 +34292,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-containerd
 
@@ -30141,6 +34341,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko18-containerd
 
@@ -30184,6 +34390,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-deb10-k17-ko19-containerd
 
@@ -30227,6 +34439,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-containerd
 
@@ -30270,6 +34488,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko18-containerd
 
@@ -30313,6 +34537,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-deb10-k18-ko19-containerd
 
@@ -30356,6 +34586,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-containerd
 
@@ -30399,6 +34635,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko18-containerd
 
@@ -30442,6 +34684,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-deb10-k19-ko19-containerd
 
@@ -30485,6 +34733,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-containerd
 
@@ -30528,6 +34782,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko18-containerd
 
@@ -30571,6 +34831,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-flatcar-ko19-containerd
 
@@ -30614,6 +34880,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-containerd
 
@@ -30657,6 +34929,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko18-containerd
 
@@ -30700,6 +34978,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-flatcar-k17-ko19-containerd
 
@@ -30743,6 +35027,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-containerd
 
@@ -30786,6 +35076,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko18-containerd
 
@@ -30829,6 +35125,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-flatcar-k18-ko19-containerd
 
@@ -30872,6 +35174,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-containerd
 
@@ -30915,6 +35223,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko18-containerd
 
@@ -30958,6 +35272,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-flatcar-k19-ko19-containerd
 
@@ -31001,6 +35321,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-containerd
 
@@ -31044,6 +35370,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-ko18-containerd
 
@@ -31087,6 +35419,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel7-ko19-containerd
 
@@ -31130,6 +35468,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-containerd
 
@@ -31173,6 +35517,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko18-containerd
 
@@ -31216,6 +35566,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel7-k17-ko19-containerd
 
@@ -31259,6 +35615,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-containerd
 
@@ -31302,6 +35664,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko18-containerd
 
@@ -31345,6 +35713,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel7-k18-ko19-containerd
 
@@ -31388,6 +35762,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-containerd
 
@@ -31431,6 +35811,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko18-containerd
 
@@ -31474,6 +35860,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel7-k19-ko19-containerd
 
@@ -31517,6 +35909,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-containerd
 
@@ -31560,6 +35958,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko18-containerd
 
@@ -31603,6 +36007,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-rhel8-ko19-containerd
 
@@ -31646,6 +36056,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-containerd
 
@@ -31689,6 +36105,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko18-containerd
 
@@ -31732,6 +36154,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-rhel8-k17-ko19-containerd
 
@@ -31775,6 +36203,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-containerd
 
@@ -31818,6 +36252,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko18-containerd
 
@@ -31861,6 +36301,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-rhel8-k18-ko19-containerd
 
@@ -31904,6 +36350,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-containerd
 
@@ -31947,6 +36399,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko18-containerd
 
@@ -31990,6 +36448,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-rhel8-k19-ko19-containerd
 
@@ -32033,6 +36497,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-containerd
 
@@ -32076,6 +36546,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko18-containerd
 
@@ -32119,6 +36595,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u1804-ko19-containerd
 
@@ -32162,6 +36644,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-containerd
 
@@ -32205,6 +36693,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko18-containerd
 
@@ -32248,6 +36742,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u1804-k17-ko19-containerd
 
@@ -32291,6 +36791,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-containerd
 
@@ -32334,6 +36840,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko18-containerd
 
@@ -32377,6 +36889,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u1804-k18-ko19-containerd
 
@@ -32420,6 +36938,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-containerd
 
@@ -32463,6 +36987,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko18-containerd
 
@@ -32506,6 +37036,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u1804-k19-ko19-containerd
 
@@ -32549,6 +37085,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-containerd
 
@@ -32592,6 +37134,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko18-containerd
 
@@ -32635,6 +37183,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-cilium-u2004-ko19-containerd
 
@@ -32678,6 +37232,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-containerd
 
@@ -32721,6 +37281,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko18-containerd
 
@@ -32764,6 +37330,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-cilium-u2004-k17-ko19-containerd
 
@@ -32807,6 +37379,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-containerd
 
@@ -32850,6 +37428,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko18-containerd
 
@@ -32893,6 +37477,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-cilium-u2004-k18-ko19-containerd
 
@@ -32936,6 +37526,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-containerd
 
@@ -32979,6 +37575,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko18-containerd
 
@@ -33022,6 +37624,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: cilium
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-cilium-u2004-k19-ko19-containerd
 
@@ -33065,6 +37673,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-containerd
 
@@ -33108,6 +37722,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko18-containerd
 
@@ -33151,6 +37771,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-amzn2-ko19-containerd
 
@@ -33194,6 +37820,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-containerd
 
@@ -33237,6 +37869,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko18-containerd
 
@@ -33280,6 +37918,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-amzn2-k17-ko19-containerd
 
@@ -33323,6 +37967,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-containerd
 
@@ -33366,6 +38016,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko18-containerd
 
@@ -33409,6 +38065,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-amzn2-k18-ko19-containerd
 
@@ -33452,6 +38114,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-containerd
 
@@ -33495,6 +38163,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko18-containerd
 
@@ -33538,6 +38212,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-amzn2-k19-ko19-containerd
 
@@ -33581,6 +38261,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-containerd
 
@@ -33624,6 +38310,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko18-containerd
 
@@ -33667,6 +38359,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb9-ko19-containerd
 
@@ -33710,6 +38408,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-containerd
 
@@ -33753,6 +38457,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko18-containerd
 
@@ -33796,6 +38506,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb9-k17-ko19-containerd
 
@@ -33839,6 +38555,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-containerd
 
@@ -33882,6 +38604,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko18-containerd
 
@@ -33925,6 +38653,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb9-k18-ko19-containerd
 
@@ -33968,6 +38702,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-containerd
 
@@ -34011,6 +38751,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko18-containerd
 
@@ -34054,6 +38800,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb9-k19-ko19-containerd
 
@@ -34097,6 +38849,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-containerd
 
@@ -34140,6 +38898,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko18-containerd
 
@@ -34183,6 +38947,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-deb10-ko19-containerd
 
@@ -34226,6 +38996,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-containerd
 
@@ -34269,6 +39045,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko18-containerd
 
@@ -34312,6 +39094,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-deb10-k17-ko19-containerd
 
@@ -34355,6 +39143,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-containerd
 
@@ -34398,6 +39192,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko18-containerd
 
@@ -34441,6 +39241,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-deb10-k18-ko19-containerd
 
@@ -34484,6 +39290,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-containerd
 
@@ -34527,6 +39339,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko18-containerd
 
@@ -34570,6 +39388,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-deb10-k19-ko19-containerd
 
@@ -34613,6 +39437,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-containerd
 
@@ -34656,6 +39486,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko18-containerd
 
@@ -34699,6 +39535,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-flatcar-ko19-containerd
 
@@ -34742,6 +39584,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-containerd
 
@@ -34785,6 +39633,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko18-containerd
 
@@ -34828,6 +39682,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-flatcar-k17-ko19-containerd
 
@@ -34871,6 +39731,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-containerd
 
@@ -34914,6 +39780,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko18-containerd
 
@@ -34957,6 +39829,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-flatcar-k18-ko19-containerd
 
@@ -35000,6 +39878,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-containerd
 
@@ -35043,6 +39927,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko18-containerd
 
@@ -35086,6 +39976,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-flatcar-k19-ko19-containerd
 
@@ -35129,6 +40025,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-containerd
 
@@ -35172,6 +40074,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko18-containerd
 
@@ -35215,6 +40123,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel7-ko19-containerd
 
@@ -35258,6 +40172,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-containerd
 
@@ -35301,6 +40221,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko18-containerd
 
@@ -35344,6 +40270,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel7-k17-ko19-containerd
 
@@ -35387,6 +40319,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-containerd
 
@@ -35430,6 +40368,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko18-containerd
 
@@ -35473,6 +40417,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel7-k18-ko19-containerd
 
@@ -35516,6 +40466,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-containerd
 
@@ -35559,6 +40515,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko18-containerd
 
@@ -35602,6 +40564,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel7-k19-ko19-containerd
 
@@ -35645,6 +40613,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-containerd
 
@@ -35688,6 +40662,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko18-containerd
 
@@ -35731,6 +40711,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-rhel8-ko19-containerd
 
@@ -35774,6 +40760,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-containerd
 
@@ -35817,6 +40809,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko18-containerd
 
@@ -35860,6 +40858,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-rhel8-k17-ko19-containerd
 
@@ -35903,6 +40907,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-containerd
 
@@ -35946,6 +40956,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko18-containerd
 
@@ -35989,6 +41005,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-rhel8-k18-ko19-containerd
 
@@ -36032,6 +41054,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-containerd
 
@@ -36075,6 +41103,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko18-containerd
 
@@ -36118,6 +41152,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-rhel8-k19-ko19-containerd
 
@@ -36161,6 +41201,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-containerd
 
@@ -36204,6 +41250,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko18-containerd
 
@@ -36247,6 +41299,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u1804-ko19-containerd
 
@@ -36290,6 +41348,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-containerd
 
@@ -36333,6 +41397,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko18-containerd
 
@@ -36376,6 +41446,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u1804-k17-ko19-containerd
 
@@ -36419,6 +41495,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-containerd
 
@@ -36462,6 +41544,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko18-containerd
 
@@ -36505,6 +41593,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u1804-k18-ko19-containerd
 
@@ -36548,6 +41642,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-containerd
 
@@ -36591,6 +41691,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko18-containerd
 
@@ -36634,6 +41740,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u1804-k19-ko19-containerd
 
@@ -36677,6 +41789,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-containerd
 
@@ -36720,6 +41838,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko18-containerd
 
@@ -36763,6 +41887,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-flannel-u2004-ko19-containerd
 
@@ -36806,6 +41936,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-containerd
 
@@ -36849,6 +41985,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko18-containerd
 
@@ -36892,6 +42034,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-flannel-u2004-k17-ko19-containerd
 
@@ -36935,6 +42083,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-containerd
 
@@ -36978,6 +42132,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko18-containerd
 
@@ -37021,6 +42181,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-flannel-u2004-k18-ko19-containerd
 
@@ -37064,6 +42230,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-containerd
 
@@ -37107,6 +42279,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko18-containerd
 
@@ -37150,6 +42328,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: flannel
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-flannel-u2004-k19-ko19-containerd
 
@@ -37193,6 +42377,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-containerd
 
@@ -37236,6 +42426,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko18-containerd
 
@@ -37279,6 +42475,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-amzn2-ko19-containerd
 
@@ -37322,6 +42524,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-containerd
 
@@ -37365,6 +42573,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko18-containerd
 
@@ -37408,6 +42622,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-amzn2-k17-ko19-containerd
 
@@ -37451,6 +42671,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-containerd
 
@@ -37494,6 +42720,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko18-containerd
 
@@ -37537,6 +42769,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-amzn2-k18-ko19-containerd
 
@@ -37580,6 +42818,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-containerd
 
@@ -37623,6 +42867,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko18-containerd
 
@@ -37666,6 +42916,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: amzn2
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-amzn2, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-amzn2-k19-ko19-containerd
 
@@ -37709,6 +42965,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-containerd
 
@@ -37752,6 +43014,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko18-containerd
 
@@ -37795,6 +43063,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb9-ko19-containerd
 
@@ -37838,6 +43112,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-containerd
 
@@ -37881,6 +43161,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko18-containerd
 
@@ -37924,6 +43210,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb9-k17-ko19-containerd
 
@@ -37967,6 +43259,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-containerd
 
@@ -38010,6 +43308,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko18-containerd
 
@@ -38053,6 +43357,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb9-k18-ko19-containerd
 
@@ -38096,6 +43406,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-containerd
 
@@ -38139,6 +43455,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko18-containerd
 
@@ -38182,6 +43504,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb9
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb9, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb9-k19-ko19-containerd
 
@@ -38225,6 +43553,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-containerd
 
@@ -38268,6 +43602,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko18-containerd
 
@@ -38311,6 +43651,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-deb10-ko19-containerd
 
@@ -38354,6 +43700,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-containerd
 
@@ -38397,6 +43749,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko18-containerd
 
@@ -38440,6 +43798,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-deb10-k17-ko19-containerd
 
@@ -38483,6 +43847,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-containerd
 
@@ -38526,6 +43896,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko18-containerd
 
@@ -38569,6 +43945,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-deb10-k18-ko19-containerd
 
@@ -38612,6 +43994,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-containerd
 
@@ -38655,6 +44043,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko18-containerd
 
@@ -38698,6 +44092,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: deb10
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-deb10, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-deb10-k19-ko19-containerd
 
@@ -38741,6 +44141,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-containerd
 
@@ -38784,6 +44190,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko18-containerd
 
@@ -38827,6 +44239,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-flatcar-ko19-containerd
 
@@ -38870,6 +44288,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-containerd
 
@@ -38913,6 +44337,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko18-containerd
 
@@ -38956,6 +44386,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-flatcar-k17-ko19-containerd
 
@@ -38999,6 +44435,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-containerd
 
@@ -39042,6 +44484,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko18-containerd
 
@@ -39085,6 +44533,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-flatcar-k18-ko19-containerd
 
@@ -39128,6 +44582,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-containerd
 
@@ -39171,6 +44631,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko18-containerd
 
@@ -39214,6 +44680,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: flatcar
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-flatcar, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-flatcar-k19-ko19-containerd
 
@@ -39257,6 +44729,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-containerd
 
@@ -39300,6 +44778,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko18-containerd
 
@@ -39343,6 +44827,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel7-ko19-containerd
 
@@ -39386,6 +44876,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-containerd
 
@@ -39429,6 +44925,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko18-containerd
 
@@ -39472,6 +44974,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel7-k17-ko19-containerd
 
@@ -39515,6 +45023,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-containerd
 
@@ -39558,6 +45072,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko18-containerd
 
@@ -39601,6 +45121,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel7-k18-ko19-containerd
 
@@ -39644,6 +45170,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-containerd
 
@@ -39687,6 +45219,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko18-containerd
 
@@ -39730,6 +45268,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel7
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel7, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel7-k19-ko19-containerd
 
@@ -39773,6 +45317,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-containerd
 
@@ -39816,6 +45366,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko18-containerd
 
@@ -39859,6 +45415,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-rhel8-ko19-containerd
 
@@ -39902,6 +45464,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-containerd
 
@@ -39945,6 +45513,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko18-containerd
 
@@ -39988,6 +45562,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-rhel8-k17-ko19-containerd
 
@@ -40031,6 +45611,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-containerd
 
@@ -40074,6 +45660,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko18-containerd
 
@@ -40117,6 +45709,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-rhel8-k18-ko19-containerd
 
@@ -40160,6 +45758,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-containerd
 
@@ -40203,6 +45807,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko18-containerd
 
@@ -40246,6 +45856,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: rhel8
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-rhel8, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-rhel8-k19-ko19-containerd
 
@@ -40289,6 +45905,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-containerd
 
@@ -40332,6 +45954,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko18-containerd
 
@@ -40375,6 +46003,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u1804-ko19-containerd
 
@@ -40418,6 +46052,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-containerd
 
@@ -40461,6 +46101,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko18-containerd
 
@@ -40504,6 +46150,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u1804-k17-ko19-containerd
 
@@ -40547,6 +46199,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-containerd
 
@@ -40590,6 +46248,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko18-containerd
 
@@ -40633,6 +46297,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u1804-k18-ko19-containerd
 
@@ -40676,6 +46346,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-containerd
 
@@ -40719,6 +46395,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko18-containerd
 
@@ -40762,6 +46444,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u1804
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u1804, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u1804-k19-ko19-containerd
 
@@ -40805,6 +46493,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-containerd
 
@@ -40848,6 +46542,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko18-containerd
 
@@ -40891,6 +46591,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-kopeio-u2004-ko19-containerd
 
@@ -40934,6 +46640,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-containerd
 
@@ -40977,6 +46689,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko18-containerd
 
@@ -41020,6 +46738,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.17'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.17
     testgrid-tab-name: kops-grid-kopeio-u2004-k17-ko19-containerd
 
@@ -41063,6 +46787,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-containerd
 
@@ -41106,6 +46836,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko18-containerd
 
@@ -41149,6 +46885,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.18'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.18
     testgrid-tab-name: kops-grid-kopeio-u2004-k18-ko19-containerd
 
@@ -41192,6 +46934,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-containerd
 
@@ -41235,6 +46983,12 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.18'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko18-containerd
 
@@ -41278,10 +47032,16 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: containerd
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/k8s_version: '1.19'
+    test.kops.k8s.io/kops_version: '1.19'
+    test.kops.k8s.io/networking: kopeio
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": ["--zones=us-east-2b", "--node-size=m6g.large", "--master-size=m6g.large", "--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201"], "k8s_version": null, "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-arm64
   cron: '33 16 * * *'
   labels:
@@ -41321,10 +47081,17 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-arm64
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": ["--api-loadbalancer-type=public"], "feature_flags": ["UseServiceAccountIAM", "PublicJWKS"], "k8s_version": null, "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--api-loadbalancer-type=public", "feature_flags": "UseServiceAccountIAM,PublicJWKS", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-public-jwks
   cron: '53 4 * * *'
   labels:
@@ -41365,10 +47132,18 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --api-loadbalancer-type=public
+    test.kops.k8s.io/feature_flags: UseServiceAccountIAM,PublicJWKS
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": ["--override=cluster.spec.cloudControllerManager.cloudProvider=aws"], "feature_flags": ["EnableExternalCloudController,SpecOverrideFlag"], "k8s_version": null, "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": null, "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-aws-cloud-controller-manager
   cron: '28 22 * * 0'
   labels:
@@ -41409,6 +47184,14 @@ periodics:
           cpu: "2"
           memory: 2Gi
   annotations:
+    test.kops.k8s.io/cloud: aws
+    test.kops.k8s.io/container_runtime: docker
+    test.kops.k8s.io/distro: u2004
+    test.kops.k8s.io/extra_flags: --override=cluster.spec.cloudControllerManager.cloudProvider=aws
+    test.kops.k8s.io/feature_flags: EnableExternalCloudController,SpecOverrideFlag
+    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/kops_version: ''
+    test.kops.k8s.io/networking: ''
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 


### PR DESCRIPTION
These should flow through into the test results, and enable stable 
analysis.