### PR TITLE
Switch master to run containerd based node e2e tests by default

### DIFF
--- a/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
+++ b/config/jobs/kubernetes/sig-node/sig-node-presubmit.yaml
@@ -1,15 +1,17 @@
 presubmits:
   kubernetes/kubernetes:
   - name: pull-kubernetes-node-e2e
-    skip_branches:
-    - release-\d+\.\d+  # per-release image
+    branches:
+    - master
     annotations:
       fork-per-release: "true"
       testgrid-alert-stale-results-hours: "24"
       testgrid-create-test-group: "true"
       testgrid-num-failures-to-alert: "10"
-    always_run: true
+    always_run: false
     cluster: k8s-infra-prow-build
+    optional: true
+    skip_report: true
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -132,11 +134,15 @@ presubmits:
           requests:
             memory: "6Gi"
   - name: pull-kubernetes-node-e2e-containerd
-    branches:
-    - master
-    always_run: false
-    optional: true
-    skip_report: true
+    skip_branches:
+    - release-\d+\.\d+  # per-release image
+    annotations:
+      fork-per-release: "true"
+      testgrid-alert-stale-results-hours: "24"
+      testgrid-create-test-group: "true"
+      testgrid-num-failures-to-alert: "10"
+    always_run: true
+    cluster: k8s-infra-prow-build
     max_concurrency: 12
     labels:
       preset-service-account: "true"
@@ -154,7 +160,6 @@ presubmits:
         - --scenario=kubernetes_e2e
         - --
         - --deployment=node
-        - --gcp-project-type=node-e2e-project
         - --gcp-zone=us-west1-b
         - '--node-test-args=--container-runtime=remote --container-runtime-endpoint=unix:///run/containerd/containerd.sock --container-runtime-process-name=/usr/bin/containerd --container-runtime-pid-file= --kubelet-flags="--cgroups-per-qos=true --cgroup-root=/ --runtime-cgroups=/system.slice/containerd.service" --extra-log="{\"name\": \"containerd.log\", \"journalctl\": [\"-u\", \"containerd\"]}"'
         - --node-tests=true
@@ -163,10 +168,12 @@ presubmits:
         - --timeout=65m
         - --node-args=--image-config-file=/workspace/test-infra/jobs/e2e_node/containerd/image-config.yaml
         resources:
+          limits:
+            cpu: 4
+            memory: 6Gi
           requests:
-            memory: "6Gi"
-    annotations:
-      testgrid-create-test-group: 'true'
+            cpu: 4
+            memory: 6Gi
   - name: pull-kubernetes-node-e2e-alpha
     branches:
     - master


### PR DESCRIPTION
Since we announced the docker deprecation it makes sense to test containerd based tests more by default. Also we don't need to run node e2e for both runtimes.

Signed-off-by: Davanum Srinivas <davanum@gmail.com>