### PR TITLE
chore: make secrets-store-csi-driver gcp tests required

### DIFF
--- a/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
+++ b/config/jobs/kubernetes-sigs/secrets-store-csi-driver/secrets-store-csi-driver-config.yaml
@@ -198,7 +198,6 @@ presubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - master
@@ -334,7 +333,6 @@ postsubmits:
     decoration_config:
       timeout: 25m
     always_run: true
-    optional: true
     path_alias: sigs.k8s.io/secrets-store-csi-driver
     branches:
     - master


### PR DESCRIPTION
- The gcp test results have been reliable so far. Enabling gcp presubmit jobs as required.

/cc @tam7t