### PR TITLE
Update config validation checks to be more correct

### DIFF
--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -2086,7 +2086,7 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEn
 
 	for i := range spec.Containers {
 		for _, mount := range spec.Containers[i].VolumeMounts {
-			if !volumeNames.Has(mount.Name) {
+			if !volumeNames.Has(mount.Name) && !decorate.VolumeMounts().Has(mount.Name) {
 				errs = append(errs, fmt.Errorf("volumeMount named %q is undefined", mount.Name))
 			}
 			if decorate.VolumeMounts().Has(mount.Name) {

--- a/prow/config/config.go
+++ b/prow/config/config.go
@@ -2092,7 +2092,7 @@ func validatePodSpec(jobType prowapi.ProwJobType, spec *v1.PodSpec, decorationEn
 			if decorate.VolumeMounts().Has(mount.Name) {
 				errs = append(errs, fmt.Errorf("volumeMount name %s is reserved for decoration", mount.Name))
 			}
-			if decorate.VolumeMountPaths().Has(mount.MountPath) {
+			if decorate.VolumeMountPathsOnTestContainer().Has(mount.MountPath) {
 				errs = append(errs, fmt.Errorf("mount %s at %s conflicts with decoration mount", mount.Name, mount.MountPath))
 			}
 		}

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -884,7 +884,7 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "fun",
-					MountPath: decorate.VolumeMountPaths().List()[0],
+					MountPath: decorate.VolumeMountPathsOnTestContainer().List()[0],
 				})
 			},
 		},
@@ -893,7 +893,7 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",
-					MountPath: filepath.Dir(decorate.VolumeMountPaths().List()[0]),
+					MountPath: filepath.Dir(decorate.VolumeMountPathsOnTestContainer().List()[0]),
 				})
 			},
 		},
@@ -902,7 +902,7 @@ func TestValidatePodSpec(t *testing.T) {
 			spec: func(s *v1.PodSpec) {
 				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
 					Name:      "foo",
-					MountPath: filepath.Join(decorate.VolumeMountPaths().List()[0], "extra"),
+					MountPath: filepath.Join(decorate.VolumeMountPathsOnTestContainer().List()[0], "extra"),
 				})
 			},
 		},

--- a/prow/config/config_test.go
+++ b/prow/config/config_test.go
@@ -907,6 +907,15 @@ func TestValidatePodSpec(t *testing.T) {
 			},
 		},
 		{
+			name: "accept mount path that works only through decoration volume",
+			spec: func(s *v1.PodSpec) {
+				s.Containers[0].VolumeMounts = append(s.Containers[0].VolumeMounts, v1.VolumeMount{
+					Name:      "foo",
+					MountPath: "/secrets/gcs",
+				})
+			},
+		},
+		{
 			name: "reject reserved volume",
 			spec: func(s *v1.PodSpec) {
 				s.Volumes = append(s.Volumes, v1.Volume{Name: decorate.VolumeMounts().List()[0]})

--- a/prow/pod-utils/decorate/podspec.go
+++ b/prow/pod-utils/decorate/podspec.go
@@ -72,9 +72,9 @@ func VolumeMounts() sets.String {
 	return sets.NewString(logMountName, codeMountName, toolsMountName, gcsCredentialsMountName, s3CredentialsMountName)
 }
 
-// VolumeMountPaths returns a string set with *MountPath consts in it.
-func VolumeMountPaths() sets.String {
-	return sets.NewString(logMountPath, codeMountPath, toolsMountPath, gcsCredentialsMountPath, s3CredentialsMountPath)
+// VolumeMountPathsOnTestContainer returns a string set with *MountPath consts in it which are applied to the test container.
+func VolumeMountPathsOnTestContainer() sets.String {
+	return sets.NewString(logMountPath, codeMountPath, toolsMountPath)
 }
 
 // PodUtilsContainerNames returns a string set with pod utility container name consts in it.


### PR DESCRIPTION
config: correctly validate mount paths

Only some of the possible decoration mounts will be makde available to
the test container provided by the user, so only check for those.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

config: fix volume definition check

If a user's mounting a volume we add to the container in decoration, it
will be valid.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---


/assign @alvaroaleman 