### PR TITLE
image-pushing/k8s-staging-nfd-operator: enable release branches and tags

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-nfd-operator.yaml
+++ b/config/jobs/image-pushing/k8s-staging-nfd-operator.yaml
@@ -16,6 +16,9 @@ postsubmits:
       # probably does).
       branches:
         - ^master$
+        - ^release-
+        # Build semver tags, too
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
       spec:
         serviceAccountName: gcb-builder
         containers:


### PR DESCRIPTION
Enable image building staging images on release branches and
semver-formatted tags.

Basically forward-port two commits doing the same for nfd (operand):
  348b95929defa5471b846abea6a0fe6e85218628
  9fb7bfaa8e0f7d0051e7f555ad573ce47fef1bee