### PR TITLE
kops-grid scripts: use python3

### DIFF
--- a/config/jobs/kubernetes/kops/Makefile
+++ b/config/jobs/kubernetes/kops/Makefile
@@ -14,5 +14,5 @@
 
 .PHONY: generate
 generate:
-	python build-grid.py > kops-periodics-grid.yaml
-	python build-pipeline.py > kops-pipeline.yaml
+	python3 build-grid.py > kops-periodics-grid.yaml
+	python3 build-pipeline.py > kops-pipeline.yaml


### PR DESCRIPTION
The yaml package is much more accessible in python3, apparently.