### PR TITLE
test images: Adds dockerhub images used in tests

### DIFF
--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.sh
@@ -22,16 +22,22 @@ readonly IMAGES=(
     busybox
     cuda-vector-add
     echoserver
+    glusterdynamic-provisioner
+    httpd
+    httpd-new
     ipc-utils
     jessie-dnsutils
     kitten
     metadata-concealment
     nautilus
+    nginx
+    nginx-new
     node-perf/tf-wide-deep
     node-perf/npb-ep
     node-perf/npb-is
     nonewprivs
     nonroot
+    perl
     pets/redis-installer
     pets/peer-finder
     pets/zookeeper-installer

--- a/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
+++ b/config/jobs/image-pushing/k8s-staging-e2e-test-images.yaml
@@ -147,6 +147,93 @@ postsubmits:
             # We override that with the echoserver image.
             - name: WHAT
               value: "echoserver"
+    - name: post-kubernetes-push-e2e-glusterdynamic-provisioner-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/glusterdynamic-provisioner\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the glusterdynamic-provisioner image.
+            - name: WHAT
+              value: "glusterdynamic-provisioner"
+    - name: post-kubernetes-push-e2e-httpd-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/httpd\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the httpd image.
+            - name: WHAT
+              value: "httpd"
+    - name: post-kubernetes-push-e2e-httpd-new-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/httpd-new\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the httpd-new image.
+            - name: WHAT
+              value: "httpd-new"
     - name: post-kubernetes-push-e2e-ipc-utils-test-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -292,6 +379,64 @@ postsubmits:
             # We override that with the nautilus image.
             - name: WHAT
               value: "nautilus"
+    - name: post-kubernetes-push-e2e-nginx-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/nginx\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the nginx image.
+            - name: WHAT
+              value: "nginx"
+    - name: post-kubernetes-push-e2e-nginx-new-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/nginx-new\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the nginx-new image.
+            - name: WHAT
+              value: "nginx-new"
     - name: post-kubernetes-push-e2e-node-perf-tf-wide-deep-test-images
       cluster: k8s-infra-prow-build-trusted
       annotations:
@@ -437,6 +582,35 @@ postsubmits:
             # We override that with the nonroot image.
             - name: WHAT
               value: "nonroot"
+    - name: post-kubernetes-push-e2e-perl-test-images
+      cluster: k8s-infra-prow-build-trusted
+      annotations:
+        testgrid-dashboards: sig-testing-images
+      decorate: true
+      # we only need to run if the test images have been changed.
+      run_if_changed: '^test\/images\/perl\/'
+      branches:
+        - ^master$
+      spec:
+        serviceAccountName: gcb-builder
+        containers:
+          - image: gcr.io/k8s-testimages/image-builder:v20200901-ab141a0
+            command:
+              - /run.sh
+            args:
+              # this is the project GCB will run in, which is the same as the GCR
+              # images are pushed to.
+              - --project=k8s-staging-e2e-test-images
+              # This is the same as above, but with -gcb appended.
+              - --scratch-bucket=gs://k8s-staging-e2e-test-images-gcb
+              - --env-passthrough=PULL_BASE_REF,WHAT
+              - --build-dir=.
+              - test/images
+            env:
+            # By default, the E2E test image's WHAT is all-conformance.
+            # We override that with the perl image.
+            - name: WHAT
+              value: "perl"
     - name: post-kubernetes-push-e2e-pets-redis-installer-test-images
       cluster: k8s-infra-prow-build-trusted
       annotations:


### PR DESCRIPTION
Adds the prow config jobs for images that are currently hosted on dockerhub but are being used in E2E tests. The image Dockerfiles are mostly noop since the purpose of these jobs is to mirror those images into our own registries, so we can then use them in tests instead of the dockerhub ones.

The PR that adds the images: https://github.com/kubernetes/kubernetes/pull/95567