### PR TITLE
Fix self-detection for github reporting when using apps auth

### DIFF
--- a/prow/github/client_test.go
+++ b/prow/github/client_test.go
@@ -2594,3 +2594,50 @@ func TestAllMethodsThatDoRequestSetOrgHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestBotUserChecker(t *testing.T) {
+	const savedLogin = "botName"
+	testCases := []struct {
+		name         string
+		checkFor     string
+		usesAppsAuth bool
+		expectMatch  bool
+	}{
+		{
+			name:         "Bot suffix with apps auth is recognized",
+			checkFor:     savedLogin + "[bot]",
+			usesAppsAuth: true,
+			expectMatch:  true,
+		},
+		{
+			name:         "No suffix with apps auth is recognized",
+			checkFor:     savedLogin,
+			usesAppsAuth: true,
+			expectMatch:  true,
+		},
+		{
+			name:         "No suffix without apps auth is recognized",
+			checkFor:     savedLogin,
+			usesAppsAuth: false,
+			expectMatch:  true,
+		},
+		{
+			name:         "Suffix without apps auth is not recognized",
+			checkFor:     savedLogin + "[bot]",
+			usesAppsAuth: false,
+			expectMatch:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		c := &client{delegate: &delegate{usesAppsAuth: tc.usesAppsAuth, userData: &UserData{Login: savedLogin}}}
+
+		checker, err := c.BotUserChecker()
+		if err != nil {
+			t.Fatalf("failed to get user checker: %v", err)
+		}
+		if actualMatch := checker(tc.checkFor); actualMatch != tc.expectMatch {
+			t.Errorf("expect match: %t, got match: %t", tc.expectMatch, actualMatch)
+		}
+	}
+}

--- a/prow/github/fakegithub/fakegithub.go
+++ b/prow/github/fakegithub/fakegithub.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -117,6 +118,13 @@ type FakeClient struct {
 // BotName returns authenticated login.
 func (f *FakeClient) BotName() (string, error) {
 	return botName, nil
+}
+
+func (f *FakeClient) BotUserChecker() (func(candidate string) bool, error) {
+	return func(candidate string) bool {
+		candidate = strings.TrimSuffix(candidate, "[bot]")
+		return candidate == botName
+	}, nil
 }
 
 // IsMember returns true if user is in org.

--- a/prow/github/report/report.go
+++ b/prow/github/report/report.go
@@ -36,7 +36,7 @@ const (
 // GitHubClient provides a client interface to report job status updates
 // through GitHub comments.
 type GitHubClient interface {
-	BotName() (string, error)
+	BotUserChecker() (func(candidate string) bool, error)
 	CreateStatus(org, repo, ref string, s github.Status) error
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	CreateComment(org, repo string, number int, comment string) error
@@ -161,11 +161,11 @@ func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.Prow
 	if err != nil {
 		return fmt.Errorf("error listing comments: %v", err)
 	}
-	botName, err := ghc.BotName()
+	botNameChecker, err := ghc.BotUserChecker()
 	if err != nil {
-		return fmt.Errorf("error getting bot name: %v", err)
+		return fmt.Errorf("error getting bot name checker: %w", err)
 	}
-	deletes, entries, updateID := parseIssueComments(pj, botName, ics)
+	deletes, entries, updateID := parseIssueComments(pj, botNameChecker, ics)
 	for _, delete := range deletes {
 		if err := ghc.DeleteComment(refs.Org, refs.Repo, delete); err != nil {
 			return fmt.Errorf("error deleting comment: %v", err)
@@ -193,14 +193,14 @@ func Report(ghc GitHubClient, reportTemplate *template.Template, pj prowapi.Prow
 // entries, and the ID of the comment to update. If there are no table entries
 // then don't make a new comment. Otherwise, if the comment to update is 0,
 // create a new comment.
-func parseIssueComments(pj prowapi.ProwJob, botName string, ics []github.IssueComment) ([]int, []string, int) {
+func parseIssueComments(pj prowapi.ProwJob, isBot func(string) bool, ics []github.IssueComment) ([]int, []string, int) {
 	var delete []int
 	var previousComments []int
 	var latestComment int
 	var entries []string
 	// First accumulate result entries and comment IDs
 	for _, ic := range ics {
-		if ic.User.Login != botName {
+		if !isBot(ic.User.Login) {
 			continue
 		}
 		// Old report comments started with the context. Delete them.

--- a/prow/jenkins/controller.go
+++ b/prow/jenkins/controller.go
@@ -51,7 +51,7 @@ type jenkinsClient interface {
 }
 
 type githubClient interface {
-	BotName() (string, error)
+	BotUserChecker() (func(candidate string) bool, error)
 	CreateStatus(org, repo, ref string, s github.Status) error
 	ListIssueComments(org, repo string, number int) ([]github.IssueComment, error)
 	CreateComment(org, repo string, number int, comment string) error

--- a/prow/jenkins/controller_test.go
+++ b/prow/jenkins/controller_test.go
@@ -155,10 +155,10 @@ func (f *fghc) GetPullRequestChanges(org, repo string, number int) ([]github.Pul
 	return f.changes, f.err
 }
 
-func (f *fghc) BotName() (string, error) {
-	f.Lock()
-	defer f.Unlock()
-	return "bot", nil
+func (f *fghc) BotUserChecker() (func(string) bool, error) {
+	return func(candidate string) bool {
+		return candidate == "bot"
+	}, nil
 }
 func (f *fghc) CreateStatus(org, repo, ref string, s github.Status) error {
 	f.Lock()


### PR DESCRIPTION
This change fixes the selfdetection in the github reporting logic when
using apps auth, where the comment author will be suffixed with [bot].

To do so, a checker function can be requested from the github client
that accounts for this. This approach was taken over directly exposing a
method on the github client for this because such a method would need to
also return an error. This in turn would mean that we would have to
change a lot of logic throughout the codebase where we currently just
pass a string around and do not always have the possibility to return an
error.