### PR TITLE
Add support for defaulting Prow monitoring config, decouple from prow.k8s.io, and update README port-forwarding instructions to include grafana.

### DIFF
--- a/config/prow/cluster/monitoring/README.md
+++ b/config/prow/cluster/monitoring/README.md
@@ -102,6 +102,13 @@ cp BUILD.bazel vendor/grafonnet
 * For `grafana`, visit [monitoring.prow.k8s.io](https://monitoring.prow.k8s.io). Anonymous users are with read-only mode.
 Use `adm` and [password](https://github.com/kubernetes/test-infra/blob/master/config/prow/cluster/monitoring/grafana_deployment.yaml#L39-L45) to become admin.
 
+If the Prow instance does not publicly expose `grafana` it can still be accessed by cluster admins via [port-forwarding](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/). Run
+
+```
+kubectl -n prow-monitoring port-forward service/grafana 8080:80
+```
+then visit [localhost:8080](http://127.0.0.1:8080).
+
 * For `prometheus` and `alertmanager`, there is no public domain configured based on the security
 concerns (no authorization out of the box).
 Cluster admins can use [k8s port-forward](https://kubernetes.io/docs/tasks/access-application-cluster/port-forward-access-application-cluster/) to

--- a/config/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
+++ b/config/prow/cluster/monitoring/mixins/grafana_dashboards/ghproxy.jsonnet
@@ -1,10 +1,12 @@
-local config =  import 'config.libsonnet';
+local config =  (import 'config.libsonnet')._config;
 local grafana = import 'grafonnet/grafana.libsonnet';
 local dashboard = grafana.dashboard;
 local graphPanel = grafana.graphPanel;
 local prometheus = grafana.prometheus;
 local template = grafana.template;
 local singlestat = grafana.singlestat;
+
+local botName = config.instance.botName;
 
 local legendConfig = {
         legend+: {
@@ -13,7 +15,7 @@ local legendConfig = {
     };
 
 local dashboardConfig = {
-        uid: config._config.grafanaDashboardIDs['ghproxy.json'],
+        uid: config.grafanaDashboardIDs['ghproxy.json'],
     };
 
 local histogramQuantileTarget(phi) = prometheus.target(
@@ -43,7 +45,7 @@ dashboard.new(
 .addTemplate(template.new(
         'login',
         'prometheus',
-        'label_values(github_user_info{login="k8s-ci-robot"}, login)',
+        'label_values(github_user_info{login="%s"}, login)' % botName,
         label='login',
         refresh='time',
     ))
@@ -104,11 +106,11 @@ dashboard.new(
         legend_sortDesc=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (mode)',
+        'sum(increase(ghcache_responses[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (mode)' % botName,
         legendFormat='{{mode}}',
     ))
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login))',
+        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login))' % botName,
         legendFormat='(No Cost)',
     )), gridPos={
     h: 6,
@@ -133,7 +135,7 @@ dashboard.new(
         #y_axis_label='% Cacheable Request Fulfilled for Free',
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) \n/ sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED|MISS|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login))',
+        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) \n/ sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED|MISS|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login))' % [botName, botName],
         legendFormat='Efficiency',
     )), gridPos={
     h: 6,
@@ -173,7 +175,7 @@ dashboard.new(
         valueName='current',
     )
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login))',
+        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login))' % botName,
         instant=true,
     )), gridPos={
     h: 6,
@@ -190,7 +192,7 @@ dashboard.new(
         format='short',
     )
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[7d]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login))',
+        'sum(increase(ghcache_responses{mode=~"COALESCED|REVALIDATED"}[7d]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login))' % botName,
         instant=true,
     )), gridPos={
     h: 6,
@@ -211,7 +213,7 @@ dashboard.new(
         max='5000',
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (api_version, login)',
+        'sum(github_token_usage * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (api_version, login)' % botName,
          legendFormat='{{login}} : {{api_version}}',
     )), gridPos={
     h: 9,
@@ -229,7 +231,7 @@ dashboard.new(
         stack=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(rate(github_request_duration_count[${range}]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (status)',
+        'sum(rate(github_request_duration_count[${range}]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (status)' % botName,
          legendFormat='{{status}}',
     )), gridPos={
     h: 9,
@@ -247,7 +249,7 @@ dashboard.new(
         stack=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(rate(github_request_duration_count{status="${status}"}[${range}]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (path)',
+        'sum(rate(github_request_duration_count{status="${status}"}[${range}]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (path)' % botName,
          legendFormat='{{path}}',
     )), gridPos={
     h: 9,
@@ -333,7 +335,7 @@ dashboard.new(
         stack=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (user_agent)',
+        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (user_agent)' % botName,
          legendFormat='{{user_agent}}',
     )), gridPos={
     h: 9,
@@ -356,7 +358,7 @@ dashboard.new(
         stack=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (path)',
+        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (path)' % botName,
          legendFormat='{{path}}',
     )), gridPos={
     h: 9,
@@ -378,7 +380,7 @@ dashboard.new(
         legend_sortDesc=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED",path="${path}"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (user_agent)',
+        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED",path="${path}"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (user_agent)' % botName,
          legendFormat='{{user_agent}}',
     )), gridPos={
     h: 9,
@@ -400,7 +402,7 @@ dashboard.new(
         legend_sortDesc=true,
     ) + legendConfig)
     .addTarget(prometheus.target(
-        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED",user_agent="${user_agent}"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="k8s-ci-robot"}) by (token_hash, login)) by (path)',
+        'sum(increase(ghcache_responses{mode=~"MISS|NO-STORE|CHANGED",user_agent="${user_agent}"}[1h]) * on(token_hash) group_left(login) max(github_user_info{login="%s"}) by (token_hash, login)) by (path)' % botName,
          legendFormat='{{path}}',
     )), gridPos={
     h: 9,

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -1,80 +1,77 @@
-{
-  _config+:: {
-    // Grafana dashboard IDs are necessary for stable links for dashboards
-    grafanaDashboardIDs: {
-      'boskos-http.json': 'eec46c579cbf4a518e5bbcbbf4913de9',
-      'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
-      'slo.json': 'ea313af4b7904c7c983d20d9572235a5',
-    },
-    // Component name constants
-    components: {
-      // Values should be lowercase for use with prometheus 'job' label.
-      crier: 'crier',
-      deck: 'deck',
-      ghproxy: 'ghproxy',
-      hook: 'hook',
-      horologium: 'horologium',
-      monitoring: 'monitoring', // Aggregate of prometheus, alertmanager, and grafana.
-      plank: 'plank', // Mutually exclusive with prowControllerManager
-      prowControllerManager: 'prow-controller-manager',
-      sinker: 'sinker',
-      tide: 'tide',
-    },
-    local comps = self.components,
+local util = import 'config_util.libsonnet';
 
-    // SLO compliance tracking config
-    slo: {
-      components: [
-        comps.deck,
-        comps.hook,
-        comps.prowControllerManager,
-        comps.sinker,
-        comps.tide,
-        comps.monitoring,
-      ],
-    },
+//
+// Edit configuration in this object.
+//
+local config = {
+  local comps = util.consts.components,
 
-    // Heartbeat jobs
-    heartbeatJobs: [
-      {name: 'ci-test-infra-prow-checkconfig', interval: '5m', alertInterval: '20m'},
-    ],
-
-    // Tide pools that are important enough to have their own graphs on the dashboard.
-    tideDashboardExplicitPools: [
-      {org: 'kubernetes', repo: 'kubernetes', branch: 'master'},
-    ],
-
-    // Additional scraping endpoints
-    probeTargets: [
-    # ATTENTION: Keep this in sync with the list in ../../additional-scrape-configs_secret.yaml
-      {url: 'https://prow.k8s.io', labels: {slo: comps.deck}},
-      {url: 'https://monitoring.prow.k8s.io', labels: {slo: comps.monitoring}},
-      {url: 'https://testgrid.k8s.io', labels: {}},
-      {url: 'https://gubernator.k8s.io', labels: {}},
-      {url: 'https://gubernator.k8s.io/pr/fejta', labels: {}}, # Deep health check of someone's PR dashboard.
-      {url: 'https://storage.googleapis.com/k8s-gubernator/triage/index.html', labels: {}},
-      {url: 'https://storage.googleapis.com/test-infra-oncall/oncall.html', labels: {}},
-    ],
-
-    // Boskos endpoints to be monitored
-    boskosResourcetypes: [
-      {instance: "104.197.27.114:9090", type: "aws-account", friendly: "AWS account"},
-      {instance: "104.197.27.114:9090", type: "gce-project", friendly: "GCE project"},
-      {instance: "35.225.208.117:9090", type: "gce-project", friendly: "GCE project (k8s-infra)"},
-      {instance: "104.197.27.114:9090", type: "gke-project", friendly: "GKE project"},
-      {instance: "104.197.27.114:9090", type: "gpu-project", friendly: "GPU project"},
-      {instance: "35.225.208.117:9090", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
-      {instance: "104.197.27.114:9090", type: "ingress-project", friendly: "Ingress project"},
-      {instance: "104.197.27.114:9090", type: "node-e2e-project", friendly: "Node e2e project"},
-      {instance: "104.197.27.114:9090", type: "scalability-project", friendly: "Scalability project"},
-      {instance: "35.225.208.117:9090", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
-      {instance: "104.197.27.114:9090", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
-    ],
-
-    // How long we go during work hours without seeing a webhook before alerting.
-    webhookMissingAlertInterval: '10m',
-
-    // How many days prow hasn't been bumped.
-    prowImageStaleByDays: 7,
+  // Instance specifics
+  instance: {
+    name: "K8s Prow",
+    botName: "k8s-ci-robot",
+    url: "https://prow.k8s.io",
+    monitoringURL: "https://monitoring.prow.k8s.io",
   },
+
+  // SLO compliance tracking config
+  slo: {
+    components: [
+      comps.deck,
+      comps.hook,
+      comps.prowControllerManager,
+      comps.sinker,
+      comps.tide,
+      comps.monitoring,
+    ],
+  },
+
+  // Heartbeat jobs
+  heartbeatJobs: [
+    {name: 'ci-test-infra-prow-checkconfig', interval: '5m', alertInterval: '20m'},
+  ],
+
+  // Tide pools that are important enough to have their own graphs on the dashboard.
+  tideDashboardExplicitPools: [
+    {org: 'kubernetes', repo: 'kubernetes', branch: 'master'},
+  ],
+
+  // Additional scraping endpoints
+  probeTargets: [
+  # ATTENTION: Keep this in sync with the list in ../../additional-scrape-configs_secret.yaml
+    {url: 'https://prow.k8s.io', labels: {slo: comps.deck}},
+    {url: 'https://monitoring.prow.k8s.io', labels: {slo: comps.monitoring}},
+    {url: 'https://testgrid.k8s.io', labels: {}},
+    {url: 'https://gubernator.k8s.io', labels: {}},
+    {url: 'https://gubernator.k8s.io/pr/fejta', labels: {}}, # Deep health check of someone's PR dashboard.
+    {url: 'https://storage.googleapis.com/k8s-gubernator/triage/index.html', labels: {}},
+    {url: 'https://storage.googleapis.com/test-infra-oncall/oncall.html', labels: {}},
+  ],
+
+  // Boskos endpoints to be monitored
+  boskosResourcetypes: [
+    {instance: "104.197.27.114:9090", type: "aws-account", friendly: "AWS account"},
+    {instance: "104.197.27.114:9090", type: "gce-project", friendly: "GCE project"},
+    {instance: "35.225.208.117:9090", type: "gce-project", friendly: "GCE project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", type: "gke-project", friendly: "GKE project"},
+    {instance: "104.197.27.114:9090", type: "gpu-project", friendly: "GPU project"},
+    {instance: "35.225.208.117:9090", type: "gpu-project", friendly: "GPU project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", type: "ingress-project", friendly: "Ingress project"},
+    {instance: "104.197.27.114:9090", type: "node-e2e-project", friendly: "Node e2e project"},
+    {instance: "104.197.27.114:9090", type: "scalability-project", friendly: "Scalability project"},
+    {instance: "35.225.208.117:9090", type: "scalability-project", friendly: "Scalability project (k8s-infra)"},
+    {instance: "104.197.27.114:9090", type: "scalability-presubmit-project", friendly: "Scalability presubmit project"}
+  ],
+
+  // How long we go during work hours without seeing a webhook before alerting.
+  webhookMissingAlertInterval: '10m',
+
+  // How many days prow hasn't been bumped.
+  prowImageStaleByDays: 7,
+};
+
+// Generate the real config by adding in constant fields and defaulting where needed.
+{
+  _config+:: util.defaultConfig(config),
+  _util+:: util,
 }

--- a/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
@@ -1,0 +1,44 @@
+{
+  local default(obj, field, value)= {[field]: if field in obj then obj[field] else value},
+
+  consts+:: {
+    // Grafana dashboard IDs are necessary for stable links for dashboards
+    grafanaDashboardIDs: {
+      'boskos-http.json': 'eec46c579cbf4a518e5bbcbbf4913de9',
+      'ghproxy.json': 'd72fe8d0400b2912e319b1e95d0ab1b3',
+      'slo.json': 'ea313af4b7904c7c983d20d9572235a5',
+    },
+    // Component name constants
+    components: {
+      // Values should be lowercase for use with prometheus 'job' label.
+      crier: 'crier',
+      deck: 'deck',
+      ghproxy: 'ghproxy',
+      hook: 'hook',
+      horologium: 'horologium',
+      monitoring: 'monitoring', // Aggregate of prometheus, alertmanager, and grafana.
+      plank: 'plank', // Mutually exclusive with prowControllerManager
+      prowControllerManager: 'prow-controller-manager',
+      sinker: 'sinker',
+      tide: 'tide',
+    },
+  },
+
+  defaultConfig(config): (
+    self.consts +
+    config +
+    // Add defaulting logic to the struct below by using '+:' to deeply override fields.
+    {
+      instance+: default(config.instance, 'botName', '(Prow bot name)')
+        + {
+          monitoringLink(path, text): (
+            if 'monitoringURL' in config.instance then
+              '<%s%s|%s>' % [config.instance.monitoringURL, path, text]
+            else
+              '%s (Requires <https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster/monitoring#access-components-web-page|port-forwarding the grafana service> and accessing path "%s")' % [text, path]
+          ),
+        },
+    }
+    + default(config, 'prowImageStaleByDays', 7)
+  ),
+}

--- a/config/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/boskos_alerts.libsonnet
@@ -21,7 +21,7 @@
               'boskos_type': '{{ $labels.type }}',
             },
             annotations: {
-              message: 'The Boskos resource "{{ $labels.type }}" has been exhausted (currently 0% free). See the <https://monitoring.prow.k8s.io/d/wSrfvNxWz/boskos-resource-usage?orgId=1|Boskos resource usage dashboard>.',
+              message: 'The Boskos resource "{{ $labels.type }}" has been exhausted (currently 0%% free). See the %s.' % [$._config.instance.monitoringLink('/d/wSrfvNxWz/boskos-resource-usage?orgId=1', 'Boskos resource usage dashboard')],
             },
           },
         ],

--- a/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/ghproxy_alerts.libsonnet
@@ -1,5 +1,7 @@
 {
   prometheusAlerts+:: {
+    local monitoringLink = $._config.instance.monitoringLink,
+    local dashboardID = $._config.grafanaDashboardIDs['ghproxy.json'],
     groups+: [
       {
         name: 'ghproxy',
@@ -13,7 +15,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+              message: '{{ $value | humanize }}%% of all requests for {{ $labels.path }} through the GitHub proxy are erroring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=9' % [dashboardID], 'the ghproxy dashboard')],
             },
           },
           {
@@ -25,7 +27,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check <https://monitoring.prow.k8s.io/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8|grafana>' % $._config.grafanaDashboardIDs['ghproxy.json'],
+              message: '{{ $value | humanize }}%% of all API requests through the GitHub proxy are errorring with code {{ $labels.status }}. Check %s.' % [monitoringLink('/d/%s/github-cache?orgId=1&refresh=1m&fullscreen&panelId=8' % [dashboardID], 'the ghproxy dashboard')],
             },
           },
           {

--- a/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/tide_alerts.libsonnet
@@ -1,6 +1,8 @@
 {
   prometheusAlerts+:: {
     local tideName = $._config.components.tide,
+    local monitoringLink = $._config.instance.monitoringLink,
+    local prowURL = $._config.instance.url,
     groups+: [
       {
         name: 'Tide progress',
@@ -16,7 +18,7 @@
               slo: tideName,
             },
             annotations: {
-              message: 'The Tide "sync" controller has not synced in 15 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
+              message: 'The Tide "sync" controller has not synced in 15 minutes. See the %s.' % monitoringLink('/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7', 'processing time graph'),
             },
           },
           {
@@ -30,7 +32,7 @@
               slo: tideName,
             },
             annotations: {
-              message: 'The Tide "status-update" controller has not synced in 30 minutes. See the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7|processing time graph>.',
+              message: 'The Tide "status-update" controller has not synced in 30 minutes. See the %s.' % monitoringLink('/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&from=now-24h&to=now&fullscreen&panelId=7', 'processing time graph'),
             },
           },
           {
@@ -43,7 +45,7 @@
               severity: 'warning',
             },
             annotations: {
-              message: 'At least one Tide pool encountered 3+ sync errors in a 10 minute window. If the TidePoolErrorRateMultiple alert has not fired this is likely an isolated configuration issue. See the <https://prow.k8s.io/tide-history|/tide-history> page and the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now|sync error graph>.',
+              message: 'At least one Tide pool encountered 3+ sync errors in a 10 minute window. If the TidePoolErrorRateMultiple alert has not fired this is likely an isolated configuration issue. See the <%s/tide-history|/tide-history> page and the %s.' % [prowURL, monitoringLink('/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now', 'sync error graph')],
             },
           },
           {
@@ -57,7 +59,7 @@
               slo: tideName,
             },
             annotations: {
-              message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <https://prow.k8s.io/tide-history|tide-history> page and the <https://monitoring.prow.k8s.io/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now|sync error graph>.',
+              message: 'Tide encountered 3+ sync errors in a 10 minute window in at least 3 different repos that it handles. See the <%s/tide-history|/tide-history> page and the %s.' % [prowURL, monitoringLink('/d/d69a91f76d8110d3e72885ee5ce8038e/tide-dashboard?orgId=1&fullscreen&panelId=6&from=now-24h&to=now', 'sync error graph')],
             },
           },
         ],


### PR DESCRIPTION
/assign @chaodaiG 
/cc @stevekuznetsov @alvaroaleman 

From now on we should avoid hardcoding values specific to the prow.k8s.io instance and instead add new config fields as needed.  Config defaulting logic and helper functions can be added to the `defaultConfig` function in the `config_util.libsonnet` file.
New config fields should provide any defaulting logic needed to ensure that prometheus rules and grafana dashboards that use them behave well when no value is specified. This will allow us to safely update the monitoring stack for different instances by simply copying the latest rules and dashboards from upstream without having to update config.