### PR TITLE
Fix cri-tools image pushing failing jobs

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-cri-tools.yaml
+++ b/config/jobs/image-pushing/k8s-staging-cri-tools.yaml
@@ -18,9 +18,11 @@ postsubmits:
               - --project=k8s-staging-cri-tools
               - --scratch-bucket=gs://k8s-staging-cri-tools-gcb
               - --gcb-config=cloudbuild-images.yaml
-              - --env-passthrough=IMAGE_TYPE=uid
+              - --env-passthrough=IMAGE_TYPE
               - images/image-user
             env:
+              - name: IMAGE_TYPE
+                value: "uid"
               - name: LOG_TO_STDOUT
                 value: "y"
     - name: post-cri-tools-push-image-user-username
@@ -41,9 +43,11 @@ postsubmits:
               - --project=k8s-staging-cri-tools
               - --scratch-bucket=gs://k8s-staging-cri-tools-gcb
               - --gcb-config=cloudbuild-images.yaml
-              - --env-passthrough=IMAGE_TYPE=username
+              - --env-passthrough=IMAGE_TYPE
               - images/image-user
             env:
+              - name: IMAGE_TYPE
+                value: "username"
               - name: LOG_TO_STDOUT
                 value: "y"
     - name: post-cri-tools-push-image-user-uid-group
@@ -64,9 +68,11 @@ postsubmits:
               - --project=k8s-staging-cri-tools
               - --scratch-bucket=gs://k8s-staging-cri-tools-gcb
               - --gcb-config=cloudbuild-images.yaml
-              - --env-passthrough=IMAGE_TYPE=uid-group
+              - --env-passthrough=IMAGE_TYPE
               - images/image-user
             env:
+              - name: IMAGE_TYPE
+                value: "uid-group"
               - name: LOG_TO_STDOUT
                 value: "y"
     - name: post-cri-tools-push-image-user-username-group
@@ -87,9 +93,11 @@ postsubmits:
               - --project=k8s-staging-cri-tools
               - --scratch-bucket=gs://k8s-staging-cri-tools-gcb
               - --gcb-config=cloudbuild-images.yaml
-              - --env-passthrough=IMAGE_TYPE=username-group
+              - --env-passthrough=IMAGE_TYPE
               - images/image-user
             env:
+              - name: IMAGE_TYPE
+                value: "username-group"
               - name: LOG_TO_STDOUT
                 value: "y"
     - name: post-cri-tools-push-image-user-multi-arch


### PR DESCRIPTION
Jobs failing as follows:

```
020/12/11 16:55:40 Failed to run some build jobs: [error running [gcloud builds submit --verbosity info --config /home/prow/go/src/github.com/kubernetes-sigs/cri-tools/images/image-user/cloudbuild-images.yaml --substitutions _IMAGE_TYPE=uid=,_GIT_TAG=v20201211-v1.19.0-55-gb76cca2 --project k8s-staging-cri-tools --gcs-log-dir gs://k8s-staging-cri-tools-gcb/logs --gcs-source-staging-dir gs://k8s-staging-cri-tools-gcb/source gs://k8s-staging-cri-tools-gcb/source/d36263ee-680e-4de6-98e7-48bcb5bd45e8.tgz]: exit status 1]
```

This is because the `env-passthrough` flag requires environmental variables to be passed and not key/value pairs.