### PR TITLE
Make it possible to override --logexporter-gcs-path

### DIFF
--- a/scenarios/kubernetes_e2e.py
+++ b/scenarios/kubernetes_e2e.py
@@ -536,8 +536,7 @@ def main(args):
     runner_args.extend(args.kubetest_args)
 
     if args.use_logexporter:
-        # TODO(fejta): Take the below value through a flag instead of env var.
-        runner_args.append('--logexporter-gcs-path=%s' % os.environ.get('GCS_ARTIFACTS_DIR', ''))
+        runner_args.append('--logexporter-gcs-path=%s' % args.logexporter_gcs_path)
 
     if args.aws:
         # Legacy - prefer passing --deployment=kops, --provider=aws,
@@ -624,6 +623,10 @@ def create_parser():
         '--use-logexporter',
         action='store_true',
         help='If we need to use logexporter tool to upload logs from nodes to GCS directly')
+    parser.add_argument(
+        '--logexporter-gcs-path',
+        default=os.environ.get('GCS_ARTIFACTS_DIR',''),
+        help='GCS path where logexporter tool will upload logs if enabled')
     parser.add_argument(
         '--kubetest_args',
         action='append',


### PR DESCRIPTION
This PR introduces a way to set --logexporter-gcs-path in kubetest to something else than GCS artifacts dir.

* If --logexporter-gcs-path arg in kubernetes_e2e is set, it will pass this value down to kubetests
* otherwise it will fallback to the old behavior

The goal is to make it possible to move scalability test logs outside gcs

Ref https://github.com/kubernetes/test-infra/issues/20275