### PR TITLE
Kops - use kubetest's --kops-zones flag rather than kops' --zone flag

### DIFF
--- a/config/jobs/kubernetes/kops/build-grid.py
+++ b/config/jobs/kubernetes/kops/build-grid.py
@@ -47,6 +47,7 @@ template = """
       - --kops-image={{kops_image}}
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version={{kops_deploy_url}}
+      - --kops-zones={{kops_zones}}
       - --provider=aws
       - --test_args={{test_args}}
       - --timeout=60m
@@ -146,7 +147,8 @@ def build_test(cloud='aws',
                kops_version=None,
                force_name=None,
                feature_flags=None,
-               extra_flags=None):
+               extra_flags=None,
+               zones=None):
     # pylint: disable=too-many-statements,too-many-branches
 
     if distro is None:
@@ -289,6 +291,11 @@ def build_test(cloud='aws',
     else:
         y = remove_line_with_prefix(y, "- --kops-feature-flags=")
 
+    if zones:
+        y = y.replace('{{kops_zones}}', ','.join(zones))
+    else:
+        y = remove_line_with_prefix(y, "- --kops-zones=")
+
     spec = {
         'cloud': cloud,
         'networking': networking,
@@ -301,6 +308,8 @@ def build_test(cloud='aws',
         spec['feature_flags'] = ','.join(feature_flags)
     if extra_flags:
         spec['extra_flags'] = ' '.join(extra_flags)
+    if zones:
+        spec['zones'] = ','.join(zones)
     jsonspec = json.dumps(spec, sort_keys=True)
 
     dashboards = [
@@ -391,8 +400,8 @@ def generate():
     build_test(force_name="scenario-arm64",
                cloud="aws",
                distro="u2004",
-               extra_flags=['--zones=us-east-2b',
-                            '--node-size=m6g.large',
+               zones=['us-east-2b'],
+               extra_flags=['--node-size=m6g.large',
                             '--master-size=m6g.large',
                             '--image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201']) # pylint: disable=line-too-long
 

--- a/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
+++ b/config/jobs/kubernetes/kops/kops-periodics-grid.yaml
@@ -47041,7 +47041,7 @@ periodics:
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-1.19
     testgrid-tab-name: kops-grid-kopeio-u2004-k19-ko19-containerd
 
-# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201", "k8s_version": null, "kops_version": null, "networking": null}
+# {"cloud": "aws", "container_runtime": "docker", "distro": "u2004", "extra_flags": "--node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201", "k8s_version": null, "kops_version": null, "networking": null, "zones": "us-east-2b"}
 - name: e2e-kops-grid-scenario-arm64
   cron: '33 16 * * *'
   labels:
@@ -47066,10 +47066,11 @@ periodics:
       - --env=KOPS_RUN_TOO_NEW_VERSION=1
       - --extract=release/latest
       - --ginkgo-parallel
-      - --kops-args=--container-runtime=docker --zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201
+      - --kops-args=--container-runtime=docker --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201
       - --kops-image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201201
       - --kops-priority-path=/workspace/kubernetes/platforms/linux/amd64
       - --kops-version=https://storage.googleapis.com/kops-ci/bin/latest-ci-updown-green.txt
+      - --kops-zones=us-east-2b
       - --provider=aws
       - --test_args=--ginkgo.skip=\[Slow\]|\[Serial\]|\[Disruptive\]|\[Flaky\]|\[Feature:.+\]|\[HPA\]|Dashboard|Services.*functioning.*NodePort|Services.*rejected.*endpoints|Services.*affinity
       - --timeout=60m
@@ -47084,10 +47085,11 @@ periodics:
     test.kops.k8s.io/cloud: aws
     test.kops.k8s.io/container_runtime: docker
     test.kops.k8s.io/distro: u2004
-    test.kops.k8s.io/extra_flags: --zones=us-east-2b --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201
+    test.kops.k8s.io/extra_flags: --node-size=m6g.large --master-size=m6g.large --image=099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-20201201
     test.kops.k8s.io/k8s_version: ''
     test.kops.k8s.io/kops_version: ''
     test.kops.k8s.io/networking: ''
+    test.kops.k8s.io/zones: us-east-2b
     testgrid-dashboards: sig-cluster-lifecycle-kops, google-aws, kops-grid, kops-distro-u2004, kops-k8s-latest
     testgrid-tab-name: kops-grid-scenario-arm64
 


### PR DESCRIPTION
This prevents kubetest from randomly assigning another zone to the job, resulting in zones from conflicting regions.

Fixes https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/e2e-kops-grid-scenario-arm64/1339247258629050368