### PR TITLE
Kops - allow newer k8s versions to be tested on kops-aws-k8s-1-20 job

### DIFF
--- a/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-versions.yaml
@@ -59,6 +59,7 @@ periodics:
       - --env=KUBE_SSH_USER=ubuntu
       - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest-1.20.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
+      - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/latest-1.20
       - --ginkgo-parallel
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64


### PR DESCRIPTION
This is currently failing because the kops master branch is still set to 1.19 release version.
Once a 1.20 alpha is cut this will no longer be necessary

https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-aws-k8s-1-20/1338781100264132608