### PR TITLE
clonerefs: Use repo link from refs if available

### DIFF
--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"os/exec"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -111,8 +110,9 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 	if refs.PathAlias != "" {
 		clonePath = refs.PathAlias
 	} else if refs.RepoLink != "" {
-		re := regexp.MustCompile(`^https?://`)
-		clonePath = re.ReplaceAllString(refs.RepoLink, "")
+		// Drop the protocol from the RepoLink
+		parts := strings.Split(refs.RepoLink, "://")
+		clonePath = parts[len(parts)-1]
 	} else {
 		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 	}

--- a/prow/pod-utils/clone/clone.go
+++ b/prow/pod-utils/clone/clone.go
@@ -22,6 +22,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -109,6 +110,9 @@ func PathForRefs(baseDir string, refs prowapi.Refs) string {
 	var clonePath string
 	if refs.PathAlias != "" {
 		clonePath = refs.PathAlias
+	} else if refs.RepoLink != "" {
+		re := regexp.MustCompile(`^https?://`)
+		clonePath = re.ReplaceAllString(refs.RepoLink, "")
 	} else {
 		clonePath = fmt.Sprintf("github.com/%s/%s", refs.Org, refs.Repo)
 	}
@@ -124,10 +128,17 @@ type gitCtx struct {
 
 // gitCtxForRefs creates a gitCtx based on the provide refs and baseDir.
 func gitCtxForRefs(refs prowapi.Refs, baseDir string, env []string, oauthToken string) gitCtx {
+	var repoURI string
+	if refs.RepoLink != "" {
+		repoURI = fmt.Sprintf("%s.git", refs.RepoLink)
+	} else {
+		repoURI = fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo)
+	}
+
 	g := gitCtx{
 		cloneDir:      PathForRefs(baseDir, refs),
 		env:           env,
-		repositoryURI: fmt.Sprintf("https://github.com/%s/%s.git", refs.Org, refs.Repo),
+		repositoryURI: repoURI,
 	}
 	if refs.CloneURI != "" {
 		g.repositoryURI = refs.CloneURI


### PR DESCRIPTION
Dynamically sets the clone URI and path to flex based on the repo link from the ref if it is available. This helps further mitigate hard coded instances of "github.com" as noted on #14130. 

Signed-off-by: Trevor Wood <Trevor.G.Wood@gmail.com>