### PR TITLE
Prow alert: make stale prow image alert configurable and set it to fire only when the staleness discovered a whole day

### DIFF
--- a/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
+++ b/config/prow/cluster/monitoring/alertmanager-prow_secret.yaml
@@ -31,14 +31,14 @@ stringData:
       - channel: '#prow-alerts'
         api_url: '{{ api_url }}'
         icon_url: https://avatars3.githubusercontent.com/u/3380462
-        text: '{{ template "custom_slack_text" . }}'
+        text: '@test-infra-oncall {{ template "custom_slack_text" . }}'
         link_names: true
     - name: 'slack-alerts'
       slack_configs:
       - channel: '#testing-ops'
         api_url: '{{ api_url }}'
         icon_url: https://avatars3.githubusercontent.com/u/3380462
-        text: '{{ template "custom_slack_text" . }}'
+        text: '@test-infra-oncall {{ template "custom_slack_text" . }}'
         link_names: true
 
     templates:

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -67,7 +67,7 @@ local config = {
   webhookMissingAlertInterval: '10m',
 
   // How many days prow hasn't been bumped.
-  prowImageStaleByDays: 7,
+  prowImageStaleByDays: {daysStale: 7, hoursToTrigger: '24h'},
 };
 
 // Generate the real config by adding in constant fields and defaulting where needed.

--- a/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config.libsonnet
@@ -67,7 +67,7 @@ local config = {
   webhookMissingAlertInterval: '10m',
 
   // How many days prow hasn't been bumped.
-  prowImageStaleByDays: {daysStale: 7, hoursToTrigger: '24h'},
+  prowImageStaleByDays: {daysStale: 7, eventDuration: '24h'},
 };
 
 // Generate the real config by adding in constant fields and defaulting where needed.

--- a/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
@@ -39,6 +39,6 @@
           ),
         },
     }
-    + default(config, 'prowImageStaleByDays', 7)
+    + default(config, 'prowImageStaleByDays', {daysStale: 7, hoursToTrigger: '24h'})
   ),
 }

--- a/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
@@ -38,7 +38,8 @@
               '%s (Requires <https://github.com/kubernetes/test-infra/tree/master/config/prow/cluster/monitoring#access-components-web-page|port-forwarding the grafana service> and accessing path "%s")' % [text, path]
           ),
         },
+      prowImageStaleByDays+: default(config.prowImageStaleByDays, 'daysStale', 7)
+        + default(config.prowImageStaleByDays, 'hoursToTrigger', '24h'),
     }
-    + default(config, 'prowImageStaleByDays', {daysStale: 7, hoursToTrigger: '24h'})
   ),
 }

--- a/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/lib/config_util.libsonnet
@@ -39,7 +39,7 @@
           ),
         },
       prowImageStaleByDays+: default(config.prowImageStaleByDays, 'daysStale', 7)
-        + default(config.prowImageStaleByDays, 'hoursToTrigger', '24h'),
+        + default(config.prowImageStaleByDays, 'eventDuration', '24h'),
     }
   ),
 }

--- a/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
@@ -8,13 +8,13 @@
             alert: 'Prow images are stale',
             expr: |||
               time()-max(prow_version) > %d * 24 * 3600
-            ||| % $._config.prowImageStaleByDays,
-            'for': '5m',
+            ||| % $._config.prowImageStaleByDays.daysStale,
+            'for': '%s' % $._config.prowImageStaleByDays.hoursToTrigger,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: '@test-infra-oncall The prow images are older than %d days.' % $._config.prowImageStaleByDays,
+              message: '@test-infra-oncall The prow images are older than %d days.' % $._config.prowImageStaleByDays.daysStale,
             },
           }
         ],

--- a/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
@@ -9,12 +9,12 @@
             expr: |||
               time()-max(prow_version) > %d * 24 * 3600
             ||| % $._config.prowImageStaleByDays.daysStale,
-            'for': '%s' % $._config.prowImageStaleByDays.hoursToTrigger,
+            'for': $._config.prowImageStaleByDays.hoursToTrigger,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: '@test-infra-oncall The prow images are older than %d days.' % $._config.prowImageStaleByDays.daysStale,
+              message: 'The prow images are older than %d days.' % $._config.prowImageStaleByDays.daysStale,
             },
           }
         ],

--- a/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
@@ -14,7 +14,7 @@
               severity: 'critical',
             },
             annotations: {
-              message: 'The prow images are older than %d days.' % $._config.prowImageStaleByDays.daysStale,
+              message: 'The prow images are older than %(daysStale)d days for %(hoursToTrigger)s.' % ($._config.prowImageStaleByDays),
             },
           }
         ],

--- a/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
+++ b/config/prow/cluster/monitoring/mixins/prometheus/stale_alerts.libsonnet
@@ -9,12 +9,12 @@
             expr: |||
               time()-max(prow_version) > %d * 24 * 3600
             ||| % $._config.prowImageStaleByDays.daysStale,
-            'for': $._config.prowImageStaleByDays.hoursToTrigger,
+            'for': $._config.prowImageStaleByDays.eventDuration,
             labels: {
               severity: 'critical',
             },
             annotations: {
-              message: 'The prow images are older than %(daysStale)d days for %(hoursToTrigger)s.' % ($._config.prowImageStaleByDays),
+              message: 'The prow images are older than %(daysStale)d days for %(eventDuration)s.' % ($._config.prowImageStaleByDays),
             },
           }
         ],


### PR DESCRIPTION
This alert fired this morning due to a temporary prow-controller-manager outage for 6 minutes, de-sensitise it since it's not meant to be that urgent