### PR TITLE
kops AWS CCM: run with kubernetes 1.19

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -416,6 +416,7 @@ def generate():
     build_test(force_name="scenario-aws-cloud-controller-manager",
                cloud="aws",
                distro="u2004",
+               k8s_version="1.19",
                feature_flags=["EnableExternalCloudController,SpecOverrideFlag"],
                extra_flags=['--override=cluster.spec.cloudControllerManager.cloudProvider=aws'])
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -47145,7 +47145,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-public-jwks
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": null, "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--override=cluster.spec.cloudControllerManager.cloudProvider=aws", "feature_flags": "EnableExternalCloudController,SpecOverrideFlag", "k8s_version": "1.19", "kops_version": null, "networking": null}
 - name: e2e-kops-grid-scenario-aws-cloud-controller-manager
   cron: '28 22 * * *'
   labels:
@@ -47165,10 +47165,10 @@ periodics:
       - --deployment=kops
       - --kops-ssh-user=ubuntu
       - --env=KUBE_SSH_USER=ubuntu
-      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/latest.txt
+      - --env=KOPS_DEPLOY_LATEST_URL=https://storage.googleapis.com/kubernetes-release/release/stable-1.19.txt
       - --env=KOPS_KUBE_RELEASE_URL=https://storage.googleapis.com/kubernetes-release/release
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
-      - --extract=release/latest
+      - --extract=release/stable-1.19
       - --ginkgo-parallel
       - --kops-args=--container-runtime=docker --override=cluster.spec.cloudControllerManager.cloudProvider=aws
       - --kops-feature-flags=EnableExternalCloudController,SpecOverrideFlag
@@ -47178,7 +47178,7 @@ periodics:
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
-      image: gcr.io/k8s-testimages/kubekins-e2e:v20201215-73fe430-master
+      image: gcr.io/k8s-testimages/kubekins-e2e:v20201215-73fe430-1.19
       resources:
         limits:
           memory: 2Gi
@@ -47191,10 +47191,10 @@ periodics:
     test.kops.k8s.io/distro: u2004
     test.kops.k8s.io/extra_flags: --override=cluster.spec.cloudControllerManager.cloudProvider=aws
     test.kops.k8s.io/feature_flags: EnableExternalCloudController,SpecOverrideFlag
-    test.kops.k8s.io/k8s_version: ''
+    test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
 # 963 jobs, total of 1701 runs per week


### PR DESCRIPTION
The AWS CCM doesn't currently have a build for 1.21; also we likely
want to validate with a stable k8s version first.