### PR TITLE
Remove kubeadm-luxas jobs results that do not exist

### DIFF
--- a/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
+++ b/config/testgrids/kubernetes/sig-cluster-lifecycle/config.yaml
@@ -3,7 +3,6 @@ dashboard_groups:
   dashboard_names:
     - sig-cluster-lifecycle-all
     - sig-cluster-lifecycle-kubeadm
-    - sig-cluster-lifecycle-multi-platform
     - sig-cluster-lifecycle-cluster-addons
     - sig-cluster-lifecycle-cluster-api
     - sig-cluster-lifecycle-cluster-api-provider-aws
@@ -25,16 +24,6 @@ dashboard_groups:
 dashboards:
 - name: sig-cluster-lifecycle-all
 - name: sig-cluster-lifecycle-kubeadm
-- name: sig-cluster-lifecycle-multi-platform
-  dashboard_tab:
-    - name: periodic-kubeadm-gce-amd64
-      test_group_name: periodic-multi-platform-kubeadm-gce-amd64
-    - name: periodic-kubeadm-scaleway-arm
-      test_group_name: periodic-multi-platform-kubeadm-scaleway-arm
-    - name: periodic-kubeadm-scaleway-arm64
-      test_group_name: periodic-multi-platform-kubeadm-scaleway-arm64
-    - name: periodic-kubeadm-packet-arm64
-      test_group_name: periodic-multi-platform-kubeadm-packet-arm64
 - name: sig-cluster-lifecycle-cluster-addons
 - name: sig-cluster-lifecycle-cluster-api
 - name: sig-cluster-lifecycle-cluster-api-provider-aws
@@ -64,15 +53,6 @@ dashboards:
 - name: sig-cluster-lifecycle-image-builder
 
 test_groups:
-# @luxas' multiarch e2e results
-- name: periodic-multi-platform-kubeadm-gce-amd64
-  gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-gce-amd64
-- name: periodic-multi-platform-kubeadm-scaleway-arm
-  gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm
-- name: periodic-multi-platform-kubeadm-scaleway-arm64
-  gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm64
-- name: periodic-multi-platform-kubeadm-packet-arm64
-  gcs_prefix: kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-packet-arm64
 - name: ci-cluster-api-provider-openstack-make-conformance-stable-k8s-ci-artifacts
   gcs_prefix: k8s-conform-capi-openstack/periodic-logs/ci-cluster-api-provider-openstack-stable-acceptance-test-master
 - name: periodic-cluster-api-provider-azure-coverage


### PR DESCRIPTION
These all produce errors on testgrid like: 
```
time="2020-12-12T00:55:08Z" level=error msg="Error updating group" func=github.com/GoogleCloudPlatform/testgrid/pkg/updater.Update.func1 file="pkg/updater/updater.go:150" config="gs://k8s-testgrid/config" error="list builds in gs://kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm64/: list objects: storage: bucket doesn't exist" group=periodic-multi-platform-kubeadm-scaleway-arm64
time="2020-12-12T00:55:08Z" level=error msg="Error updating group" func=github.com/GoogleCloudPlatform/testgrid/pkg/updater.Update.func1 file="pkg/updater/updater.go:150" config="gs://k8s-testgrid/config" error="list builds in gs://kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-scaleway-arm/: list objects: storage: bucket doesn't exist" group=periodic-multi-platform-kubeadm-scaleway-arm
time="2020-12-12T00:55:08Z" level=error msg="Error updating group" func=github.com/GoogleCloudPlatform/testgrid/pkg/updater.Update.func1 file="pkg/updater/updater.go:150" config="gs://k8s-testgrid/config" error="list builds in gs://kubernetes-multiarch-e2e-results/logs/kubeadm-luxas-packet-arm64/: list objects: storage: bucket doesn't exist" group=periodic-multi-platform-kubeadm-packet-arm64
```