### PR TITLE
kops-grid: support extra dashboards for scenarios

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -148,7 +148,8 @@ def build_test(cloud='aws',
                kops_zones=None,
                force_name=None,
                feature_flags=None,
-               extra_flags=None):
+               extra_flags=None,
+               extra_dashboards=None):
     # pylint: disable=too-many-statements,too-many-branches
 
     if distro is None:
@@ -328,6 +329,9 @@ def build_test(cloud='aws',
     else:
         dashboards.append('kops-k8s-latest')
 
+    if extra_dashboards:
+        dashboards.extend(extra_dashboards)
+
     annotations = {
         'testgrid-dashboards': ', '.join(dashboards),
         'testgrid-tab-name': tab,
@@ -418,7 +422,8 @@ def generate():
                distro="u2004",
                k8s_version="1.19",
                feature_flags=["EnableExternalCloudController,SpecOverrideFlag"],
-               extra_flags=['--override=cluster.spec.cloudControllerManager.cloudProvider=aws'])
+               extra_flags=['--override=cluster.spec.cloudControllerManager.cloudProvider=aws'],
+               extra_dashboards=['sig-aws-cloud-provider-aws'])
 
     print("")
     print("# %d jobs, total of %d runs per week" % (job_count, runs_per_week))

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -47194,7 +47194,7 @@ periodics:
     test.kops.k8s.io/k8s_version: '1.19'
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
-    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
+    testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19, sig-aws-cloud-provider-aws
     testgrid-tab-name: kops-grid-scenario-aws-cloud-controller-manager
 
 # 963 jobs, total of 1701 runs per week


### PR DESCRIPTION
Also add the AWS CCM scenario to the sig-aws-cloud-provider-aws dashboard.