### PR TITLE
Flagutil: Add Github enablement options

### DIFF
--- a/prow/flagutil/BUILD.bazel
+++ b/prow/flagutil/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "doc.go",
         "git.go",
         "github.go",
+        "github_enablement.go",
         "instrumentation.go",
         "jira.go",
         "k8s_client.go",
@@ -58,6 +59,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "github_enablement_test.go",
         "github_test.go",
         "kubernetes_cluster_clients_test.go",
     ],

--- a/prow/flagutil/github_enablement.go
+++ b/prow/flagutil/github_enablement.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+// GitHubEnablementOptions allows enable/disable functionality on a github org or
+// org/repo level. If either EnabledOrgs or EnabledRepos is set, only org/repos in
+// those are allowed, otherwise everything that is not in DisabledOrgs or DisabledRepos
+// is allowed.
+type GitHubEnablementOptions struct {
+	enabledOrgs   Strings
+	enabledRepos  Strings
+	disabledOrgs  Strings
+	disabledRepos Strings
+}
+
+func (o *GitHubEnablementOptions) AddFlags(fs *flag.FlagSet) {
+	fs.Var(&o.enabledOrgs, "github-enabled-org", "Enabled github org. Can be passed multiple times. If set, all orgs or repos that are not allowed via --gitbub-enabled-orgs or --github-enabled-repos will be ignored")
+	fs.Var(&o.enabledRepos, "github-enabled-repo", "Enabled github repo in org/repo format. Can be passed multiple times. If set, all orgs or repos that are not allowed via --gitbub-enabled-orgs or --github-enabled-repos will be ignored")
+	fs.Var(&o.disabledOrgs, "github-disabled-org", "Disabled github org. Can be passed multiple times. Orgs that are in this list will be ignored.")
+	fs.Var(&o.disabledRepos, "github-disabled-repo", "Disabled github repo in org/repo format. Can be passed multiple times. Repos that are in this list will be ignored.")
+}
+
+func (o *GitHubEnablementOptions) Validate() error {
+	var errs []error
+
+	for _, enabledRepo := range o.enabledRepos.vals {
+		if err := validateOrgRepoFormat(enabledRepo); err != nil {
+			errs = append(errs, fmt.Errorf("--github-enabled-repo=%s is invalid: %w", enabledRepo, err))
+		}
+	}
+	for _, disabledRepo := range o.disabledRepos.vals {
+		if err := validateOrgRepoFormat(disabledRepo); err != nil {
+			errs = append(errs, fmt.Errorf("--github-disabled-repo=%s is invalid: %w", disabledRepo, err))
+		}
+	}
+
+	if intersection := o.enabledOrgs.StringSet().Intersection(o.disabledOrgs.StringSet()); len(intersection) != 0 {
+		errs = append(errs, fmt.Errorf("%v is in both --github-enabled-org and --github-disabled-org", intersection.List()))
+	}
+
+	if intersection := o.enabledRepos.StringSet().Intersection(o.disabledRepos.StringSet()); len(intersection) != 0 {
+		errs = append(errs, fmt.Errorf("%v is in both --github-enabled-repo and --github-disabled-repo", intersection.List()))
+	}
+
+	return utilerrors.NewAggregate(errs)
+}
+
+func validateOrgRepoFormat(orgRepo string) error {
+	components := strings.Split(orgRepo, "/")
+	if n := len(components); n != 2 || components[0] == "" || components[1] == "" {
+		return fmt.Errorf("%q is not in org/repo format", orgRepo)
+	}
+
+	return nil
+}
+
+func (o *GitHubEnablementOptions) EnablementChecker() func(org, repo string) bool {
+	enabledOrgs := o.enabledOrgs.StringSet()
+	enabledRepos := o.enabledRepos.StringSet()
+	disabledOrgs := o.disabledOrgs.StringSet()
+	diabledRepos := o.disabledRepos.StringSet()
+	return func(org, repo string) bool {
+		if len(enabledOrgs) > 0 || len(enabledRepos) > 0 {
+			if !enabledOrgs.Has(org) && !enabledRepos.Has(org+"/"+repo) {
+				return false
+			}
+		}
+
+		return !disabledOrgs.Has(org) && !diabledRepos.Has(org+"/"+repo)
+	}
+}

--- a/prow/flagutil/github_enablement_test.go
+++ b/prow/flagutil/github_enablement_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package flagutil
+
+import (
+	"testing"
+)
+
+func TestGitHubEnablementValidation(t *testing.T) {
+	testCases := []struct {
+		name                    string
+		gitHubEnablementOptions GitHubEnablementOptions
+		expectedErrorString     string
+	}{
+		{
+			name: "Empty config is valid",
+		},
+		{
+			name: "Valid config",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledOrgs:   Strings{vals: []string{"org-a"}},
+				enabledRepos:  Strings{vals: []string{"org-b/repo-a"}},
+				disabledOrgs:  Strings{vals: []string{"org-c"}},
+				disabledRepos: Strings{vals: []string{"org-a/repo-b"}},
+			},
+		},
+		{
+			name: "Invalid enabled repo",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledRepos: Strings{vals: []string{"not-a-valid-repo"}},
+			},
+			expectedErrorString: `--github-enabled-repo=not-a-valid-repo is invalid: "not-a-valid-repo" is not in org/repo format`,
+		},
+		{
+			name: "Invalid disabled repo",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				disabledRepos: Strings{vals: []string{"not-a-valid-repo"}},
+			},
+			expectedErrorString: `--github-disabled-repo=not-a-valid-repo is invalid: "not-a-valid-repo" is not in org/repo format`,
+		},
+		{
+			name: "Org overlap",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledOrgs:  Strings{vals: []string{"org-a", "org-b"}},
+				disabledOrgs: Strings{vals: []string{"org-b", "org-c"}},
+			},
+			expectedErrorString: "[org-b] is in both --github-enabled-org and --github-disabled-org",
+		},
+		{
+			name: "Repo overlap",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledRepos:  Strings{vals: []string{"org-a/repo-a", "org-b/repo-b"}},
+				disabledRepos: Strings{vals: []string{"org-a/repo-a", "org-b/repo-b"}},
+			},
+			expectedErrorString: "[org-a/repo-a org-b/repo-b] is in both --github-enabled-repo and --github-disabled-repo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var actualErrMsg string
+			actualErr := tc.gitHubEnablementOptions.Validate()
+			if actualErr != nil {
+				actualErrMsg = actualErr.Error()
+			}
+			if actualErrMsg != tc.expectedErrorString {
+				t.Errorf("actual error %v does not match expected error %q", actualErr, tc.expectedErrorString)
+			}
+		})
+	}
+}
+
+func TestEnablementChecker(t *testing.T) {
+	inOrg, inRepo := "org", "repo"
+	testCases := []struct {
+		name                    string
+		gitHubEnablementOptions GitHubEnablementOptions
+		expectAllowed           bool
+	}{
+		{
+			name:          "Defalt allows everything",
+			expectAllowed: true,
+		},
+		{
+			name: "Allowed orgs do not include it, forbidden",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledOrgs: Strings{vals: []string{"other"}},
+			},
+		},
+		{
+			name: "Allowed orgs include it, allowed",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledOrgs: Strings{vals: []string{"org"}},
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "Allowed repos do not include it, forbidden",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledRepos: Strings{vals: []string{"other/repo"}},
+			},
+		},
+		{
+			name: "Allowed repos include it, allowed",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledRepos: Strings{vals: []string{"org/repo"}},
+			},
+			expectAllowed: true,
+		},
+		{
+			name: "Disabled orgs include it, forbidden",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				disabledOrgs: Strings{vals: []string{"org"}},
+			},
+		},
+		{
+			name: "Disabled repos include it, forbidden",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				disabledRepos: Strings{vals: []string{"org/repo"}},
+			},
+		},
+		{
+			name: "Allowed orgs and disabled repos include it, forbidden",
+			gitHubEnablementOptions: GitHubEnablementOptions{
+				enabledOrgs:   Strings{vals: []string{"org"}},
+				disabledRepos: Strings{vals: []string{"org/repo"}},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := tc.gitHubEnablementOptions.EnablementChecker()(inOrg, inRepo); result != tc.expectAllowed {
+				t.Errorf("expected result %t, got result %t", tc.expectAllowed, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These allow to enable/disable components based on github organization or
repo. This is intended to be used to migrate components from github
personal access token to github apps auth.