### PR TITLE
Crier: Add github enablement flags

### DIFF
--- a/prow/cmd/crier/main.go
+++ b/prow/cmd/crier/main.go
@@ -173,6 +173,7 @@ func (o *options) parseArgs(fs *flag.FlagSet, args []string) error {
 	o.client.AddFlags(fs)
 	o.storage.AddFlags(fs)
 	o.instrumentationOptions.AddFlags(fs)
+	o.githubEnablement.AddFlags(fs)
 
 	fs.Parse(args)
 


### PR DESCRIPTION
Missed that before, making it impossible to set the flags