### PR TITLE
Ghoproxy: Only set cache age header for non-304 responses

### DIFF
--- a/ghproxy/ghcache/ghcache.go
+++ b/ghproxy/ghcache/ghcache.go
@@ -180,8 +180,10 @@ func (u upstreamTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 		resp.Header.Set("Cache-Control", "no-store")
 	} else {
 		resp.Header.Set("Cache-Control", "no-cache")
-		// Used for metrics about the age of cached requests
-		resp.Header.Set(cacheEntryCreationDateHeader, strconv.Itoa(int(time.Now().Unix())))
+		if resp.StatusCode != http.StatusNotModified {
+			// Used for metrics about the age of cached requests
+			resp.Header.Set(cacheEntryCreationDateHeader, strconv.Itoa(int(time.Now().Unix())))
+		}
 	}
 	if etag != "" {
 		resp.Header.Set("X-Conditional-Request", etag)

--- a/ghproxy/ghmetrics/ghmetrics.go
+++ b/ghproxy/ghmetrics/ghmetrics.go
@@ -85,7 +85,7 @@ var cacheEntryAge = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "ghcache_cache_entry_age_seconds",
 		Help:    "The age of cache entries by API path.",
-		Buckets: []float64{900, 1800, 3600, 7200, 14400},
+		Buckets: []float64{5, 900, 1800, 3600, 7200, 14400},
 	},
 	[]string{"token_hash", "path", "user_agent"},
 )


### PR DESCRIPTION
Also adds a 5 seconds cache age bucket as a control bucket.