### PR TITLE
Remove obsolete log dumping env var from scalability preset

### DIFF
--- a/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
+++ b/config/jobs/kubernetes/sig-scalability/sig-scalability-presets.yaml
@@ -87,10 +87,6 @@ presets:
   # instead of relying on the deprecated one from k/k repository.
   - name: USE_TEST_INFRA_LOG_DUMPING
     value: "true"
-  # Older edition of USE_TEST_INFRA_LOG_DUMPING env var.
-  # TODO: Remove it after kubekins-e2e image bump in SIG Scalability jobs.
-  - name: USE_KUBEKINS_LOG_DUMPING
-    value: "true"
   # If log dumping of nodes is enabled and logexporter creation fails or less than 50 %
   # of the nodes got logexported successfully, then report a failure.
   - name: LOG_DUMP_EXPECTED_SUCCESS_PERCENTAGE
@@ -223,10 +219,6 @@ presets:
   # Switch to using log-dump.sh script included in the kubekins-e2e image
   # instead of relying on the deprecated one from k/k repository.
   - name: USE_TEST_INFRA_LOG_DUMPING
-    value: "true"
-  # Older edition of USE_TEST_INFRA_LOG_DUMPING env var.
-  # TODO: Remove it after kubekins-e2e image bump in SIG Scalability jobs.
-  - name: USE_KUBEKINS_LOG_DUMPING
     value: "true"
   # If log dumping of nodes is enabled and logexporter creation fails or less than 50 %
   # of the nodes got logexported successfully, then report a failure.


### PR DESCRIPTION
Follow-up on https://github.com/kubernetes/test-infra/pull/20228. `kubekins-e2e` images got bumped to a sufficiently new version to safely remove this environment variable.

/kind cleanup
/sig scalability
/assign @wojtek-t 