### PR TITLE
Fix secret token path to be absolute and move autobump config file

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-trusted.yaml
@@ -875,7 +875,7 @@ periodics:
       - go
       - run
       - experiment/autobumper/main.go
-      - --config=config/jobs/kubernetes/test-infra/autobump-config.yaml
+      - --config=config/prow/autobump-config.yaml
       volumeMounts:
       - name: github
         mountPath: /etc/github-token

--- a/config/prow/autobump-config.yaml
+++ b/config/prow/autobump-config.yaml
@@ -1,6 +1,6 @@
 ---
 gitHubLogin: "k8s-ci-robot"
-gitHubToken: "etc/github-token/oauth"
+gitHubToken: "/etc/github-token/oauth"
 gitName: "Kubernetes Prow Robot"
 gitEmail: "k8s.ci.robot@gmail.com"
 onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"


### PR DESCRIPTION
The token in the autobump-config file was using a relative path instead of an absolute one. 