### PR TITLE
Add debug message for image pusher

### DIFF
--- a/prow/push.sh
+++ b/prow/push.sh
@@ -54,7 +54,9 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
   gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
+gcloud config get-value account || { echo "Debugging, ignore failure"; true; }
 gcloud auth configure-docker
+gcloud config get-value account || { echo "Debugging, ignore failure"; true; }
 
 # Build and push the current commit, failing on any uncommitted changes.
 new_version="v$(date -u '+%Y%m%d')-$(git describe --tags --always --dirty)"


### PR DESCRIPTION
Postsubmit prow image pushing job has been consistently failing with:

```
ERROR: (gcloud.auth.docker-helper) You do not currently have an active account selected.
Please run:
  $ gcloud auth login
to obtain new credentials.
If you have already logged in with a different account:
    $ gcloud config set account ACCOUNT
to select an already authenticated account to use.
```

https://testgrid.k8s.io/sig-testing-prow#push-prow

Not sure what's going on, add some debugging logs to help