### PR TITLE
downloadkubernetes: add job to validate the downloadkubernetes index and general checks

### DIFF
--- a/config/jobs/kubernetes-sigs/downloadkubernetes/OWNERS
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- release-engineering-approvers
+
+reviewers:
+- release-engineering-reviewers
+
+labels:
+- sig/release
+- area/release-eng

--- a/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/downloadkubernetes/downloadkubernetes-presubmits.yaml
@@ -1,0 +1,30 @@
+presubmits:
+  kubernetes-sigs/downloadkubernetes:
+  - name: pull-downloadkubernetes-verify-index
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/downloadkubernetes"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - verify-index
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-alert-email: release-managers+alerts@kubernetes.io
+  - name: pull-downloadkubernetes-verify
+    always_run: true
+    optional: false
+    decorate: true
+    path_alias: "sigs.k8s.io/downloadkubernetes"
+    spec:
+      containers:
+      - image: gcr.io/k8s-staging-releng/releng-ci:latest
+        command:
+        - make
+        - verify
+    annotations:
+      testgrid-dashboards: sig-release-releng-presubmits
+      testgrid-alert-email: release-managers+alerts@kubernetes.io


### PR DESCRIPTION
 - Adding the job to validate the index.html as was discussed in the past
 - also add the job to do general checks like golangci-lint, shellchecks...

/assign @saschagrunert @justaugustus 