### PR TITLE
[Kettle] Use table ID over Name to avoid loss of transparency 

### DIFF
--- a/kettle/model.py
+++ b/kettle/model.py
@@ -167,12 +167,19 @@ class Database:
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
             try:
+<<<<<<< HEAD
                 data = zlib.decompress(dataz).decode('utf-8', 'replace')
+=======
+                data = zlib.decompress(dataz).decode('utf-8')
+>>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
                 if data:
                     results.append(data)
             except UnicodeDecodeError:
                 print(f'Failed to decode data for {path}')
+<<<<<<< HEAD
                 break
+=======
+>>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
         return results
 
     def get_oldest_emitted(self, incremental_table):

--- a/kettle/model.py
+++ b/kettle/model.py
@@ -167,19 +167,12 @@ class Database:
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
             try:
-<<<<<<< HEAD
                 data = zlib.decompress(dataz).decode('utf-8', 'replace')
-=======
-                data = zlib.decompress(dataz).decode('utf-8')
->>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
                 if data:
                     results.append(data)
             except UnicodeDecodeError:
                 print(f'Failed to decode data for {path}')
-<<<<<<< HEAD
                 break
-=======
->>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
         return results
 
     def get_oldest_emitted(self, incremental_table):

--- a/kettle/stream.py
+++ b/kettle/stream.py
@@ -123,7 +123,7 @@ def insert_data(bq_client, table, rows_iter):
     # Insert rows with row_ids into table, retrying as necessary.
     errors = retry(bq_client.insert_rows, table, rows, skip_invalid_rows=True)
     if not errors:
-        print('Loaded {} builds into {}'.format(len(rows), table.friendly_name))
+        print('Loaded {} builds into {}'.format(len(rows), table.full_table_id))
     else:
         print('Errors:')
         pprint.pprint(errors)

--- a/kettle/stream_test.py
+++ b/kettle/stream_test.py
@@ -61,7 +61,7 @@ class FakeClient:
 
 class FakeTable:
     def __init__(self, name, schema):
-        self.friendly_name = name
+        self.full_table_id = f'bq.table.{name}'
         self.schema = schema
 
 class FakeSchemaField:


### PR DESCRIPTION
#20001

> Loaded 3 builds into None

This fixes the issue where logging does not report true name of table being loaded.

/area kettle
/cc @amwat 