### PR TITLE
Add branch protection and milestone applier for k/website 1.21

### DIFF
--- a/config/prow/config.yaml
+++ b/config/prow/config.yaml
@@ -339,8 +339,6 @@ branch-protection:
           branches:
             master:
               protect: true
-            dev-1.18:
-              protect: true
             release-1.4:
               protect: true
             release-1.5:
@@ -368,6 +366,12 @@ branch-protection:
             release-1.16:
               protect: true
             release-1.17:
+              protect: true
+            release-1.18:
+              protect: true
+            release-1.19:
+              protect: true
+            release-1.20:
               protect: true
     kubernetes-client:
       protect: true

--- a/config/prow/plugins.yaml
+++ b/config/prow/plugins.yaml
@@ -360,7 +360,7 @@ milestone_applier:
     release-0.4: v0.4
     release-0.3: v0.3
   kubernetes/website:
-    dev-1.20: 1.20
+    dev-1.21: 1.21
 
 repo_milestone:
   # Default maintainer


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Add branch protection for dev-1.21 (future release)
- Add branch protection to missing release branches
- Add milestone applier configuration for dev-1.21

/cc @kubernetes/sig-docs-leads 