### PR TITLE
Crier: Allow enabling/disabling on org/repo level

### DIFF
--- a/prow/cmd/crier/BUILD.bazel
+++ b/prow/cmd/crier/BUILD.bazel
@@ -62,5 +62,8 @@ go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],
     embed = [":go_default_library"],
-    deps = ["//prow/flagutil:go_default_library"],
+    deps = [
+        "//prow/flagutil:go_default_library",
+        "@com_github_google_go_cmp//cmp:go_default_library",
+    ],
 )

--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -45,10 +45,11 @@ import (
 )
 
 type options struct {
-	client         prowflagutil.KubernetesOptions
-	cookiefilePath string
-	gerritProjects gerritclient.ProjectsFlag
-	github         prowflagutil.GitHubOptions
+	client           prowflagutil.KubernetesOptions
+	cookiefilePath   string
+	gerritProjects   gerritclient.ProjectsFlag
+	github           prowflagutil.GitHubOptions
+	githubEnablement prowflagutil.GitHubEnablementOptions
 
 	configPath    string
 	jobConfigPath string
@@ -135,8 +136,10 @@ func (o *options) validate() error {
 		o.k8sBlobStorageWorkers = o.k8sGCSWorkers
 	}
 
-	if err := o.client.Validate(o.dryrun); err != nil {
-		return err
+	for _, opt := range []interface{ Validate(bool) error }{&o.client, &o.githubEnablement} {
+		if err := opt.Validate(o.dryrun); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -231,7 +234,7 @@ func main() {
 		}
 		hasReporter = true
 		slackReporter := slackreporter.New(slackConfig, o.dryrun, secretAgent.GetTokenGenerator(o.slackTokenFile))
-		if err := crier.New(mgr, slackReporter, o.slackWorkers); err != nil {
+		if err := crier.New(mgr, slackReporter, o.slackWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct slack reporter controller")
 		}
 	}
@@ -243,14 +246,14 @@ func main() {
 		}
 
 		hasReporter = true
-		if err := crier.New(mgr, gerritReporter, o.gerritWorkers); err != nil {
+		if err := crier.New(mgr, gerritReporter, o.gerritWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct gerrit reporter controller")
 		}
 	}
 
 	if o.pubsubWorkers > 0 {
 		hasReporter = true
-		if err := crier.New(mgr, pubsubreporter.NewReporter(cfg), o.pubsubWorkers); err != nil {
+		if err := crier.New(mgr, pubsubreporter.NewReporter(cfg), o.pubsubWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct pubsub reporter controller")
 		}
 	}
@@ -269,7 +272,7 @@ func main() {
 
 		hasReporter = true
 		githubReporter := githubreporter.NewReporter(githubClient, cfg, prowapi.ProwJobAgent(o.reportAgent))
-		if err := crier.New(mgr, githubReporter, o.githubWorkers); err != nil {
+		if err := crier.New(mgr, githubReporter, o.githubWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct github reporter controller")
 		}
 	}
@@ -281,7 +284,7 @@ func main() {
 		}
 
 		hasReporter = true
-		if err := crier.New(mgr, gcsreporter.New(cfg, opener, o.dryrun), o.blobStorageWorkers); err != nil {
+		if err := crier.New(mgr, gcsreporter.New(cfg, opener, o.dryrun), o.blobStorageWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 			logrus.WithError(err).Fatal("failed to construct gcsreporter controller")
 		}
 
@@ -292,7 +295,7 @@ func main() {
 			}
 
 			k8sGcsReporter := k8sgcsreporter.New(cfg, opener, coreClients, float32(o.k8sReportFraction), o.dryrun)
-			if err := crier.New(mgr, k8sGcsReporter, o.k8sBlobStorageWorkers); err != nil {
+			if err := crier.New(mgr, k8sGcsReporter, o.k8sBlobStorageWorkers, o.githubEnablement.EnablementChecker()); err != nil {
 				logrus.WithError(err).Fatal("failed to construct k8sgcsreporter controller")
 			}
 		}

--- a/prow/cmd/crier/main_test.go
+++ b/prow/cmd/crier/main_test.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/test-infra/prow/flagutil"
 	prowflagutil "k8s.io/test-infra/prow/flagutil"
 )
@@ -175,17 +177,25 @@ func TestOptions(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
-		var actual options
-		err := actual.parseArgs(flags, tc.args)
-		switch {
-		case err == nil && tc.expected == nil:
-			t.Errorf("%s: failed to return an error", tc.name)
-		case err != nil && tc.expected != nil:
-			t.Errorf("%s: unexpected error: %v", tc.name, err)
-		case tc.expected != nil && !reflect.DeepEqual(*tc.expected, actual):
-			t.Errorf("%s: actual %v != expected %v", tc.name, actual, *tc.expected)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			flags := flag.NewFlagSet(tc.name, flag.ContinueOnError)
+			var actual options
+			err := actual.parseArgs(flags, tc.args)
+			switch {
+			case err == nil && tc.expected == nil:
+				t.Fatalf("%s: failed to return an error", tc.name)
+			case err != nil && tc.expected != nil:
+				t.Fatalf("%s: unexpected error: %v", tc.name, err)
+			}
+
+			if tc.expected == nil {
+				return
+			}
+			if diff := cmp.Diff(actual, *tc.expected, cmp.Exporter(func(_ reflect.Type) bool { return true })); diff != "" {
+				t.Errorf("Result differs from expected: %s", diff)
+			}
+
+		})
 	}
 }
 

--- a/prow/flagutil/github_enablement.go
+++ b/prow/flagutil/github_enablement.go
@@ -42,7 +42,7 @@ func (o *GitHubEnablementOptions) AddFlags(fs *flag.FlagSet) {
 	fs.Var(&o.disabledRepos, "github-disabled-repo", "Disabled github repo in org/repo format. Can be passed multiple times. Repos that are in this list will be ignored.")
 }
 
-func (o *GitHubEnablementOptions) Validate() error {
+func (o *GitHubEnablementOptions) Validate(_ bool) error {
 	var errs []error
 
 	for _, enabledRepo := range o.enabledRepos.vals {

--- a/prow/flagutil/github_enablement_test.go
+++ b/prow/flagutil/github_enablement_test.go
@@ -73,7 +73,7 @@ func TestGitHubEnablementValidation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			var actualErrMsg string
-			actualErr := tc.gitHubEnablementOptions.Validate()
+			actualErr := tc.gitHubEnablementOptions.Validate(false)
 			if actualErr != nil {
 				actualErrMsg = actualErr.Error()
 			}


### PR DESCRIPTION
This changes crier to use the githubenablement options so it can be
disabled based on org/repo. The allows running multiple sharded crier
instances which in turn allows migrating them to github apps
authentication.

The default still remains to be enabled for everything.