### PR TITLE
Rename USE_KUBEKINS_LOG_DUMPING to USE_TEST_INFRA_LOG_DUMPING

### DIFF
--- a/kubetest/e2e.go
+++ b/kubetest/e2e.go
@@ -519,7 +519,7 @@ func logDumpPath(provider string) string {
 	// Use the log dumping script outside of kubernetes/kubernetes repo.
 	// Guarding against K8s provider as the script is tested only for gce
 	// and gke cases at the moment.
-	if os.Getenv("USE_KUBEKINS_LOG_DUMPING") != "" && (provider == "gce" || provider == "gke") {
+	if os.Getenv("USE_TEST_INFRA_LOG_DUMPING") == "true" && (provider == "gce" || provider == "gke") {
 		if logDumpPath := os.Getenv("LOG_DUMP_SCRIPT_PATH"); logDumpPath != "" {
 			return logDumpPath
 		}


### PR DESCRIPTION
The former name of the env var was confusing and didn't reflect the intent of setting it to `true` precisely.

/sig scalability
/assign @wojtek-t 