### PR TITLE
Setting lgtm_acts_as_approve to false for service-apis

### DIFF
--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -95,6 +95,9 @@ approve:
   - kubernetes/cloud-provider-gcp
   require_self_approval: false
   ignore_review_state: false
+- repos:
+  - kubernetes-sigs/service-apis
+  lgtm_acts_as_approve: false
 
 # Lower bounds in number of lines changed; XS is assumed to be zero.
 size:


### PR DESCRIPTION
Although it appears to be more common for `lgtm` to be equivalent to `approve` for approvers, this seems like it could result in some accidental approves. Disabling this will help ensure all service-apis PRs are intentionally approved. More context in https://kubernetes.slack.com/archives/CR0H13KGA/p1607361291247300.

/cc @hbagdi @bowei 