### PR TITLE
Fix missing GitUser for git v2

### DIFF
--- a/prow/git/v2/client_factory.go
+++ b/prow/git/v2/client_factory.go
@@ -85,7 +85,7 @@ func (cfo *ClientFactoryOpts) Apply(target *ClientFactoryOpts) {
 		target.Token = cfo.Token
 	}
 	if cfo.GitUser != nil {
-		target.Token = cfo.Token
+		target.GitUser = cfo.GitUser
 	}
 	if cfo.Censor != nil {
 		target.Censor = cfo.Censor


### PR DESCRIPTION
Fix missing GitUser for git v2.

When we use the `Commit` func, it panics on `/prow/git/v2/publisher.go:53`