### PR TITLE
storage migrator: enable kind at prow preset

### DIFF
--- a/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
+++ b/config/jobs/kubernetes-sigs/kube-storage-version-migrator/kube-storage-version-migrator-presubmits.yaml
@@ -91,9 +91,8 @@ presubmits:
     always_run: true
     optional: true
     labels:
-      preset-service-account: "true"
-      preset-k8s-ssh: "true"
       preset-dind-enabled: "true"
+      preset-kind-volume-mounts: "true"
     spec:
       containers:
       - image: gcr.io/k8s-testimages/kubekins-e2e:v20201208-8b354d9-master


### PR DESCRIPTION
enable the preset to make kind run at Prow works https://github.com/kubernetes/test-infra/pull/11510; also removed the labels that this job doesn't need

/assign @caesarxuchao 