### PR TITLE
Don't protect aws-ebs-csi-driver gh-pages branch

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -406,6 +406,10 @@ branch-protection:
         - "^dependabot/" # don't protect branches created by dependabot
         - "^greenkeeper/" # don't protect branches created by greenkeeper
       repos:
+        aws-ebs-csi-driver:
+          branches:
+            gh-pages:
+              protect: false
         kube-batch:
           required_status_checks:
             contexts:


### PR DESCRIPTION
We want this GitHub action https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/.github/workflows/helm-chart-release.yaml (using https://github.com/helm/chart-releaser-action) to automatically update our index file https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/gh-pages/index.yaml and create GitHub releases.

To allow the GitHub action to push to GitHub, the gh-pages branch can't be protected. ` ! [remote rejected] HEAD -> gh-pages (protected branch hook declined)` https://github.com/kubernetes-sigs/aws-ebs-csi-driver/runs/1513656332. So I am making the branch unprotected. We won't accept PRs to it, from now on only the GitHub action ought to write to it.

@ayberk 

Ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/624#issuecomment-740209058