### PR TITLE
[Kettle] Don't log traceback when empty json object is hit

### DIFF
--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -67,7 +67,7 @@ class GCSClient:
                         return resp.json()
                     except json.decoder.JSONDecodeError:
                         logging.exception('Failed to decode request for %s',
-                                           urllib.parse.unquote(url))
+                                          urllib.parse.unquote(url))
                         return None
                 return resp.text
             except requests.exceptions.RequestException:

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -66,7 +66,8 @@ class GCSClient:
                     try:
                         return resp.json()
                     except json.decoder.JSONDecodeError:
-                        logging.exception('Failed to decode request for %s', path)
+                        logging.exception('Failed to decode request for %s',
+                                           urllib.parse.unquote(url))
                         return None
                 return resp.text
             except requests.exceptions.RequestException:
@@ -84,7 +85,7 @@ class GCSClient:
         """Get an object from GCS."""
         bucket, path = self._parse_uri(path)
         return self._request(f'{bucket}/o/{urllib.parse.quote(path, "")}',
-                             {'alt': 'media'}, as_json=as_json)
+                             {}, as_json=as_json)
 
     def ls(self,
            path,

--- a/kettle/make_db.py
+++ b/kettle/make_db.py
@@ -66,8 +66,8 @@ class GCSClient:
                     try:
                         return resp.json()
                     except json.decoder.JSONDecodeError:
-                        logging.exception('Failed to decode request for %s',
-                                          urllib.parse.unquote(url))
+                        logging.error('Failed to decode request for %s',
+                                      urllib.parse.unquote(url))
                         return None
                 return resp.text
             except requests.exceptions.RequestException:
@@ -83,9 +83,9 @@ class GCSClient:
 
     def get(self, path, as_json=False):
         """Get an object from GCS."""
-        bucket, path = self._parse_uri(path)
-        return self._request(f'{bucket}/o/{urllib.parse.quote(path, "")}',
-                             {}, as_json=as_json)
+        bucket, prefix = self._parse_uri(path)
+        return self._request(f'{bucket}/o/{urllib.parse.quote(prefix, "")}',
+                             {'alt': 'media'}, as_json=as_json)
 
     def ls(self,
            path,
@@ -97,8 +97,8 @@ class GCSClient:
         """Lists objects under a path on gcs."""
         # pylint: disable=invalid-name
 
-        bucket, path = self._parse_uri(path)
-        params = {'prefix': path, 'fields': 'nextPageToken'}
+        bucket, prefix = self._parse_uri(path)
+        params = {'prefix': prefix, 'fields': 'nextPageToken'}
         if delim:
             params['delimiter'] = '/'
             if dirs:

--- a/kettle/model.py
+++ b/kettle/model.py
@@ -167,12 +167,19 @@ class Database:
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
             try:
+<<<<<<< HEAD
                 data = zlib.decompress(dataz).decode('utf-8', 'replace')
+=======
+                data = zlib.decompress(dataz).decode('utf-8')
+>>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
                 if data:
                     results.append(data)
             except UnicodeDecodeError:
                 print(f'Failed to decode data for {path}')
+<<<<<<< HEAD
                 break
+=======
+>>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
         return results
 
     def get_oldest_emitted(self, incremental_table):

--- a/kettle/model.py
+++ b/kettle/model.py
@@ -167,19 +167,12 @@ class Database:
                 'select data from file where path between ? and ?',
                 (path, path + '\x7F')):
             try:
-<<<<<<< HEAD
                 data = zlib.decompress(dataz).decode('utf-8', 'replace')
-=======
-                data = zlib.decompress(dataz).decode('utf-8')
->>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
                 if data:
                     results.append(data)
             except UnicodeDecodeError:
                 print(f'Failed to decode data for {path}')
-<<<<<<< HEAD
                 break
-=======
->>>>>>> d6e2dee58b (Skip data collection for malformed test results in db)
         return results
 
     def get_oldest_emitted(self, incremental_table):


### PR DESCRIPTION
/hold this needs to be tested in staging

#20236

Seems that for some paths, pulling with `alt:media` causes no data to be returned for specific job paths. I do not know the root cause but removing this option fixes it. (I also believe it might be time to update the REST uri path)

/area kettle