### PR TITLE
Adding presubmit jobs for COSI projects provision-sidecar and csi-ada…

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-sig-storage.sh
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.sh
@@ -39,6 +39,8 @@ readonly BROKEN_REPOS=(
     kubernetes-csi/csi-driver-iscsi
     kubernetes-csi/csi-proxy
     kubernetes-sigs/container-object-storage-interface-controller
+    kubernetes-sigs/container-object-storage-interface-provisioner-sidecar
+    kubernetes-sigs/container-object-storage-interface-csi-adapter
 )
 
 cat >"${OUTPUT}" <<EOF

--- a/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
+++ b/config/jobs/image-pushing/k8s-staging-sig-storage.yaml
@@ -436,6 +436,64 @@ postsubmits:
               - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
               - --env-passthrough=PULL_BASE_REF
               - .
+  kubernetes-sigs/container-object-storage-interface-provisioner-sidecar:
+    - name: post-container-object-storage-interface-provisioner-sidecar-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
+  kubernetes-sigs/container-object-storage-interface-csi-adapter:
+    - name: post-container-object-storage-interface-csi-adapter-push-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-storage-image-build
+      decorate: true
+      branches:
+        # For publishing canary images.
+        - ^master$
+        - ^release-
+        # For publishing tagged images. Those will only get built once, i.e.
+        # existing images are not getting overwritten. A new tag must be set to
+        # trigger another image build. Images are only built for tags that follow
+        # the semver format (regex from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string).
+        - ^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-sig-storage
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-sig-storage-gcb
+              - --env-passthrough=PULL_BASE_REF
+              - .
 
 # Canary images are used by some Prow jobs to ensure that the upcoming releases
 # of the sidecars work together. We don't promote those canary images.

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-csi-adapter.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/container-object-storage-interface-csi-adapter:
+  - name: pull-container-object-storage-interface-csi-adapter-build
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-csi-adapter
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-csi-adapter
+      testgrid-tab-name: build
+      description: Build test in container-object-storage-interface-csi-adapter repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        # Plain make runs also verify
+        - make
+
+  - name: pull-container-object-storage-interface-csi-adapter-unit
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-csi-adapter
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-csi-adapter
+      testgrid-tab-name: unit
+      description: Unit tests in container-object-storage-interface-csi-adapter repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        - make
+        args:
+        - test

--- a/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
+++ b/config/jobs/kubernetes-sigs/container-object-storage-interface/container-object-storage-interface-provisioner-sidecar.yaml
@@ -1,0 +1,32 @@
+presubmits:
+  kubernetes-sigs/container-object-storage-interface-provisioner-sidecar:
+  - name: pull-container-object-storage-interface-provisioner-sidecar-build
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-provisioner-sidecar
+      testgrid-tab-name: build
+      description: Build test in container-object-storage-interface-provisioner-sidecar repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        # Plain make runs also verify
+        - make
+
+  - name: pull-container-object-storage-interface-provisioner-sidecar-unit
+    always_run: true
+    decorate: true
+    path_alias: sigs.k8s.io/container-object-storage-interface-provisioner-sidecar
+    annotations:
+      testgrid-dashboards: sig-storage-container-object-storage-interface-provisioner-sidecar
+      testgrid-tab-name: unit
+      description: Unit tests in container-object-storage-interface-provisioner-sidecar repo.
+    spec:
+      containers:
+      - image: golang:1.13.10
+        command:
+        - make
+        args:
+        - test

--- a/config/testgrids/kubernetes/sig-storage/config.yaml
+++ b/config/testgrids/kubernetes/sig-storage/config.yaml
@@ -16,6 +16,8 @@ dashboard_groups:
     - sig-storage-image-build
     - sig-storage-container-object-storage-interface-api
     - sig-storage-container-object-storage-interface-controller
+    - sig-storage-container-object-storage-interface-provisioner-sidecar
+    - sig-storage-container-object-storage-interface-csi-adapter
 
 dashboards:
 - name: sig-storage-kubernetes
@@ -119,3 +121,5 @@ dashboards:
 - name: sig-storage-image-build
 - name: sig-storage-container-object-storage-interface-api
 - name: sig-storage-container-object-storage-interface-controller
+- name: sig-storage-container-object-storage-interface-provisioner-sidecar
+- name: sig-storage-container-object-storage-interface-csi-adapter


### PR DESCRIPTION
…pter

This PR adds Container Object Storage component 'provisioner-sidecar' and 'csi-adapter' to the CI process.
<continuation of work for COSI : https://github.com/kubernetes/test-infra/pull/19831>
/sig-storage
ping @xing-yang @wlan0 @rrati 
/release-note-none