### PR TITLE
Skip SCTP test on k8sstable1 alpha features

### DIFF
--- a/config/jobs/kubernetes/generated/generated.yaml
+++ b/config/jobs/kubernetes/generated/generated.yaml
@@ -2021,7 +2021,7 @@ periodics:
       - --env=KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false
       - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
       - --runtime-config=api/all=true
-      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+      - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0 --minStartupPods=8
       env:
       image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
       resources:

--- a/releng/test_config.yaml
+++ b/releng/test_config.yaml
@@ -389,7 +389,8 @@ jobs:
     - --env=ENABLE_CACHE_MUTATION_DETECTOR=true
     - --runtime-config=api/all=true
     - --test_args=--ginkgo.focus=\[Feature:(Audit|BlockVolume|PodPreset|ExpandCSIVolumes|ExpandInUseVolumes)\]|Networking
-      --ginkgo.skip=Networking-Performance|IPv6|Feature:Volumes --minStartupPods=8
+      --ginkgo.skip=\[Feature:(SCTPConnectivity|Volumes|Networking-Performance|Networking-IPv6)\]|csi-hostpath-v0
+      --minStartupPods=8
     sigOwners: [sig-cloud-provider-gcp]
     releaseBlocking: true
 


### PR DESCRIPTION
Updates k8sstable1 alpha features job to skip SCTP tests, which are only
meant to be run by network plugin developers.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

xref #17125 #18296

These changes were generated by `releng/generated_tests.py`.

I am going to follow up with an investigation of how we modify generated jobs in `test_config.yaml` because it leads to divergence such as this.

/assign @aojea 

/cc @kubernetes/release-managers @kubernetes/ci-signal 