### PR TITLE
Enable azure csi in-tree plugin presubmit test in out-of-tree ccm repo

### DIFF
--- a/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
+++ b/config/jobs/kubernetes-sigs/cloud-provider-azure/cloud-provider-azure-config.yaml
@@ -201,6 +201,65 @@ presubmits:
       testgrid-tab-name: pr-cloud-provider-azure-e2e-ccm
       description: "Runs Azure specific tests with cloud-provider-azure (https://github.com/kubernetes-sigs/cloud-provider-azure)."
       testgrid-num-columns-recent: '30'
+  - name: pull-kubernetes-e2e-azure-disk-vmss-ccm
+    decorate: true
+    always_run: false
+    optional: true
+    run_if_changed: 'azure.*\.go'
+    path_alias: sigs.k8s.io/cloud-provider-azure
+    branches:
+      - master
+    labels:
+      preset-service-account: "true"
+      preset-azure-cred: "true"
+      preset-dind-enabled: "true"
+    extra_refs:
+      - org: kubernetes-sigs
+        repo: azuredisk-csi-driver
+        base_ref: master
+        path_alias: sigs.k8s.io/azuredisk-csi-driver
+    spec:
+      containers:
+        - image: gcr.io/k8s-testimages/kubekins-e2e:v20201203-4778e22-master
+          command:
+            - runner.sh
+            - kubetest
+          args:
+            # Generic e2e test args
+            - --test
+            - --up
+            - --down
+            - --build=quick
+            - --dump=$(ARTIFACTS)
+            # Azure-specific test args
+            - --provider=skeleton
+            - --deployment=aksengine
+            - --aksengine-ccm
+            - --aksengine-cnm
+            - --aksengine-admin-username=azureuser
+            - --aksengine-creds=$(AZURE_CREDENTIALS)
+            - --aksengine-orchestratorRelease=1.20
+            - --aksengine-deploy-custom-k8s
+            - --aksengine-location=westus2
+            - --aksengine-public-key=$(AZURE_SSH_PUBLIC_KEY_FILE)
+            - --aksengine-template-url=https://raw.githubusercontent.com/kubernetes-sigs/azuredisk-csi-driver/master/test/e2e/manifest/in-tree-vmss.json
+            - --aksengine-download-url=https://aka.ms/aks-engine/aks-engine-k8s-e2e.tar.gz
+            # Specific test args
+            - --test-azure-disk-csi-driver
+            - --ginkgo-parallel=1
+            - --timeout=420m
+          securityContext:
+            privileged: true
+          env:
+            - name: AZURE_STORAGE_DRIVER
+              value: "kubernetes.io/azure-disk" # In-tree Azure disk storage class
+            - name: ENABLE_TOPOLOGY
+              value: "true"
+    annotations:
+      testgrid-dashboards: provider-azure-cloud-provider-azure, provider-azure-presubmit
+      testgrid-tab-name: pr-k8s-azure-disk-e2e-vmss-ccm-master
+      description: Run Azure Disk e2e test on a VMSS-based availability zone cluster with Azure Disk in-tree volume plugin in an out-of-tree ccm enabled cluster.
+      testgrid-num-columns-recent: '30'
   - name: pull-cloud-provider-azure-unit
     always_run: true
     decorate: true


### PR DESCRIPTION
Enable azure csi in-tree plugin presubmit test in out-of-tree ccm repo. These tests would be triggered when there is any modification in `azure.*\.go` in `cloud-provider-azure/pkg`.

/area provider/azure