### PR TITLE
Prow integration test job use RBE

### DIFF
--- a/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
+++ b/config/jobs/kubernetes/test-infra/test-infra-presubmits.yaml
@@ -105,6 +105,7 @@ presubmits:
     skip_report: true
     optional: true
     labels:
+      preset-service-account: "true"
       preset-bazel-scratch-dir: "true"
       preset-dind-enabled: "true"
       preset-kind-volume-mounts: "true"
@@ -115,7 +116,7 @@ presubmits:
         - runner.sh
         args:
         - prow/test/integration/test.sh
-        - --create-cluster
+        - --config=ci
         # docker-in-docker needs privileged mode
         securityContext:
           privileged: true


### PR DESCRIPTION
Prow integration test uses bazel for some steps, and it takes more than 13 minutes, and most of the time spent were on bazel, use RBE try to speed it up

See an example run: https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/test-infra/20262/pull-test-infra-integration/1339354315625598976