### PR TITLE
Github: Add apps auth support for the v4 client

### DIFF
--- a/prow/github/BUILD.bazel
+++ b/prow/github/BUILD.bazel
@@ -22,6 +22,7 @@ go_test(
         "//ghproxy/ghcache:go_default_library",
         "@com_github_dgrijalva_jwt_go_v4//:go_default_library",
         "@com_github_google_go_cmp//cmp:go_default_library",
+        "@com_github_shurcool_githubv4//:go_default_library",
         "@com_github_sirupsen_logrus//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_utils//diff:go_default_library",

--- a/prow/github/app_auth_roundtripper.go
+++ b/prow/github/app_auth_roundtripper.go
@@ -102,9 +102,9 @@ func (arr *appsRoundTripper) addAppAuth(r *http.Request) *appsAuthError {
 }
 
 func (arr *appsRoundTripper) addAppInstallationAuth(r *http.Request) *appsAuthError {
-	org := r.Header.Get(githubOrgHeaderKey)
-	if org == "" {
-		return &appsAuthError{fmt.Errorf("request didn't have %s header set, can not infer org", githubOrgHeaderKey)}
+	var org string
+	if v := r.Context().Value(githubOrgHeaderKey); v != nil {
+		org = v.(string)
 	}
 
 	installationID, err := arr.installationIDFor(org)

--- a/prow/github/client.go
+++ b/prow/github/client.go
@@ -238,6 +238,7 @@ type Client interface {
 
 	Throttle(hourlyTokens, burst int)
 	Query(ctx context.Context, q interface{}, vars map[string]interface{}) error
+	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 
 	SetMax404Retries(int)
 
@@ -352,7 +353,7 @@ type httpClient interface {
 
 // Interface for how prow interacts with the graphql client, which we may throttle.
 type gqlClient interface {
-	Query(ctx context.Context, q interface{}, vars map[string]interface{}) error
+	QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error
 }
 
 // throttler sets a ceiling on the rate of GitHub requests.
@@ -431,10 +432,14 @@ func (t *throttler) Do(req *http.Request) (*http.Response, error) {
 }
 
 func (t *throttler) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
+	return t.QueryWithGitHubAppsSupport(ctx, q, vars, "")
+}
+
+func (t *throttler) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
 	t.Wait()
 	t.lock.Lock()
 	defer t.lock.Unlock()
-	return t.graph.Query(ctx, q, vars)
+	return t.graph.QueryWithGitHubAppsSupport(ctx, q, vars, org)
 }
 
 // Throttle client to a rate of at most hourlyTokens requests per hour,
@@ -508,7 +513,7 @@ func newClient(fields logrus.Fields, getToken func() []byte, censor func([]byte)
 		logger: logrus.WithFields(fields).WithField("client", "github"),
 		delegate: &delegate{
 			time: &standardTime{},
-			gqlc: githubql.NewEnterpriseClient(
+			gqlc: &graphQLGitHubAppsAuthClientWrapper{githubql.NewEnterpriseClient(
 				graphqlEndpoint,
 				&http.Client{
 					Timeout: maxRequestTime,
@@ -516,7 +521,7 @@ func newClient(fields logrus.Fields, getToken func() []byte, censor func([]byte)
 						Source: newReloadingTokenSource(getToken),
 						Base:   graphQLTransport,
 					},
-				}),
+				})},
 			client:        httpClient,
 			bases:         bases,
 			getToken:      getToken,
@@ -541,6 +546,15 @@ func newClient(fields logrus.Fields, getToken func() []byte, censor func([]byte)
 	}
 
 	return c
+}
+
+type graphQLGitHubAppsAuthClientWrapper struct {
+	*githubql.Client
+}
+
+func (c *graphQLGitHubAppsAuthClientWrapper) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
+	ctx = context.WithValue(ctx, githubOrgHeaderKey, org)
+	return c.Client.Query(ctx, q, vars)
 }
 
 // addHeaderTransport implements http.RoundTripper
@@ -867,7 +881,7 @@ func (c *client) doRequest(method, path, accept, org string, body interface{}) (
 		req.Header.Add("User-Agent", userAgent)
 	}
 	if org != "" {
-		req.Header.Set(githubOrgHeaderKey, org)
+		req = req.WithContext(context.WithValue(req.Context(), githubOrgHeaderKey, org))
 	}
 	// Disable keep-alive so that we don't get flakes when GitHub closes the
 	// connection prematurely.
@@ -2959,11 +2973,15 @@ func (c *client) GetFile(org, repo, filepath, commit string) ([]byte, error) {
 	return decoded, nil
 }
 
-// Query runs a GraphQL query using shurcooL/githubql's client.
 func (c *client) Query(ctx context.Context, q interface{}, vars map[string]interface{}) error {
+	return c.QueryWithGitHubAppsSupport(ctx, q, vars, "")
+}
+
+// QueryWithGitHubAppsSupport runs a GraphQL query using shurcooL/githubql's client.
+func (c *client) QueryWithGitHubAppsSupport(ctx context.Context, q interface{}, vars map[string]interface{}, org string) error {
 	// Don't log query here because Query is typically called multiple times to get all pages.
 	// Instead log once per search and include total search cost.
-	return c.gqlc.Query(ctx, q, vars)
+	return c.delegate.gqlc.QueryWithGitHubAppsSupport(ctx, q, vars, org)
 }
 
 // CreateTeam adds a team with name to the org, returning a struct with the new ID.


### PR DESCRIPTION
This change adds apps auth support to the Github V4 client. This is
achieved by adding a new method that takes an additional org argument,
then using the context to pass this through to the underlying
roundtripper. For consistency, the client was changed to use the Context
for this everywhere instead of a header on the V3 api.

We use the context to pass the org on because the code that constructs
the V4 requests is part of a dependency, giving us no way to use a
Header. (Ab-)using the context for this allows us to get away without
requiring changes to our dependencies.

The second commit makes blunderbuss use this by means of a wrapper that sets the "org" attribute based off of the event the request came from.