### PR TITLE
Do not make logexporter logs public by default

### DIFF
--- a/logexporter/cmd/Dockerfile
+++ b/logexporter/cmd/Dockerfile
@@ -15,12 +15,13 @@
 # This file builds an image for the log exporter tool. For more info,
 # have a look at the tool's README.md file.
 
-# Base image must have 'journalctl' binary.
-FROM fedora
+FROM debian:stretch-20201209-slim
+# systemd is needed as journalctl is used to fetch logs from
+# k8s components that are run on nodes as systemd services.
+RUN apt-get update && \
+    apt-get install -y systemd python3
 
 # Setup gcloud SDK for using gsutil.
-RUN dnf -y -q install which
-RUN dnf -y -q install python27
 ADD ["https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz", \
      "/workspace/"]
 ENV PATH=/google-cloud-sdk/bin:/workspace:${PATH} \

--- a/logexporter/cmd/main.go
+++ b/logexporter/cmd/main.go
@@ -202,9 +202,8 @@ func uploadLogfilesToGCS(logDir string) error {
 	gcsLogPath := *gcsPath + "/" + *nodeName
 	klog.Infof("Uploading logfiles to GCS at path '%v'", gcsLogPath)
 	for uploadAttempt := 0; uploadAttempt < 3; uploadAttempt++ {
-		// Upload the files with compression (-z) and parallelism (-m) for speeding
-		// up, and set their ACL to make them publicly readable.
-		if err = runCommand("gsutil", "-m", "-q", "cp", "-a", "public-read", "-c",
+		// Upload the files with compression (-z) and parallelism (-m) for speeding up.
+		if err = runCommand("gsutil", "-m", "-q", "cp", "-c",
 			"-z", "log,txt,xml", logDir+"/*", gcsLogPath); err != nil {
 			klog.Errorf("Attempt %v to upload to GCS failed: %v", uploadAttempt, err)
 			continue
@@ -219,7 +218,7 @@ func uploadLogfilesToGCS(logDir string) error {
 // fetch the list of nodes on which logexporter succeeded.
 func writeSuccessMarkerFile() error {
 	markerFilePath := *gcsPath + "/logexported-nodes-registry/" + *nodeName + ".txt"
-	cmd := exec.Command("gsutil", "-q", "cp", "-a", "public-read", "-", markerFilePath)
+	cmd := exec.Command("gsutil", "-q", "cp", "-", markerFilePath)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("Failed to get stdin pipe to write marker file: %v", err)


### PR DESCRIPTION
Remove the ACL argument from logexporter's `gsutil` command invocations so that logs are private by default.

Additionally fix the logexporter's Dockerfile:
* add explicit download of systemd package,
* fix the base image tag (instead of using `latest`) and switch to Debian which is lighter than Fedora,
* download Python 3 instead of deprecated Python 2.

/sig scalability
/assign @jkaniuk @wojtek-t 